### PR TITLE
Move Match and SavedMatch to shared model files

### DIFF
--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -517,23 +517,6 @@
 
 
 
-    public class Match
-    {
-        public Stack<GameState> History { get; set; } = new Stack<GameState>();
-        public List<GameState> HistoryList { get; set; } = new List<GameState>();
-        public string Player1 { get; set; }
-        public string Player2 { get; set; }
-        public string Player3 { get; set; }
-        public string Player4 { get; set; }
-        public bool Complete { get; set; }
-    }
-
-    public class SavedMatch
-    {
-        public int SavedMatchId { get; set; }
-        public string MatchJson { get; set; }
-        public bool Complete { get; set; }
-    }
 
     [Inject] private IDbContextFactory<MyDbContext> DbFactory { get; set; }
     private bool isSaving;

--- a/DropShot/Data/MyDbContext.cs
+++ b/DropShot/Data/MyDbContext.cs
@@ -1,7 +1,6 @@
 using DropShot.Models;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
-using static DropShot.Components.TennisScore;
 
 namespace DropShot.Data
 {

--- a/DropShot/Models/Match.cs
+++ b/DropShot/Models/Match.cs
@@ -1,0 +1,12 @@
+namespace DropShot.Models;
+
+public class Match
+{
+    public Stack<GameState> History { get; set; } = new Stack<GameState>();
+    public List<GameState> HistoryList { get; set; } = new List<GameState>();
+    public string Player1 { get; set; }
+    public string Player2 { get; set; }
+    public string Player3 { get; set; }
+    public string Player4 { get; set; }
+    public bool Complete { get; set; }
+}

--- a/DropShot/Models/SavedMatch.cs
+++ b/DropShot/Models/SavedMatch.cs
@@ -1,0 +1,8 @@
+namespace DropShot.Models;
+
+public class SavedMatch
+{
+    public int SavedMatchId { get; set; }
+    public string MatchJson { get; set; }
+    public bool Complete { get; set; }
+}

--- a/DropShot/Models/UserState.cs
+++ b/DropShot/Models/UserState.cs
@@ -1,5 +1,4 @@
-﻿using DropShot.Components.Pages;
-
+﻿
 namespace DropShot.Models
 {
     public class UserState


### PR DESCRIPTION
## Summary
- `Match` and `SavedMatch` were defined inside `TennisScore.razor`'s `@code` block, forcing `MyDbContext.cs` to use `using static DropShot.Components.TennisScore` — a UI component leaking into the data layer
- Created `Models/Match.cs` and `Models/SavedMatch.cs` in the `DropShot.Models` namespace
- Removed both class definitions from `TennisScore.razor`
- Removed `using static DropShot.Components.TennisScore` from `MyDbContext.cs`
- Removed `using DropShot.Components.Pages` from `UserState.cs` (Match is now in the same namespace)

## Test plan
- [ ] `dotnet build` with no errors
- [ ] Navigate to `/tennisscore`, start and complete a match
- [ ] Verify the match is saved to the DB correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)