### PR TITLE
Auto-link new account to existing player record on registration

### DIFF
--- a/DropShot/Components/Account/Pages/Register.razor
+++ b/DropShot/Components/Account/Pages/Register.razor
@@ -6,6 +6,7 @@
 @using Microsoft.AspNetCore.Identity
 @using Microsoft.AspNetCore.WebUtilities
 @using DropShot.Data
+@using Microsoft.EntityFrameworkCore
 
 @inject UserManager<ApplicationUser> UserManager
 @inject IUserStore<ApplicationUser> UserStore
@@ -14,6 +15,7 @@
 @inject NavigationManager NavigationManager
 @inject IdentityRedirectManager RedirectManager
 @inject EmailService EmailService
+@inject IDbContextFactory<MyDbContext> DbFactory
 
 <PageTitle>Register</PageTitle>
 
@@ -82,6 +84,21 @@
 
         Logger.LogInformation("User created a new account with password.");
 
+        // Auto-link to an existing unlinked Player record with the same email
+        var linkedPlayer = false;
+        await using (var db = await DbFactory.CreateDbContextAsync())
+        {
+            var player = await db.Players.FirstOrDefaultAsync(p =>
+                p.Email == Input.Email && p.UserId == null);
+            if (player is not null)
+            {
+                player.UserId = await UserManager.GetUserIdAsync(user);
+                await db.SaveChangesAsync();
+                linkedPlayer = true;
+                Logger.LogInformation("Linked new user {Email} to existing player record.", Input.Email);
+            }
+        }
+
         var userId = await UserManager.GetUserIdAsync(user);
         var code = await UserManager.GenerateEmailConfirmationTokenAsync(user);
         code = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(code));
@@ -95,11 +112,11 @@
         {
             RedirectManager.RedirectTo(
                 "Account/RegisterConfirmation",
-                new() { ["email"] = Input.Email, ["returnUrl"] = ReturnUrl });
+                new() { ["email"] = Input.Email, ["returnUrl"] = ReturnUrl, ["linkedPlayer"] = linkedPlayer });
         }
 
         await SignInManager.SignInAsync(user, isPersistent: false);
-        RedirectManager.RedirectTo(ReturnUrl);
+        RedirectManager.RedirectTo(linkedPlayer ? $"/?linkedPlayer=true" : (ReturnUrl ?? "/"));
     }
 
     private ApplicationUser CreateUser()

--- a/DropShot/Components/Account/Pages/RegisterConfirmation.razor
+++ b/DropShot/Components/Account/Pages/RegisterConfirmation.razor
@@ -15,6 +15,13 @@
 
 <StatusMessage Message="@statusMessage" />
 
+@if (LinkedPlayer)
+{
+    <div class="alert alert-info">
+        Your account has been linked to an existing player profile with this email address.
+    </div>
+}
+
 @if (emailConfirmationLink is not null)
 {
     <p>
@@ -39,6 +46,9 @@ else
 
     [SupplyParameterFromQuery]
     private string? ReturnUrl { get; set; }
+
+    [SupplyParameterFromQuery]
+    private bool LinkedPlayer { get; set; }
 
     protected override async Task OnInitializedAsync()
     {

--- a/DropShot/Components/Pages/Home.razor
+++ b/DropShot/Components/Pages/Home.razor
@@ -10,7 +10,12 @@
 @using System.Text.RegularExpressions
 @using System.ComponentModel.DataAnnotations
 
-
+@if (LinkedPlayer)
+{
+    <MudAlert Severity="Severity.Info" Class="mb-4" ShowCloseIcon="true" CloseIconClicked="@(() => LinkedPlayer = false)">
+        Your account has been linked to an existing player profile with this email address.
+    </MudAlert>
+}
 
 <MudCarousel Class="mud-width-full" Style="height:400px;" ShowArrows="@arrows" ShowBullets="@bullets" EnableSwipeGesture="@enableSwipeGesture" AutoCycle="@autocycle" TData="object">
     <MudCarouselItem Transition="transition" Color="@Color.Primary">
@@ -49,4 +54,7 @@
     private bool enableSwipeGesture = true;
     private bool autocycle = true;
     private Transition transition = Transition.Slide;
+
+    [SupplyParameterFromQuery]
+    private bool LinkedPlayer { get; set; }
 }


### PR DESCRIPTION
## Summary

- After a new account is created, checks for an existing `Player` record with the same email and no linked `UserId`
- If found, sets `player.UserId` to the new user's ID automatically
- Notifies the user via:
  - An info alert on the **Register Confirmation** page (email confirmation flow)
  - A dismissable info alert on the **Home** page (direct sign-in flow)

## Test plan
- [ ] Register with an email that matches an existing unlinked player — account is linked and notice is shown
- [ ] Register with an email that has no matching player — normal registration flow, no notice
- [ ] Register with an email that matches a player already linked to another account — no change made (UserId not overwritten)

🤖 Generated with [Claude Code](https://claude.com/claude-code)