### PR TITLE
Add Friends page with friend requests and management

### DIFF
--- a/DropShot/Components/Layout/NavMenu.razor
+++ b/DropShot/Components/Layout/NavMenu.razor
@@ -74,6 +74,11 @@
         <AuthorizeView>
             <Authorized>
                 <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="friends">
+                        <MudIcon Icon="@Icons.Material.Filled.Group" Class="nav-icon" /> Friends
+                    </NavLink>
+                </div>
+                <div class="nav-item px-3">
                     <NavLink class="nav-link" href="Account/Manage">
                         <MudIcon Icon="@Icons.Material.Filled.Person" Class="nav-icon" /> @context.User.Identity?.Name
                     </NavLink>

--- a/DropShot/Components/Pages/Friends.razor
+++ b/DropShot/Components/Pages/Friends.razor
@@ -1,0 +1,229 @@
+@page "/friends"
+@rendermode InteractiveServer
+@attribute [Authorize]
+@using System.Security.Claims
+@using Microsoft.AspNetCore.Authorization
+@using Microsoft.EntityFrameworkCore
+@using DropShot.Models
+@using DropShot.Data
+
+@inject IDbContextFactory<MyDbContext> DbFactory
+@inject ISnackbar Snackbar
+@inject AuthenticationStateProvider AuthStateProvider
+
+<MudProviders />
+
+<MudText Typo="Typo.h4" Class="mb-4">Friends</MudText>
+
+@if (_myPlayer == null)
+{
+    <MudAlert Severity="Severity.Info">
+        You don't have a player profile linked to your account yet. Ask an administrator to link one.
+    </MudAlert>
+}
+else
+{
+    @* ── Add Friend ──────────────────────────────────────────────── *@
+    <MudPaper Class="pa-4 mb-4">
+        <MudText Typo="Typo.h6" Class="mb-3">Add Friend</MudText>
+        <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+            <MudAutocomplete T="Player" Label="Search players" SearchFunc="SearchPlayers"
+                             ToStringFunc="@(p => p?.DisplayName ?? "")"
+                             @bind-Value="_selectedPlayer"
+                             ResetValueOnEmptyText="true" Variant="Variant.Outlined"
+                             Style="max-width:320px" />
+            <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                       Disabled="@(_selectedPlayer == null)"
+                       OnClick="SendRequest">Send Request</MudButton>
+        </MudStack>
+    </MudPaper>
+
+    @* ── Incoming Requests ───────────────────────────────────────── *@
+    @if (_incoming.Count > 0)
+    {
+        <MudPaper Class="pa-4 mb-4">
+            <MudText Typo="Typo.h6" Class="mb-3">
+                Incoming Requests
+                <MudChip T="string" Size="Size.Small" Color="Color.Warning" Class="ml-2">@_incoming.Count</MudChip>
+            </MudText>
+            <MudTable Items="@_incoming" Dense="true" Hover="true">
+                <HeaderContent>
+                    <MudTh>Player</MudTh>
+                    <MudTh>Requested</MudTh>
+                    <MudTh></MudTh>
+                </HeaderContent>
+                <RowTemplate>
+                    <MudTd>@context.Player.DisplayName</MudTd>
+                    <MudTd>@context.RequestedAt.ToLocalTime().ToString("dd MMM yyyy")</MudTd>
+                    <MudTd>
+                        <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Success"
+                                   OnClick="@(() => AcceptRequest(context))">Accept</MudButton>
+                        <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Error"
+                                   Class="ml-1" OnClick="@(() => DeclineRequest(context))">Decline</MudButton>
+                    </MudTd>
+                </RowTemplate>
+            </MudTable>
+        </MudPaper>
+    }
+
+    @* ── My Friends ──────────────────────────────────────────────── *@
+    <MudPaper Class="pa-4 mb-4">
+        <MudText Typo="Typo.h6" Class="mb-3">My Friends</MudText>
+        @if (_friends.Count == 0)
+        {
+            <MudText Typo="Typo.caption" Color="Color.Secondary">No friends yet. Send a request above!</MudText>
+        }
+        else
+        {
+            <MudTable Items="@_friends" Dense="true" Hover="true">
+                <HeaderContent>
+                    <MudTh>Player</MudTh>
+                    <MudTh>Friends since</MudTh>
+                    <MudTh></MudTh>
+                </HeaderContent>
+                <RowTemplate>
+                    <MudTd>@FriendName(context)</MudTd>
+                    <MudTd>@context.RequestedAt.ToLocalTime().ToString("dd MMM yyyy")</MudTd>
+                    <MudTd>
+                        <MudIconButton Icon="@Icons.Material.Filled.PersonRemove" Size="Size.Small"
+                                       Color="Color.Error" OnClick="@(() => RemoveFriend(context))" />
+                    </MudTd>
+                </RowTemplate>
+            </MudTable>
+        }
+    </MudPaper>
+
+    @* ── Outgoing Requests ───────────────────────────────────────── *@
+    @if (_outgoing.Count > 0)
+    {
+        <MudPaper Class="pa-4 mb-4">
+            <MudText Typo="Typo.h6" Class="mb-3">Pending Requests Sent</MudText>
+            <MudTable Items="@_outgoing" Dense="true" Hover="true">
+                <HeaderContent>
+                    <MudTh>Player</MudTh>
+                    <MudTh>Sent</MudTh>
+                    <MudTh></MudTh>
+                </HeaderContent>
+                <RowTemplate>
+                    <MudTd>@context.Friend.DisplayName</MudTd>
+                    <MudTd>@context.RequestedAt.ToLocalTime().ToString("dd MMM yyyy")</MudTd>
+                    <MudTd>
+                        <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Default"
+                                   OnClick="@(() => CancelRequest(context))">Cancel</MudButton>
+                    </MudTd>
+                </RowTemplate>
+            </MudTable>
+        </MudPaper>
+    }
+}
+
+@code {
+    private Player? _myPlayer;
+    private List<PlayerFriend> _friends = [];
+    private List<PlayerFriend> _incoming = [];
+    private List<PlayerFriend> _outgoing = [];
+    private List<Player> _allPlayers = [];
+    private Player? _selectedPlayer;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var authState = await AuthStateProvider.GetAuthenticationStateAsync();
+        var userId = authState.User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (userId == null) return;
+
+        await using var db = DbFactory.CreateDbContext();
+        _myPlayer = await db.Players.FirstOrDefaultAsync(p => p.UserId == userId);
+        if (_myPlayer == null) return;
+
+        await LoadAll(db);
+    }
+
+    private async Task LoadAll(MyDbContext db)
+    {
+        if (_myPlayer == null) return;
+        var pid = _myPlayer.PlayerId;
+
+        var allRelations = await db.PlayerFriends
+            .Include(pf => pf.Player)
+            .Include(pf => pf.Friend)
+            .Where(pf => pf.PlayerId == pid || pf.FriendPlayerId == pid)
+            .ToListAsync();
+
+        _friends  = allRelations.Where(pf => pf.Status == FriendStatus.Accepted).ToList();
+        _incoming = allRelations.Where(pf => pf.Status == FriendStatus.Pending && pf.FriendPlayerId == pid).ToList();
+        _outgoing = allRelations.Where(pf => pf.Status == FriendStatus.Pending && pf.PlayerId == pid).ToList();
+
+        var relatedIds = allRelations
+            .Select(pf => pf.PlayerId == pid ? pf.FriendPlayerId : pf.PlayerId)
+            .ToHashSet();
+        relatedIds.Add(pid);
+
+        _allPlayers = await db.Players
+            .Where(p => !relatedIds.Contains(p.PlayerId))
+            .OrderBy(p => p.DisplayName)
+            .ToListAsync();
+    }
+
+    private Task<IEnumerable<Player>> SearchPlayers(string text, CancellationToken ct)
+    {
+        var results = string.IsNullOrWhiteSpace(text)
+            ? _allPlayers
+            : _allPlayers.Where(p => p.DisplayName.Contains(text, StringComparison.OrdinalIgnoreCase));
+        return Task.FromResult(results);
+    }
+
+    // Returns the friend's display name relative to the current player.
+    private string FriendName(PlayerFriend pf) =>
+        pf.PlayerId == _myPlayer!.PlayerId ? pf.Friend.DisplayName : pf.Player.DisplayName;
+
+    private async Task SendRequest()
+    {
+        if (_myPlayer == null || _selectedPlayer == null) return;
+        await using var db = DbFactory.CreateDbContext();
+        db.PlayerFriends.Add(new PlayerFriend
+        {
+            PlayerId       = _myPlayer.PlayerId,
+            FriendPlayerId = _selectedPlayer.PlayerId
+        });
+        await db.SaveChangesAsync();
+        Snackbar.Add($"Friend request sent to {_selectedPlayer.DisplayName}.", Severity.Success);
+        _selectedPlayer = null;
+        await LoadAll(db);
+    }
+
+    private async Task AcceptRequest(PlayerFriend req)
+    {
+        await using var db = DbFactory.CreateDbContext();
+        var pf = await db.PlayerFriends.FindAsync(req.PlayerId, req.FriendPlayerId);
+        if (pf != null) { pf.Status = FriendStatus.Accepted; await db.SaveChangesAsync(); }
+        Snackbar.Add("Friend request accepted.", Severity.Success);
+        await LoadAll(db);
+    }
+
+    private async Task DeclineRequest(PlayerFriend req)
+    {
+        await using var db = DbFactory.CreateDbContext();
+        var pf = await db.PlayerFriends.FindAsync(req.PlayerId, req.FriendPlayerId);
+        if (pf != null) { db.PlayerFriends.Remove(pf); await db.SaveChangesAsync(); }
+        Snackbar.Add("Request declined.", Severity.Warning);
+        await LoadAll(db);
+    }
+
+    private async Task CancelRequest(PlayerFriend req)
+    {
+        await using var db = DbFactory.CreateDbContext();
+        var pf = await db.PlayerFriends.FindAsync(req.PlayerId, req.FriendPlayerId);
+        if (pf != null) { db.PlayerFriends.Remove(pf); await db.SaveChangesAsync(); }
+        Snackbar.Add("Request cancelled.", Severity.Warning);
+        await LoadAll(db);
+    }
+
+    private async Task RemoveFriend(PlayerFriend pf)
+    {
+        await using var db = DbFactory.CreateDbContext();
+        var record = await db.PlayerFriends.FindAsync(pf.PlayerId, pf.FriendPlayerId);
+        if (record != null) { db.PlayerFriends.Remove(record); await db.SaveChangesAsync(); }
+        Snackbar.Add("Friend removed.", Severity.Warning);
+        await LoadAll(db);
+    }
+}


### PR DESCRIPTION
## Summary

- New `/friends` page for all authenticated users with a linked Player profile
- Send friend requests via player search autocomplete (excludes existing friends and pending requests)
- Incoming requests section: Accept / Decline buttons
- My Friends section: list of accepted friends with Remove
- Pending Sent section: list of outgoing requests with Cancel
- Friends nav link added (authenticated users only)
- Uses the existing `PlayerFriend` model and `PlayerFriends` DbSet — no migration needed

## Test plan

- [ ] Log in as Player A → search for Player B → send request → appears in "Pending Sent"
- [ ] Log in as Player B → see request in "Incoming Requests" → Accept → both see each other in "My Friends"
- [ ] Decline a request → record removed, player reappears in Add Friend search
- [ ] Cancel an outgoing request → record removed
- [ ] Remove a friend → disappears from both sides' friends lists
- [ ] User with no linked Player sees the "no profile linked" info alert

🤖 Generated with [Claude Code](https://claude.com/claude-code)