### PR TITLE
Add role-based access control (Admin and ClubAdmin)

### DIFF
--- a/DropShot/Components/Layout/NavMenu.razor
+++ b/DropShot/Components/Layout/NavMenu.razor
@@ -60,6 +60,14 @@
             </NavLink>
         </div>
 
+        <AuthorizeView Roles="Admin">
+            <div class="nav-item px-3">
+                <NavLink class="nav-link" href="admin/users">
+                    <span class="bi bi-shield-lock-nav-menu" aria-hidden="true"></span> User Management
+                </NavLink>
+            </div>
+        </AuthorizeView>
+
         <AuthorizeView>
             <Authorized>
                 <div class="nav-item px-3">

--- a/DropShot/Components/Pages/Admin/UserManagement.razor
+++ b/DropShot/Components/Pages/Admin/UserManagement.razor
@@ -1,0 +1,213 @@
+@page "/admin/users"
+@rendermode InteractiveServer
+@attribute [Authorize(Roles = "Admin")]
+@using Microsoft.AspNetCore.Authorization
+@using Microsoft.AspNetCore.Identity
+@using Microsoft.EntityFrameworkCore
+@using DropShot.Data
+@using DropShot.Models
+@inject UserManager<ApplicationUser> UserManager
+@inject IDbContextFactory<MyDbContext> DbFactory
+@inject ISnackbar Snackbar
+
+<MudText Typo="Typo.h4" Class="mb-4">User Management</MudText>
+
+<MudTable Items="@_rows" Hover="true" Breakpoint="Breakpoint.Sm" Loading="@_loading" Dense="true">
+    <HeaderContent>
+        <MudTh>Username</MudTh>
+        <MudTh>Email</MudTh>
+        <MudTh Style="text-align:center">Super Admin</MudTh>
+        <MudTh>Club Admin Assignments</MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd DataLabel="Username">@context.User.UserName</MudTd>
+        <MudTd DataLabel="Email">@context.User.Email</MudTd>
+
+        @* ── Super Admin toggle ─────────────────────────────────────── *@
+        <MudTd DataLabel="Super Admin" Style="text-align:center">
+            <MudSwitch T="bool"
+                       Value="@context.IsAdmin"
+                       ValueChanged="@(v => ToggleAdmin(context, v))"
+                       Color="Color.Primary" />
+        </MudTd>
+
+        @* ── Club Admin assignments ─────────────────────────────────── *@
+        <MudTd DataLabel="Club Admin">
+            <MudStack Row="true" Wrap="Wrap.Wrap" AlignItems="AlignItems.Center" Spacing="1">
+                @foreach (var ca in context.ClubAssignments)
+                {
+                    <MudChip T="string" Size="Size.Small" Color="Color.Info"
+                             OnClose="@(() => RemoveClubAdmin(context, ca.ClubId))"
+                             CloseIcon="@Icons.Material.Filled.Close">
+                        @ca.ClubName
+                    </MudChip>
+                }
+                <MudIconButton Icon="@Icons.Material.Filled.AddCircleOutline"
+                               Size="Size.Small" Color="Color.Success"
+                               Title="Add club admin assignment"
+                               OnClick="@(() => OpenAddClubDialog(context))" />
+            </MudStack>
+        </MudTd>
+    </RowTemplate>
+    <NoRecordsContent>
+        <MudText>No users found.</MudText>
+    </NoRecordsContent>
+</MudTable>
+
+@* ── Add Club Admin Dialog ─────────────────────────────────────────── *@
+<MudDialog @bind-Visible="_showAddClubDialog">
+    <TitleContent>Assign Club Admin – @(_targetRow?.User.UserName)</TitleContent>
+    <DialogContent>
+        <MudSelect @bind-Value="_selectedClubId" Label="Select Club" Variant="Variant.Outlined">
+            @foreach (var club in AvailableClubs)
+            {
+                <MudSelectItem T="int?" Value="@((int?)club.ClubId)">@club.Name</MudSelectItem>
+            }
+        </MudSelect>
+        @if (!AvailableClubs.Any())
+        {
+            <MudText Typo="Typo.caption" Class="mt-2" Style="color:grey">
+                This user is already an admin of all clubs.
+            </MudText>
+        }
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@(() => _showAddClubDialog = false)">Cancel</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                   Disabled="@(_selectedClubId == null)"
+                   OnClick="SaveClubAdmin">Add</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    private bool _loading = true;
+    private List<UserRow> _rows = [];
+    private List<Club> _allClubs = [];
+
+    private bool _showAddClubDialog;
+    private UserRow? _targetRow;
+    private int? _selectedClubId;
+
+    private IEnumerable<Club> AvailableClubs =>
+        _targetRow is null
+            ? []
+            : _allClubs.Where(c => _targetRow.ClubAssignments.All(a => a.ClubId != c.ClubId));
+
+    private sealed class UserRow
+    {
+        public ApplicationUser User { get; init; } = null!;
+        public bool IsAdmin { get; set; }
+        public List<ClubAdminRow> ClubAssignments { get; set; } = [];
+    }
+
+    private sealed record ClubAdminRow(int ClubId, string ClubName);
+
+    protected override async Task OnInitializedAsync() => await Load();
+
+    private async Task Load()
+    {
+        _loading = true;
+
+        await using var db = DbFactory.CreateDbContext();
+        _allClubs = await db.Clubs.OrderBy(c => c.Name).ToListAsync();
+
+        // Load all club admin assignments grouped by UserId in one query
+        var allAssignments = await db.ClubAdministrators
+            .Include(ca => ca.Club)
+            .ToListAsync();
+        var assignmentsByUser = allAssignments
+            .GroupBy(ca => ca.UserId)
+            .ToDictionary(g => g.Key, g => g
+                .Select(ca => new ClubAdminRow(ca.ClubId, ca.Club.Name))
+                .ToList());
+
+        var users = UserManager.Users.OrderBy(u => u.UserName).ToList();
+
+        _rows = [];
+        foreach (var user in users)
+        {
+            var isAdmin = await UserManager.IsInRoleAsync(user, "Admin");
+            assignmentsByUser.TryGetValue(user.Id, out var clubs);
+            _rows.Add(new UserRow
+            {
+                User = user,
+                IsAdmin = isAdmin,
+                ClubAssignments = clubs ?? []
+            });
+        }
+
+        _loading = false;
+    }
+
+    // ── Admin role toggle ────────────────────────────────────────────────────
+
+    private async Task ToggleAdmin(UserRow row, bool makeAdmin)
+    {
+        if (makeAdmin)
+            await UserManager.AddToRoleAsync(row.User, "Admin");
+        else
+            await UserManager.RemoveFromRoleAsync(row.User, "Admin");
+
+        row.IsAdmin = makeAdmin;
+        Snackbar.Add(
+            $"{row.User.UserName} {(makeAdmin ? "granted" : "removed from")} Admin role.",
+            makeAdmin ? Severity.Success : Severity.Warning);
+    }
+
+    // ── Club admin assignments ───────────────────────────────────────────────
+
+    private void OpenAddClubDialog(UserRow row)
+    {
+        _targetRow = row;
+        _selectedClubId = null;
+        _showAddClubDialog = true;
+    }
+
+    private async Task SaveClubAdmin()
+    {
+        if (_targetRow is null || _selectedClubId is null) return;
+
+        await using var db = DbFactory.CreateDbContext();
+
+        // Insert the ClubAdministrator row
+        db.ClubAdministrators.Add(new ClubAdministrator
+        {
+            UserId = _targetRow.User.Id,
+            ClubId = _selectedClubId.Value,
+            AssignedAt = DateTime.UtcNow
+        });
+        await db.SaveChangesAsync();
+
+        // Ensure the user has the ClubAdmin role
+        if (!await UserManager.IsInRoleAsync(_targetRow.User, "ClubAdmin"))
+            await UserManager.AddToRoleAsync(_targetRow.User, "ClubAdmin");
+
+        var clubName = _allClubs.First(c => c.ClubId == _selectedClubId.Value).Name;
+        _targetRow.ClubAssignments.Add(new ClubAdminRow(_selectedClubId.Value, clubName));
+
+        _showAddClubDialog = false;
+        Snackbar.Add($"{_targetRow.User.UserName} is now a Club Admin for {clubName}.", Severity.Success);
+    }
+
+    private async Task RemoveClubAdmin(UserRow row, int clubId)
+    {
+        await using var db = DbFactory.CreateDbContext();
+
+        var record = await db.ClubAdministrators
+            .FindAsync(row.User.Id, clubId);
+        if (record is not null)
+        {
+            db.ClubAdministrators.Remove(record);
+            await db.SaveChangesAsync();
+        }
+
+        row.ClubAssignments.RemoveAll(a => a.ClubId == clubId);
+
+        // If this was the last club, remove the ClubAdmin role too
+        if (row.ClubAssignments.Count == 0)
+            await UserManager.RemoveFromRoleAsync(row.User, "ClubAdmin");
+
+        var clubName = _allClubs.FirstOrDefault(c => c.ClubId == clubId)?.Name ?? clubId.ToString();
+        Snackbar.Add($"Removed {row.User.UserName} as Club Admin for {clubName}.", Severity.Warning);
+    }
+}

