### PR TITLE
Add courts, multi-match support, and scoreboard improvements

### DIFF
--- a/DropShot/Components/Pages/Match.razor
+++ b/DropShot/Components/Pages/Match.razor
@@ -1,5 +1,73 @@
-﻿@page "/match"
+@page "/match"
+@rendermode InteractiveServer
+@using DropShot.Data
+@using DropShot.Models
+@using Microsoft.EntityFrameworkCore
+@using MudBlazor
+@inject NavigationManager Navigation
+@inject MyDbContext DbContext
 
-<TennisScore /> 
+<MudProviders />
 
+<MudText Typo="Typo.h5" Class="pa-4">Active Matches</MudText>
 
+@if (_matches.Count == 0)
+{
+    <MudText Class="px-4 pb-2" Color="Color.Secondary">No active matches.</MudText>
+}
+else
+{
+    <MudList T="SavedMatch" Class="px-2">
+        @foreach (var m in _matches)
+        {
+            <MudListItem T="SavedMatch">
+                <MudCard Outlined="true" Class="mb-2" Style="cursor:pointer" @onclick="@(() => Navigation.NavigateTo($"/match/{m.SavedMatchId}"))">
+                    <MudCardContent Class="py-2 px-3">
+                        <MudText Typo="Typo.subtitle1">
+                            @PlayerLabel(m)
+                        </MudText>
+                        <MudText Typo="Typo.caption" Color="Color.Secondary">
+                            @(m.CourtId.HasValue && _courtNames.TryGetValue(m.CourtId.Value, out var cname) ? cname : "No court") &middot; Started @m.CreatedAt.ToLocalTime().ToString("g")
+                        </MudText>
+                    </MudCardContent>
+                </MudCard>
+            </MudListItem>
+        }
+    </MudList>
+}
+
+<MudButton Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Filled.Add"
+           Class="ma-4" OnClick="@(() => Navigation.NavigateTo("/match/0"))">
+    Start New Match
+</MudButton>
+
+@code {
+    private List<SavedMatch> _matches = [];
+    private Dictionary<int, string> _courtNames = [];
+
+    protected override async Task OnInitializedAsync()
+    {
+        _matches = await DbContext.SavedMatch
+            .Where(m => !m.Complete)
+            .OrderByDescending(m => m.CreatedAt)
+            .ToListAsync();
+
+        var courtIds = _matches.Where(m => m.CourtId.HasValue).Select(m => m.CourtId!.Value).Distinct().ToList();
+        if (courtIds.Count > 0)
+        {
+            _courtNames = await DbContext.Courts
+                .Include(c => c.Club)
+                .Where(c => courtIds.Contains(c.CourtId))
+                .ToDictionaryAsync(c => c.CourtId, c => $"{c.Club.Name} — {c.Name}");
+        }
+    }
+
+    private static string PlayerLabel(SavedMatch m)
+    {
+        var p1 = string.IsNullOrWhiteSpace(m.Player1) ? "?" : m.Player1;
+        var p2 = string.IsNullOrWhiteSpace(m.Player2) ? "?" : m.Player2;
+        if (!string.IsNullOrWhiteSpace(m.Player3) && !string.IsNullOrWhiteSpace(m.Player4))
+            return $"{p1} & {m.Player2}  vs  {m.Player3} & {m.Player4}";
+        return $"{p1}  vs  {p2}";
+    }
+}

--- a/DropShot/Components/Pages/Scoreboard.razor
+++ b/DropShot/Components/Pages/Scoreboard.razor
@@ -1,86 +1,165 @@
-﻿@page "/score"
+@page "/score"
 @rendermode InteractiveServer
 @using DropShot.Data
 @using DropShot.Models
 @using Microsoft.AspNetCore.SignalR.Client
 @using Microsoft.EntityFrameworkCore
 @using Newtonsoft.Json
+@using MudBlazor
 @inject NavigationManager Navigation
-  
-
 @inject MyDbContext DbContext
