### PR TITLE
Remove duplicate service injections in TennisScore.razor

### DIFF
--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -16,9 +16,7 @@
 @inject MyDbContext DbContext
 @inject NavigationManager Navigation
 @inject UserState State
-@inject IDialogService Dialog
 @inject IDialogService DialogService
-@inject NavigationManager NavigationManager
 
 <MudCollapse Expanded="_expanded" Style="margin-top: 10px;">
     <MudPaper Class="pa-4">


### PR DESCRIPTION
IDialogService and NavigationManager were each injected twice under different names. Removed the unused aliases (Dialog, NavigationManager) keeping the ones referenced in code (DialogService, Navigation).