--- a/DropShot/Components/Pages/Clubs.razor
+++ b/DropShot/Components/Pages/Clubs.razor
@@ -5,15 +5,21 @@
 @using Microsoft.EntityFrameworkCore
 @using DropShot.Models
 @using DropShot.Data
+@using DropShot.Services
 @inject IDbContextFactory<MyDbContext> DbFactory
 @inject ISnackbar Snackbar
+@inject ClubAuthorizationService AuthzService
+@inject AuthenticationStateProvider AuthStateProvider
 
 <MudText Typo="Typo.h4" Class="mb-4">Clubs</MudText>
 
-<MudButton Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Filled.Add"
-           OnClick="OpenAddDialog" Class="mb-4">
-    Add Club
-</MudButton>
+@if (_isAdmin)
+{
+    <MudButton Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Filled.Add"
+               OnClick="OpenAddDialog" Class="mb-4">
+        Add Club
+    </MudButton>
+}
 
 <MudTable Items="@_clubs" Hover="true" Breakpoint="Breakpoint.Sm" Loading="@_loading">
     <HeaderContent>
@@ -29,12 +35,18 @@
         <MudTd DataLabel="Email">@(context.Email ?? "—")</MudTd>
         <MudTd DataLabel="Courts">@context.Courts.Count</MudTd>
         <MudTd DataLabel="Actions">
