### PR TITLE
Add result entry validation and admin verification workflow

### DIFF
--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -108,6 +108,7 @@
                             <MudSelectItem T="int" Value="3">Best of 3</MudSelectItem>
                             <MudSelectItem T="int" Value="5">Best of 5</MudSelectItem>
                         </MudSelect>
+                        <MudCheckBox @bind-Value="Model.RequireVerification" Label="Require admin verification of results" Class="mt-2" />
                     </MudItem>
                 </MudGrid>
 
@@ -299,11 +300,17 @@
                         </MudTd>
                         <MudTd>
                             @if (context.Player1Id.HasValue && context.Player2Id.HasValue
-                                 && context.Status is not (FixtureStatus.Completed or FixtureStatus.Cancelled or FixtureStatus.Walkover))
+                                 && context.Status is not (FixtureStatus.Completed or FixtureStatus.Cancelled or FixtureStatus.Walkover or FixtureStatus.AwaitingVerification))
                             {
                                 <MudIconButton Icon="@Icons.Material.Filled.Scoreboard" Size="Size.Small"
                                                Color="Color.Success" Title="Submit Score"
                                                OnClick="@(() => OpenSubmitScoreAsync(context))" />
+                            }
+                            @if (context.Status == FixtureStatus.AwaitingVerification && _canEdit)
+                            {
+                                <MudIconButton Icon="@Icons.Material.Filled.AdminPanelSettings" Size="Size.Small"
+                                               Color="Color.Warning" Title="Override / Enter Result"
+                                               OnClick="@(() => OpenOverrideResultAsync(context))" />
                             }
                             <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="Size.Small"
                                            OnClick="@(() => OpenEditFixtureDialog(context))" />
@@ -541,6 +548,7 @@
         public int? HostClubId { get; set; }
         public int? RulesSetId { get; set; }
         public int BestOf { get; set; } = 3;
+        public bool RequireVerification { get; set; } = false;
     }
 
     private sealed class StageForm
@@ -608,7 +616,8 @@
                 EligibleSex = comp.EligibleSex,
                 HostClubId = comp.HostClubId,
                 RulesSetId = comp.RulesSetId,
-                BestOf = comp.BestOf
+                BestOf = comp.BestOf,
+                RequireVerification = comp.RequireVerification
             };
             _stages = comp.Stages.ToList();
             _participants = comp.Participants.ToList();
@@ -683,6 +692,7 @@
         comp.HostClubId = Model.HostClubId;
         comp.RulesSetId = Model.RulesSetId;
         comp.BestOf = Model.BestOf;
+        comp.RequireVerification = Model.RequireVerification;
     }
 
     // ── Stages ──────────────────────────────────────────────────────────────
@@ -904,19 +914,40 @@
         f.Status = _fixtureForm.Status;
     }
 
-    private async Task OpenSubmitScoreAsync(CompetitionFixture fixture)
+    private async Task<CompetitionFixture?> LoadFixtureForDialogAsync(int fixtureId)
     {
         await using var db = DbFactory.CreateDbContext();
-        var loaded = await db.CompetitionFixtures
+        return await db.CompetitionFixtures
             .Include(f => f.Competition)
             .Include(f => f.Stage)
             .Include(f => f.Player1).Include(f => f.Player2)
             .Include(f => f.Player3).Include(f => f.Player4)
-            .FirstOrDefaultAsync(f => f.CompetitionFixtureId == fixture.CompetitionFixtureId);
+            .FirstOrDefaultAsync(f => f.CompetitionFixtureId == fixtureId);
+    }
+
+    private async Task OpenSubmitScoreAsync(CompetitionFixture fixture)
+    {
+        var loaded = await LoadFixtureForDialogAsync(fixture.CompetitionFixtureId);
         if (loaded == null) return;
 
         var parameters = new DialogParameters<SubmitScoreDialog> { { x => x.Fixture, loaded } };
         var dialog = await DialogService.ShowAsync<SubmitScoreDialog>("Submit Score", parameters);
+        var result = await dialog.Result;
+        if (!result.Canceled)
+            await OnParametersSetAsync();
+    }
+
+    private async Task OpenOverrideResultAsync(CompetitionFixture fixture)
+    {
+        var loaded = await LoadFixtureForDialogAsync(fixture.CompetitionFixtureId);
+        if (loaded == null) return;
+
+        var parameters = new DialogParameters<SubmitScoreDialog>
+        {
+            { x => x.Fixture, loaded },
+            { x => x.AdminOverride, true }
+        };
+        var dialog = await DialogService.ShowAsync<SubmitScoreDialog>("Override Result", parameters);
         var result = await dialog.Result;
         if (!result.Canceled)
             await OnParametersSetAsync();
@@ -1292,6 +1323,7 @@
         FixtureStatus.Completed => Color.Success,
         FixtureStatus.Cancelled => Color.Error,
         FixtureStatus.Walkover => Color.Info,
+        FixtureStatus.AwaitingVerification => Color.Secondary,
         _ => Color.Default
     };
 }