+@inject IDbContextFactory<MyDbContext> DbFactory
 
+<MudProviders />
 
-<div style="display: flex">
-    @foreach (var set in currentScore.SetScores)
+<MudSelect T="int?" Value="_selectedCourtId" ValueChanged="OnCourtChanged" Label="Select Court"
+           Variant="Variant.Outlined" Style="max-width: 400px; margin: 12px;" Clearable="true">
+    @foreach (var court in _allCourts)
+    {
+        <MudSelectItem T="int?" Value="@((int?)court.CourtId)">@court.Club.Name — @court.Name</MudSelectItem>
+    }
+</MudSelect>
+
+@if (_selectedCourt != null)
+{
+    <MudText Typo="Typo.h5" Align="Align.Center" Style="margin-top: 8px; letter-spacing: 2px; text-transform: uppercase;">
+        @_selectedCourt.Club.Name — @_selectedCourt.Name
+    </MudText>
+}
+
+@if (_activeMatch != null)
+{
+    <MudText Typo="Typo.subtitle1" Align="Align.Center" Style="margin-bottom: 4px;">
+        @PlayerLabel(_activeMatch)
+    </MudText>
+}
+
+@if (!currentScore.isComplete)
+{
+    <div style="display: flex; justify-content: center; gap: 40px; margin-top: 8px; margin-bottom: 4px;">
+        <MudText Typo="Typo.h3" Style="min-width: 70px; text-align: center; font-weight: bold;">@PointDisplay(currentScore.UserPts, currentScore.OppPts, currentScore.DeuceCount, currentScore.TieBreak, true)</MudText>
+        <MudText Typo="Typo.h3" Style="min-width: 70px; text-align: center; font-weight: bold;">@PointDisplay(currentScore.OppPts, currentScore.UserPts, currentScore.DeuceCount, currentScore.TieBreak, false)</MudText>
+    </div>
+}
+
+<div style="display: flex; justify-content: center; margin-top: 4px;">
+    @foreach (var set in currentScore.SetScores ?? Enumerable.Empty<SetScore>())
     {
         <DotDigit Number="@set.UserGames" />
     }
     <DotDigit Number="@currentScore.UserG" />
-    @for (int i = 0; i < 5 - currentScore.SetScores.Count() -1 ; i++)
+    @for (int i = 0; i < 5 - (currentScore.SetScores?.Count() ?? 0) - 1; i++)
     {
         <DotDigit Number="0" />
     }
 </div>
 
-<div style="display: flex">
-    @foreach (var set in currentScore.SetScores)
+<div style="display: flex; justify-content: center;">
+    @foreach (var set in currentScore.SetScores ?? Enumerable.Empty<SetScore>())
     {
         <DotDigit Number="@set.OpponentGames" />
     }
     <DotDigit Number="@currentScore.OppG" />
-    @for (int i = 0; i < 5 - currentScore.SetScores.Count() -1; i++)
+    @for (int i = 0; i < 5 - (currentScore.SetScores?.Count() ?? 0) - 1; i++)
     {
         <DotDigit Number="0" />
     }
 </div>
 
