### PR TITLE
Add client-side search to all listing pages

### DIFF
--- a/DropShot/Components/Layout/NavMenu.razor
+++ b/DropShot/Components/Layout/NavMenu.razor
@@ -2,7 +2,7 @@
 
 @inject NavigationManager NavigationManager
 
-<div class="top-row ps-3 navbar navbar-dark">
+<div class="top-row navbar navbar-dark">
     <div class="container-fluid">
         <a class="navbar-brand" href="">
             <img src="/Images/Logo.png" class="navbar-logo" alt="DropShot Logo" />

--- a/DropShot/Components/Layout/NavMenu.razor.css
+++ b/DropShot/Components/Layout/NavMenu.razor.css
@@ -17,18 +17,20 @@
 
 .top-row {
     height: 3.5rem;
-    background-color: rgb(5, 39, 103) !important;
+    background-color: #000000 !important;
 }
 
 .navbar-brand {
     font-size: 1.1rem;
+    display: flex;
+    align-items: center;
+    padding: 0;
 }
 
 .navbar-logo {
     height: 2rem;
     width: auto;
     margin-right: 0.5rem;
-    vertical-align: middle;
 }
 
 .bi {

--- a/DropShot/Components/Pages/Admin/UserManagement.razor
+++ b/DropShot/Components/Pages/Admin/UserManagement.razor
@@ -21,7 +21,12 @@
 
 <ErrorBoundary>
     <ChildContent>
-<MudTable Items="@_rows" Hover="true" Breakpoint="Breakpoint.Sm" Loading="@_loading" Dense="true">
+<MudTextField @bind-Value="_searchText" Placeholder="Search users..."
+              Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search"
+              Immediate="true" Class="mb-4" />
+
+<MudTable Items="@_rows" Hover="true" Breakpoint="Breakpoint.Sm" Loading="@_loading" Dense="true"
+          Filter="@(row => FilterUsers(row))">
     <HeaderContent>
         <MudTh>Username</MudTh>
         <MudTh>Email</MudTh>
@@ -153,6 +158,12 @@
     private bool _loading = true;
     private string? _error;
     private List<UserRow> _rows = [];
+    private string _searchText = "";
+
+    private bool FilterUsers(UserRow row) =>
+        string.IsNullOrWhiteSpace(_searchText) ||
+        (row.User.UserName ?? "").Contains(_searchText, StringComparison.OrdinalIgnoreCase) ||
+        (row.User.Email ?? "").Contains(_searchText, StringComparison.OrdinalIgnoreCase);
     private List<Club> _allClubs = [];
     private bool _isSuperAdmin;
     private string? _currentUserId;

--- a/DropShot/Components/Pages/Clubs.razor
+++ b/DropShot/Components/Pages/Clubs.razor
@@ -21,7 +21,12 @@
     </MudButton>
 }
 
-<MudTable Items="@_clubs" Hover="true" Breakpoint="Breakpoint.Sm" Loading="@_loading">
+<MudTextField @bind-Value="_searchText" Placeholder="Search clubs..."
+              Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search"
+              Immediate="true" Class="mb-4" />
+
+<MudTable Items="@_clubs" Hover="true" Breakpoint="Breakpoint.Sm" Loading="@_loading"
+          Filter="@(club => FilterClubs(club))">
     <HeaderContent>
         <MudTh>Name</MudTh>
         <MudTh>Town</MudTh>