--- a/DropShot/Components/Pages/Competitions.razor
+++ b/DropShot/Components/Pages/Competitions.razor
@@ -13,6 +13,21 @@
 @inject ClubAuthorizationService AuthzService
 @inject AuthenticationStateProvider AuthStateProvider
 
+@if (_pendingVerifications.Count > 0)
+{
+    <MudAlert Severity="Severity.Warning" Class="mb-4">
+        <MudText><strong>Results awaiting verification (@_pendingVerifications.Count)</strong></MudText>
+        <MudList T="string" Dense="true">
+            @foreach (var (label, compId) in _pendingVerifications)
+            {
+                <MudListItem T="string">
+                    <MudLink Href="@($"/competition/{compId}")">@label</MudLink>
+                </MudListItem>
+            }
+        </MudList>
+    </MudAlert>
+}
+
 <MudTextField @bind-Value="_searchText" Placeholder="Search competitions..."
               Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search"
               Immediate="true" Class="mb-4" />
@@ -56,6 +71,7 @@
     private List<Competition> _competitions = [];
     private string _searchText = "";
     private bool _isAdmin;
+    private List<(string Label, int CompetitionId)> _pendingVerifications = [];
 
     private bool FilterCompetitions(Competition c) =>
         string.IsNullOrWhiteSpace(_searchText) ||
@@ -79,6 +95,26 @@
                 HostClubId = c.HostClubId
             })
             .ToListAsync();
+
+        // Load pending verifications for admins / club admins
+        if (_isAdmin || _editableClubIds.Count > 0)
+        {
+            _pendingVerifications = (await dbc.CompetitionFixtures
+                .Where(f => f.Status == FixtureStatus.AwaitingVerification
+                    && (f.Competition.HostClubId == null
+                        ? _isAdmin
+                        : (_isAdmin || _editableClubIds.Contains(f.Competition.HostClubId!.Value))))
+                .Select(f => new
+                {
+                    f.CompetitionId,
+                    Label = f.FixtureLabel != null
+                        ? f.Competition.CompetitionName + " — " + f.FixtureLabel
+                        : f.Competition.CompetitionName
+                })
+                .ToListAsync())
+                .Select(f => (f.Label, f.CompetitionId))
+                .ToList();
+        }
     }
 
     private bool CanEdit(Competition c) =>