- 
 @code {
     private HubConnection? hubConnection;
-    private string? userInput;
-    private string? messageInput;
-    private List<string> messages = new();
-    private List<Score> scores = new();
-    private Stack<GameState> history = new();
+    private List<Court> _allCourts = [];
+    private int? _selectedCourtId;
+    private Court? _selectedCourt => _allCourts.FirstOrDefault(c => c.CourtId == _selectedCourtId);
+    private SavedMatch? _activeMatch;
     GameState currentScore = new(0, 0, 0, 0, 0, 0, false, 0, true, 0, 0, new List<SetScore>(), DateTime.Now, false);
 
     protected override async Task OnInitializedAsync()
     {
-        scores = await DbContext.Score.ToListAsync();
-
-        hubConnection = new HubConnectionBuilder()
-            .WithUrl(Navigation.ToAbsoluteUri("/chathub"))
-            .Build();
-
-        hubConnection.On<string, string>("ReceiveMessage", async (user, message) =>
-        {
-            // FIX: Use nullable type and null check to avoid CS8600
-            GameState? gameState = JsonConvert.DeserializeObject<GameState>(user);
-            if (gameState != null)
-            {
-                currentScore = gameState;
-            }
-            await InvokeAsync(StateHasChanged);
-        });
-
-        await hubConnection.StartAsync();
+        _allCourts = await DbContext.Courts
+            .Include(c => c.Club)
+            .OrderBy(c => c.Club.Name).ThenBy(c => c.Name)
+            .ToListAsync();
     }
 
-
-    private void SendMessage()
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        Console.WriteLine("SendMessage clicked"); // 👈 log to browser console
-
-
-        if (hubConnection is not null && !string.IsNullOrWhiteSpace(userInput) && !string.IsNullOrWhiteSpace(messageInput))
+        if (firstRender && hubConnection is null)
         {
-              hubConnection.SendAsync("SendMessage", userInput, messageInput);
-            messageInput = string.Empty;
+            hubConnection = new HubConnectionBuilder()
+                .WithUrl(Navigation.ToAbsoluteUri("/chathub"))
+                .Build();
+
+            hubConnection.On<string, string>("ReceiveMessage", async (user, message) =>
+            {
+                if (_selectedCourtId.HasValue)
+                {
+                    if (!int.TryParse(message, out int msgCourtId) || msgCourtId != _selectedCourtId.Value)
+                        return;
+                }
+
+                GameState? gameState = JsonConvert.DeserializeObject<GameState>(user);
+                if (gameState != null)
+                    currentScore = gameState;
+
+                // Refresh match details when scoring starts (e.g. a new match just began on this court)
+                if (_activeMatch == null && _selectedCourtId.HasValue)
+                {
+                    using var dbc = DbFactory.CreateDbContext();
+                    _activeMatch = await dbc.SavedMatch
+                        .FirstOrDefaultAsync(m => m.CourtId == _selectedCourtId && !m.Complete);
+                }
+
+                await InvokeAsync(StateHasChanged);
+            });
+
+            await hubConnection.StartAsync();
         }
+    }
+
+    private async Task OnCourtChanged(int? courtId)
+    {
+        _selectedCourtId = courtId;
+        currentScore = new GameState(0, 0, 0, 0, 0, 0, false, 0, true, 0, 0, new List<SetScore>(), DateTime.Now, false);
+        _activeMatch = null;
+
+        if (courtId.HasValue)
+        {
+            _activeMatch = await DbContext.SavedMatch
+                .FirstOrDefaultAsync(m => m.CourtId == courtId && !m.Complete);
+
+            if (_activeMatch?.MatchJson is { } json)
+            {
+                var match = JsonConvert.DeserializeObject<DropShot.Models.Match>(json);
+                var latest = match?.HistoryList?.FirstOrDefault();
+                if (latest != null)
+                    currentScore = latest;
+            }
+        }
+    }
+
+    private static string PointDisplay(int myPts, int oppPts, int deuceCount, bool tieBreak, bool isUser)
+    {
+        if (tieBreak)
+            return myPts.ToString();
+
+        if (deuceCount > 0)
+        {
+            if (myPts > oppPts) return "Ad";
+            if (myPts < oppPts) return "";
+            return "Deuce";
+        }
+
+        return myPts switch { 0 => "0", 1 => "15", 2 => "30", _ => "40" };
+    }
+
+    private static string PlayerLabel(SavedMatch m)
+    {
+        if (!string.IsNullOrWhiteSpace(m.Player3) && !string.IsNullOrWhiteSpace(m.Player4))
+            return $"{m.Player1} & {m.Player2}  vs  {m.Player3} & {m.Player4}";
+        return $"{m.Player1}  vs  {m.Player2}";
     }
 
     public bool IsConnected =>
         hubConnection?.State == HubConnectionState.Connected;
 }
-

