### PR TITLE
Fix banner logo alignment and background colour

### DIFF
--- a/DropShot/Components/Layout/NavMenu.razor
+++ b/DropShot/Components/Layout/NavMenu.razor
@@ -2,7 +2,7 @@
 
 @inject NavigationManager NavigationManager
 
-<div class="top-row ps-3 navbar navbar-dark">
+<div class="top-row navbar navbar-dark">
     <div class="container-fluid">
         <a class="navbar-brand" href="">
             <img src="/Images/Logo.png" class="navbar-logo" alt="DropShot Logo" />

--- a/DropShot/Components/Layout/NavMenu.razor.css
+++ b/DropShot/Components/Layout/NavMenu.razor.css
@@ -17,18 +17,20 @@
 
 .top-row {
     height: 3.5rem;
-    background-color: rgb(5, 39, 103) !important;
+    background-color: #000000 !important;
 }
 
 .navbar-brand {
     font-size: 1.1rem;
+    display: flex;
+    align-items: center;
+    padding: 0;
 }
 
 .navbar-logo {
     height: 2rem;
     width: auto;
     margin-right: 0.5rem;
-    vertical-align: middle;
 }
 
 .bi {


### PR DESCRIPTION
## Summary
- Banner background changed to black (`#000`) to match the logo image background so it blends seamlessly
- Removed `ps-3` from the `top-row` div to fix the `container-fluid` being offset to the right
- Switched `.navbar-brand` to flexbox for proper vertical centring of logo and text
- Zeroed out Bootstrap's default `navbar-brand` padding which was pushing the banner content too low

## Test plan
- [ ] Logo blends into the black banner background with no visible border
- [ ] Logo and "DropShot" text are vertically centred within the banner
- [ ] Banner content is horizontally aligned correctly (not offset to the right)

🤖 Generated with [Claude Code](https://claude.com/claude-code)