### PR TITLE
Move GameState and SetScore to shared model files

### DIFF
--- a/DropShot/Components/Pages/Scoreboard.razor
+++ b/DropShot/Components/Pages/Scoreboard.razor
@@ -43,7 +43,7 @@
     private List<string> messages = new();
     private List<Score> scores = new();
     private Stack<GameState> history = new();
-    GameState currentScore = new(0, 0, 0, 0, 0, 0, false, 0, true, 0, 0, new List<SetScore>());
+    GameState currentScore = new(0, 0, 0, 0, 0, 0, false, 0, true, 0, 0, new List<SetScore>(), DateTime.Now, false);
 
     protected override async Task OnInitializedAsync()
     {
@@ -67,27 +67,6 @@
         await hubConnection.StartAsync();
     }
 
-      public record GameState(
-        int UserPts,
-        int OppPts,
-        int UserG,
-        int OppG,
-        int UserS,
-        int OppS,
-        bool TieBreak,
-        int DeuceCount,
-        bool IsUserServing,
-        int UserGamesSnapshot,
-        int OpponentGamesSnapshot,
-        List<SetScore>? SetScores
-    );
-
-    public class SetScore
-    {
-        public int SetNumber { get; set; }
-        public int UserGames { get; set; }
-        public int OpponentGames { get; set; }
-    }
 
     private void SendMessage()
     {

--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -475,24 +475,6 @@
     private int deuceCount = 0;
     private bool isMatchEnded = false;
 
-    // Define a record to replace the tuple snapshot
-    public record GameState(
-        int UserPts,
-        int OppPts,
-        int UserG,
-        int OppG,
-        int UserS,
-        int OppS,
-        bool TieBreak,
-        int DeuceCount,
-        bool IsUserServing,
-        int UserGamesSnapshot,
-        int OpponentGamesSnapshot,
-        List<SetScore>? SetScores,
-        DateTime Timestamp,
-        bool isComplete
-    );
-
     // Initialize history with a GameState containing zeros and a null SetScores
     private Stack<GameState> history = new(new[] { new GameState(0, 0, 0, 0, 0, 0, false, 0, false, 0, 0, new List<SetScore>(), DateTime.Now, false) });
 
@@ -536,22 +518,6 @@
     }
 
 
-    public class SetScore
-    {
-        public int SetNumber { get; set; }
-        public int UserGames { get; set; }
-        public int OpponentGames { get; set; }
-
-
-        public SetScore Clone()
-                => new SetScore
-                {
-                    UserGames = this.UserGames,
-                    OpponentGames = this.OpponentGames,
-                    SetNumber = this.SetNumber,
-                };
-
-    }
 
     public class Match
     {

--- a/DropShot/Models/GameState.cs
+++ b/DropShot/Models/GameState.cs
@@ -1,0 +1,18 @@
+namespace DropShot.Models;
+
+public record GameState(
+    int UserPts,
+    int OppPts,
+    int UserG,
+    int OppG,
+    int UserS,
+    int OppS,
+    bool TieBreak,
+    int DeuceCount,
+    bool IsUserServing,
+    int UserGamesSnapshot,
+    int OpponentGamesSnapshot,
+    List<SetScore>? SetScores,
+    DateTime Timestamp,
+    bool isComplete
+);

--- a/DropShot/Models/SetScore.cs
+++ b/DropShot/Models/SetScore.cs
@@ -1,0 +1,16 @@
+namespace DropShot.Models;
+
+public class SetScore
+{
+    public int SetNumber { get; set; }
+    public int UserGames { get; set; }
+    public int OpponentGames { get; set; }
+
+    public SetScore Clone()
+        => new SetScore
+        {
+            UserGames = this.UserGames,
+            OpponentGames = this.OpponentGames,
+            SetNumber = this.SetNumber,
+        };
+}


### PR DESCRIPTION
Both types were defined identically inside TennisScore.razor and Scoreboard.razor. Extracted them to Models/GameState.cs and Models/SetScore.cs so there is a single source of truth.

Updated Scoreboard's initial GameState to use the full 14-parameter version (adding Timestamp and isComplete) to match TennisScore.