### PR TITLE
Fix broken buttons/snackbars/dialogs and Match page not loading

### DIFF
--- a/DropShot/Components/Layout/MainLayout.razor
+++ b/DropShot/Components/Layout/MainLayout.razor
@@ -1,9 +1,11 @@
 ﻿ <meta name="viewport" content="width=device-width, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
 @inherits LayoutComponentBase
 <MudThemeProvider IsDarkMode="true" Theme="_theme" />
-<MudPopoverProvider />
-<MudDialogProvider />
-<MudSnackbarProvider />
+@* Popover/Dialog/Snackbar providers are intentionally NOT here.
+   Each @rendermode InteractiveServer page injects <MudProviders /> directly
+   so the providers share the page's circuit DI scope.  Having them here too
+   caused "duplicate subscriber" errors because SSR and circuit both rendered
+   a MudPopoverProvider for the same page. *@
 <div class="page">
     <div class="sidebar">
         <NavMenu />

--- a/DropShot/Components/MudProviders.razor
+++ b/DropShot/Components/MudProviders.razor
@@ -1,10 +1,7 @@
-﻿@rendermode InteractiveServer
-@* Required *@
-<MudThemeProvider />
+@* Place this component at the top of every @rendermode InteractiveServer page.
+   It brings MudBlazor's providers into the same circuit scope as the page so
+   that Snackbar, Dialog and Popover services share the circuit's DI scope and
+   can update the UI in response to events raised by the page. *@
 <MudPopoverProvider />
-
-@* Needed for dialogs *@
 <MudDialogProvider />
-
-@* Needed for snackbars *@
 <MudSnackbarProvider />

--- a/DropShot/Components/Pages/Admin/UserManagement.razor
+++ b/DropShot/Components/Pages/Admin/UserManagement.razor
@@ -12,6 +12,8 @@
 @inject ISnackbar Snackbar
 @inject IDialogService Dialog
 
+<MudProviders />
+
 @if (_error is not null)
 {
     <MudAlert Severity="Severity.Error" Class="mb-4">@_error</MudAlert>

--- a/DropShot/Components/Pages/Clubs.razor
+++ b/DropShot/Components/Pages/Clubs.razor
@@ -11,6 +11,8 @@
 @inject ClubAuthorizationService AuthzService
 @inject AuthenticationStateProvider AuthStateProvider
 
+<MudProviders />
+
 <MudText Typo="Typo.h4" Class="mb-4">Clubs</MudText>
 
 @if (_isAdmin)

--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -15,6 +15,8 @@
 @inject ClubAuthorizationService AuthzService
 @inject AuthenticationStateProvider AuthStateProvider
 
+<MudProviders />
+
 <MudText Typo="Typo.h5" Class="mb-4">@(IsEdit ? "Edit Competition" : "New Competition")</MudText>
 
 <MudGrid>

--- a/DropShot/Components/Pages/Players.razor
+++ b/DropShot/Components/Pages/Players.razor
@@ -8,6 +8,8 @@
 @inject IDbContextFactory<MyDbContext> DbFactory
 @inject ISnackbar Snackbar
 
+<MudProviders />
+
 <MudText Typo="Typo.h4" Class="mb-4">Players</MudText>
 
 <MudButton Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Filled.PersonAdd"

--- a/DropShot/Components/Pages/RulesSets.razor
+++ b/DropShot/Components/Pages/RulesSets.razor
@@ -8,6 +8,8 @@
 @inject IDbContextFactory<MyDbContext> DbFactory
 @inject ISnackbar Snackbar
 
+<MudProviders />
+
 <MudText Typo="Typo.h4" Class="mb-4">Rules Sets</MudText>
 
 <AuthorizeView Roles="Admin">

--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -21,6 +21,8 @@
 @inject TennisScoreService ScoreService
 @inject ISnackbar Snackbar
 
+<MudProviders />
+
 <MudCollapse Expanded="_expanded" Style="margin-top: 10px;">
     <MudPaper Class="pa-4">
         <MudStack Spacing="2">
@@ -477,22 +479,11 @@
             .Select(p => p.DisplayName)
             .ToListAsync();
 
-        // using var dbc = DbFactory.CreateDbContext();
-        if (hubConnection is not null)
-        {
-            loaded = true;
-            return;
-        }
-
         var savedMatch = await DbContext.SavedMatch
             .FirstOrDefaultAsync(m => !m.Complete);
 
-        // Fix CS8602: Check for null before dereferencing savedMatch
         if (savedMatch != null && !string.IsNullOrEmpty(savedMatch.MatchJson))
         {
-            // Fix CS0266: Specify the type parameter for DeserializeObject
-            // Fix CS8601: Use null-forgiving operator if you are sure MatchJson is not null, or handle null
-
             if (CurrentMatch == null)
             {
                 CurrentMatch = JsonConvert.DeserializeObject<Match>(savedMatch.MatchJson) ?? new Match();
@@ -503,19 +494,23 @@
                 ScoreService.RestoreFromGameState(_state, history.Peek());
         }
 
-        hubConnection = new HubConnectionBuilder()
-            .WithUrl(Navigation.ToAbsoluteUri("/chathub"))
-            .Build();
-
-        // hubConnection.On<string, string>("ReceiveMessage", async (user, message) =>
-        // {
-        //     scores = await dbc.Score.ToListAsync();
-
-        //     await InvokeAsync(StateHasChanged);
-        // });
-
-        await hubConnection.StartAsync();
+        // Mark as loaded after DB queries so content renders immediately.
+        // The hub connection is deferred to OnAfterRenderAsync so it only
+        // runs in the browser — never during SSR pre-rendering, which would
+        // throw because WebSockets aren't available server-side.
         loaded = true;
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender && hubConnection is null)
+        {
+            hubConnection = new HubConnectionBuilder()
+                .WithUrl(Navigation.ToAbsoluteUri("/chathub"))
+                .Build();
+
+            await hubConnection.StartAsync();
+        }
     }
 
     private Stack<GameState> history = new(new[] { new GameState(0, 0, 0, 0, 0, 0, false, 0, false, 0, 0, new List<SetScore>(), DateTime.Now, false) });


