### PR TITLE
Move settings and undo buttons below opponent scoring button

### DIFF
--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -226,16 +226,6 @@
                 </div>
             </div>
 
-            <!-- Controls Row -->
-            <div class="controls-row">
-                <button class="settings-btn no-zoom-element" @onclick="@OnExpandCollapseClick">
-                    <MudIcon Icon="@Icons.Material.Filled.Settings" Title="Settings" Size="Size.Large" />
-                </button>
-                <button class="undo-btn no-zoom-element" @onclick="UndoLastPoint">
-                    <MudIcon Icon="@Icons.Material.Filled.Undo" Title="Undo" Size="Size.Large" />
-                </button>
-            </div>
-
             <!-- Bottom Player Button -->
             <div style="display: flex">
                 @if (Label_Switch1)
@@ -279,6 +269,16 @@
                 </button> *@
 
                 }
+            </div>
+
+            <!-- Controls Row -->
+            <div class="controls-row">
+                <button class="settings-btn no-zoom-element" @onclick="@OnExpandCollapseClick">
+                    <MudIcon Icon="@Icons.Material.Filled.Settings" Title="Settings" Size="Size.Large" />
+                </button>
+                <button class="undo-btn no-zoom-element" @onclick="UndoLastPoint">
+                    <MudIcon Icon="@Icons.Material.Filled.Undo" Title="Undo" Size="Size.Large" />
+                </button>
             </div>
         </div>
     </section>


### PR DESCRIPTION
## Summary
- Moves the settings (gear) and undo buttons from between the score display and the opponent's scoring avatars to below the opponent's scoring avatars

## Test plan
- [ ] Open a match and verify settings and undo buttons appear below the opponent's avatar(s)
- [ ] Confirm both buttons function correctly
- [ ] Verify layout in both singles and doubles modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)