### PR TITLE
Improvements #5-#8: players from DB, real league table, cleanup

### DIFF
--- a/DropShot/Components/Pages/LeagueTable.razor
+++ b/DropShot/Components/Pages/LeagueTable.razor
@@ -1,57 +1,90 @@
-﻿@page "/league"
+@page "/league"
 @rendermode InteractiveServer
+@using DropShot.Models
+@using Microsoft.EntityFrameworkCore
+@using Newtonsoft.Json
+@inject IDbContextFactory<DropShot.Data.MyDbContext> DbFactory
 
-<h3>LeagueTable</h3>
+<h3>League Table</h3>
 
-<MudTable Items="@Elements.Take(4)" Hover="true" Breakpoint="Breakpoint.Sm" Loading="@_loading" LoadingProgressColor="Color.Info">
+<MudTable Items="@Elements" Hover="true" Breakpoint="Breakpoint.Sm" Loading="@_loading" LoadingProgressColor="Color.Info">
     <HeaderContent>
-        <MudTh>Team Name</MudTh>
+        <MudTh>Player</MudTh>
         <MudTh>Played</MudTh>
         <MudTh>Won</MudTh>
         <MudTh>Lost</MudTh>
-        <MudTh>Drawn</MudTh>
         <MudTh>Points</MudTh>
     </HeaderContent>
     <RowTemplate>
-        <MudTd DataLabel="TeamName">@context.TeamName</MudTd>
+        <MudTd DataLabel="Player">@context.PlayerName</MudTd>
         <MudTd DataLabel="Played">@context.Played</MudTd>
         <MudTd DataLabel="Won">@context.Won</MudTd>
-        <MudTd DataLabel="Lost" HideSmall="_hidePosition">@context.Lost</MudTd>
-        <MudTd DataLabel="Drawn">@context.Drawn</MudTd>
+        <MudTd DataLabel="Lost">@context.Lost</MudTd>
         <MudTd DataLabel="Points">@context.Points</MudTd>
     </RowTemplate>
+    <NoRecordsContent>
+        <MudText>No completed matches yet.</MudText>
+    </NoRecordsContent>
 </MudTable>
- 
 
 @code {
-    private bool _hidePosition;
-    private bool _loading;
-    private List<TeamRecord> Elements = new List<TeamRecord>();
+    private bool _loading = true;
+    private List<PlayerRecord> Elements = [];
 
-    private class TeamRecord
+    private record PlayerRecord(int Position, string PlayerName, int Played, int Won, int Lost, int Points);
+
+    // Minimal DTO matching the serialized Match structure in SavedMatch.MatchJson
+    private class MatchSummary
     {
-        public TeamRecord(string teamName)
-        {
-            TeamName = teamName;
-        }
-
-        public string TeamName { get; set; }
-        public int Played { get; set; }
-        public int Won { get; set; }
-        public int Drawn { get; set; }
-        public int Lost { get; set; }
-        public int Points { get; set; }
-        public int Position { get; set; }
+        public string? Player1 { get; set; }
+        public string? Player2 { get; set; }
+        public List<GameState>? HistoryList { get; set; }
     }
 
     protected override async Task OnInitializedAsync()
     {
-        // Elements = new List<TeamRecord>();
-        Elements.Add(new TeamRecord("Team A") { Played = 10, Won = 6, Drawn = 2, Lost = 2, Points = 20, Position = 1 });
-        Elements.Add(new TeamRecord("Team B") { Played = 10, Won = 5, Drawn = 3, Lost = 2, Points = 18, Position = 2 });
-        Elements.Add(new TeamRecord("Team C") { Played = 10, Won = 4, Drawn = 4, Lost = 2, Points = 16, Position = 3 });
-        Elements.Add(new TeamRecord("Team D") { Played = 10, Won = 3, Drawn = 5, Lost = 2, Points = 14, Position = 4 });
-        Elements.Add(new TeamRecord("Team E") { Played = 10, Won = 2, Drawn = 6, Lost = 2, Points = 12, Position = 5 });
+        await using var dbc = DbFactory.CreateDbContext();
+        var savedMatches = await dbc.SavedMatch
+            .Where(m => m.Complete)
+            .ToListAsync();
 
+        var stats = new Dictionary<string, (int Played, int Won)>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var sm in savedMatches)
+        {
+            if (string.IsNullOrEmpty(sm.MatchJson)) continue;
+            var match = JsonConvert.DeserializeObject<MatchSummary>(sm.MatchJson);
+            if (match is null) continue;
+
+            var finalState = match.HistoryList?.LastOrDefault();
+            if (finalState is null) continue;
+
+            var players = new[] { match.Player1, match.Player2 }
+                .Where(p => !string.IsNullOrEmpty(p))
+                .ToList();
+
+            foreach (var p in players)
+            {
+                if (!stats.ContainsKey(p)) stats[p] = (0, 0);
+                stats[p] = (stats[p].Played + 1, stats[p].Won);
+            }
+
+            var winner = finalState.UserS > finalState.OppS ? match.Player1 : match.Player2;
+            if (!string.IsNullOrEmpty(winner) && stats.ContainsKey(winner))
+                stats[winner] = (stats[winner].Played, stats[winner].Won + 1);
+        }
+
+        Elements = stats
+            .OrderByDescending(kv => kv.Value.Won)
+            .Select((kv, i) => new PlayerRecord(
+                i + 1,
+                kv.Key,
+                kv.Value.Played,
+                kv.Value.Won,
+                kv.Value.Played - kv.Value.Won,
+                kv.Value.Won * 3))
+            .ToList();
+
+        _loading = false;
     }
 }

