### PR TITLE
Scoreboard enhancements and fix multi-step undo

### DIFF
--- a/DropShot/Components/Pages/Scoreboard.razor
+++ b/DropShot/Components/Pages/Scoreboard.razor
@@ -36,13 +36,24 @@
 
 @if (!currentScore.isComplete)
 {
-    <div style="display: flex; justify-content: center; gap: 40px; margin-top: 8px; margin-bottom: 4px;">
-        <MudText Typo="Typo.h3" Style="min-width: 70px; text-align: center; font-weight: bold;">@PointDisplay(currentScore.UserPts, currentScore.OppPts, currentScore.DeuceCount, currentScore.TieBreak, true)</MudText>
-        <MudText Typo="Typo.h3" Style="min-width: 70px; text-align: center; font-weight: bold;">@PointDisplay(currentScore.OppPts, currentScore.UserPts, currentScore.DeuceCount, currentScore.TieBreak, false)</MudText>
+    <div style="display: flex; justify-content: center; gap: 40px; margin-top: 8px; margin-bottom: 4px; align-items: center;">
+        <div style="display: flex; align-items: center; gap: 6px;">
+            <span style="font-size: 1.4rem; visibility: @(currentScore.IsUserServing ? "visible" : "hidden");">🎾</span>
+            <MudText Typo="Typo.h3" Style="font-weight: bold;">@PointDisplay(currentScore.UserPts, currentScore.OppPts, currentScore.DeuceCount, currentScore.TieBreak, true)</MudText>
+        </div>
+        <div style="display: flex; align-items: center; gap: 6px;">
+            <MudText Typo="Typo.h3" Style="font-weight: bold;">@PointDisplay(currentScore.OppPts, currentScore.UserPts, currentScore.DeuceCount, currentScore.TieBreak, false)</MudText>
+            <span style="font-size: 1.4rem; visibility: @(!currentScore.IsUserServing ? "visible" : "hidden");">🎾</span>
+        </div>
     </div>
 }
 
-<div style="display: flex; justify-content: center; margin-top: 4px;">
+@if (currentScore.TieBreak)
+{
+    <div class="scoreboard-tiebreak">TIE BREAK</div>
+}
+
+<div style="display: flex; justify-content: center; margin-top: 4px; align-items: center;">
     @foreach (var set in currentScore.SetScores ?? Enumerable.Empty<SetScore>())
     {
         <DotDigit Number="@set.UserGames" />
@@ -54,7 +65,7 @@
     }
 </div>
 
