### PR TITLE
Use website logo as coin in coin toss

### DIFF
--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -39,16 +39,7 @@
         <MudText Typo="Typo.h4" Style="color: white; letter-spacing: 2px;">COIN TOSS</MudText>
 
         <div class="coin-wrap">
-            <div class="coin @(_coinAnimating ? "coin-spinning" : "")">
-                @if (_coinAnimating)
-                {
-                    <span>🎾</span>
-                }
-                else
-                {
-                    <span class="coin-result">@_coinTossWinnerName</span>
-                }
-            </div>
+            <div class="coin @(_coinAnimating ? "coin-spinning" : "coin-landed")"></div>
         </div>
 
         @if (!_coinAnimating)

--- a/DropShot/Components/TennisScore.razor.css
+++ b/DropShot/Components/TennisScore.razor.css
@@ -152,16 +152,13 @@
 }
 
 .coin {
-    width: 140px;
-    height: 140px;
+    width: 180px;
+    height: 180px;
     border-radius: 50%;
-    background: radial-gradient(circle at 38% 38%, #FFE566, #FFA500 60%, #B8860B);
-    border: 5px solid #DAA520;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 48px;
-    box-shadow: 0 0 28px rgba(255, 215, 0, 0.55), inset 0 2px 6px rgba(255,255,255,0.25);
+    background-image: url('/Images/Logo.png');
+    background-size: cover;
+    background-position: center;
+    box-shadow: 0 0 32px rgba(0, 230, 180, 0.5);
     will-change: transform;
 }
 
@@ -169,12 +166,7 @@
     animation: coinFlip 5s cubic-bezier(0.25, 0.1, 0.25, 1) forwards;
 }
 
-.coin-result {
-    font-size: 15px;
-    font-weight: bold;
-    color: #222;
-    text-align: center;
-    padding: 0 12px;
+.coin-landed {
     animation: coinLand 0.35s ease-out forwards;
 }
 


### PR DESCRIPTION
## Summary
Replaces the gold CSS coin with the circular `Logo.png` image (180px, `border-radius: 50%`). A teal glow (`rgba(0, 230, 180, 0.5)`) is applied on the coin to match the brand colour. The logo spins during the coin toss animation and settles with the `coin-landed` bounce effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)