### PR TITLE
Fix MudBlazor CSS loss on /admin/users (move base href before CSS links)

### DIFF
--- a/DropShot/Components/App.razor
+++ b/DropShot/Components/App.razor
@@ -4,9 +4,9 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <base href="/" />
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet" />
     <link href="_content/MudBlazor/MudBlazor.min.css?v=@(MudBlazor.Metadata.Version)" rel="stylesheet" />
-    <base href="/" />
     <link rel="stylesheet" href="bootstrap/bootstrap.min.css" />
     <link rel="stylesheet" href="app.css" />
     <link rel="stylesheet" href="DropShot.styles.css" />

--- a/DropShot/Components/Pages/Admin/UserManagement.razor
+++ b/DropShot/Components/Pages/Admin/UserManagement.razor
@@ -12,10 +12,6 @@
 @inject ISnackbar Snackbar
 @inject IDialogService Dialog
 
-@* Ensure MudThemeProvider runs inside this circuit so it re-applies CSS variables
-   after MudBlazor's JS initialisation, which clears them when the circuit starts. *@
-<MudThemeProvider IsDarkMode="true" />
-
 @if (_error is not null)
 {
     <MudAlert Severity="Severity.Error" Class="mb-4">@_error</MudAlert>


### PR DESCRIPTION
## Summary

- Moves `<base href="/" />` to before all relative `<link>` tags in `App.razor`
- Removes the `<MudThemeProvider>` workaround that was added to `UserManagement.razor`

## Root Cause

The `<base href="/">` tag was placed **after** the MudBlazor CSS `<link>` in `App.razor`. Browsers resolve relative URLs against the current page's directory until they encounter a `<base>` element, so pressing F5 on `/admin/users`:

- Base directory (before `<base>` is seen) = `/admin/`
- `_content/MudBlazor/MudBlazor.min.css` → `/admin/_content/MudBlazor/MudBlazor.min.css` → **404**
- All MudBlazor styling lost

Single-segment paths like `/players` appeared to work because their implicit base directory is already `/`, so the relative URL happened to resolve correctly.

## Test plan

- [ ] F5 on `/admin/users` — MudBlazor styling should be intact
- [ ] F5 on `/players`, `/clubs`, `/competitions` — confirm no regressions
- [ ] Navigate between pages — confirm no flickering or styling changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)