-            <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="Size.Small"
-                           OnClick="@(() => StartEdit(context))" />
-            <MudIconButton Icon="@Icons.Material.Filled.SportsTennis" Size="Size.Small" Color="Color.Info"
-                           Title="Manage courts" OnClick="@(() => OpenCourts(context))" />
-            <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small" Color="Color.Error"
-                           OnClick="@(() => DeleteClub(context))" />
+            @if (_isAdmin || _editableClubIds.Contains(context.ClubId))
+            {
+                <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="Size.Small"
+                               OnClick="@(() => StartEdit(context))" />
+                <MudIconButton Icon="@Icons.Material.Filled.SportsTennis" Size="Size.Small" Color="Color.Info"
+                               Title="Manage courts" OnClick="@(() => OpenCourts(context))" />
+            }
+            @if (_isAdmin)
+            {
+                <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small" Color="Color.Error"
+                               OnClick="@(() => DeleteClub(context))" />
+            }
         </MudTd>
     </RowTemplate>
     <NoRecordsContent>
@@ -136,6 +148,8 @@
 @code {
     private bool _loading = true;
     private List<Club> _clubs = [];
+    private bool _isAdmin;
+    private HashSet<int> _editableClubIds = [];
 
     private bool _showClubDialog;
     private Club? _editingClub;
@@ -165,7 +179,13 @@
         public bool IsIndoor { get; set; }
     }
 