--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -11,6 +11,7 @@
 @using System.Threading
 
 @page "/tennisscore"
+@page "/match/{MatchId:int}"
 @rendermode InteractiveServer
 
 @using DropShot.Services
@@ -125,6 +126,13 @@
                          SelectValueOnTab="@selectedOnTab"
                          AdornmentColor="Color.Primary" />
     }
+
+    <MudSelect T="int?" @bind-Value="_selectedCourtId" Label="Court (optional)" Variant="Variant.Outlined" Style="margin: 10px;" Clearable="true">
+        @foreach (var court in _courts)
+        {
+            <MudSelectItem T="int?" Value="@((int?)court.CourtId)">@court.Club.Name — @court.Name</MudSelectItem>
+        }
+    </MudSelect>
 
     <MudSelect @bind-Value="_state.BestOf" Label="Best Of" Variant="Variant.Outlined" Style="margin: 10px;">
         <MudSelectItem Value="1">1 Set</MudSelectItem>
@@ -346,20 +354,13 @@
             _state.IsMatchEnded = true;
             if (CurrentMatch != null)
                 _winner = ScoreService.EndMatch(_state, CurrentMatch, Label_Switch1);
+            SaveHistory();
         }
     }
 
-    // Change ReloadPage from static to instance method to fix CS0120
     public void ReloadPage()
     {
-        history = new(new[] { new GameState(0, 0, 0, 0, 0, 0, false, 0, false, 0, 0, new List<SetScore>(), DateTime.Now, false) });
-        _value = "";
-        _value2 = "";
-        _value3 = "";
-        _value4 = "";
-        _winner = "";
-        _state = new();
-        CurrentMatch = null;
+        Navigation.NavigateTo("/match");
     }
 
     private async Task<IEnumerable<string>> Search1(string value, CancellationToken token)
@@ -413,7 +414,8 @@
             Player1 = _value,
             Player2 = _value2,
             Player3 = _value3,
-            Player4 = _value4
+            Player4 = _value4,
+            CourtId = _selectedCourtId
         };
 
         _coinTossUserServes = Random.Shared.Next(2) == 0;
@@ -429,14 +431,51 @@
         await InvokeAsync(StateHasChanged);
     }
 
-    private void StartAfterCoinToss()
+    private async Task StartAfterCoinToss()
     {
         _state.IsUserServing = _coinTossUserServes;
         CurrentMatch = _pendingMatch;
         _showCoinToss = false;
+
+        // Persist the new match immediately so we get a stable SavedMatchId for the URL.
+        await SaveInitialMatchAsync();
+
+        // Navigate to /match/{id} so that refreshing the page restores this exact match.
+        if (_savedMatchId > 0)
+            Navigation.NavigateTo($"/match/{_savedMatchId}", replace: true);
     }
 
+    private async Task SaveInitialMatchAsync()
+    {
+        var snapshotList = _state.SetScores.Select(s => s.Clone()).ToList();
+        var initialState = new GameState(_state.UserPoints, _state.OppPoints, _state.UserGames, _state.OppGames, _state.UserSets, _state.OppSets, _state.IsTieBreak, _state.DeuceCount, _state.IsUserServing, _state.UserGames, _state.OppGames, snapshotList, DateTime.Now, false);
+        history.Push(initialState);
+        CurrentMatch.History = history;
+        CurrentMatch.HistoryList = history.ToList();
+
+        using var dbc = DbFactory.CreateDbContext();
+        var matchToSave = new SavedMatch
+        {
+            MatchJson = JsonConvert.SerializeObject(CurrentMatch),
+            Complete = false,
+            Player1 = CurrentMatch.Player1,
+            Player2 = CurrentMatch.Player2,
+            Player3 = CurrentMatch.Player3,
+            Player4 = CurrentMatch.Player4,
+            CourtId = (_selectedCourtId is > 0) ? _selectedCourtId : null,
+            CreatedAt = DateTime.UtcNow
+        };
+        dbc.SavedMatch.Add(matchToSave);
+        await dbc.SaveChangesAsync();
+        _savedMatchId = matchToSave.SavedMatchId;
+    }
+
+    [Parameter] public int MatchId { get; set; }
+    private int _savedMatchId;
+
     private List<string> _states = [];
