### PR TITLE
Add court editing

### DIFF
--- a/DropShot.Maui/Components/Pages/CourtsDialog.razor
+++ b/DropShot.Maui/Components/Pages/CourtsDialog.razor
@@ -17,17 +17,48 @@
                     <MudTh></MudTh>
                 </HeaderContent>
                 <RowTemplate>
-                    <MudTd>@context.Name</MudTd>
-                    <MudTd>@context.Surface</MudTd>
-                    <MudTd>
-                        <MudIcon Icon="@(context.IsIndoor ? Icons.Material.Filled.Check : Icons.Material.Filled.Close)"
-                                 Color="@(context.IsIndoor ? Color.Success : Color.Default)" Size="Size.Small" />
-                    </MudTd>
-                    <MudTd>
-                        <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small"
-                                       Color="Color.Error"
-                                       OnClick="@(() => DeleteCourtAsync(context))" />
-                    </MudTd>
+                    @if (_editingCourtId == context.CourtId)
+                    {
+                        <MudTd>
+                            <MudTextField @bind-Value="_editName" Variant="Variant.Outlined" Margin="Margin.Dense" />
+                        </MudTd>
+                        <MudTd>
+                            <MudSelect @bind-Value="_editSurface" Variant="Variant.Outlined" Margin="Margin.Dense" T="CourtSurface">
+                                @foreach (CourtSurface s in Enum.GetValues<CourtSurface>())
+                                {
+                                    <MudSelectItem Value="s">@s</MudSelectItem>
+                                }
+                            </MudSelect>
+                        </MudTd>
+                        <MudTd>
+                            <MudCheckBox @bind-Value="_editIsIndoor" />
+                        </MudTd>
+                        <MudTd>
+                            <MudIconButton Icon="@Icons.Material.Filled.Save" Size="Size.Small"
+                                           Color="Color.Primary" OnClick="SaveEditAsync"
+                                           Disabled="string.IsNullOrWhiteSpace(_editName)" />
+                            <MudIconButton Icon="@Icons.Material.Filled.Cancel" Size="Size.Small"
+                                           OnClick="CancelEdit" />
+                        </MudTd>
+                    }
+                    else
+                    {
+                        <MudTd>@context.Name</MudTd>
+                        <MudTd>@context.Surface</MudTd>
+                        <MudTd>
+                            <MudIcon Icon="@(context.IsIndoor ? Icons.Material.Filled.Check : Icons.Material.Filled.Close)"
+                                     Color="@(context.IsIndoor ? Color.Success : Color.Default)" Size="Size.Small" />
+                        </MudTd>
+                        <MudTd>
+                            <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="Size.Small"
+                                           OnClick="@(() => StartEdit(context))"
+                                           Disabled="_editingCourtId.HasValue" />
+                            <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small"
+                                           Color="Color.Error"
+                                           OnClick="@(() => DeleteCourtAsync(context))"
+                                           Disabled="_editingCourtId.HasValue" />
+                        </MudTd>
+                    }
                 </RowTemplate>
             </MudTable>
 
@@ -67,6 +98,11 @@
     private CourtSurface _newSurface = CourtSurface.Hard;
     private bool _newIsIndoor;
 
+    private int? _editingCourtId;
+    private string _editName = "";
+    private CourtSurface _editSurface = CourtSurface.Hard;
+    private bool _editIsIndoor;
+
     protected override async Task OnInitializedAsync()
     {
         await LoadCourtsAsync();
@@ -100,6 +136,37 @@
             _newCourtName = "";
             _newIsIndoor = false;
             Snackbar.Add("Court added.", Severity.Success);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+    }