-    protected override async Task OnInitializedAsync() => await LoadClubs();
+    protected override async Task OnInitializedAsync()
+    {
+        var authState = await AuthStateProvider.GetAuthenticationStateAsync();
+        _isAdmin = await AuthzService.IsAdminAsync(authState.User);
+        _editableClubIds = [.. await AuthzService.GetAdminClubIdsAsync(authState.User)];
+        await LoadClubs();
+    }
 
     private async Task LoadClubs()
     {

--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -1,14 +1,19 @@
 @page "/competition/{Id:int}"
 @rendermode InteractiveServer
+@attribute [Authorize]
 
 @using System.ComponentModel.DataAnnotations
+@using Microsoft.AspNetCore.Authorization
 @using DropShot.Data
 @using DropShot.Models
+@using DropShot.Services
 @using Microsoft.EntityFrameworkCore
 
 @inject IDbContextFactory<MyDbContext> DbFactory
 @inject NavigationManager Nav
 @inject ISnackbar Snackbar
+@inject ClubAuthorizationService AuthzService
+@inject AuthenticationStateProvider AuthStateProvider
 
 <MudText Typo="Typo.h5" Class="mb-4">@(IsEdit ? "Edit Competition" : "New Competition")</MudText>
 
@@ -17,6 +22,14 @@
     <MudItem xs="12" md="8">
         <MudPaper Class="pa-4 mb-4">
             <MudText Typo="Typo.h6" Class="mb-3">Details</MudText>
+
+            @if (!_canEdit)
+            {
+                <MudAlert Severity="Severity.Warning" Class="mb-3">
+                    You do not have permission to edit this competition.
+                    Only Admins or Club Admins for the host club may make changes.
+                </MudAlert>
+            }
 
             <MudForm @ref="_form" @bind-IsValid="_isValid" @bind-Errors="_errors">
                 <MudGrid Spacing="2">
@@ -86,7 +99,7 @@
 
                 <MudStack Row="true" Spacing="2" Class="mt-4">
                     <MudButton Color="Color.Primary" Variant="Variant.Filled"
-                               Disabled="@_isSaving" OnClick="SubmitAsync">
+                               Disabled="@(_isSaving || !_canEdit)" OnClick="SubmitAsync">
                         @if (_isSaving)
                         {
                             <MudProgressCircular Indeterminate="true" Size="Size.Small" Class="mr-2" />
@@ -222,6 +235,7 @@
     private MudForm? _form;
     private bool _isValid;
     private bool _isSaving;
+    private bool _canEdit;
     private string[] _errors = [];
     private string? _serverError;
     private bool IsEdit => Id != 0;
@@ -262,6 +276,7 @@
     protected override async Task OnParametersSetAsync()
     {
         _serverError = null;
+        var authState = await AuthStateProvider.GetAuthenticationStateAsync();
         await using var db = DbFactory.CreateDbContext();
 
         _clubs = await db.Clubs.OrderBy(c => c.Name).ToListAsync();
@@ -277,6 +292,8 @@
                 .FirstOrDefaultAsync(c => c.CompetitionID == Id);
 
             if (comp is null) { _serverError = $"Competition {Id} not found."; return; }
+
+            _canEdit = await AuthzService.CanEditCompetitionAsync(authState.User, comp.HostClubId);
 
             Model = new CompetitionFormModel
             {
@@ -295,6 +312,8 @@
         }
         else
         {
+            // Only Admins can create new competitions
+            _canEdit = await AuthzService.IsAdminAsync(authState.User);
             Model = new CompetitionFormModel();
             _stages = [];
             _participants = [];

--- a/DropShot/Components/Pages/Competitions.razor
+++ b/DropShot/Components/Pages/Competitions.razor
@@ -1,58 +1,69 @@
-﻿@page "/competitions"
+@page "/competitions"
 @rendermode InteractiveServer
+@attribute [Authorize]
 
-@using System.Net.Http.Json
+@using Microsoft.AspNetCore.Authorization
 @using DropShot.Data
 @using DropShot.Models
+@using DropShot.Services
 @using Microsoft.EntityFrameworkCore
 
-@* Example route in your Competition page *@
-@* @page "/competition/{id:int}" *@
-
 @inject NavigationManager Nav
+@inject IDbContextFactory<MyDbContext> DbFactory
+@inject ClubAuthorizationService AuthzService
+@inject AuthenticationStateProvider AuthStateProvider
 
-<MudDataGrid Items="@copetitions" Filterable="false" SortMode="@SortMode.None" Groupable="false">
+<MudDataGrid Items="@_competitions" Filterable="false" SortMode="@SortMode.None" Groupable="false">
     <Columns>
         <PropertyColumn Property="x => x.CompetitionName" />
         <PropertyColumn Property="x => x.CompetitionFormat" />
         <TemplateColumn CellClass="d-flex justify-end">
             <CellTemplate>
-                <MudStack Row>
+                @if (CanEdit(context.Item))
+                {
                     <MudButton Size="@Size.Small"
                                Variant="@Variant.Filled"
                                Color="@Color.Primary"
-                               OnClick="@(() => Nav.NavigateTo($"/competition/{@context.Item.CompetitionID}"))">
+                               OnClick="@(() => Nav.NavigateTo($"/competition/{context.Item.CompetitionID}"))">
                         Edit
                     </MudButton>
-                </MudStack>
+                }
             </CellTemplate>
         </TemplateColumn>
     </Columns>
 </MudDataGrid>
 
-<MudButton Size="@Size.Small"
-           Variant="@Variant.Filled"
-           Color="@Color.Primary"
-           OnClick="@(() => Nav.NavigateTo($"/competition/0"))">
-    Add New
-</MudButton>
+@if (_isAdmin)
+{
+    <MudButton Size="@Size.Small" Variant="@Variant.Filled" Color="@Color.Primary" Class="mt-3"
+               OnClick="@(() => Nav.NavigateTo($"/competition/0"))">
+        Add New
+    </MudButton>
+}
 
 @code {
-    public IEnumerable<Competition> copetitions;
-    
-    [Inject] private IDbContextFactory<MyDbContext> DbFactory { get; set; }
+    private List<Competition> _competitions = [];
+    private bool _isAdmin;
+    private HashSet<int> _editableClubIds = [];
 
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
-        using var dbc = DbFactory.CreateDbContext();
+        var authState = await AuthStateProvider.GetAuthenticationStateAsync();
+        _isAdmin = await AuthzService.IsAdminAsync(authState.User);
+        _editableClubIds = [.. await AuthzService.GetAdminClubIdsAsync(authState.User)];
 
-        var comps = dbc.Competition.ToList();
-
-        copetitions = comps.Select(c => new Competition
-        {
-            CompetitionID = c.CompetitionID,
-            CompetitionName = c.CompetitionName,
-            CompetitionFormat = c.CompetitionFormat
-        });
+        await using var dbc = DbFactory.CreateDbContext();
+        _competitions = await dbc.Competition
+            .Select(c => new Competition
+            {
+                CompetitionID = c.CompetitionID,
+                CompetitionName = c.CompetitionName,
+                CompetitionFormat = c.CompetitionFormat,
+                HostClubId = c.HostClubId
+            })
+            .ToListAsync();
     }
+
+    private bool CanEdit(Competition c) =>
+        _isAdmin || (c.HostClubId.HasValue && _editableClubIds.Contains(c.HostClubId.Value));
 }

--- a/DropShot/Components/Pages/RulesSets.razor
+++ b/DropShot/Components/Pages/RulesSets.razor
@@ -10,10 +10,12 @@
 
 <MudText Typo="Typo.h4" Class="mb-4">Rules Sets</MudText>
 
-<MudButton Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Filled.Add"
-           OnClick="OpenAddDialog" Class="mb-4">
-    Add Rules Set
-</MudButton>
+<AuthorizeView Roles="Admin">
+    <MudButton Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Filled.Add"
+               OnClick="OpenAddDialog" Class="mb-4">
+        Add Rules Set
+    </MudButton>
+</AuthorizeView>
 
 <MudTable Items="@_sets" Hover="true" Breakpoint="Breakpoint.Sm" Loading="@_loading">
     <HeaderContent>
@@ -27,12 +29,14 @@
         <MudTd DataLabel="Description">@(context.Description ?? "—")</MudTd>
         <MudTd DataLabel="Rules">@context.Items.Count</MudTd>
         <MudTd DataLabel="Actions">
-            <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="Size.Small"
-                           OnClick="@(() => StartEdit(context))" />
-            <MudIconButton Icon="@Icons.Material.Filled.List" Size="Size.Small" Color="Color.Info"
-                           Title="Manage rules" OnClick="@(() => OpenItems(context))" />
-            <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small" Color="Color.Error"
-                           OnClick="@(() => DeleteSet(context))" />
+            <AuthorizeView Roles="Admin" Context="auth">
+                <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="Size.Small"
+                               OnClick="@(() => StartEdit(context))" />
+                <MudIconButton Icon="@Icons.Material.Filled.List" Size="Size.Small" Color="Color.Info"
+                               Title="Manage rules" OnClick="@(() => OpenItems(context))" />
+                <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small" Color="Color.Error"
+                               OnClick="@(() => DeleteSet(context))" />
+            </AuthorizeView>
         </MudTd>
     </RowTemplate>
     <NoRecordsContent>

--- a/DropShot/Data/Migrations/20260328124141_AddClubAdministrators.Designer.cs
+++ b/DropShot/Data/Migrations/20260328124141_AddClubAdministrators.Designer.cs
@@ -4,6 +4,7 @@ using DropShot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DropShot.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260328124141_AddClubAdministrators")]
+    partial class AddClubAdministrators
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DropShot/Data/Migrations/20260328124141_AddClubAdministrators.cs
+++ b/DropShot/Data/Migrations/20260328124141_AddClubAdministrators.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropShot.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddClubAdministrators : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ClubAdministrators",
+                columns: table => new
+                {
+                    UserId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    ClubId = table.Column<int>(type: "int", nullable: false),
+                    AssignedAt = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ClubAdministrators", x => new { x.UserId, x.ClubId });
+                    table.ForeignKey(
+                        name: "FK_ClubAdministrators_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_ClubAdministrators_Clubs_ClubId",
+                        column: x => x.ClubId,
+                        principalTable: "Clubs",
+                        principalColumn: "ClubId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ClubAdministrators_ClubId",
+                table: "ClubAdministrators",
+                column: "ClubId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ClubAdministrators");
+        }
+    }
+}

--- a/DropShot/Data/MyDbContext.cs
+++ b/DropShot/Data/MyDbContext.cs
@@ -17,6 +17,7 @@ namespace DropShot.Data
         public DbSet<Club> Clubs { get; set; }
         public DbSet<Court> Courts { get; set; }
         public DbSet<ClubMember> ClubMembers { get; set; }
+        public DbSet<ClubAdministrator> ClubAdministrators { get; set; }
         public DbSet<CompetitionParticipant> CompetitionParticipants { get; set; }
         public DbSet<CompetitionStage> CompetitionStages { get; set; }
         public DbSet<CompetitionFixture> CompetitionFixtures { get; set; }
@@ -116,6 +117,22 @@ namespace DropShot.Data
                       .WithMany(p => p.ClubMemberships)
                       .HasForeignKey(cm => cm.PlayerId)
                       .OnDelete(DeleteBehavior.Cascade);
+            });
+
+            // ── ClubAdministrator ────────────────────────────────────────────────
+            builder.Entity<ClubAdministrator>(entity =>
+            {
+                entity.HasKey(ca => new { ca.UserId, ca.ClubId });
+
+                entity.HasOne(ca => ca.User)
+                      .WithMany()
+                      .HasForeignKey(ca => ca.UserId)
+                      .OnDelete(DeleteBehavior.Restrict);   // block user deletion while club admin assignments exist
+
+                entity.HasOne(ca => ca.Club)
+                      .WithMany(c => c.Administrators)
+                      .HasForeignKey(ca => ca.ClubId)
+                      .OnDelete(DeleteBehavior.Cascade);    // deleting a club removes its admin assignments
             });
 
             // ── CompetitionParticipant ───────────────────────────────────────────

