### PR TITLE
Replace magic numbers with configurable match settings

### DIFF
--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -97,6 +97,19 @@
                          AdornmentColor="Color.Primary" />
     }
 
+    <MudSelect @bind-Value="bestOf" Label="Best Of" Variant="Variant.Outlined" Style="margin: 10px;">
+        <MudSelectItem Value="1">1 Set</MudSelectItem>
+        <MudSelectItem Value="3">Best of 3</MudSelectItem>
+        <MudSelectItem Value="5">Best of 5</MudSelectItem>
+    </MudSelect>
+
+    <MudSelect @bind-Value="gamesFirstTo" Label="Games Per Set" Variant="Variant.Outlined" Style="margin: 10px;">
+        <MudSelectItem Value="4">First to 4</MudSelectItem>
+        <MudSelectItem Value="6">First to 6</MudSelectItem>
+    </MudSelect>
+
+    <MudSwitch @bind-Value="unlimitedDeuce" Label="Unlimited Deuce" Color="Color.Success" Style="margin: 10px;" />
+
     <MudButton Variant="Variant.Filled" EndIcon="@Icons.Material.Filled.PlayArrow" Style="margin: 10px;" OnClick="ButtonOnClick">Start Match</MudButton>
 }
 
@@ -387,10 +400,10 @@
     private int userSets = 0;
     private int opponentSets = 0;
     private bool isTieBreak = false;
-    private int bestOf = 5;
+    private int bestOf = 3;
     private int gamesFirstTo = 6;
     private bool gameScoring = true;
-    private int maxDeuce = 99999;
+    private bool unlimitedDeuce = true;
     private bool isUserServing = true; // Start with user serving
     private List<Score> scores = new();
     private HubConnection? hubConnection;
@@ -655,9 +668,9 @@
         {
             int diff = userPoints - opponentPoints;
 
-            if (!(deuceCount > maxDeuce))
+            if (unlimitedDeuce)
             {
-                // Normal tennis logic before deuce
+                // Normal tennis logic — deuce can repeat indefinitely
                 if (diff >= 2)
                 {
                     userGames++;
@@ -673,7 +686,7 @@
             }
             else
             {
-                if (diff == 2 || diff == -2 || (diff == 1 && opponentPoints > 3) || (diff == -1 && userPoints > 3) || deuceCount > maxDeuce)
+                if (diff == 2 || diff == -2 || (diff == 1 && opponentPoints > 3) || (diff == -1 && userPoints > 3))
                 {
                     if (diff > 0)
                         userGames++;


### PR DESCRIPTION
## Summary
- `bestOf = 5`, `gamesFirstTo = 6`, and `maxDeuce = 99999` were hardcoded magic numbers with no UI to change them
- Added **Best Of** selector (1 set / Best of 3 / Best of 5) to the match setup screen
- Added **Games Per Set** selector (first to 4 or 6) to the match setup screen
- Added **Unlimited Deuce** toggle to the match setup screen
- Replaced the `maxDeuce = 99999` sentinel with a clear `unlimitedDeuce` bool — the old value was an arbitrary large number masquerading as "infinity"
- Changed default `bestOf` from 5 → 3 (more appropriate for casual play)

## Test plan
- [ ] Navigate to `/tennisscore` with no active match
- [ ] Confirm Best Of, Games Per Set, and Unlimited Deuce controls appear before the Start Match button
- [ ] Start a match with Best of 1 / First to 4 / Unlimited Deuce off — verify the set ends at 4 games and deuce resolves on the next point after advantage
- [ ] Start a match with Best of 5 / First to 6 / Unlimited Deuce on — verify standard tennis rules apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)