### PR TITLE
Add Wimbledon scoreboard layout with layout selector

### DIFF
--- a/DropShot/Components/Pages/Scoreboard.razor
+++ b/DropShot/Components/Pages/Scoreboard.razor
@@ -9,78 +9,94 @@
 @inject NavigationManager Navigation
 @inject MyDbContext DbContext
 @inject IDbContextFactory<MyDbContext> DbFactory
+@inject IJSRuntime JS
 
 <MudProviders />
 
-<MudSelect T="int?" Value="_selectedCourtId" ValueChanged="OnCourtChanged" Label="Select Court"
-           Variant="Variant.Outlined" Style="max-width: 400px; margin: 12px;" Clearable="true">
-    @foreach (var court in _allCourts)
+<div style="display: flex; gap: 12px; align-items: flex-end; flex-wrap: wrap; margin: 12px;">
+    <MudSelect T="int?" Value="_selectedCourtId" ValueChanged="OnCourtChanged" Label="Select Court"
+               Variant="Variant.Outlined" Style="max-width: 300px;" Clearable="true">
+        @foreach (var court in _allCourts)
+        {
+            <MudSelectItem T="int?" Value="@((int?)court.CourtId)">@court.Club.Name — @court.Name</MudSelectItem>
+        }
+    </MudSelect>
+    <MudSelect T="string" Value="_selectedLayout" ValueChanged="OnLayoutChanged" Label="Layout"
+               Variant="Variant.Outlined" Style="max-width: 180px;">
+        <MudSelectItem T="string" Value=@("default")>Default</MudSelectItem>
+        <MudSelectItem T="string" Value=@("wimbledon")>Wimbledon</MudSelectItem>
+    </MudSelect>
+</div>
+
+@if (_selectedLayout == "wimbledon")
+{
+    <WimbledonScoreboard Score="currentScore" ActiveMatch="_activeMatch" SelectedCourt="_selectedCourt" />
+}
+else
+{
+    @if (_selectedCourt != null)
     {
-        <MudSelectItem T="int?" Value="@((int?)court.CourtId)">@court.Club.Name — @court.Name</MudSelectItem>
+        <MudText Typo="Typo.h5" Align="Align.Center" Style="margin-top: 8px; letter-spacing: 2px; text-transform: uppercase;">
+            @_selectedCourt.Club.Name — @_selectedCourt.Name
+        </MudText>
     }
-</MudSelect>
 
-@if (_selectedCourt != null)
-{
-    <MudText Typo="Typo.h5" Align="Align.Center" Style="margin-top: 8px; letter-spacing: 2px; text-transform: uppercase;">
-        @_selectedCourt.Club.Name — @_selectedCourt.Name
-    </MudText>
-}
+    @if (_activeMatch != null)
+    {
+        <MudText Typo="Typo.subtitle1" Align="Align.Center" Style="margin-bottom: 4px;">
+            @PlayerLabel(_activeMatch)
+        </MudText>
+    }
 
-@if (_activeMatch != null)
-{
-    <MudText Typo="Typo.subtitle1" Align="Align.Center" Style="margin-bottom: 4px;">
-        @PlayerLabel(_activeMatch)
-    </MudText>
-}
-
-@if (!currentScore.isComplete)
-{
-    <div style="display: flex; justify-content: center; gap: 40px; margin-top: 8px; margin-bottom: 4px; align-items: center;">
-        <div style="display: flex; align-items: center; gap: 6px;">
-            <span style="font-size: 1.4rem; visibility: @(currentScore.IsUserServing ? "visible" : "hidden");">🎾</span>
-            <MudText Typo="Typo.h3" Style="font-weight: bold;">@PointDisplay(currentScore.UserPts, currentScore.OppPts, currentScore.DeuceCount, currentScore.TieBreak, true)</MudText>
+    @if (!currentScore.isComplete)
+    {
+        <div style="display: flex; justify-content: center; gap: 40px; margin-top: 8px; margin-bottom: 4px; align-items: center;">
+            <div style="display: flex; align-items: center; gap: 6px;">
+                <span style="font-size: 1.4rem; visibility: @(currentScore.IsUserServing ? "visible" : "hidden");">🎾</span>
+                <MudText Typo="Typo.h3" Style="font-weight: bold;">@PointDisplay(currentScore.UserPts, currentScore.OppPts, currentScore.DeuceCount, currentScore.TieBreak, true)</MudText>
+            </div>
+            <div style="display: flex; align-items: center; gap: 6px;">
+                <MudText Typo="Typo.h3" Style="font-weight: bold;">@PointDisplay(currentScore.OppPts, currentScore.UserPts, currentScore.DeuceCount, currentScore.TieBreak, false)</MudText>
+                <span style="font-size: 1.4rem; visibility: @(!currentScore.IsUserServing ? "visible" : "hidden");">🎾</span>
+            </div>
         </div>
-        <div style="display: flex; align-items: center; gap: 6px;">
-            <MudText Typo="Typo.h3" Style="font-weight: bold;">@PointDisplay(currentScore.OppPts, currentScore.UserPts, currentScore.DeuceCount, currentScore.TieBreak, false)</MudText>
-            <span style="font-size: 1.4rem; visibility: @(!currentScore.IsUserServing ? "visible" : "hidden");">🎾</span>
-        </div>
+    }
+
+    @if (currentScore.TieBreak)
+    {
+        <div class="scoreboard-tiebreak">TIE BREAK</div>
+    }
+
+    <div style="display: flex; justify-content: center; margin-top: 4px; align-items: center;">
+        @foreach (var set in currentScore.SetScores ?? Enumerable.Empty<SetScore>())
+        {
+            <DotDigit Number="@set.UserGames" />
+        }
+        <DotDigit Number="@currentScore.UserG" />
+        @for (int i = 0; i < 5 - (currentScore.SetScores?.Count() ?? 0) - 1; i++)
+        {
+            <DotDigit Number="0" />
+        }
+    </div>
+
+    <div style="display: flex; justify-content: center; align-items: center;">
+        @foreach (var set in currentScore.SetScores ?? Enumerable.Empty<SetScore>())
+        {
+            <DotDigit Number="@set.OpponentGames" />
+        }
+        <DotDigit Number="@currentScore.OppG" />
+        @for (int i = 0; i < 5 - (currentScore.SetScores?.Count() ?? 0) - 1; i++)
+        {
+            <DotDigit Number="0" />
+        }
     </div>
 }
-
-@if (currentScore.TieBreak)
-{
-    <div class="scoreboard-tiebreak">TIE BREAK</div>
-}
-
-<div style="display: flex; justify-content: center; margin-top: 4px; align-items: center;">
-    @foreach (var set in currentScore.SetScores ?? Enumerable.Empty<SetScore>())
-    {
-        <DotDigit Number="@set.UserGames" />
-    }
-    <DotDigit Number="@currentScore.UserG" />
-    @for (int i = 0; i < 5 - (currentScore.SetScores?.Count() ?? 0) - 1; i++)
-    {
-        <DotDigit Number="0" />
-    }
-</div>
-
-<div style="display: flex; justify-content: center; align-items: center;">
-    @foreach (var set in currentScore.SetScores ?? Enumerable.Empty<SetScore>())
-    {
-        <DotDigit Number="@set.OpponentGames" />
-    }
-    <DotDigit Number="@currentScore.OppG" />
-    @for (int i = 0; i < 5 - (currentScore.SetScores?.Count() ?? 0) - 1; i++)
-    {
-        <DotDigit Number="0" />
-    }
-</div>
 
 @code {
     private HubConnection? hubConnection;
     private List<Court> _allCourts = [];
     private int? _selectedCourtId;
+    private string _selectedLayout = "default";
     private Court? _selectedCourt => _allCourts.FirstOrDefault(c => c.CourtId == _selectedCourtId);
     private SavedMatch? _activeMatch;
     GameState currentScore = new(0, 0, 0, 0, 0, 0, false, 0, true, 0, 0, new List<SetScore>(), DateTime.Now, false, "", "");
@@ -95,6 +111,19 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+        if (firstRender)
+        {
+            var savedLayout = await JS.InvokeAsync<string?>("localStorage.getItem", "scoreboard-layout");
+            if (!string.IsNullOrEmpty(savedLayout))
+                _selectedLayout = savedLayout;
+
+            var savedCourt = await JS.InvokeAsync<string?>("localStorage.getItem", "scoreboard-court");
+            if (int.TryParse(savedCourt, out int courtId))
+                await OnCourtChanged(courtId);
+
+            StateHasChanged();
+        }
+
         if (firstRender && hubConnection is null)
         {
             hubConnection = new HubConnectionBuilder()
@@ -131,6 +160,7 @@
     private async Task OnCourtChanged(int? courtId)
     {
         _selectedCourtId = courtId;
+        await JS.InvokeVoidAsync("localStorage.setItem", "scoreboard-court", courtId?.ToString() ?? "");
         currentScore = new GameState(0, 0, 0, 0, 0, 0, false, 0, true, 0, 0, new List<SetScore>(), DateTime.Now, false, "", "");
         _activeMatch = null;
 
@@ -147,6 +177,12 @@
                     currentScore = latest;
             }
         }
+    }
+
+    private async Task OnLayoutChanged(string layout)
+    {
+        _selectedLayout = layout;
+        await JS.InvokeVoidAsync("localStorage.setItem", "scoreboard-layout", layout);
     }
 
     private static string PointDisplay(int myPts, int oppPts, int deuceCount, bool tieBreak, bool isUser)

--- a/DropShot/Components/WimbledonScoreboard.razor
+++ b/DropShot/Components/WimbledonScoreboard.razor
@@ -1,0 +1,142 @@
+@using DropShot.Models
+@implements IDisposable
+
+<div class="wimbledon-board">
+
+    @* Time bar *@
+    <div class="wb-time-bar">
+        <span class="wb-clock">@_currentTime</span>
+        <span class="wb-elapsed">@_elapsedTime</span>
+    </div>
+
+    @* Column headers *@
+    <div class="wb-header">
+        <div class="wb-prev-sets-label">PREVIOUS SETS</div>
+        <div class="wb-name-spacer"></div>
+        <div class="wb-live-headers">
+            <span>SETS</span>
+            <span>GAMES</span>
+            <span>POINTS</span>
+        </div>
+    </div>
+
+    @* Court / match info *@
+    @if (SelectedCourt != null)
+    {
+        <div class="wb-court-label">@SelectedCourt.Club.Name &mdash; @SelectedCourt.Name</div>
+    }
+
+    @* Player 1 row *@
+    <div class="wb-player-row @(Score.IsUserServing ? "wb-serving" : "")">
+        <div class="wb-prev-sets">
+            @foreach (var set in Score.SetScores ?? Enumerable.Empty<SetScore>())
+            {
+                <span class="wb-prev-score">@set.UserGames</span>
+            }
+        </div>
+        <div class="wb-name">
+            @if (Score.IsUserServing)
+            {
+                <span class="wb-serve-dot">&#9679;</span>
+            }
+            @(string.IsNullOrWhiteSpace(Score.UserName) ? (ActiveMatch?.Player1 ?? "Player 1") : Score.UserName)
+        </div>
+        <div class="wb-live-scores">
+            <span>@Score.UserS</span>
+            <span>@Score.UserG</span>
+            <span>@PointDisplay(Score.UserPts, Score.OppPts, Score.DeuceCount, Score.TieBreak)</span>
+        </div>
+    </div>
+
+    @* "v" separator *@
+    <div class="wb-separator">
+        <div class="wb-prev-sets-spacer"></div>
+        <div class="wb-vs">v</div>
+        <div class="wb-live-scores-spacer"></div>
+    </div>
+
+    @* Player 2 row *@
+    <div class="wb-player-row @(!Score.IsUserServing ? "wb-serving" : "")">
+        <div class="wb-prev-sets">
+            @foreach (var set in Score.SetScores ?? Enumerable.Empty<SetScore>())
+            {
+                <span class="wb-prev-score">@set.OpponentGames</span>
+            }
+        </div>
+        <div class="wb-name">
+            @if (!Score.IsUserServing)
+            {
+                <span class="wb-serve-dot">&#9679;</span>
+            }
+            @(string.IsNullOrWhiteSpace(Score.OpponentName) ? (ActiveMatch?.Player2 ?? "Player 2") : Score.OpponentName)
+        </div>
+        <div class="wb-live-scores">
+            <span>@Score.OppS</span>
+            <span>@Score.OppG</span>
+            <span>@PointDisplay(Score.OppPts, Score.UserPts, Score.DeuceCount, Score.TieBreak)</span>
+        </div>
+    </div>
+
+    @if (Score.TieBreak)
+    {
+        <div class="wb-tiebreak-badge">TIE BREAK</div>
+    }
+
+</div>
+
+@code {
+    [Parameter, EditorRequired] public GameState Score { get; set; } = default!;
+    [Parameter] public SavedMatch? ActiveMatch { get; set; }
+    [Parameter] public Court? SelectedCourt { get; set; }
+
+    private string _currentTime = "";
+    private string _elapsedTime = "";
+    private System.Timers.Timer? _timer;
+
+    protected override void OnInitialized()
+    {
+        UpdateTimes();
+        _timer = new System.Timers.Timer(30_000);
+        _timer.Elapsed += async (_, _) =>
+        {
+            UpdateTimes();
+            await InvokeAsync(StateHasChanged);
+        };
+        _timer.Start();
+    }
+
+    protected override void OnParametersSet()
+    {
+        UpdateTimes();
+    }
+
+    private void UpdateTimes()
+    {
+        var now = DateTime.Now;
+        _currentTime = now.ToString("H.mm");
+
+        if (ActiveMatch != null)
+        {
+            var elapsed = DateTime.UtcNow - ActiveMatch.CreatedAt;
+            _elapsedTime = $"{(int)elapsed.TotalHours}.{elapsed.Minutes:D2}";
+        }
+        else
+        {
+            _elapsedTime = "0.00";
+        }
+    }
+
+    public void Dispose() => _timer?.Dispose();
+
+    private static string PointDisplay(int myPts, int oppPts, int deuceCount, bool tieBreak)
+    {
+        if (tieBreak) return myPts.ToString();
+        if (deuceCount > 0)
+        {
+            if (myPts > oppPts) return "Ad";
+            if (myPts < oppPts) return "";
+            return "Deuce";
+        }
+        return myPts switch { 0 => "0", 1 => "15", 2 => "30", _ => "40" };
+    }
+}

--- a/DropShot/Components/WimbledonScoreboard.razor.css
+++ b/DropShot/Components/WimbledonScoreboard.razor.css
@@ -1,0 +1,188 @@
+/* ── Outer container ──────────────────────────────────────────── */
+.wimbledon-board {
+    background-color: #0d1117;
+    color: #ffffff;
+    font-family: Georgia, 'Times New Roman', serif;
+    max-width: 700px;
+    margin: 20px auto;
+    border: 1px solid #2a2a3a;
+    border-radius: 4px;
+    overflow: hidden;
+}
+
+/* ── Time bar ─────────────────────────────────────────────────── */
+.wb-time-bar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 6px 16px;
+    background-color: #0a0e15;
+    border-bottom: 1px solid #2a2a3a;
+}
+
+.wb-clock,
+.wb-elapsed {
+    font-family: Georgia, 'Times New Roman', serif;
+    font-size: 1.4rem;
+    font-weight: bold;
+    color: #ffffff;
+    letter-spacing: 0.05em;
+    min-width: 60px;
+}
+
+.wb-elapsed {
+    text-align: right;
+}
+
+/* ── Court label ──────────────────────────────────────────────── */
+.wb-court-label {
+    text-align: center;
+    font-size: 0.7rem;
+    font-family: 'Helvetica Neue', Arial, sans-serif;
+    letter-spacing: 0.15em;
+    color: #888888;
+    text-transform: uppercase;
+    padding: 4px 12px;
+    border-bottom: 1px solid #1c1c2e;
+}
+
+/* ── Header row ───────────────────────────────────────────────── */
+.wb-header {
+    display: flex;
+    align-items: center;
+    background-color: #0a0e15;
+    border-bottom: 2px solid #2a2a3a;
+    padding: 6px 12px;
+}
+
+.wb-prev-sets-label {
+    font-size: 0.62rem;
+    font-family: 'Helvetica Neue', Arial, sans-serif;
+    letter-spacing: 0.14em;
+    color: #c9a84c;
+    text-transform: uppercase;
+    min-width: 150px;
+    flex-shrink: 0;
+}
+
+.wb-name-spacer {
+    flex: 1;
+}
+
+.wb-live-headers {
+    display: flex;
+    min-width: 195px;
+    justify-content: space-around;
+    font-size: 0.62rem;
+    font-family: 'Helvetica Neue', Arial, sans-serif;
+    letter-spacing: 0.14em;
+    color: #c9a84c;
+    text-transform: uppercase;
+    flex-shrink: 0;
+}
+
+/* ── Player rows ──────────────────────────────────────────────── */
+.wb-player-row {
+    display: flex;
+    align-items: center;
+    padding: 10px 12px;
+    border-bottom: 1px solid #1c1c2e;
+    min-height: 56px;
+}
+
+.wb-player-row.wb-serving {
+    background-color: #131720;
+}
+
+/* Previous set scores */
+.wb-prev-sets {
+    display: flex;
+    gap: 4px;
+    min-width: 150px;
+    flex-shrink: 0;
+    align-items: center;
+}
+
+.wb-prev-score {
+    display: inline-block;
+    width: 26px;
+    text-align: center;
+    font-size: 1.25rem;
+    color: #cccccc;
+}
+
+/* Player name */
+.wb-name {
+    flex: 1;
+    font-size: 1.2rem;
+    font-weight: bold;
+    letter-spacing: 0.03em;
+    padding: 0 12px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* Serve indicator dot */
+.wb-serve-dot {
+    color: #c9a84c;
+    font-size: 0.65rem;
+    margin-right: 7px;
+    vertical-align: middle;
+}
+
+/* Live score columns */
+.wb-live-scores {
+    display: flex;
+    min-width: 195px;
+    justify-content: space-around;
+    flex-shrink: 0;
+    align-items: center;
+}
+
+.wb-live-scores span {
+    display: inline-block;
+    width: 65px;
+    text-align: center;
+    font-size: 1.5rem;
+    font-weight: bold;
+}
+
+/* ── "v" separator ────────────────────────────────────────────── */
+.wb-separator {
+    display: flex;
+    align-items: center;
+    padding: 2px 12px;
+    border-bottom: 1px solid #1c1c2e;
+}
+
+.wb-prev-sets-spacer {
+    min-width: 150px;
+    flex-shrink: 0;
+}
+
+.wb-vs {
+    flex: 1;
+    font-size: 0.8rem;
+    color: #777777;
+    padding-left: 12px;
+    font-style: italic;
+}
+
+.wb-live-scores-spacer {
+    min-width: 195px;
+    flex-shrink: 0;
+}
+
+/* ── Tie-break badge ──────────────────────────────────────────── */
+.wb-tiebreak-badge {
+    text-align: center;
+    padding: 6px;
+    font-size: 0.72rem;
+    font-family: 'Helvetica Neue', Arial, sans-serif;
+    letter-spacing: 0.16em;
+    color: #c9a84c;
+    text-transform: uppercase;
+    background-color: #0a0e15;
+    border-top: 1px solid #2a2a3a;
+}


### PR DESCRIPTION
## Summary
- Adds a **Layout** dropdown to the scoreboard page alongside the court selector, with options for Default and Wimbledon
- New **Wimbledon-style scoreboard** component replicating the classic look: dark background, tabular grid with previous set scores (left), player names (centre), and live sets/games/points (right), in Georgia serif with gold accents
- Both the selected layout and selected court are **persisted to localStorage** so they survive page refreshes
- Time bar at the top of the Wimbledon board shows **current time** (left) and **match elapsed time** (right), calculated correctly using UTC to match `CreatedAt` storage

## Test plan
- [ ] Navigate to `/score`, confirm Layout dropdown appears next to Select Court
- [ ] Select Wimbledon layout — board renders with correct columns and styling
- [ ] Select a court with an active match — player names, previous sets, and live scores populate
- [ ] Serving player shows gold dot indicator
- [ ] Tiebreak: TIE BREAK badge appears at bottom
- [ ] Refresh page — selected court and layout are restored from localStorage
- [ ] Elapsed time starts at 0.00 and increments correctly (not offset by timezone)
- [ ] Default layout is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)