### PR TITLE
Add queryable columns to SavedMatch (hybrid schema)

### DIFF
--- a/DropShot/Components/Pages/LeagueTable.razor
+++ b/DropShot/Components/Pages/LeagueTable.razor
@@ -1,8 +1,6 @@
 @page "/league"
 @rendermode InteractiveServer
-@using DropShot.Models
 @using Microsoft.EntityFrameworkCore
-@using Newtonsoft.Json
 @inject IDbContextFactory<DropShot.Data.MyDbContext> DbFactory
 
 <h3>League Table</h3>
@@ -33,45 +31,29 @@
 
     private record PlayerRecord(int Position, string PlayerName, int Played, int Won, int Lost, int Points);
 
-    // Minimal DTO matching the serialized Match structure in SavedMatch.MatchJson
-    private class MatchSummary
-    {
-        public string? Player1 { get; set; }
-        public string? Player2 { get; set; }
-        public List<GameState>? HistoryList { get; set; }
-    }
-
     protected override async Task OnInitializedAsync()
     {
         await using var dbc = DbFactory.CreateDbContext();
-        var savedMatches = await dbc.SavedMatch
-            .Where(m => m.Complete)
+        var matches = await dbc.SavedMatch
+            .Where(m => m.Complete && m.Player1 != null)
+            .Select(m => new { m.Player1, m.Player2, m.WinnerName })
             .ToListAsync();
 
         var stats = new Dictionary<string, (int Played, int Won)>(StringComparer.OrdinalIgnoreCase);
 
-        foreach (var sm in savedMatches)
+        foreach (var m in matches)
         {
-            if (string.IsNullOrEmpty(sm.MatchJson)) continue;
-            var match = JsonConvert.DeserializeObject<MatchSummary>(sm.MatchJson);
-            if (match is null) continue;
-
-            var finalState = match.HistoryList?.LastOrDefault();
-            if (finalState is null) continue;
-
-            var players = new[] { match.Player1, match.Player2 }
-                .Where(p => !string.IsNullOrEmpty(p))
-                .ToList();
+            var players = new[] { m.Player1, m.Player2 }
+                .Where(p => !string.IsNullOrEmpty(p));
 
             foreach (var p in players)
             {
-                if (!stats.ContainsKey(p)) stats[p] = (0, 0);
-                stats[p] = (stats[p].Played + 1, stats[p].Won);
+                if (!stats.ContainsKey(p!)) stats[p!] = (0, 0);
+                stats[p!] = (stats[p!].Played + 1, stats[p!].Won);
             }
 
-            var winner = finalState.UserS > finalState.OppS ? match.Player1 : match.Player2;
-            if (!string.IsNullOrEmpty(winner) && stats.ContainsKey(winner))
-                stats[winner] = (stats[winner].Played, stats[winner].Won + 1);
+            if (!string.IsNullOrEmpty(m.WinnerName) && stats.ContainsKey(m.WinnerName))
+                stats[m.WinnerName] = (stats[m.WinnerName].Played, stats[m.WinnerName].Won + 1);
         }
 
         Elements = stats

--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -482,9 +482,14 @@
             dbc.SavedMatch.Add(matchToSave);
         }
 
-        string currentMatchString = JsonConvert.SerializeObject(CurrentMatch);
-        matchToSave.MatchJson = currentMatchString;
+        matchToSave.MatchJson = JsonConvert.SerializeObject(CurrentMatch);
         matchToSave.Complete = CurrentMatch.Complete;
+        matchToSave.Player1 = CurrentMatch.Player1;
+        matchToSave.Player2 = CurrentMatch.Player2;
+        matchToSave.Player3 = CurrentMatch.Player3;
+        matchToSave.Player4 = CurrentMatch.Player4;
+        matchToSave.WinnerName = _state.IsMatchEnded ? _winner : null;
+        if (matchToSave.CreatedAt == default) matchToSave.CreatedAt = DateTime.UtcNow;
         await dbc.SaveChangesAsync();
 
 