### PR DESCRIPTION
## Summary

Two separate root causes were identified and fixed.

### 1. Buttons, snackbars and dialogs not working (all interactive pages)

Each `@rendermode InteractiveServer` page creates its own **circuit** with its own scoped DI container. The `MudSnackbarProvider`, `MudDialogProvider` and `MudPopoverProvider` in the SSR `MainLayout` are bound to the **SSR request scope** — a completely different instance from the circuit's scope. So when an interactive page calls `Snackbar.Add(...)` or `DialogService.ShowAsync(...)`, the event fires on the circuit's `ISnackbar`/`IDialogService`, but no provider is listening on that instance. Nothing happens.

**Fix:** Stripped `MudProviders.razor` of its own `@rendermode` (so it inherits the parent circuit's mode) and removed the stray `MudThemeProvider` inside it. Added `<MudProviders />` at the top of every interactive page that uses snackbars, dialogs or popovers: `Players`, `RulesSets`, `Clubs`, `CompetitionPage`, `UserManagement`, `TennisScore`.

### 2. Match page blank on F5 / navigation

`TennisScore.OnInitializedAsync` called `hubConnection.StartAsync()` which tries to open a WebSocket. During SSR pre-rendering this throws because WebSockets are not available server-side. The exception left `loaded = false`, causing all page content to be gated behind `@if (loaded && ...)` — the page rendered blank and stayed blank.

**Fix:** Moved hub connection setup to `OnAfterRenderAsync(firstRender)` which only runs in the browser after the circuit connects. Database queries and `loaded = true` remain in `OnInitializedAsync` so the player-selection form pre-renders correctly.

## Test plan

- [ ] Navigate to `/players` → click **Add Player** → dialog opens → fill in name → **Save** → success snackbar appears and player shows in list
- [ ] Navigate to `/rules` → add/edit a rules set → success snackbar appears
- [ ] Navigate to `/clubs` → add/edit a club → success snackbar appears
- [ ] Navigate to `/admin/users` → role-change dialog opens and works
- [ ] F5 on `/match` → player-selection form renders immediately (not blank)
- [ ] Navigate from another page to `/match` → form renders correctly
- [ ] Confirm no regression on styling (dark theme intact on all pages including `/admin/users`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)