### PR TITLE
Fix MudBlazor styling loss by setting InteractiveServer at app root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 ##
 ## Get latest from `dotnet new gitignore`
 
+# Claude Code memory
+.claude/
+
 # dotenv files
 .env
 

--- a/DropShot/Components/App.razor
+++ b/DropShot/Components/App.razor
@@ -15,7 +15,7 @@
 </head>
 
 <body>
-    <Routes />
+    <Routes @rendermode="InteractiveServer" />
     <script src="_content/MudBlazor/MudBlazor.min.js?v=@(MudBlazor.Metadata.Version)"></script>
     <script src="_framework/blazor.web.js"></script>
 </body>


### PR DESCRIPTION
## Summary

One-line fix for the persistent styling loss issue.

**Root cause:** `<Routes />` in `App.razor` had no render mode, meaning the app shell (layout, `MudThemeProvider`, `MudDialogProvider`, etc.) rendered as **static SSR**. Individual pages used `@rendermode InteractiveServer`, creating a mixed mode. When navigating between static and interactive pages, MudBlazor's JavaScript loses track of the DOM and CSS state, breaking all styling site-wide with no recovery until the browser is closed.

**Fix:** Add `@rendermode="InteractiveServer"` to `<Routes />` so the entire app runs within a single persistent SignalR circuit. This is the standard setup for a MudBlazor Blazor Server application.

## Test plan
- [ ] Hard refresh on `/admin/users` no longer causes styling loss
- [ ] Navigating between pages maintains consistent styling
- [ ] MudBlazor dialogs, snackbars, and theme work correctly throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)