--- a/DropShot/Data/Migrations/20260326000000_AddSavedMatchMetadata.cs
+++ b/DropShot/Data/Migrations/20260326000000_AddSavedMatchMetadata.cs
@@ -1,0 +1,86 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropShot.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSavedMatchMetadata : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "MatchJson",
+                table: "SavedMatch",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Player1",
+                table: "SavedMatch",
+                type: "nvarchar(256)",
+                maxLength: 256,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Player2",
+                table: "SavedMatch",
+                type: "nvarchar(256)",
+                maxLength: 256,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Player3",
+                table: "SavedMatch",
+                type: "nvarchar(256)",
+                maxLength: 256,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Player4",
+                table: "SavedMatch",
+                type: "nvarchar(256)",
+                maxLength: 256,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "WinnerName",
+                table: "SavedMatch",
+                type: "nvarchar(512)",
+                maxLength: 512,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "CreatedAt",
+                table: "SavedMatch",
+                type: "datetime2",
+                nullable: false,
+                defaultValueSql: "GETUTCDATE()");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(name: "Player1", table: "SavedMatch");
+            migrationBuilder.DropColumn(name: "Player2", table: "SavedMatch");
+            migrationBuilder.DropColumn(name: "Player3", table: "SavedMatch");
+            migrationBuilder.DropColumn(name: "Player4", table: "SavedMatch");
+            migrationBuilder.DropColumn(name: "WinnerName", table: "SavedMatch");
+            migrationBuilder.DropColumn(name: "CreatedAt", table: "SavedMatch");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "MatchJson",
+                table: "SavedMatch",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+        }
+    }
+}

--- a/DropShot/Data/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/DropShot/Data/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -43,7 +43,7 @@ namespace DropShot.Migrations
                     b.ToTable("AppSettings");
                 });
 
-            modelBuilder.Entity("DropShot.Components.TennisScore+SavedMatch", b =>
+            modelBuilder.Entity("DropShot.Models.SavedMatch", b =>
                 {
                     b.Property<int>("SavedMatchId")
                         .ValueGeneratedOnAdd()
@@ -55,8 +55,31 @@ namespace DropShot.Migrations
                         .HasColumnType("bit");
 
                     b.Property<string>("MatchJson")
-                        .IsRequired()
                         .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("Player1")
+                        .HasMaxLength(256)
+                        .HasColumnType("nvarchar(256)");
+
+                    b.Property<string>("Player2")
+                        .HasMaxLength(256)
+                        .HasColumnType("nvarchar(256)");
+
+                    b.Property<string>("Player3")
+                        .HasMaxLength(256)
+                        .HasColumnType("nvarchar(256)");
+
+                    b.Property<string>("Player4")
+                        .HasMaxLength(256)
+                        .HasColumnType("nvarchar(256)");
+
+                    b.Property<string>("WinnerName")
+                        .HasMaxLength(512)
+                        .HasColumnType("nvarchar(512)");
+
+                    b.Property<DateTime>("CreatedAt")
+                        .HasColumnType("datetime2")
+                        .HasDefaultValueSql("GETUTCDATE()");
 
                     b.HasKey("SavedMatchId");
 

--- a/DropShot/Models/SavedMatch.cs
+++ b/DropShot/Models/SavedMatch.cs
@@ -3,6 +3,12 @@ namespace DropShot.Models;
 public class SavedMatch
 {
     public int SavedMatchId { get; set; }
-    public string MatchJson { get; set; }
+    public string? MatchJson { get; set; }
     public bool Complete { get; set; }
+    public string? Player1 { get; set; }
+    public string? Player2 { get; set; }
+    public string? Player3 { get; set; }
+    public string? Player4 { get; set; }
+    public string? WinnerName { get; set; }
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 }


### PR DESCRIPTION
## Summary
- Adds `Player1`, `Player2`, `Player3`, `Player4`, `WinnerName`, and `CreatedAt` columns to the `SavedMatch` table
- `LeagueTable` now queries these columns directly — no JSON deserialisation
- `TennisScore.SaveHistory()` populates the new columns on every save
- EF migration (`20260326000000_AddSavedMatchMetadata`) and snapshot updated; existing rows keep nulls and are filtered out by `WHERE Player1 IS NOT NULL`

## Test plan
- [ ] `dotnet build` — 0 errors
- [ ] Apply migration: `dotnet ef database update`
- [ ] Play and complete a match — verify `SavedMatch` row has Player1/2 and WinnerName populated
- [ ] Navigate to `/league` — standings display correctly
- [ ] Reload mid-match — confirm undo/restore still works (MatchJson still present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)