--- a/DropShot/Models/Club.cs
+++ b/DropShot/Models/Club.cs
@@ -22,6 +22,7 @@ public class Club
 
     public ICollection<Court> Courts { get; set; } = [];
     public ICollection<ClubMember> Members { get; set; } = [];
+    public ICollection<ClubAdministrator> Administrators { get; set; } = [];
     public ICollection<Competition> Competitions { get; set; } = [];
     public ICollection<ClubLadder> Ladders { get; set; } = [];
 }

--- a/DropShot/Models/ClubAdministrator.cs
+++ b/DropShot/Models/ClubAdministrator.cs
@@ -1,0 +1,13 @@
+using DropShot.Data;
+
+namespace DropShot.Models;
+
+public class ClubAdministrator
+{
+    public string UserId { get; set; } = "";
+    public int ClubId { get; set; }
+    public DateTime AssignedAt { get; set; } = DateTime.UtcNow;
+
+    public ApplicationUser User { get; set; } = null!;
+    public Club Club { get; set; } = null!;
+}

--- a/DropShot/Program.cs
+++ b/DropShot/Program.cs
@@ -1,4 +1,5 @@
 using DropShot.Components;
+using DropShot.Services;
 using DropShot.Components.Account;
 using DropShot.Data;
 using DropShot.Models;