--- a/DropShot/Components/Pages/VerifyResult.razor
+++ b/DropShot/Components/Pages/VerifyResult.razor
@@ -1,0 +1,81 @@
+@page "/verify-result/{Token}"
+@using DropShot.Data
+@using DropShot.Models
+@using DropShot.Services
+@using Microsoft.EntityFrameworkCore
+
+@inject IDbContextFactory<MyDbContext> DbFactory
+
+<PageTitle>Verify Result</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Small" Class="mt-8">
+    <MudCard>
+        <MudCardContent>
+            @if (_loading)
+            {
+                <MudStack AlignItems="AlignItems.Center" Spacing="3">
+                    <MudProgressCircular Indeterminate="true" />
+                    <MudText>Verifying result…</MudText>
+                </MudStack>
+            }
+            else if (_success)
+            {
+                <MudStack Spacing="3">
+                    <MudAlert Severity="Severity.Success">Result verified — competition updated.</MudAlert>
+                    @if (_competitionId.HasValue)
+                    {
+                        <MudButton Href="@($"/competitions/{_competitionId}")" Variant="Variant.Filled" Color="Color.Primary">
+                            View Competition
+                        </MudButton>
+                    }
+                </MudStack>
+            }
+            else
+            {
+                <MudAlert Severity="Severity.Warning">@_message</MudAlert>
+            }
+        </MudCardContent>
+    </MudCard>
+</MudContainer>
+
+@code {
+    [Parameter] public string Token { get; set; } = "";
+
+    private bool _loading = true;
+    private bool _success;
+    private string _message = "";
+    private int? _competitionId;
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (!Guid.TryParse(Token, out var token))
+        {
+            _message = "Invalid verification link.";
+            _loading = false;
+            return;
+        }
+
+        await using var db = DbFactory.CreateDbContext();
+
+        var fixture = await db.CompetitionFixtures
+            .Include(f => f.Competition)
+            .FirstOrDefaultAsync(f => f.VerificationToken == token && f.Status == FixtureStatus.AwaitingVerification);
+
+        if (fixture == null)
+        {
+            _message = "This link has already been used or could not be found.";
+            _loading = false;
+            return;
+        }
+
+        fixture.Status = FixtureStatus.Completed;
+        fixture.VerificationToken = null;
+        await db.SaveChangesAsync();
+
+        await CompetitionProgressionService.TryAdvanceAsync(db, fixture.CompetitionId, fixture.CompetitionFixtureId);
+
+        _competitionId = fixture.CompetitionId;
+        _success = true;
+        _loading = false;
+    }
+}

--- a/DropShot/Components/SubmitScoreDialog.razor
+++ b/DropShot/Components/SubmitScoreDialog.razor
@@ -4,6 +4,7 @@
 @using Microsoft.EntityFrameworkCore
 
 @inject IDbContextFactory<MyDbContext> DbFactory
+@inject ResultVerificationService ResultVerificationService
 
 <MudDialog>
     <TitleContent>
@@ -88,6 +89,7 @@
     [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = default!;
 
     [Parameter] public CompetitionFixture Fixture { get; set; } = default!;
+    [Parameter] public bool AdminOverride { get; set; }
 
     private int _bestOf = 3;
     private int?[] _score1 = new int?[3];
@@ -175,6 +177,17 @@
             _error = "Please enter at least one set score.";
             return;
         }
+
+        // Validate no tied sets
+        for (int i = 0; i < _bestOf; i++)
+        {
+            if (_score1[i].HasValue && _score2[i].HasValue && _score1[i] == _score2[i])
+            {
+                _error = $"Set {i + 1} is a tie — one player must win each set.";
+                return;
+            }
+        }
+
         if (_winnerPlayerId == null)
         {
             _error = "Please select a winner.";
@@ -188,12 +201,43 @@
         var fx = await db.CompetitionFixtures.FindAsync(Fixture.CompetitionFixtureId);
         if (fx != null)
         {
-            fx.Status        = FixtureStatus.Completed;
-            fx.ResultSummary = resultSummary;
+            fx.ResultSummary  = resultSummary;
             fx.WinnerPlayerId = _winnerPlayerId;
+
+            bool requireVerification = !AdminOverride && (Fixture.Competition?.RequireVerification ?? false);
+            if (requireVerification)
+            {
+                fx.Status            = FixtureStatus.AwaitingVerification;
+                fx.VerificationToken = Guid.NewGuid();
+            }
+            else
+            {
+                fx.Status            = FixtureStatus.Completed;
+                fx.VerificationToken = null;
+            }
+
             await db.SaveChangesAsync();
 
-            await CompetitionProgressionService.TryAdvanceAsync(db, Fixture.CompetitionId, Fixture.CompetitionFixtureId);
+            fx.Competition  = Fixture.Competition;
+            fx.Player1      = Fixture.Player1;
+            fx.Player2      = Fixture.Player2;
+            fx.Player3      = Fixture.Player3;
+            fx.Player4      = Fixture.Player4;
+            fx.FixtureLabel = Fixture.FixtureLabel;
+
+            if (requireVerification)
+            {
+                var adminEmailsTask = ResultVerificationService.GetAdminEmailsForCompetitionAsync(Fixture.CompetitionId, db);
+                await Task.WhenAll(ResultVerificationService.SendResultNotificationAsync(fx), adminEmailsTask);
+                await ResultVerificationService.SendAdminVerificationEmailsAsync(fx, adminEmailsTask.Result);
+                _saving = false;
+                MudDialog.Close(DialogResult.Ok(true));
+                return;
+            }
+
+            await Task.WhenAll(
+                ResultVerificationService.SendResultNotificationAsync(fx),
+                CompetitionProgressionService.TryAdvanceAsync(db, Fixture.CompetitionId, Fixture.CompetitionFixtureId));
         }
 
         _saving = false;

--- a/DropShot/Data/Migrations/20260331212112_AddResultVerification.Designer.cs
+++ b/DropShot/Data/Migrations/20260331212112_AddResultVerification.Designer.cs
@@ -4,6 +4,7 @@ using DropShot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DropShot.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260331212112_AddResultVerification")]
+    partial class AddResultVerification
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DropShot/Data/Migrations/20260331212112_AddResultVerification.cs
+++ b/DropShot/Data/Migrations/20260331212112_AddResultVerification.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropShot.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddResultVerification : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "VerificationToken",
+                table: "CompetitionFixtures",
+                type: "uniqueidentifier",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "RequireVerification",
+                table: "Competition",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "VerificationToken",
+                table: "CompetitionFixtures");
+
+            migrationBuilder.DropColumn(
+                name: "RequireVerification",
+                table: "Competition");
+        }
+    }
+}

