### PR TITLE
Fix duplicate MudThemeProvider and add UserManagement ErrorBoundary

### DIFF
--- a/DropShot/Components/Layout/MainLayout.razor
+++ b/DropShot/Components/Layout/MainLayout.razor
@@ -1,13 +1,15 @@
 ﻿ <meta name="viewport" content="width=device-width, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
 @inherits LayoutComponentBase
-<MudProviders />
+<MudThemeProvider @bind-IsDarkMode="@_isDarkMode" Theme="_theme" />
+<MudPopoverProvider />
+<MudDialogProvider />
+<MudSnackbarProvider />
 <div class="page">
     <div class="sidebar">
         <NavMenu />
     </div>
 
     <main>
-        <MudThemeProvider @bind-IsDarkMode="@_isDarkMode" Theme="_theme" />
         
         <article class="content px-4">
             @Body

--- a/DropShot/Components/Pages/Admin/UserManagement.razor
+++ b/DropShot/Components/Pages/Admin/UserManagement.razor
@@ -19,6 +19,8 @@
 
 <MudText Typo="Typo.h4" Class="mb-4">User Management</MudText>
 
+<ErrorBoundary>
+    <ChildContent>
 <MudTable Items="@_rows" Hover="true" Breakpoint="Breakpoint.Sm" Loading="@_loading" Dense="true">
     <HeaderContent>
         <MudTh>Username</MudTh>
@@ -91,6 +93,13 @@
         <MudText>No users found.</MudText>
     </NoRecordsContent>
 </MudTable>
+    </ChildContent>
+    <ErrorContent>
+        <MudAlert Severity="Severity.Error" Class="mt-4">
+            An error occurred rendering the user list. Please reload the page.
+        </MudAlert>
+    </ErrorContent>
+</ErrorBoundary>
 
 @* ── Add Club Admin Dialog ─────────────────────────────────────────── *@
 <MudDialog @bind-Visible="_showAddClubDialog">
@@ -209,7 +218,7 @@
                 .Select(ca => new ClubAdminRow(ca.ClubId, ca.Club.Name))
                 .ToList());
 
-        var users = UserManager.Users.OrderBy(u => u.UserName).ToList();
+        var users = await UserManager.Users.OrderBy(u => u.UserName).ToListAsync();
 
         _rows = [];
         foreach (var user in users)


### PR DESCRIPTION
## Summary

- **Duplicate `MudThemeProvider` removed** — `MainLayout` had both `<MudProviders />` (which includes a `MudThemeProvider`) and an explicit `<MudThemeProvider @bind-IsDarkMode @Theme>`. Two providers competing over CSS variable injection into the `<head>` is the root cause of styling being lost site-wide. Replaced with explicit individual providers using the correct theme/dark mode configuration.
- **`<ErrorBoundary>` added** around the UserManagement table — catches render-time exceptions (not covered by `try/catch` in lifecycle methods) and shows an error alert instead of breaking the Blazor circuit.
- **`ToListAsync()`** — changed the synchronous `UserManager.Users.ToList()` to async to avoid blocking the circuit thread.

## Test plan
- [ ] Refresh User Management page — styling remains intact site-wide
- [ ] Navigate between pages — MudBlazor theme, dialogs, and snackbars work consistently
- [ ] If a render error occurs in UserManagement, an error alert appears rather than a blank/broken layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)