@@ -43,6 +44,7 @@ builder.Services.AddIdentityCore<ApplicationUser>(options => options.SignIn.Requ
 
 builder.Services.AddScoped<UserState>();
 builder.Services.AddScoped<TennisScoreService>();
+builder.Services.AddScoped<ClubAuthorizationService>();
 
 builder.Services.AddSingleton<EmailService>();
 
@@ -73,4 +75,15 @@ app.MapRazorComponents<App>()
 // Add additional endpoints required by the Identity /Account Razor components.
 app.MapAdditionalIdentityEndpoints();
 app.MapHub<ChatHub>("/chathub");
+// ── Seed roles ───────────────────────────────────────────────────────────────
+using (var scope = app.Services.CreateScope())
+{
+    var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<IdentityRole>>();
+    foreach (var roleName in new[] { "Admin", "ClubAdmin" })
+    {
+        if (!await roleManager.RoleExistsAsync(roleName))
+            await roleManager.CreateAsync(new IdentityRole(roleName));
+    }
+}
+
 app.Run();

--- a/DropShot/Services/ClubAuthorizationService.cs
+++ b/DropShot/Services/ClubAuthorizationService.cs
@@ -1,0 +1,62 @@
+using System.Security.Claims;
+using DropShot.Data;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+
+namespace DropShot.Services;
+
+/// <summary>
+/// Provides fine-grained authorization checks for club and competition editing.
+/// Inject into Blazor pages and pass the current ClaimsPrincipal.
+/// </summary>
+public class ClubAuthorizationService(
+    UserManager<ApplicationUser> userManager,
+    IDbContextFactory<MyDbContext> dbFactory)
+{
+    /// <summary>Returns true if the user holds the global Admin role.</summary>
+    public async Task<bool> IsAdminAsync(ClaimsPrincipal user)
+    {
+        var appUser = await userManager.GetUserAsync(user);
+        if (appUser is null) return false;
+        return await userManager.IsInRoleAsync(appUser, "Admin");
+    }
+
+    /// <summary>Returns the list of ClubIds the user is an administrator of.</summary>
+    public async Task<List<int>> GetAdminClubIdsAsync(ClaimsPrincipal user)
+    {
+        var userId = userManager.GetUserId(user);
+        if (userId is null) return [];
+
+        await using var db = dbFactory.CreateDbContext();
+        return await db.ClubAdministrators
+            .Where(ca => ca.UserId == userId)
+            .Select(ca => ca.ClubId)
+            .ToListAsync();
+    }
+
+    /// <summary>Returns true if the user can edit the given club (Admin or assigned ClubAdmin).</summary>
+    public async Task<bool> CanEditClubAsync(ClaimsPrincipal user, int clubId)
+    {
+        if (await IsAdminAsync(user)) return true;
+
+        var userId = userManager.GetUserId(user);
+        if (userId is null) return false;
+
+        await using var db = dbFactory.CreateDbContext();
+        return await db.ClubAdministrators
+            .AnyAsync(ca => ca.UserId == userId && ca.ClubId == clubId);
+    }
+
+    /// <summary>
+    /// Returns true if the user can edit the given competition.
+    /// Admin can edit any competition. ClubAdmin can only edit competitions
+    /// that have a host club they administer. Competitions with no host club
+    /// are Admin-only.
+    /// </summary>
+    public async Task<bool> CanEditCompetitionAsync(ClaimsPrincipal user, int? hostClubId)
+    {
+        if (await IsAdminAsync(user)) return true;
+        if (hostClubId is null) return false;
+        return await CanEditClubAsync(user, hostClubId.Value);
+    }
+}


### PR DESCRIPTION
## Summary
- **Two roles**: `Admin` (super user, full access) and `ClubAdmin` (scoped to assigned clubs)
- **`ClubAdministrator` model**: join table linking `ApplicationUser` to `Club`, with EF migration
- **`ClubAuthorizationService`**: scoped service used by all pages to check permissions
- **`/admin/users` page**: Admin-only UI to toggle the Admin role per user and manage club admin assignments (grants/revokes `ClubAdmin` role automatically as clubs are added/removed)
- **Roles seeded on startup**: `Admin` and `ClubAdmin` created idempotently via `RoleManager`

## Permissions enforced

| Page | Admin | ClubAdmin | Authenticated user |
|---|---|---|---|
| User Management | Full access | Blocked | Blocked |
| Competitions list | Edit all + Add New | Edit own-club competitions | View only |
| Competition detail | Full edit | Edit if host club matches | Read-only (save disabled) |
| Clubs list | Edit + Delete + Add | Edit + Courts for own clubs | View only |
| Rules Sets | Add / Edit / Delete | View only | View only |

## Test plan
- [ ] Run `dotnet ef database update` to apply the `AddClubAdministrators` migration
- [ ] Log in as an Admin user — confirm User Management link appears in nav
- [ ] On User Management page, grant another user the Admin role and verify the toggle persists
- [ ] Assign a user as ClubAdmin for a specific club; confirm `ClubAdmin` role is granted automatically
- [ ] Remove the last club assignment and confirm `ClubAdmin` role is also removed
- [ ] Log in as a ClubAdmin — confirm they can edit their club and its competitions, but not others
- [ ] Confirm a plain authenticated user sees no Edit/Add buttons on Competitions, Clubs, or Rules Sets

🤖 Generated with [Claude Code](https://claude.com/claude-code)