+
+    private void StartEdit(CourtDto court)
+    {
+        _editingCourtId = court.CourtId;
+        _editName = court.Name;
+        _editSurface = court.Surface;
+        _editIsIndoor = court.IsIndoor;
+    }
+
+    private void CancelEdit() => _editingCourtId = null;
+
+    private async Task SaveEditAsync()
+    {
+        if (_editingCourtId is null) return;
+        try
+        {
+            var updated = await Api.UpdateCourtAsync(ClubId, _editingCourtId.Value,
+                new UpdateCourtRequest(_editName.Trim(), _editSurface, _editIsIndoor));
+            if (updated is not null)
+            {
+                var idx = _courts.FindIndex(c => c.CourtId == updated.CourtId);
+                if (idx >= 0) _courts[idx] = updated;
+            }
+            _editingCourtId = null;
+            Snackbar.Add("Court updated.", Severity.Success);
         }
         catch (Exception ex)
         {

--- a/DropShot.Maui/Services/ApiService.cs
+++ b/DropShot.Maui/Services/ApiService.cs
@@ -123,6 +123,13 @@ public class ApiService(HttpClient http)
         return await r.Content.ReadFromJsonAsync<CourtDto>();
     }
 
+    public async Task<CourtDto?> UpdateCourtAsync(int clubId, int courtId, UpdateCourtRequest req)
+    {
+        var r = await http.PutAsJsonAsync($"api/clubs/{clubId}/courts/{courtId}", req);
+        r.EnsureSuccessStatusCode();
+        return await r.Content.ReadFromJsonAsync<CourtDto>();
+    }
+
     public async Task DeleteCourtAsync(int clubId, int courtId)
     {
         var r = await http.DeleteAsync($"api/clubs/{clubId}/courts/{courtId}");

--- a/DropShot.Shared/Dtos/ClubDtos.cs
+++ b/DropShot.Shared/Dtos/ClubDtos.cs
@@ -42,3 +42,4 @@ public record SaveClubRequest(
     string? Website);
 
 public record AddCourtRequest(string Name, CourtSurface Surface, bool IsIndoor);
+public record UpdateCourtRequest(string Name, CourtSurface Surface, bool IsIndoor);

--- a/DropShot/Components/Pages/Clubs.razor
+++ b/DropShot/Components/Pages/Clubs.razor
@@ -136,13 +136,44 @@
                 <MudTh></MudTh>
             </HeaderContent>
             <RowTemplate>
-                <MudTd>@context.Name</MudTd>
-                <MudTd>@context.Surface</MudTd>
-                <MudTd><MudIcon Icon="@(context.IsIndoor ? Icons.Material.Filled.CheckBox : Icons.Material.Filled.CheckBoxOutlineBlank)" Size="Size.Small" /></MudTd>
-                <MudTd>
-                    <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small" Color="Color.Error"
-                                   OnClick="@(() => DeleteCourt(context))" />
-                </MudTd>
+                @if (_editingCourt?.CourtId == context.CourtId)
+                {
+                    <MudTd>
+                        <MudTextField @bind-Value="_courtEditForm.Name" Variant="Variant.Outlined" Margin="Margin.Dense" />
+                    </MudTd>
+                    <MudTd>
+                        <MudSelect @bind-Value="_courtEditForm.Surface" Variant="Variant.Outlined" Margin="Margin.Dense">
+                            @foreach (CourtSurface s in Enum.GetValues<CourtSurface>())
+                            {
+                                <MudSelectItem Value="@s">@s</MudSelectItem>
+                            }
+                        </MudSelect>
+                    </MudTd>
+                    <MudTd>
+                        <MudCheckBox @bind-Value="_courtEditForm.IsIndoor" />
+                    </MudTd>
+                    <MudTd>
+                        <MudIconButton Icon="@Icons.Material.Filled.Save" Size="Size.Small" Color="Color.Primary"
+                                       OnClick="SaveEditCourt"
+                                       Disabled="string.IsNullOrWhiteSpace(_courtEditForm.Name)" />
+                        <MudIconButton Icon="@Icons.Material.Filled.Cancel" Size="Size.Small"
+                                       OnClick="CancelEditCourt" />
+                    </MudTd>
+                }
+                else
+                {
+                    <MudTd>@context.Name</MudTd>
+                    <MudTd>@context.Surface</MudTd>
+                    <MudTd><MudIcon Icon="@(context.IsIndoor ? Icons.Material.Filled.CheckBox : Icons.Material.Filled.CheckBoxOutlineBlank)" Size="Size.Small" /></MudTd>
+                    <MudTd>
+                        <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="Size.Small"
+                                       OnClick="@(() => StartEditCourt(context))"
+                                       Disabled="_editingCourt is not null" />
+                        <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small" Color="Color.Error"
+                                       OnClick="@(() => DeleteCourt(context))"
+                                       Disabled="_editingCourt is not null" />
+                    </MudTd>
+                }
             </RowTemplate>
             <NoRecordsContent><MudText Typo="Typo.caption">No courts yet.</MudText></NoRecordsContent>
         </MudTable>
@@ -173,6 +204,8 @@
     private Club? _courtsClub;
     private List<Court> _courts = [];
     private CourtForm _courtForm = new();
+    private Court? _editingCourt;
+    private CourtForm _courtEditForm = new();
 
     private sealed class ClubForm
     {
@@ -283,6 +316,7 @@
     {
         _courtsClub = club;
         _courtForm = new CourtForm();
+        _editingCourt = null;
         await using var dbc = DbFactory.CreateDbContext();
         _courts = await dbc.Courts.Where(c => c.ClubId == club.ClubId).OrderBy(c => c.Name).ToListAsync();
         _showCourtsDialog = true;
@@ -305,6 +339,33 @@
         _courtForm = new CourtForm();
         Snackbar.Add("Court added.", Severity.Success);
         await LoadClubs();
+    }
+
+    private void StartEditCourt(Court court)
+    {
+        _editingCourt = court;
+        _courtEditForm = new CourtForm { Name = court.Name, Surface = court.Surface, IsIndoor = court.IsIndoor };
+    }
+
+    private void CancelEditCourt() => _editingCourt = null;
+
+    private async Task SaveEditCourt()
+    {
+        if (_editingCourt is null || string.IsNullOrWhiteSpace(_courtEditForm.Name)) return;
+        await using var dbc = DbFactory.CreateDbContext();
+        var c = await dbc.Courts.FindAsync(_editingCourt.CourtId);
+        if (c is not null)
+        {
+            c.Name = _courtEditForm.Name.Trim();
+            c.Surface = _courtEditForm.Surface;
+            c.IsIndoor = _courtEditForm.IsIndoor;
+            await dbc.SaveChangesAsync();
+            _editingCourt.Name = c.Name;
+            _editingCourt.Surface = c.Surface;
+            _editingCourt.IsIndoor = c.IsIndoor;
+        }
+        _editingCourt = null;
+        Snackbar.Add("Court updated.", Severity.Success);
     }
 
     private async Task DeleteCourt(Court court)

--- a/DropShot/Controllers/ClubsController.cs
+++ b/DropShot/Controllers/ClubsController.cs
@@ -99,6 +99,22 @@ public class ClubsController(
             (DropShot.Shared.CourtSurface)court.Surface, court.IsIndoor));
     }
 
+    [HttpPut("{id:int}/courts/{courtId:int}")]
+    public async Task<ActionResult<CourtDto>> UpdateCourt(int id, int courtId, [FromBody] UpdateCourtRequest req)
+    {
+        if (!await authzService.CanEditClubAsync(User, id)) return Forbid();
+
+        await using var db = dbFactory.CreateDbContext();
+        var court = await db.Courts.FindAsync(courtId);
+        if (court is null || court.ClubId != id) return NotFound();
+        court.Name = req.Name.Trim();
+        court.Surface = (DropShot.Models.CourtSurface)req.Surface;
+        court.IsIndoor = req.IsIndoor;
+        await db.SaveChangesAsync();
+        return Ok(new CourtDto(court.CourtId, court.ClubId, court.Name,
+            (DropShot.Shared.CourtSurface)court.Surface, court.IsIndoor));
+    }
+
     [HttpDelete("{id:int}/courts/{courtId:int}")]
     public async Task<IActionResult> DeleteCourt(int id, int courtId)
     {


### PR DESCRIPTION
## Summary
- Adds inline edit (pencil icon) per court row in the courts dialog — both web (`Clubs.razor`) and MAUI (`CourtsDialog.razor`)
- New `PUT api/clubs/{id}/courts/{courtId}` endpoint in `ClubsController`
- `UpdateCourtRequest` DTO in shared library
- `UpdateCourtAsync` method in MAUI `ApiService`

## Test plan
- [ ] Open Clubs page, click the courts icon on a club
- [ ] Click edit on a court row — fields become editable inline
- [ ] Change name/surface/indoor and Save — row updates, snackbar confirms
- [ ] Click Cancel — row reverts unchanged
- [ ] Edit/Delete buttons on other rows are disabled while one row is being edited

🤖 Generated with [Claude Code](https://claude.com/claude-code)