@@ -148,6 +153,13 @@
 @code {
     private bool _loading = true;
     private List<Club> _clubs = [];
+    private string _searchText = "";
+
+    private bool FilterClubs(Club club) =>
+        string.IsNullOrWhiteSpace(_searchText) ||
+        club.Name.Contains(_searchText, StringComparison.OrdinalIgnoreCase) ||
+        (club.Town ?? "").Contains(_searchText, StringComparison.OrdinalIgnoreCase) ||
+        (club.Email ?? "").Contains(_searchText, StringComparison.OrdinalIgnoreCase);
     private bool _isAdmin;
     private HashSet<int> _editableClubIds = [];
 

--- a/DropShot/Components/Pages/Competitions.razor
+++ b/DropShot/Components/Pages/Competitions.razor
@@ -13,7 +13,12 @@
 @inject ClubAuthorizationService AuthzService
 @inject AuthenticationStateProvider AuthStateProvider
 
-<MudDataGrid Items="@_competitions" Filterable="false" SortMode="@SortMode.None" Groupable="false">
+<MudTextField @bind-Value="_searchText" Placeholder="Search competitions..."
+              Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search"
+              Immediate="true" Class="mb-4" />
+
+<MudDataGrid Items="@_competitions" Filterable="false" SortMode="@SortMode.None" Groupable="false"
+             QuickFilter="@FilterCompetitions">
     <Columns>
         <PropertyColumn Property="x => x.CompetitionName" />
         <PropertyColumn Property="x => x.CompetitionFormat" />
@@ -43,7 +48,13 @@
 
 @code {
     private List<Competition> _competitions = [];
+    private string _searchText = "";
     private bool _isAdmin;
+
+    private bool FilterCompetitions(Competition c) =>
+        string.IsNullOrWhiteSpace(_searchText) ||
+        (c.CompetitionName ?? "").Contains(_searchText, StringComparison.OrdinalIgnoreCase) ||
+        c.CompetitionFormat.ToString().Contains(_searchText, StringComparison.OrdinalIgnoreCase);
     private HashSet<int> _editableClubIds = [];
 
     protected override async Task OnInitializedAsync()

--- a/DropShot/Components/Pages/LeagueTable.razor
+++ b/DropShot/Components/Pages/LeagueTable.razor
@@ -5,7 +5,12 @@
 
 <h3>League Table</h3>
 
-<MudTable Items="@Elements" Hover="true" Breakpoint="Breakpoint.Sm" Loading="@_loading" LoadingProgressColor="Color.Info">
+<MudTextField @bind-Value="_searchText" Placeholder="Search players..."
+              Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search"
+              Immediate="true" Class="mb-4" />
+
+<MudTable Items="@Elements" Hover="true" Breakpoint="Breakpoint.Sm" Loading="@_loading" LoadingProgressColor="Color.Info"
+          Filter="@(row => string.IsNullOrWhiteSpace(_searchText) || row.PlayerName.Contains(_searchText, StringComparison.OrdinalIgnoreCase))">
     <HeaderContent>
         <MudTh>Player</MudTh>
         <MudTh>Played</MudTh>
@@ -27,6 +32,7 @@
 
 @code {
     private bool _loading = true;
+    private string _searchText = "";
     private List<PlayerRecord> Elements = [];
 
     private record PlayerRecord(int Position, string PlayerName, int Played, int Won, int Lost, int Points);

--- a/DropShot/Components/Pages/Players.razor
+++ b/DropShot/Components/Pages/Players.razor
@@ -15,7 +15,12 @@
     Add Player
 </MudButton>
 
-<MudTable Items="@_players" Hover="true" Breakpoint="Breakpoint.Sm" Loading="@_loading">
+<MudTextField @bind-Value="_searchText" Placeholder="Search players..."
+              Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search"
+              Immediate="true" Class="mb-4" />
+
+<MudTable Items="@_players" Hover="true" Breakpoint="Breakpoint.Sm" Loading="@_loading"
+          Filter="@(row => FilterPlayers(row))">
     <HeaderContent>
         <MudTh>Display Name</MudTh>
         <MudTh>Name</MudTh>
@@ -169,6 +174,14 @@
 
     private bool _loading = true;
     private List<PlayerRow> _players = [];
+    private string _searchText = "";
+
+    private bool FilterPlayers(PlayerRow row) =>
+        string.IsNullOrWhiteSpace(_searchText) ||
+        row.Player.DisplayName.Contains(_searchText, StringComparison.OrdinalIgnoreCase) ||
+        (row.Player.FirstName ?? "").Contains(_searchText, StringComparison.OrdinalIgnoreCase) ||
+        (row.Player.LastName ?? "").Contains(_searchText, StringComparison.OrdinalIgnoreCase) ||
+        (row.Player.Email ?? "").Contains(_searchText, StringComparison.OrdinalIgnoreCase);
 
     private bool _showAddDialog;
     private bool _showEditDialog;

--- a/DropShot/Components/Pages/RulesSets.razor
+++ b/DropShot/Components/Pages/RulesSets.razor
@@ -17,7 +17,12 @@
     </MudButton>
 </AuthorizeView>
 
-<MudTable Items="@_sets" Hover="true" Breakpoint="Breakpoint.Sm" Loading="@_loading">
+<MudTextField @bind-Value="_searchText" Placeholder="Search rules sets..."
+              Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search"
+              Immediate="true" Class="mb-4" />
+
+<MudTable Items="@_sets" Hover="true" Breakpoint="Breakpoint.Sm" Loading="@_loading"
+          Filter="@(set => FilterSets(set))">
     <HeaderContent>
         <MudTh>Name</MudTh>
         <MudTh>Description</MudTh>
@@ -96,6 +101,12 @@
 @code {
     private bool _loading = true;
     private List<RulesSet> _sets = [];
+    private string _searchText = "";
+
+    private bool FilterSets(RulesSet set) =>
+        string.IsNullOrWhiteSpace(_searchText) ||
+        set.Name.Contains(_searchText, StringComparison.OrdinalIgnoreCase) ||
+        (set.Description ?? "").Contains(_searchText, StringComparison.OrdinalIgnoreCase);
 
     private bool _showSetDialog;
     private RulesSet? _editingSet;


### PR DESCRIPTION
## Summary
- Adds a search text field with magnifying glass icon above each listing table on all 6 pages: Players, Clubs, Competitions, User Management, Rules Sets, and League Table
- Filters rows immediately as the user types using MudBlazor's built-in `Filter` (MudTable) and `QuickFilter` (MudDataGrid) parameters
- No additional database queries — filtering is done entirely client-side against the already-loaded in-memory list

## Test plan
- [ ] Navigate to each listing page and confirm the search box appears above the table
- [ ] Type a search term and confirm rows filter immediately
- [ ] Clear the search and confirm all rows return
- [ ] Confirm existing add/edit/delete functionality is unaffected on each page

🤖 Generated with [Claude Code](https://claude.com/claude-code)