### PR TITLE
Use UK date format on all date pickers

### DIFF
--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -48,10 +48,10 @@
                     </MudItem>
 
                     <MudItem xs="12" sm="6">
-                        <MudDatePicker @bind-Date="Model.StartDateDt" Label="Start Date (optional)" />
+                        <MudDatePicker @bind-Date="Model.StartDateDt" Label="Start Date (optional)" DateFormat="dd/MM/yyyy" />
                     </MudItem>
                     <MudItem xs="12" sm="6">
-                        <MudDatePicker @bind-Date="Model.EndDateDt" Label="End Date (optional)" />
+                        <MudDatePicker @bind-Date="Model.EndDateDt" Label="End Date (optional)" DateFormat="dd/MM/yyyy" />
                     </MudItem>
 
                     <MudItem xs="12" sm="4">

--- a/DropShot/Components/Pages/Players.razor
+++ b/DropShot/Components/Pages/Players.razor
@@ -81,7 +81,7 @@
             </MudItem>
             <MudItem xs="6">
                 <MudDatePicker @bind-Date="_form.DateOfBirthDt" Label="Date of Birth" Variant="Variant.Outlined"
-                               MaxDate="@DateTime.Today" />
+                               MaxDate="@DateTime.Today" DateFormat="dd/MM/yyyy" />
             </MudItem>
             <MudItem xs="6">
                 <MudSelect @bind-Value="_form.Sex" Label="Sex" Variant="Variant.Outlined" Clearable="true">
@@ -124,7 +124,7 @@
             </MudItem>
             <MudItem xs="6">
                 <MudDatePicker @bind-Date="_form.DateOfBirthDt" Label="Date of Birth" Variant="Variant.Outlined"
-                               MaxDate="@DateTime.Today" />
+                               MaxDate="@DateTime.Today" DateFormat="dd/MM/yyyy" />
             </MudItem>
             <MudItem xs="6">
                 <MudSelect @bind-Value="_form.Sex" Label="Sex" Variant="Variant.Outlined" Clearable="true">


### PR DESCRIPTION
## Summary

- Set `DateFormat="dd/MM/yyyy"` on all `MudDatePicker` components
- Affects: Start Date and End Date on Competition page, Date of Birth (add and edit dialogs) on Players page

## Test plan
- [ ] Date pickers display and accept dates in dd/MM/yyyy format

🤖 Generated with [Claude Code](https://claude.com/claude-code)