--- a/DropShot/Models/Competition.cs
+++ b/DropShot/Models/Competition.cs
@@ -22,6 +22,7 @@
         public int? RulesSetId { get; set; }
         public int? HostClubId { get; set; }
         public int BestOf { get; set; } = 3;
+        public bool RequireVerification { get; set; } = false;
 
         public RulesSet? Rules { get; set; }
         public Club? HostClub { get; set; }

--- a/DropShot/Models/CompetitionFixture.cs
+++ b/DropShot/Models/CompetitionFixture.cs
@@ -6,7 +6,8 @@ public enum FixtureStatus : byte
     InProgress = 2,
     Completed = 3,
     Cancelled = 4,
-    Walkover = 5
+    Walkover = 5,
+    AwaitingVerification = 6
 }
 
 public class CompetitionFixture
@@ -29,6 +30,7 @@ public class CompetitionFixture
     public int? SavedMatchId { get; set; }
     public string? ResultSummary { get; set; }
     public int? WinnerPlayerId { get; set; }
+    public Guid? VerificationToken { get; set; }
 
     public Competition Competition { get; set; } = null!;
     public CompetitionStage? Stage { get; set; }

--- a/DropShot/Program.cs
+++ b/DropShot/Program.cs
@@ -75,6 +75,7 @@ builder.Services.AddScoped<TennisScoreService>();
 builder.Services.AddScoped<ClubAuthorizationService>();
 builder.Services.AddScoped<JwtTokenService>();
 builder.Services.AddSingleton<EmailService>();
+builder.Services.AddScoped<ResultVerificationService>();
 builder.Services.AddMudServices();
 
 var app = builder.Build();