+    private List<Court> _courts = [];
+    private int? _selectedCourtId;
 
     private async Task<IEnumerable<string>> Search(string value, CancellationToken token)
     {
@@ -477,19 +516,26 @@
             .Select(p => p.DisplayName)
             .ToListAsync();
 
-        var savedMatch = await DbContext.SavedMatch
-            .FirstOrDefaultAsync(m => !m.Complete);
+        _courts = await DbContext.Courts
+            .Include(c => c.Club)
+            .Where(c => !DbContext.SavedMatch.Any(m => !m.Complete && m.CourtId == c.CourtId))
+            .OrderBy(c => c.Club.Name).ThenBy(c => c.Name)
+            .ToListAsync();
 
-        if (savedMatch != null && !string.IsNullOrEmpty(savedMatch.MatchJson))
+        if (MatchId > 0)
         {
-            if (CurrentMatch == null)
+            var savedMatch = await DbContext.SavedMatch
+                .FirstOrDefaultAsync(m => m.SavedMatchId == MatchId && !m.Complete);
+
+            if (savedMatch != null && !string.IsNullOrEmpty(savedMatch.MatchJson))
             {
                 CurrentMatch = JsonConvert.DeserializeObject<Match>(savedMatch.MatchJson) ?? new Match();
+                history = new Stack<GameState>(CurrentMatch.HistoryList.AsEnumerable().Reverse());
+                if (history.Any())
+                    ScoreService.RestoreFromGameState(_state, history.Peek());
+                _savedMatchId = savedMatch.SavedMatchId;
+                _selectedCourtId = savedMatch.CourtId;
             }
-            history = new Stack<GameState>(CurrentMatch.HistoryList.AsEnumerable().Reverse());
-
-            if (history.Any())
-                ScoreService.RestoreFromGameState(_state, history.Peek());
         }
 
         // Mark as loaded after DB queries so content renders immediately.
@@ -530,7 +576,9 @@
 
         using var dbc = DbFactory.CreateDbContext();
 
-        var matchToSave = await dbc.SavedMatch.FirstOrDefaultAsync();
+        var matchToSave = _savedMatchId > 0
+            ? await dbc.SavedMatch.FirstOrDefaultAsync(m => m.SavedMatchId == _savedMatchId)
+            : null;
         if (matchToSave == null)
         {
             matchToSave = new SavedMatch();
@@ -544,15 +592,17 @@
         matchToSave.Player3 = CurrentMatch.Player3;
         matchToSave.Player4 = CurrentMatch.Player4;
         matchToSave.WinnerName = _state.IsMatchEnded ? _winner : null;
+        matchToSave.CourtId = (_selectedCourtId is > 0) ? _selectedCourtId : null;
         if (matchToSave.CreatedAt == default) matchToSave.CreatedAt = DateTime.UtcNow;
         await dbc.SaveChangesAsync();
+        _savedMatchId = matchToSave.SavedMatchId;
 
 
         string json = JsonConvert.SerializeObject(history.Peek());
 
         if (hubConnection is not null)
         {
-            hubConnection.SendAsync("SendMessage", $"{json}", "");
+            hubConnection.SendAsync("SendMessage", $"{json}", CurrentMatch.CourtId?.ToString() ?? "");
         }
     }
 
@@ -588,6 +638,7 @@
             CurrentMatch.Complete = false;
         _state.IsMatchEnded = false;
         _winner = "";
+        SaveHistory();
     }
 
     private void OpenSettings() { }

