### PR TITLE
Add sticky mobile top banner and logo

### DIFF
--- a/DropShot/Components/Layout/MainLayout.razor.css
+++ b/DropShot/Components/Layout/MainLayout.razor.css
@@ -44,6 +44,14 @@ main {
     .top-row ::deep a, .top-row ::deep .btn-link {
         margin-left: 0;
     }
+
+    .sidebar {
+        height: 0;
+    }
+
+    main {
+        padding-top: 3.5rem;
+    }
 }
 
 @media (min-width: 641px) {

--- a/DropShot/Components/Layout/NavMenu.razor
+++ b/DropShot/Components/Layout/NavMenu.razor
@@ -4,7 +4,10 @@
 
 <div class="top-row ps-3 navbar navbar-dark">
     <div class="container-fluid">
-        <a class="navbar-brand" href="">DropShot</a>
+        <a class="navbar-brand" href="">
+            <img src="/Images/Logo.png" class="navbar-logo" alt="DropShot Logo" />
+            DropShot
+        </a>
     </div>
 </div>
 

--- a/DropShot/Components/Layout/NavMenu.razor.css
+++ b/DropShot/Components/Layout/NavMenu.razor.css
@@ -17,11 +17,18 @@
 
 .top-row {
     height: 3.5rem;
-    background-color: rgba(0,0,0,0.4);
+    background-color: rgb(5, 39, 103) !important;
 }
 
 .navbar-brand {
     font-size: 1.1rem;
+}
+
+.navbar-logo {
+    height: 2rem;
+    width: auto;
+    margin-right: 0.5rem;
+    vertical-align: middle;
 }
 
 .bi {
@@ -88,6 +95,34 @@
 
 .navbar-toggler:checked ~ .nav-scrollable {
     display: block;
+}
+
+@media (max-width: 640.98px) {
+    .top-row {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        z-index: 100;
+    }
+
+    .navbar-toggler {
+        position: fixed;
+        top: 0.5rem;
+        right: 1rem;
+        z-index: 101;
+    }
+
+    .nav-scrollable {
+        position: fixed;
+        top: 3.5rem;
+        left: 0;
+        right: 0;
+        z-index: 99;
+        background-image: linear-gradient(120deg, rgb(5, 98, 103) 0%, rgb(5, 39, 103) 70%);
+        max-height: calc(100vh - 3.5rem);
+        overflow-y: auto;
+    }
 }
 
 @media (min-width: 641px) {


### PR DESCRIPTION
## Summary
- Fixes the top navigation banner so it stays fixed at the top of the screen when scrolling on mobile
- Adds the DropShot logo image next to the brand text in the navbar
- Dropdown menu appears below the fixed banner and overlays page content
- Solid background colour on the banner to prevent transparency

## Test plan
- [ ] View the app on a mobile-sized viewport (< 641px)
- [ ] Scroll the page — banner should remain fixed at the top
- [ ] Tap the hamburger — nav menu should drop down below the banner
- [ ] Tap a nav item — menu should close
- [ ] Verify logo appears next to "DropShot" text
- [ ] Check desktop (> 641px) — sidebar behaviour should be unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)