### PR TITLE
Disable SSR pre-rendering to fix page flickering

### DIFF
--- a/DropShot/Components/App.razor
+++ b/DropShot/Components/App.razor
@@ -15,7 +15,7 @@
 </head>
 
 <body>
-    <Routes @rendermode="InteractiveServer" />
+    <Routes @rendermode="new InteractiveServerRenderMode(prerender: false)" />
     <script src="_content/MudBlazor/MudBlazor.min.js?v=@(MudBlazor.Metadata.Version)"></script>
     <script src="_framework/blazor.web.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- Changes `<Routes @rendermode="InteractiveServer" />` to `new InteractiveServerRenderMode(prerender: false)`
- SSR pre-rendering was causing every page to visibly flicker as the server-rendered HTML was replaced when the Blazor SignalR circuit connected
- This fully disables the SSR pre-render step so the circuit renders directly, eliminating the flicker

## Test plan
- [ ] Navigate to several pages — confirm no flickering on load
- [ ] Refresh UserManagement page — confirm site-wide styling is preserved
- [ ] Confirm all interactive features (dialogs, toggles, snackbars) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)