-<div style="display: flex; justify-content: center;">
+<div style="display: flex; justify-content: center; align-items: center;">
     @foreach (var set in currentScore.SetScores ?? Enumerable.Empty<SetScore>())
     {
         <DotDigit Number="@set.OpponentGames" />
@@ -72,7 +83,7 @@
     private int? _selectedCourtId;
     private Court? _selectedCourt => _allCourts.FirstOrDefault(c => c.CourtId == _selectedCourtId);
     private SavedMatch? _activeMatch;
-    GameState currentScore = new(0, 0, 0, 0, 0, 0, false, 0, true, 0, 0, new List<SetScore>(), DateTime.Now, false);
+    GameState currentScore = new(0, 0, 0, 0, 0, 0, false, 0, true, 0, 0, new List<SetScore>(), DateTime.Now, false, "", "");
 
     protected override async Task OnInitializedAsync()
     {
@@ -120,7 +131,7 @@
     private async Task OnCourtChanged(int? courtId)
     {
         _selectedCourtId = courtId;
-        currentScore = new GameState(0, 0, 0, 0, 0, 0, false, 0, true, 0, 0, new List<SetScore>(), DateTime.Now, false);
+        currentScore = new GameState(0, 0, 0, 0, 0, 0, false, 0, true, 0, 0, new List<SetScore>(), DateTime.Now, false, "", "");
         _activeMatch = null;
 
         if (courtId.HasValue)

--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -154,6 +154,22 @@
 {
     <section class="bg-tennis overlay-dark">
         <div class="score-container">
+            <!-- Match Header -->
+            @{
+                var _headerCourt = _courts.FirstOrDefault(c => c.CourtId == _selectedCourtId);
+            }
+            <div style="text-align: center; padding: 4px 8px;">
+                @if (_headerCourt != null)
+                {
+                    <div style="font-size: 0.85rem; color: #aaa; letter-spacing: 1px; text-transform: uppercase;">
+                        @_headerCourt.Club.Name — @_headerCourt.Name
+                    </div>
+                }
+                <div style="font-size: 1rem; color: white; font-weight: bold;">
+                    @GetUserDisplayName() <span style="color: #aaa;">vs</span> @GetOpponentDisplayName()
+                </div>
+            </div>
+
             <!-- Top Player Button -->
             <div style="display: flex">
                 <MudAvatarGroup Max="3" Spacing="2" MaxColor="Color.Primary">
@@ -431,6 +447,24 @@
         await InvokeAsync(StateHasChanged);
     }
 
+    private string GetUserDisplayName()
+    {
+        if (CurrentMatch != null)
+            return !string.IsNullOrEmpty(CurrentMatch.Player3)
+                ? $"{CurrentMatch.Player1} & {CurrentMatch.Player2}"
+                : CurrentMatch.Player1;
+        return Label_Switch1 ? $"{_value} & {_value2}" : _value;
+    }
+
+    private string GetOpponentDisplayName()
+    {
+        if (CurrentMatch != null)
+            return !string.IsNullOrEmpty(CurrentMatch.Player3)
+                ? $"{CurrentMatch.Player3} & {CurrentMatch.Player4}"
+                : CurrentMatch.Player2;
+        return Label_Switch1 ? $"{_value3} & {_value4}" : _value2;
+    }
+
     private async Task StartAfterCoinToss()
     {
         _state.IsUserServing = _coinTossUserServes;
@@ -443,12 +477,24 @@
         // Navigate to /match/{id} so that refreshing the page restores this exact match.
         if (_savedMatchId > 0)
             Navigation.NavigateTo($"/match/{_savedMatchId}", replace: true);
+
+        // Broadcast initial state so the scoreboard shows player names and serve indicator immediately.
+        var initialState = new GameState(
+            0, 0, 0, 0, 0, 0, false, 0, _state.IsUserServing,
+            0, 0, new List<SetScore>(), DateTime.Now, false,
+            GetUserDisplayName(), GetOpponentDisplayName()
+        );
+        if (hubConnection is not null)
+        {
+            await hubConnection.SendAsync("SendMessage",
+                JsonConvert.SerializeObject(initialState), CurrentMatch.CourtId?.ToString() ?? "");
+        }
     }
 
     private async Task SaveInitialMatchAsync()
     {
         var snapshotList = _state.SetScores.Select(s => s.Clone()).ToList();
-        var initialState = new GameState(_state.UserPoints, _state.OppPoints, _state.UserGames, _state.OppGames, _state.UserSets, _state.OppSets, _state.IsTieBreak, _state.DeuceCount, _state.IsUserServing, _state.UserGames, _state.OppGames, snapshotList, DateTime.Now, false);
+        var initialState = new GameState(_state.UserPoints, _state.OppPoints, _state.UserGames, _state.OppGames, _state.UserSets, _state.OppSets, _state.IsTieBreak, _state.DeuceCount, _state.IsUserServing, _state.UserGames, _state.OppGames, snapshotList, DateTime.Now, false, GetUserDisplayName(), GetOpponentDisplayName());
         history.Push(initialState);
         CurrentMatch.History = history;
         CurrentMatch.HistoryList = history.ToList();
@@ -557,7 +603,7 @@
         }
     }
 
-    private Stack<GameState> history = new(new[] { new GameState(0, 0, 0, 0, 0, 0, false, 0, false, 0, 0, new List<SetScore>(), DateTime.Now, false) });
+    private Stack<GameState> history = new(new[] { new GameState(0, 0, 0, 0, 0, 0, false, 0, false, 0, 0, new List<SetScore>(), DateTime.Now, false, "", "") });
 
 
 
@@ -565,12 +611,8 @@
     [Inject] private IDbContextFactory<MyDbContext> DbFactory { get; set; }
     private bool isSaving;
 
-    private async void SaveHistory()
+    private async Task PersistAndBroadcast()
     {
-        var snapshotList = _state.SetScores.Select(s => s.Clone()).ToList();
-
-        history.Push(new GameState(_state.UserPoints, _state.OppPoints, _state.UserGames, _state.OppGames, _state.UserSets, _state.OppSets, _state.IsTieBreak, _state.DeuceCount, _state.IsUserServing, _state.UserGames, _state.OppGames, snapshotList, DateTime.Now, _state.IsMatchEnded));
-
         CurrentMatch.History = history;
         CurrentMatch.HistoryList = history.ToList();
 
@@ -597,13 +639,21 @@
         await dbc.SaveChangesAsync();
         _savedMatchId = matchToSave.SavedMatchId;
 
-
-        string json = JsonConvert.SerializeObject(history.Peek());
-
-        if (hubConnection is not null)
+        if (hubConnection is not null && history.Any())
         {
-            hubConnection.SendAsync("SendMessage", $"{json}", CurrentMatch.CourtId?.ToString() ?? "");
+            await hubConnection.SendAsync("SendMessage",
+                JsonConvert.SerializeObject(history.Peek()),
+                CurrentMatch.CourtId?.ToString() ?? "");
         }
+    }
+
+    private async void SaveHistory()
+    {
+        var snapshotList = _state.SetScores.Select(s => s.Clone()).ToList();
+
+        history.Push(new GameState(_state.UserPoints, _state.OppPoints, _state.UserGames, _state.OppGames, _state.UserSets, _state.OppSets, _state.IsTieBreak, _state.DeuceCount, _state.IsUserServing, _state.UserGames, _state.OppGames, snapshotList, DateTime.Now, _state.IsMatchEnded, GetUserDisplayName(), GetOpponentDisplayName()));
+
+        await PersistAndBroadcast();
     }
 
     private void UserWinsPoint()
@@ -628,7 +678,7 @@
         SaveHistory();
     }
 
-    private void UndoLastPoint()
+    private async void UndoLastPoint()
     {
         if (history.Any())
             history.Pop();
@@ -638,7 +688,7 @@
             CurrentMatch.Complete = false;
         _state.IsMatchEnded = false;
         _winner = "";
-        SaveHistory();
+        await PersistAndBroadcast();
     }
 
     private void OpenSettings() { }

--- a/DropShot/Models/GameState.cs
+++ b/DropShot/Models/GameState.cs
@@ -14,5 +14,7 @@ public record GameState(
     int OpponentGamesSnapshot,
     List<SetScore>? SetScores,
     DateTime Timestamp,
-    bool isComplete
+    bool isComplete,
+    string UserName,
+    string OpponentName
 );

--- a/DropShot/wwwroot/app.css
+++ b/DropShot/wwwroot/app.css
@@ -50,3 +50,24 @@ h1:focus {
 .darker-border-checkbox.form-check-input {
     border-color: #929292;
 }
+
+.scoreboard-player-name {
+    font-size: 1.4rem;
+    font-weight: bold;
+    color: white;
+    margin-bottom: 4px;
+}
+
+.scoreboard-serve-indicator {
+    display: inline-block;
+    width: 50px;
+    font-size: 1.5rem;
+}
+
+.scoreboard-tiebreak {
+    margin-top: 16px;
+    font-size: 2rem;
+    font-weight: bold;
+    color: gold;
+    letter-spacing: 0.1em;
+}


### PR DESCRIPTION
## Summary
- **Scoreboard** now shows player names, court info, and serve indicator (🎾) immediately after the coin toss — no point needed to trigger the first broadcast
- **Serve indicator** on scoreboard sits to the left of player 1's points and right of player 2's, using `visibility` rather than conditional rendering so scores don't shift
- **TIE BREAK** banner displayed on the scoreboard in gold when a tiebreak is in progress
- **Scoring screen** header now shows the court name and player names throughout the match
- **Fix: undo only worked once** — extracted a `PersistAndBroadcast()` helper so `UndoLastPoint()` can save to DB and broadcast without pushing a duplicate state back onto the history stack; undo can now step back through the full match history

## Test plan
- [ ] Start a match, open `/score` on a second device — player names and serve indicator should appear immediately after "Let's Play!" (before any point is scored)
- [ ] Score points and verify the 🎾 moves correctly without the scores jumping left/right
- [ ] Play to 6–6 in a set and confirm the TIE BREAK banner appears on the scoreboard; disappears after the tiebreak ends
- [ ] Score several points then press undo multiple times — should step back one point at a time all the way to 0–0
- [ ] Resume scoring after undoing and confirm history continues correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)