--- a/DropShot/Data/Migrations/20260329212712_AddCourtToSavedMatch.Designer.cs
+++ b/DropShot/Data/Migrations/20260329212712_AddCourtToSavedMatch.Designer.cs
@@ -4,6 +4,7 @@ using DropShot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DropShot.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260329212712_AddCourtToSavedMatch")]
+    partial class AddCourtToSavedMatch
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DropShot/Data/Migrations/20260329212712_AddCourtToSavedMatch.cs
+++ b/DropShot/Data/Migrations/20260329212712_AddCourtToSavedMatch.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropShot.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCourtToSavedMatch : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "CourtId",
+                table: "SavedMatch",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SavedMatch_CourtId",
+                table: "SavedMatch",
+                column: "CourtId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_SavedMatch_Courts_CourtId",
+                table: "SavedMatch",
+                column: "CourtId",
+                principalTable: "Courts",
+                principalColumn: "CourtId",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_SavedMatch_Courts_CourtId",
+                table: "SavedMatch");
+
+            migrationBuilder.DropIndex(
+                name: "IX_SavedMatch_CourtId",
+                table: "SavedMatch");
+
+            migrationBuilder.DropColumn(
+                name: "CourtId",
+                table: "SavedMatch");
+        }
+    }
+}

--- a/DropShot/Data/MyDbContext.cs
+++ b/DropShot/Data/MyDbContext.cs
@@ -197,6 +197,15 @@ namespace DropShot.Data
                       .OnDelete(DeleteBehavior.SetNull);
             });
 
+            // ── SavedMatch ───────────────────────────────────────────────────────
+            builder.Entity<SavedMatch>(entity =>
+            {
+                entity.HasOne<Court>()
+                      .WithMany()
+                      .HasForeignKey(m => m.CourtId)
+                      .OnDelete(DeleteBehavior.SetNull);
+            });
+
             // ── PlayerFriend (self-referential) ──────────────────────────────────
             builder.Entity<PlayerFriend>(entity =>
             {

--- a/DropShot/Models/Match.cs
+++ b/DropShot/Models/Match.cs
@@ -9,4 +9,5 @@ public class Match
     public string Player3 { get; set; }
     public string Player4 { get; set; }
     public bool Complete { get; set; }
+    public int? CourtId { get; set; }
 }

--- a/DropShot/Models/SavedMatch.cs
+++ b/DropShot/Models/SavedMatch.cs
@@ -11,4 +11,5 @@ public class SavedMatch
     public string? Player4 { get; set; }
     public string? WinnerName { get; set; }
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public int? CourtId { get; set; }
 }


### PR DESCRIPTION
## Summary

- **Courts linked to matches** — `SavedMatch` gains a `CourtId` FK (new EF migration); court dropdown on match setup excludes courts already occupied by an active match; FK is sourced from `_selectedCourtId` (always a valid DB value) to prevent the `CourtId = 0` FK violation
- **Multi-match / per-tab scoring** — `/match` lists all active matches; starting a new match navigates to `/match/{id}` so each browser tab is independent and page refresh restores the correct match
- **Scoreboard improvements** — dropdown shows all courts (not just active ones); selecting a court pre-loads the current score and player names without waiting for the next point; SignalR updates filter to the selected court; point score (0/15/30/40/Deuce/Ad) displayed above set and game scores in larger text; undo now triggers a SignalR update
- **Match lifecycle** — ending a match via the dialog now persists `Complete = true` so it disappears from the active match list

## Test plan

- [ ] Run `dotnet ef database update` to apply the `AddCourtToSavedMatch` migration
- [ ] Create at least one Club and Court via the Clubs page
- [ ] Start a match at `/match`, select a court — verify that court no longer appears in the dropdown when starting a second match
- [ ] Open `/score` in a second tab, select the court — verify the current score appears immediately without waiting for a point
- [ ] Score points and undo — verify the scoreboard updates on both scoring and undo
- [ ] End the match via the dialog — verify it disappears from the `/match` list
- [ ] Open two browser tabs to `/match/{id1}` and `/match/{id2}` simultaneously — verify each tab scores independently
- [ ] Refresh a scoring tab — verify it reloads the correct match

🤖 Generated with [Claude Code](https://claude.com/claude-code)