--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -364,11 +364,7 @@
         };
     }
 
-    private string[] _states =
-    {
-        "Alan Beattie", "Andrew Beattie", "Mark Buchner", "Kevin Beattie", "Ronald Beattie",
-        "Ian Kerr", "James Daniel"
-    };
+    private List<string> _states = [];
 
     private async Task<IEnumerable<string>> Search(string value, CancellationToken token)
     {
@@ -415,6 +411,11 @@
 
     protected override async Task OnInitializedAsync()
     {
+        _states = await DbContext.Users
+            .Select(u => u.UserName)
+            .OrderBy(u => u)
+            .ToListAsync();
+
         // using var dbc = DbFactory.CreateDbContext();
         if (hubConnection is not null)
         {

--- a/DropShot/Program.cs
+++ b/DropShot/Program.cs
@@ -30,9 +30,8 @@ builder.Services.AddAuthentication(options =>
     })
     .AddIdentityCookies();
 
-var connectionString = builder.Configuration.GetConnectionString("DefaultConnection") ?? throw new InvalidOperationException("Connection string 'DefaultConnection' not found.");
-builder.Services.AddDbContext<MyDbContext>(options =>
-    options.UseSqlServer(connectionString));
+builder.Services.AddScoped<MyDbContext>(sp =>
+    sp.GetRequiredService<IDbContextFactory<MyDbContext>>().CreateDbContext());
 builder.Services.AddDatabaseDeveloperPageExceptionFilter();
 
 builder.Services.AddIdentityCore<ApplicationUser>(options => options.SignIn.RequireConfirmedAccount = true)


### PR DESCRIPTION
## Summary
- **#5** `TennisScore.razor`: Replace hardcoded 7-name player array with an async query from Identity users (`DbContext.Users`), so new registrations appear automatically
- **#6** `LeagueTable.razor`: Replace 5 fake hardcoded teams with real player standings derived from completed `SavedMatch` records — deserializes each match JSON and calculates played/won/lost/points per player
- **#7** Delete `Component.razor` — empty 1-line placeholder accidentally committed
- **#8** `Program.cs`: Remove the duplicate `AddDbContext` call (which duplicated the connection string config) and replace with a scoped wrapper that delegates to the existing `IDbContextFactory`, so all consumers (direct injection + Identity) continue to work from a single config source

## Test plan
- [ ] `dotnet build` — 0 errors
- [ ] Register a new user and confirm they appear in the player dropdowns on `/tennisscore`
- [ ] Navigate to `/league` — shows real standings if completed matches exist, or "No completed matches yet" if empty
- [ ] Complete a match and confirm it appears in the league table
- [ ] Confirm `/competitions`, login, and register still work (DbContext still resolves via factory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)