--- a/DropShot/Services/ResultVerificationService.cs
+++ b/DropShot/Services/ResultVerificationService.cs
@@ -1,0 +1,72 @@
+using DropShot.Data;
+using DropShot.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace DropShot.Services;
+
+public class ResultVerificationService(EmailService emailService, IConfiguration config, ILogger<ResultVerificationService> logger)
+{
+    private string BaseUrl => config["App:BaseUrl"]?.TrimEnd('/') ?? "";
+
+    public async Task SendResultNotificationAsync(CompetitionFixture fixture)
+    {
+        var (subject, body) = ResultEmailContent(fixture);
+
+        var emails = new[] { fixture.Player1, fixture.Player2, fixture.Player3, fixture.Player4 }
+            .Where(p => p?.Email != null)
+            .Select(p => p!.Email!)
+            .Distinct()
+            .Select(email => SendSafe(email, subject, body, "result notification"));
+
+        await Task.WhenAll(emails);
+    }
+
+    public async Task SendAdminVerificationEmailsAsync(CompetitionFixture fixture, IEnumerable<string> adminEmails)
+    {
+        if (fixture.VerificationToken == null) return;
+
+        var title = FixtureTitle(fixture);
+        var verifyUrl = $"{BaseUrl}/verify-result/{fixture.VerificationToken}";
+        var subject = $"Result verification required: {title}";
+        var body = $"A result has been submitted for {title}.\n\nResult: {fixture.ResultSummary}\n\nClick the link below to verify this result:\n{verifyUrl}";
+
+        await Task.WhenAll(adminEmails.Select(email => SendSafe(email, subject, body, "admin verification")));
+    }
+
+    public async Task<List<string>> GetAdminEmailsForCompetitionAsync(int competitionId, MyDbContext db)
+    {
+        return await db.ClubAdministrators
+            .Where(ca => db.Competition.Any(c => c.CompetitionID == competitionId && c.HostClubId == ca.ClubId))
+            .Join(db.Users, ca => ca.UserId, u => u.Id, (_, u) => u.Email)
+            .Where(email => email != null)
+            .Select(email => email!)
+            .ToListAsync();
+    }
+
+    private static string FixtureTitle(CompetitionFixture fixture)
+    {
+        var name = fixture.Competition?.CompetitionName ?? "Competition";
+        return fixture.FixtureLabel != null ? $"{name} — {fixture.FixtureLabel}" : name;
+    }
+
+    private static (string subject, string body) ResultEmailContent(CompetitionFixture fixture)
+    {
+        var title = FixtureTitle(fixture);
+        return (
+            $"Match result: {title}",
+            $"The result for your match in {title} has been recorded: {fixture.ResultSummary}."
+        );
+    }
+
+    private async Task SendSafe(string email, string subject, string body, string context)
+    {
+        try
+        {
+            await emailService.SendEmailAsync(email, subject, body);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to send {Context} email to {Email}", context, email);
+        }
+    }
+}

--- a/DropShot/appsettings.json
+++ b/DropShot/appsettings.json
@@ -10,6 +10,9 @@
     }
   },
   "AllowedHosts": "*",
+  "App": {
+    "BaseUrl": "https://localhost:7000"
+  },
   "Jwt": {
     "Key": "CHANGE-THIS-TO-A-LONG-RANDOM-SECRET-KEY-IN-PRODUCTION",
     "Issuer": "DropShot",


### PR DESCRIPTION
## Summary

- **Score validation**: Tied set scores (e.g. 5–5) are now blocked at submission with a per-set error message
- **Verification workflow**: Competitions can require admin verification before a result is official — submitting sets the fixture to `AwaitingVerification`, emails all players the result, and emails club admins a non-expiring verification link (`/verify-result/{token}`)
- **Admin override**: Admins see an override button on any `AwaitingVerification` fixture; uses a new `AdminOverride` parameter on `SubmitScoreDialog` (no mutation hacks) to bypass verification and complete the result immediately
- **Admin banner**: The Competitions list page shows a warning banner of all pending verifications for the logged-in admin's clubs
- **Competition setting**: `Require admin verification of results` checkbox added to the competition editor
- **EF migration**: `AddResultVerification` adds `Competition.RequireVerification` (bit) and `CompetitionFixture.VerificationToken` (uniqueidentifier)

## Test plan

- [ ] Enter equal scores for a set (e.g. 5–5) → error shown, submit blocked
- [ ] Submit a valid result on a competition with `RequireVerification = false` → fixture completes immediately, players receive email
- [ ] Submit a valid result on a competition with `RequireVerification = true` → fixture moves to `AwaitingVerification`, players notified, admins receive email with link
- [ ] Navigate to the verification link → fixture completes, bracket progresses, confirmation shown
- [ ] Navigate to the same link again → "already used" message shown
- [ ] As admin, click Override on an `AwaitingVerification` fixture → result accepted, token cleared, fixture completes
- [ ] Log in as club admin → Competitions page shows banner listing pending verifications

## Notes

- `App:BaseUrl` in `appsettings.json` must be set to the production URL for verification links to work correctly
- The EF migration will apply automatically on app startup if auto-migrate is configured; otherwise run `dotnet ef database update`

🤖 Generated with [Claude Code](https://claude.com/claude-code)