### PR TITLE
Add match behaviour, friends-first autocomplete, competition admins, templates, and admin emailing

### DIFF
--- a/DropShot/Components/EditScoreDialog.razor
+++ b/DropShot/Components/EditScoreDialog.razor
@@ -1,0 +1,70 @@
+@using MudBlazor
+
+<MudDialog>
+    <TitleContent>
+        <MudText Typo="Typo.h6">Edit Score</MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudAlert Severity="Severity.Warning" Class="mb-4">
+            Editing the score will clear all point history. This cannot be undone.
+        </MudAlert>
+
+        <MudText Typo="Typo.subtitle2" Class="mb-2">@UserName</MudText>
+        <MudStack Row="true" Spacing="2" Class="mb-3">
+            <MudNumericField @bind-Value="UserSets" Label="Sets" Min="0" Max="9" Variant="Variant.Outlined" Style="max-width:100px;" />
+            <MudNumericField @bind-Value="UserGames" Label="Games" Min="0" Max="13" Variant="Variant.Outlined" Style="max-width:100px;" />
+            <MudNumericField @bind-Value="UserPoints" Label="Points" Min="0" Max="99" Variant="Variant.Outlined" Style="max-width:100px;" />
+        </MudStack>
+
+        <MudText Typo="Typo.subtitle2" Class="mb-2">@OpponentName</MudText>
+        <MudStack Row="true" Spacing="2" Class="mb-3">
+            <MudNumericField @bind-Value="OppSets" Label="Sets" Min="0" Max="9" Variant="Variant.Outlined" Style="max-width:100px;" />
+            <MudNumericField @bind-Value="OppGames" Label="Games" Min="0" Max="13" Variant="Variant.Outlined" Style="max-width:100px;" />
+            <MudNumericField @bind-Value="OppPoints" Label="Points" Min="0" Max="99" Variant="Variant.Outlined" Style="max-width:100px;" />
+        </MudStack>
+
+        <MudSwitch @bind-Value="IsUserServing" Label="@($"{UserName} is serving")" Color="Color.Primary" />
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel">Cancel</MudButton>
+        <MudButton Color="Color.Warning" Variant="Variant.Filled" OnClick="Submit">Apply</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = null!;
+
+    [Parameter] public int UserSets { get; set; }
+    [Parameter] public int OppSets { get; set; }
+    [Parameter] public int UserGames { get; set; }
+    [Parameter] public int OppGames { get; set; }
+    [Parameter] public int UserPoints { get; set; }
+    [Parameter] public int OppPoints { get; set; }
+    [Parameter] public bool IsUserServing { get; set; }
+    [Parameter] public string UserName { get; set; } = "Player 1";
+    [Parameter] public string OpponentName { get; set; } = "Player 2";
+
+    private void Cancel() => MudDialog.Cancel();
+
+    private void Submit() => MudDialog.Close(DialogResult.Ok(new EditScoreResult
+    {
+        UserSets = UserSets,
+        OppSets = OppSets,
+        UserGames = UserGames,
+        OppGames = OppGames,
+        UserPoints = UserPoints,
+        OppPoints = OppPoints,
+        IsUserServing = IsUserServing
+    }));
+
+    public class EditScoreResult
+    {
+        public int UserSets { get; set; }
+        public int OppSets { get; set; }
+        public int UserGames { get; set; }
+        public int OppGames { get; set; }
+        public int UserPoints { get; set; }
+        public int OppPoints { get; set; }
+        public bool IsUserServing { get; set; }
+    }
+}

--- a/DropShot/Components/Pages/Clubs.razor
+++ b/DropShot/Components/Pages/Clubs.razor
@@ -51,6 +51,10 @@
             }
             <MudIconButton Icon="@Icons.Material.Filled.Schedule" Size="Size.Small" Color="Color.Secondary"
                            Title="Scheduling templates" OnClick="@(() => OpenTemplates(context))" />
+            <MudIconButton Icon="@Icons.Material.Filled.EmojiEvents" Size="Size.Small" Color="Color.Warning"
+                           Title="Competition templates" OnClick="@(() => OpenCompetitionTemplates(context))" />
+            <MudIconButton Icon="@Icons.Material.Filled.Email" Size="Size.Small" Color="Color.Default"
+                           Title="Email templates" OnClick="@(() => OpenEmailTemplates(context))" />
             @if (_isAdmin)
             {
                 <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small" Color="Color.Error"
@@ -276,6 +280,156 @@
     </DialogActions>
 </MudDialog>
 
+@* ── Competition Templates Dialog ─────────────────────────────────── *@
+<MudDialog @bind-Visible="_showCompetitionTemplatesDialog" Options="@(new DialogOptions { MaxWidth = MaxWidth.Medium, FullWidth = true })">
+    <TitleContent>Competition Templates – @(_competitionTemplatesClub?.Name)</TitleContent>
+    <DialogContent>
+        <MudGrid Spacing="2" Class="mb-3">
+            <MudItem xs="9">
+                <MudTextField @bind-Value="_newCompTemplateName" Label="Template Name" Variant="Variant.Outlined"
+                              Placeholder="e.g. Standard Singles" />
+            </MudItem>
+            <MudItem xs="3" Class="d-flex align-center">
+                <MudButton Variant="Variant.Filled" Color="Color.Primary" Size="Size.Small"
+                           OnClick="AddCompetitionTemplate" Disabled="string.IsNullOrWhiteSpace(_newCompTemplateName)">Add</MudButton>
+            </MudItem>
+        </MudGrid>
+
+        @foreach (var ct in _competitionTemplatesList)
+        {
+            <MudPaper Class="pa-3 mb-3" Outlined="true">
+                <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Class="mb-2">
+                    <MudText Typo="Typo.subtitle2">@ct.Name</MudText>
+                    <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small" Color="Color.Error"
+                                   OnClick="@(() => DeleteCompetitionTemplate(ct))" />
+                </MudStack>
+                <MudGrid Spacing="1" Class="mb-2">
+                    <MudItem xs="6" sm="3">
+                        <MudSelect @bind-Value="ct.Format" Label="Format" Variant="Variant.Outlined" Margin="Margin.Dense" Clearable="true">
+                            @foreach (CompetitionFormat f in Enum.GetValues<CompetitionFormat>())
+                            {
+                                <MudSelectItem T="CompetitionFormat?" Value="@((CompetitionFormat?)f)">@f</MudSelectItem>
+                            }
+                        </MudSelect>
+                    </MudItem>
+                    <MudItem xs="6" sm="3">
+                        <MudNumericField @bind-Value="ct.BestOf" Label="Best Of" Variant="Variant.Outlined" Margin="Margin.Dense" Min="1" Max="5" />
+                    </MudItem>
+                    <MudItem xs="6" sm="3">
+                        <MudNumericField @bind-Value="ct.MaxAge" Label="Max Age" Variant="Variant.Outlined" Margin="Margin.Dense" Min="0" />
+                    </MudItem>
+                    <MudItem xs="6" sm="3">
+                        <MudButton Variant="Variant.Outlined" Size="Size.Small" OnClick="@(() => SaveCompetitionTemplate(ct))">Save</MudButton>
+                    </MudItem>
+                </MudGrid>
+                @* Match windows *@
+                <MudGrid Spacing="1" Class="mb-2">
+                    <MudItem xs="4">
+                        <MudSelect @bind-Value="_newCTWindowDay[ct.CompetitionTemplateId]" Label="Day"
+                                   Variant="Variant.Outlined" Margin="Margin.Dense">
+                            @foreach (DayOfWeek d in Enum.GetValues<DayOfWeek>())
+                            {
+                                <MudSelectItem Value="@d">@d</MudSelectItem>
+                            }
+                        </MudSelect>
+                    </MudItem>
+                    <MudItem xs="3">
+                        <MudTimePicker @bind-Time="_newCTWindowStart[ct.CompetitionTemplateId]"
+                                       Label="From" Variant="Variant.Outlined" Margin="Margin.Dense" AmPm="false" />
+                    </MudItem>
+                    <MudItem xs="3">
+                        <MudTimePicker @bind-Time="_newCTWindowEnd[ct.CompetitionTemplateId]"
+                                       Label="To" Variant="Variant.Outlined" Margin="Margin.Dense" AmPm="false" />
+                    </MudItem>
+                    <MudItem xs="2" Class="d-flex align-center">
+                        <MudButton Variant="Variant.Outlined" Size="Size.Small"
+                                   OnClick="@(() => AddCTWindow(ct))">Add</MudButton>
+                    </MudItem>
+                </MudGrid>
+                @if (ct.Windows.Count > 0)
+                {
+                    <MudSimpleTable Dense="true">
+                        <thead><tr><th>Day</th><th>From</th><th>To</th><th></th></tr></thead>
+                        <tbody>
+                            @foreach (var w in ct.Windows)
+                            {
+                                <tr>
+                                    <td>@w.DayOfWeek</td>
+                                    <td>@w.StartTime.ToString(@"hh\:mm")</td>
+                                    <td>@w.EndTime.ToString(@"hh\:mm")</td>
+                                    <td>
+                                        <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small"
+                                                       Color="Color.Error" OnClick="@(() => DeleteCTWindow(ct, w))" />
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </MudSimpleTable>
+                }
+                else
+                {
+                    <MudText Typo="Typo.caption" Color="Color.Secondary">No windows defined.</MudText>
+                }
+            </MudPaper>
+        }
+        @if (_competitionTemplatesList.Count == 0)
+        {
+            <MudText Typo="Typo.caption">No competition templates yet. Add one above.</MudText>
+        }
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@(() => _showCompetitionTemplatesDialog = false)">Close</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@* ── Email Templates Dialog ───────────────────────────────────────── *@
+<MudDialog @bind-Visible="_showEmailTemplatesDialog" Options="@(new DialogOptions { MaxWidth = MaxWidth.Medium, FullWidth = true })">
+    <TitleContent>Email Templates – @(_emailTemplatesClub?.Name)</TitleContent>
+    <DialogContent>
+        <MudGrid Spacing="2" Class="mb-3">
+            <MudItem xs="12" sm="5">
+                <MudTextField @bind-Value="_newEmailTemplateName" Label="Template Name" Variant="Variant.Outlined" />
+            </MudItem>
+            <MudItem xs="12" sm="5">
+                <MudTextField @bind-Value="_newEmailTemplateSubject" Label="Subject" Variant="Variant.Outlined" />
+            </MudItem>
+            <MudItem xs="12">
+                <MudTextField @bind-Value="_newEmailTemplateBody" Label="Body" Variant="Variant.Outlined"
+                              Lines="3" HelperText="Variables: {PlayerName}, {CompetitionName}, {MatchLink}" />
+            </MudItem>
+            <MudItem xs="12">
+                <MudButton Variant="Variant.Filled" Color="Color.Primary" Size="Size.Small"
+                           OnClick="AddEmailTemplate"
+                           Disabled="@(string.IsNullOrWhiteSpace(_newEmailTemplateName) || string.IsNullOrWhiteSpace(_newEmailTemplateSubject))">
+                    Add Template
+                </MudButton>
+            </MudItem>
+        </MudGrid>
+
+        @foreach (var et in _emailTemplatesList)
+        {
+            <MudPaper Class="pa-3 mb-3" Outlined="true">
+                <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
+                    <div>
+                        <MudText Typo="Typo.subtitle2">@et.Name</MudText>
+                        <MudText Typo="Typo.caption"><strong>Subject:</strong> @et.Subject</MudText>
+                        <MudText Typo="Typo.caption" Style="white-space:pre-wrap">@(et.Body.Length > 100 ? et.Body[..100] + "…" : et.Body)</MudText>
+                    </div>
+                    <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small" Color="Color.Error"
+                                   OnClick="@(() => DeleteEmailTemplate(et))" />
+                </MudStack>
+            </MudPaper>
+        }
+        @if (_emailTemplatesList.Count == 0)
+        {
+            <MudText Typo="Typo.caption">No email templates yet. Add one above.</MudText>
+        }
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@(() => _showEmailTemplatesDialog = false)">Close</MudButton>
+    </DialogActions>
+</MudDialog>
+
 @code {
     private bool _loading = true;
     private List<Club> _clubs = [];
@@ -307,6 +461,23 @@
     private Dictionary<int, DayOfWeek> _newWindowDay = [];
     private Dictionary<int, TimeSpan?> _newWindowStart = [];
     private Dictionary<int, TimeSpan?> _newWindowEnd = [];
+
+    // Competition Templates
+    private bool _showCompetitionTemplatesDialog;
+    private Club? _competitionTemplatesClub;
+    private List<CompetitionTemplate> _competitionTemplatesList = [];
+    private string _newCompTemplateName = "";
+    private Dictionary<int, DayOfWeek> _newCTWindowDay = [];
+    private Dictionary<int, TimeSpan?> _newCTWindowStart = [];
+    private Dictionary<int, TimeSpan?> _newCTWindowEnd = [];
+
+    // Email Templates
+    private bool _showEmailTemplatesDialog;
+    private Club? _emailTemplatesClub;
+    private List<ClubEmailTemplate> _emailTemplatesList = [];
+    private string _newEmailTemplateName = "";
+    private string _newEmailTemplateSubject = "";
+    private string _newEmailTemplateBody = "";
 
     private sealed class ClubForm
     {
@@ -559,4 +730,144 @@
     }
 
     private static string? NullIfEmpty(string? s) => string.IsNullOrWhiteSpace(s) ? null : s.Trim();
+
+    // ── Competition Templates ─────────────────────────────────────────────────
+
+    private async Task OpenCompetitionTemplates(Club club)
+    {
+        _competitionTemplatesClub = club;
+        await using var dbc = DbFactory.CreateDbContext();
+        _competitionTemplatesList = await dbc.CompetitionTemplates
+            .Include(t => t.Windows)
+            .Where(t => t.ClubId == club.ClubId)
+            .OrderBy(t => t.Name)
+            .ToListAsync();
+        _newCTWindowDay = _competitionTemplatesList.ToDictionary(t => t.CompetitionTemplateId, _ => DayOfWeek.Monday);
+        _newCTWindowStart = _competitionTemplatesList.ToDictionary(t => t.CompetitionTemplateId, _ => (TimeSpan?)null);
+        _newCTWindowEnd = _competitionTemplatesList.ToDictionary(t => t.CompetitionTemplateId, _ => (TimeSpan?)null);
+        _newCompTemplateName = "";
+        _showCompetitionTemplatesDialog = true;
+    }
+
+    private async Task AddCompetitionTemplate()
+    {
+        if (_competitionTemplatesClub == null || string.IsNullOrWhiteSpace(_newCompTemplateName)) return;
+        await using var dbc = DbFactory.CreateDbContext();
+        var t = new CompetitionTemplate
+        {
+            ClubId = _competitionTemplatesClub.ClubId,
+            Name = _newCompTemplateName.Trim()
+        };
+        dbc.CompetitionTemplates.Add(t);
+        await dbc.SaveChangesAsync();
+        t.Windows = [];
+        _competitionTemplatesList.Add(t);
+        _newCTWindowDay[t.CompetitionTemplateId] = DayOfWeek.Monday;
+        _newCTWindowStart[t.CompetitionTemplateId] = null;
+        _newCTWindowEnd[t.CompetitionTemplateId] = null;
+        _newCompTemplateName = "";
+        Snackbar.Add("Template added.", Severity.Success);
+    }
+
+    private async Task SaveCompetitionTemplate(CompetitionTemplate t)
+    {
+        await using var dbc = DbFactory.CreateDbContext();
+        var dbT = await dbc.CompetitionTemplates.FindAsync(t.CompetitionTemplateId);
+        if (dbT == null) return;
+        dbT.Format = t.Format;
+        dbT.BestOf = t.BestOf;
+        dbT.MaxAge = t.MaxAge;
+        dbT.EligibleSex = t.EligibleSex;
+        dbT.RulesSetId = t.RulesSetId;
+        await dbc.SaveChangesAsync();
+        Snackbar.Add("Template saved.", Severity.Success);
+    }
+
+    private async Task DeleteCompetitionTemplate(CompetitionTemplate t)
+    {
+        await using var dbc = DbFactory.CreateDbContext();
+        var dbT = await dbc.CompetitionTemplates.FindAsync(t.CompetitionTemplateId);
+        if (dbT != null) { dbc.CompetitionTemplates.Remove(dbT); await dbc.SaveChangesAsync(); }
+        _competitionTemplatesList.Remove(t);
+        _newCTWindowDay.Remove(t.CompetitionTemplateId);
+        _newCTWindowStart.Remove(t.CompetitionTemplateId);
+        _newCTWindowEnd.Remove(t.CompetitionTemplateId);
+        Snackbar.Add("Template deleted.", Severity.Warning);
+    }
+
+    private async Task AddCTWindow(CompetitionTemplate t)
+    {
+        var start = _newCTWindowStart.GetValueOrDefault(t.CompetitionTemplateId);
+        var end = _newCTWindowEnd.GetValueOrDefault(t.CompetitionTemplateId);
+        if (start == null || end == null) { Snackbar.Add("Please set both start and end times.", Severity.Warning); return; }
+        if (end <= start) { Snackbar.Add("End time must be after start time.", Severity.Warning); return; }
+        await using var dbc = DbFactory.CreateDbContext();
+        var w = new CompetitionTemplateWindow
+        {
+            CompetitionTemplateId = t.CompetitionTemplateId,
+            DayOfWeek = _newCTWindowDay[t.CompetitionTemplateId],
+            StartTime = start.Value,
+            EndTime = end.Value
+        };
+        dbc.CompetitionTemplateWindows.Add(w);
+        await dbc.SaveChangesAsync();
+        ((ICollection<CompetitionTemplateWindow>)t.Windows).Add(w);
+        _newCTWindowStart[t.CompetitionTemplateId] = null;
+        _newCTWindowEnd[t.CompetitionTemplateId] = null;
+        Snackbar.Add("Window added.", Severity.Success);
+    }
+
+    private async Task DeleteCTWindow(CompetitionTemplate t, CompetitionTemplateWindow w)
+    {
+        await using var dbc = DbFactory.CreateDbContext();
+        var dbW = await dbc.CompetitionTemplateWindows.FindAsync(w.CompetitionTemplateWindowId);
+        if (dbW != null) { dbc.CompetitionTemplateWindows.Remove(dbW); await dbc.SaveChangesAsync(); }
+        ((ICollection<CompetitionTemplateWindow>)t.Windows).Remove(w);
+        Snackbar.Add("Window removed.", Severity.Warning);
+    }
+
+    // ── Email Templates ───────────────────────────────────────────────────────
+
+    private async Task OpenEmailTemplates(Club club)
+    {
+        _emailTemplatesClub = club;
+        await using var dbc = DbFactory.CreateDbContext();
+        _emailTemplatesList = await dbc.ClubEmailTemplates
+            .Where(t => t.ClubId == club.ClubId)
+            .OrderBy(t => t.Name)
+            .ToListAsync();
+        _newEmailTemplateName = "";
+        _newEmailTemplateSubject = "";
+        _newEmailTemplateBody = "";
+        _showEmailTemplatesDialog = true;
+    }
+
+    private async Task AddEmailTemplate()
+    {
+        if (_emailTemplatesClub == null || string.IsNullOrWhiteSpace(_newEmailTemplateName) || string.IsNullOrWhiteSpace(_newEmailTemplateSubject)) return;
+        await using var dbc = DbFactory.CreateDbContext();
+        var t = new ClubEmailTemplate
+        {
+            ClubId = _emailTemplatesClub.ClubId,
+            Name = _newEmailTemplateName.Trim(),
+            Subject = _newEmailTemplateSubject.Trim(),
+            Body = _newEmailTemplateBody.Trim()
+        };
+        dbc.ClubEmailTemplates.Add(t);
+        await dbc.SaveChangesAsync();
+        _emailTemplatesList.Add(t);
+        _newEmailTemplateName = "";
+        _newEmailTemplateSubject = "";
+        _newEmailTemplateBody = "";
+        Snackbar.Add("Email template added.", Severity.Success);
+    }
+
+    private async Task DeleteEmailTemplate(ClubEmailTemplate t)
+    {
+        await using var dbc = DbFactory.CreateDbContext();
+        var dbT = await dbc.ClubEmailTemplates.FindAsync(t.ClubEmailTemplateId);
+        if (dbT != null) { dbc.ClubEmailTemplates.Remove(dbT); await dbc.SaveChangesAsync(); }
+        _emailTemplatesList.Remove(t);
+        Snackbar.Add("Email template deleted.", Severity.Warning);
+    }
 }

--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -15,6 +15,8 @@
 @inject ClubAuthorizationService AuthzService
 @inject AuthenticationStateProvider AuthStateProvider
 @inject IDialogService DialogService
+@inject AdminEmailService AdminEmailSvc
+@using DropShot.Services
 
 <MudProviders />
 
@@ -288,6 +290,141 @@
                     <NoRecordsContent><MudText Typo="Typo.caption">No participants yet.</MudText></NoRecordsContent>
                 </MudTable>
             </MudPaper>
+
+            @* ── Apply Competition Template ───────────────────── *@
+            @if (_competitionTemplates.Count > 0)
+            {
+                <MudPaper Class="pa-4 mb-4">
+                    <MudText Typo="Typo.h6" Class="mb-3">Apply Competition Template</MudText>
+                    <MudSelect T="int?" Label="Choose a template to apply" Variant="Variant.Outlined"
+                               Value="_selectedCompetitionTemplateId" Clearable="true"
+                               ValueChanged="ApplyCompetitionTemplate">
+                        @foreach (var t in _competitionTemplates)
+                        {
+                            <MudSelectItem T="int?" Value="@((int?)t.CompetitionTemplateId)">@t.Name</MudSelectItem>
+                        }
+                    </MudSelect>
+                    <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mt-1">
+                        Applying a template updates format, scoring, age, and match windows in-memory. Save the competition to persist.
+                    </MudText>
+                </MudPaper>
+            }
+
+            @* ── Competition Admins ───────────────────────────── *@
+            @if (IsEdit && _canEdit)
+            {
+                <MudPaper Class="pa-4 mb-4">
+                    <MudText Typo="Typo.h6" Class="mb-3">Competition Admins</MudText>
+                    <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Class="mb-3">
+                        <MudTextField @bind-Value="_newAdminEmail" Label="User email"
+                                      Variant="Variant.Outlined" Style="max-width:300px" Margin="Margin.Dense" />
+                        <MudButton Variant="Variant.Outlined" Size="Size.Small"
+                                   Disabled="@string.IsNullOrWhiteSpace(_newAdminEmail)"
+                                   OnClick="AddCompetitionAdmin">Add Admin</MudButton>
+                    </MudStack>
+                    @if (_competitionAdmins.Count > 0)
+                    {
+                        <MudSimpleTable Dense="true">
+                            <thead><tr><th>User</th><th>Assigned</th><th></th></tr></thead>
+                            <tbody>
+                                @foreach (var a in _competitionAdmins)
+                                {
+                                    <tr>
+                                        <td>@a.UserEmail</td>
+                                        <td>@a.AssignedAt.ToLocalTime().ToString("dd MMM yyyy")</td>
+                                        <td>
+                                            <MudIconButton Icon="@Icons.Material.Filled.Delete"
+                                                           Size="Size.Small" Color="Color.Error"
+                                                           OnClick="@(() => RemoveCompetitionAdmin(a))" />
+                                        </td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </MudSimpleTable>
+                    }
+                    else
+                    {
+                        <MudText Typo="Typo.caption" Color="Color.Secondary">No competition-specific admins assigned.</MudText>
+                    }
+                </MudPaper>
+            }
+
+            @* ── Send Email ───────────────────────────────────── *@
+            @if (IsEdit && _canEdit)
+            {
+                <MudPaper Class="pa-4 mb-4">
+                    <MudText Typo="Typo.h6" Class="mb-3">Send Email</MudText>
+
+                    <MudText Typo="Typo.subtitle2" Class="mb-2">Match-Specific</MudText>
+                    <MudGrid Spacing="2">
+                        <MudItem xs="12" sm="6">
+                            <MudSelect @bind-Value="_emailFixtureId" Label="Fixture" Variant="Variant.Outlined"
+                                       Clearable="true">
+                                @foreach (var f in _fixtures.Where(f => f.Player1Id.HasValue))
+                                {
+                                    <MudSelectItem T="int?" Value="@((int?)f.CompetitionFixtureId)">
+                                        @(string.IsNullOrEmpty(f.FixtureLabel) ? $"Fixture {f.CompetitionFixtureId}" : f.FixtureLabel)
+                                    </MudSelectItem>
+                                }
+                            </MudSelect>
+                        </MudItem>
+                        @if (_emailTemplates.Count > 0)
+                        {
+                            <MudItem xs="12" sm="6">
+                                <MudSelect T="int?" Label="Load from template (optional)" Variant="Variant.Outlined"
+                                           Clearable="true" ValueChanged="LoadEmailTemplate">
+                                    @foreach (var t in _emailTemplates)
+                                    {
+                                        <MudSelectItem T="int?" Value="@((int?)t.ClubEmailTemplateId)">@t.Name</MudSelectItem>
+                                    }
+                                </MudSelect>
+                            </MudItem>
+                        }
+                        <MudItem xs="12">
+                            <MudTextField @bind-Value="_emailSubject" Label="Subject" Variant="Variant.Outlined" />
+                        </MudItem>
+                        <MudItem xs="12">
+                            <MudTextField @bind-Value="_emailBody" Label="Body" Variant="Variant.Outlined"
+                                          Lines="4" HelperText="Variables: {PlayerName}, {CompetitionName}, {MatchLink}" />
+                        </MudItem>
+                        <MudItem xs="12">
+                            <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                                       Disabled="@(_emailFixtureId == null || string.IsNullOrWhiteSpace(_emailSubject))"
+                                       OnClick="SendMatchEmail">Send to Fixture Players</MudButton>
+                        </MudItem>
+                    </MudGrid>
+
+                    <MudDivider Class="my-4" />
+
+                    <MudText Typo="Typo.subtitle2" Class="mb-2">Competition-Wide</MudText>
+                    <MudGrid Spacing="2">
+                        @if (_emailTemplates.Count > 0)
+                        {
+                            <MudItem xs="12">
+                                <MudSelect T="int?" Label="Load from template (optional)" Variant="Variant.Outlined"
+                                           Clearable="true" ValueChanged="LoadCompEmailTemplate">
+                                    @foreach (var t in _emailTemplates)
+                                    {
+                                        <MudSelectItem T="int?" Value="@((int?)t.ClubEmailTemplateId)">@t.Name</MudSelectItem>
+                                    }
+                                </MudSelect>
+                            </MudItem>
+                        }
+                        <MudItem xs="12">
+                            <MudTextField @bind-Value="_compEmailSubject" Label="Subject" Variant="Variant.Outlined" />
+                        </MudItem>
+                        <MudItem xs="12">
+                            <MudTextField @bind-Value="_compEmailBody" Label="Body" Variant="Variant.Outlined"
+                                          Lines="4" HelperText="Variables: {PlayerName}, {CompetitionName}, {MatchLink}" />
+                        </MudItem>
+                        <MudItem xs="12">
+                            <MudButton Variant="Variant.Outlined" Color="Color.Primary"
+                                       Disabled="@string.IsNullOrWhiteSpace(_compEmailSubject)"
+                                       OnClick="SendCompetitionEmail">Send to All Participants</MudButton>
+                        </MudItem>
+                    </MudGrid>
+                </MudPaper>
+            }
 
             @* ── Teams (only for Team competitions) ──────────── *@
             @if (Model.CompetitionFormat == CompetitionFormat.Team)
@@ -623,6 +760,24 @@
     private List<ClubSchedulingTemplate> _clubTemplates = [];
     private int? _selectedTemplateId;
 
+    // Competition templates
+    private List<CompetitionTemplate> _competitionTemplates = [];
+    private int? _selectedCompetitionTemplateId;
+    private bool _templateWindowsApplied;
+
+    // Competition admins
+    private record CompetitionAdminRow(string UserId, string UserEmail, DateTime AssignedAt);
+    private List<CompetitionAdminRow> _competitionAdmins = [];
+    private string _newAdminEmail = "";
+
+    // Send Email
+    private List<ClubEmailTemplate> _emailTemplates = [];
+    private int? _emailFixtureId;
+    private string _emailSubject = "";
+    private string _emailBody = "";
+    private string _compEmailSubject = "";
+    private string _compEmailBody = "";
+
     // Schedule options
     private bool _scheduleDeleteExisting;
 
@@ -696,7 +851,7 @@
 
             if (comp is null) { _serverError = $"Competition {Id} not found."; return; }
 
-            _canEdit = await AuthzService.CanEditCompetitionAsync(authState.User, comp.HostClubId);
+            _canEdit = await AuthzService.CanEditCompetitionAsync(authState.User, comp.HostClubId, Id);
 
             Model = new CompetitionFormModel
             {
@@ -731,7 +886,18 @@
                     .Where(t => t.ClubId == comp.HostClubId.Value)
                     .OrderBy(t => t.Name)
                     .ToListAsync();
+                _competitionTemplates = await db.CompetitionTemplates
+                    .Include(t => t.Windows)
+                    .Where(t => t.ClubId == comp.HostClubId.Value)
+                    .OrderBy(t => t.Name)
+                    .ToListAsync();
+                _emailTemplates = await db.ClubEmailTemplates
+                    .Where(t => t.ClubId == comp.HostClubId.Value)
+                    .OrderBy(t => t.Name)
+                    .ToListAsync();
             }
+
+            await LoadCompetitionAdmins(db);
         }
         else
         {
@@ -767,6 +933,21 @@
                 if (comp is null) { _serverError = "Competition no longer exists."; return; }
                 ApplyModel(comp, name);
                 await db.SaveChangesAsync();
+
+                if (_templateWindowsApplied)
+                {
+                    var old = await db.CompetitionMatchWindows.Where(w => w.CompetitionId == Id).ToListAsync();
+                    db.CompetitionMatchWindows.RemoveRange(old);
+                    db.CompetitionMatchWindows.AddRange(_matchWindows.Select(w => new CompetitionMatchWindow
+                    {
+                        CompetitionId = Id,
+                        DayOfWeek = w.DayOfWeek,
+                        StartTime = w.StartTime,
+                        EndTime = w.EndTime
+                    }));
+                    await db.SaveChangesAsync();
+                    _templateWindowsApplied = false;
+                }
             }
             else
             {
@@ -1134,6 +1315,124 @@
         _matchWindows.AddRange(toAdd);
         _matchWindows = [.. _matchWindows.OrderBy(x => x.DayOfWeek).ThenBy(x => x.StartTime)];
         Snackbar.Add($"Imported {toAdd.Count} window(s) from '{template.Name}'.", Severity.Success);
+    }
+
+    // ── Competition Templates ────────────────────────────────────────────────
+
+    private void ApplyCompetitionTemplate(int? templateId)
+    {
+        _selectedCompetitionTemplateId = templateId;
+        if (templateId == null) return;
+        var t = _competitionTemplates.FirstOrDefault(x => x.CompetitionTemplateId == templateId);
+        if (t == null) return;
+
+        if (t.Format.HasValue) Model.CompetitionFormat = t.Format.Value;
+        if (t.RulesSetId.HasValue) Model.RulesSetId = t.RulesSetId;
+        if (t.BestOf.HasValue) Model.BestOf = t.BestOf.Value;
+        if (t.MaxAge.HasValue) Model.MaxAge = t.MaxAge;
+        if (t.EligibleSex.HasValue) Model.EligibleSex = t.EligibleSex;
+
+        if (t.Windows.Count > 0)
+        {
+            _matchWindows = t.Windows.Select(w => new CompetitionMatchWindow
+            {
+                CompetitionId = Id,
+                DayOfWeek = w.DayOfWeek,
+                StartTime = w.StartTime,
+                EndTime = w.EndTime
+            }).ToList();
+            _templateWindowsApplied = true;
+            Snackbar.Add($"Template '{t.Name}' applied. Save to persist.", Severity.Info);
+        }
+        else
+        {
+            Snackbar.Add($"Template '{t.Name}' applied.", Severity.Success);
+        }
+    }
+
+    // ── Competition Admins ───────────────────────────────────────────────────
+
+    private async Task LoadCompetitionAdmins(MyDbContext db)
+    {
+        _competitionAdmins = await db.CompetitionAdmins
+            .Where(ca => ca.CompetitionId == Id)
+            .Join(db.Users, ca => ca.UserId, u => u.Id,
+                  (ca, u) => new CompetitionAdminRow(ca.UserId, u.Email ?? "", ca.AssignedAt))
+            .ToListAsync();
+    }
+
+    private async Task AddCompetitionAdmin()
+    {
+        if (string.IsNullOrWhiteSpace(_newAdminEmail)) return;
+        await using var db = DbFactory.CreateDbContext();
+        var user = await db.Users.FirstOrDefaultAsync(u => u.Email == _newAdminEmail.Trim());
+        if (user == null) { Snackbar.Add("No user found with that email.", Severity.Warning); return; }
+        if (_competitionAdmins.Any(a => a.UserId == user.Id)) { Snackbar.Add("Already an admin.", Severity.Info); return; }
+        db.CompetitionAdmins.Add(new CompetitionAdmin { CompetitionId = Id, UserId = user.Id });
+        await db.SaveChangesAsync();
+        _newAdminEmail = "";
+        await LoadCompetitionAdmins(db);
+        Snackbar.Add("Admin added.", Severity.Success);
+    }
+
+    private async Task RemoveCompetitionAdmin(CompetitionAdminRow row)
+    {
+        await using var db = DbFactory.CreateDbContext();
+        var ca = await db.CompetitionAdmins.FindAsync(Id, row.UserId);
+        if (ca != null) { db.CompetitionAdmins.Remove(ca); await db.SaveChangesAsync(); }
+        _competitionAdmins.RemoveAll(a => a.UserId == row.UserId);
+        Snackbar.Add("Admin removed.", Severity.Warning);
+    }
+
+    // ── Send Email ───────────────────────────────────────────────────────────
+
+    private void LoadEmailTemplate(int? templateId)
+    {
+        if (templateId == null) return;
+        var t = _emailTemplates.FirstOrDefault(x => x.ClubEmailTemplateId == templateId);
+        if (t == null) return;
+        _emailSubject = t.Subject;
+        _emailBody = t.Body;
+    }
+
+    private void LoadCompEmailTemplate(int? templateId)
+    {
+        if (templateId == null) return;
+        var t = _emailTemplates.FirstOrDefault(x => x.ClubEmailTemplateId == templateId);
+        if (t == null) return;
+        _compEmailSubject = t.Subject;
+        _compEmailBody = t.Body;
+    }
+
+    private async Task SendMatchEmail()
+    {
+        if (_emailFixtureId == null) return;
+        await using var db = DbFactory.CreateDbContext();
+        var fullFixture = await db.CompetitionFixtures
+            .Include(f => f.Competition)
+            .Include(f => f.Player1).Include(f => f.Player2)
+            .Include(f => f.Player3).Include(f => f.Player4)
+            .FirstOrDefaultAsync(f => f.CompetitionFixtureId == _emailFixtureId);
+        if (fullFixture == null) return;
+
+        await AdminEmailSvc.SendMatchEmailAsync(fullFixture, _emailSubject, _emailBody);
+        Snackbar.Add("Emails sent to fixture players.", Severity.Success);
+    }
+
+    private async Task SendCompetitionEmail()
+    {
+        if (string.IsNullOrWhiteSpace(_compEmailSubject)) return;
+        await using var db = DbFactory.CreateDbContext();
+        var participants = await db.CompetitionParticipants
+            .Where(cp => cp.CompetitionId == Id)
+            .Include(cp => cp.Player)
+            .Select(cp => cp.Player!)
+            .Where(p => p != null && p.Email != null)
+            .ToListAsync();
+
+        await AdminEmailSvc.SendCompetitionEmailAsync(
+            participants, Model.CompetitionName, _compEmailSubject, _compEmailBody, Id);
+        Snackbar.Add($"Emails sent to {participants.Count} participant(s).", Severity.Success);
     }
 
     private async Task ScheduleFixtures()

--- a/DropShot/Components/Pages/Competitions.razor
+++ b/DropShot/Components/Pages/Competitions.razor
@@ -72,18 +72,20 @@
     private string _searchText = "";
     private bool _isAdmin;
     private List<(string Label, int CompetitionId)> _pendingVerifications = [];
+    private HashSet<int> _editableClubIds = [];
+    private HashSet<int> _competitionAdminIds = [];
 
     private bool FilterCompetitions(Competition c) =>
         string.IsNullOrWhiteSpace(_searchText) ||
         (c.CompetitionName ?? "").Contains(_searchText, StringComparison.OrdinalIgnoreCase) ||
         c.CompetitionFormat.ToString().Contains(_searchText, StringComparison.OrdinalIgnoreCase);
-    private HashSet<int> _editableClubIds = [];
 
     protected override async Task OnInitializedAsync()
     {
         var authState = await AuthStateProvider.GetAuthenticationStateAsync();
         _isAdmin = await AuthzService.IsAdminAsync(authState.User);
         _editableClubIds = [.. await AuthzService.GetAdminClubIdsAsync(authState.User)];
+        _competitionAdminIds = await AuthzService.GetEditableCompetitionIdsAsync(authState.User);
 
         await using var dbc = DbFactory.CreateDbContext();
         _competitions = await dbc.Competition
@@ -96,14 +98,14 @@
             })
             .ToListAsync();
 
-        // Load pending verifications for admins / club admins
-        if (_isAdmin || _editableClubIds.Count > 0)
+        // Load pending verifications for admins / club admins / competition admins
+        if (_isAdmin || _editableClubIds.Count > 0 || _competitionAdminIds.Count > 0)
         {
             _pendingVerifications = (await dbc.CompetitionFixtures
                 .Where(f => f.Status == FixtureStatus.AwaitingVerification
-                    && (f.Competition.HostClubId == null
-                        ? _isAdmin
-                        : (_isAdmin || _editableClubIds.Contains(f.Competition.HostClubId!.Value))))
+                    && (_isAdmin
+                        || (f.Competition.HostClubId.HasValue && _editableClubIds.Contains(f.Competition.HostClubId.Value))
+                        || _competitionAdminIds.Contains(f.CompetitionId)))
                 .Select(f => new
                 {
                     f.CompetitionId,
@@ -118,5 +120,7 @@
     }
 
     private bool CanEdit(Competition c) =>
-        _isAdmin || (c.HostClubId.HasValue && _editableClubIds.Contains(c.HostClubId.Value));
+        _isAdmin ||
+        (c.HostClubId.HasValue && _editableClubIds.Contains(c.HostClubId.Value)) ||
+        _competitionAdminIds.Contains(c.CompetitionID);
 }

--- a/DropShot/Components/Pages/Match.razor
+++ b/DropShot/Components/Pages/Match.razor
@@ -3,19 +3,23 @@
 @using DropShot.Data
 @using DropShot.Models
 @using Microsoft.EntityFrameworkCore
+@using Microsoft.AspNetCore.Components.Authorization
+@using System.Security.Claims
 @using MudBlazor
 @inject NavigationManager Navigation
-@inject MyDbContext DbContext
+@inject IDbContextFactory<MyDbContext> DbFactory
+@inject AuthenticationStateProvider AuthStateProvider
+@inject IJSRuntime JS
 
 <MudProviders />
 
 <MudText Typo="Typo.h5" Class="pa-4">Active Matches</MudText>
 
-@if (_matches.Count == 0)
+@if (_loaded && _matches.Count == 0)
 {
     <MudText Class="px-4 pb-2" Color="Color.Secondary">No active matches.</MudText>
 }
-else
+else if (_loaded)
 {
     <MudList T="SavedMatch" Class="px-2">
         @foreach (var m in _matches)
@@ -44,21 +48,53 @@ else
 @code {
     private List<SavedMatch> _matches = [];
     private Dictionary<int, string> _courtNames = [];
+    private bool _loaded;
+    private string? _userId;
 
     protected override async Task OnInitializedAsync()
     {
-        _matches = await DbContext.SavedMatch
-            .Where(m => !m.Complete)
-            .OrderByDescending(m => m.CreatedAt)
-            .ToListAsync();
+        var authState = await AuthStateProvider.GetAuthenticationStateAsync();
+        _userId = authState.User.FindFirstValue(ClaimTypes.NameIdentifier);
+    }
 
-        var courtIds = _matches.Where(m => m.CourtId.HasValue).Select(m => m.CourtId!.Value).Distinct().ToList();
-        if (courtIds.Count > 0)
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
         {
-            _courtNames = await DbContext.Courts
-                .Include(c => c.Club)
-                .Where(c => courtIds.Contains(c.CourtId))
-                .ToDictionaryAsync(c => c.CourtId, c => $"{c.Club.Name} — {c.Name}");
+            using var db = DbFactory.CreateDbContext();
+
+            if (_userId != null)
+            {
+                // Logged-in users see all authenticated matches + their own
+                _matches = await db.SavedMatch
+                    .Where(m => !m.Complete && (m.UserId != null || (m.UserId == null && m.DeviceToken == null)))
+                    .OrderByDescending(m => m.CreatedAt)
+                    .ToListAsync();
+            }
+            else
+            {
+                // Anonymous users see only their device-token matches
+                var deviceToken = await JS.InvokeAsync<string?>("localStorage.getItem", "dropshot-device-token");
+                if (!string.IsNullOrEmpty(deviceToken))
+                {
+                    _matches = await db.SavedMatch
+                        .Where(m => !m.Complete && m.DeviceToken == deviceToken && m.UserId == null)
+                        .OrderByDescending(m => m.CreatedAt)
+                        .ToListAsync();
+                }
+            }
+
+            var courtIds = _matches.Where(m => m.CourtId.HasValue).Select(m => m.CourtId!.Value).Distinct().ToList();
+            if (courtIds.Count > 0)
+            {
+                _courtNames = await db.Courts
+                    .Include(c => c.Club)
+                    .Where(c => courtIds.Contains(c.CourtId))
+                    .ToDictionaryAsync(c => c.CourtId, c => $"{c.Club.Name} — {c.Name}");
+            }
+
+            _loaded = true;
+            await InvokeAsync(StateHasChanged);
         }
     }
 

--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -9,6 +9,8 @@
 @using Newtonsoft.Json
 @using MudBlazor
 @using System.Threading
+@using System.Security.Claims
+@using Microsoft.AspNetCore.Components.Authorization
 
 @page "/tennisscore"
 @page "/match/{MatchId:int}"
@@ -21,6 +23,8 @@
 @inject IDialogService DialogService
 @inject TennisScoreService ScoreService
 @inject ISnackbar Snackbar
+@inject AuthenticationStateProvider AuthStateProvider
+@inject IJSRuntime JS
 
 @* FixtureId is passed as a query param when starting a match from a competition fixture *@
 
@@ -32,7 +36,7 @@
             <MudText>Settings</MudText>
             <MudDivider />
             <MudSwitch @bind-Value="_state.GameScoring" Label="Game Scoring" LabelPlacement="Placement.Start" Color="Color.Success" />
-            <MudButton Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Save" Color="Color.Info" Size="Size.Small" OnClick="@OnExpandCollapseClick">Save</MudButton>
+            <MudButton Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Save" Color="Color.Info" Size="Size.Small" OnClick="@SaveSettings">Save</MudButton>
             <MudButton Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Cancel" Color="Color.Error" Size="Size.Small" OnClick="@(() => OpenDialogAsync(_fullScreen))">End Match</MudButton>
         </MudStack>
     </MudPaper>
@@ -66,7 +70,8 @@
 {
     <MudSwitch @bind-Value="Label_Switch1" Label="Doubles" Color="Color.Success" />
 
-    <MudAutocomplete @bind-Value="_value"
+    <MudAutocomplete Value="_value"
+                     ValueChanged="@((string v) => { _value = v; _ = CheckAndOfferFriendRequest(v); })"
                      Label="Player 1"
                      SearchFunc="@Search1"
                      ResetValueOnEmptyText="@resetValueOnEmptyText"
@@ -82,7 +87,8 @@
     {
         <MudText Typo="Typo.h1">vs</MudText>
     }
-    <MudAutocomplete @bind-Value="_value2"
+    <MudAutocomplete Value="_value2"
+                     ValueChanged="@((string v) => { _value2 = v; _ = CheckAndOfferFriendRequest(v); })"
                      Label="Player 2"
                      SearchFunc="@Search1"
                      ResetValueOnEmptyText="@resetValueOnEmptyText"
@@ -102,7 +108,8 @@
 
     @if (Label_Switch1)
     {
-        <MudAutocomplete @bind-Value="_value3"
+        <MudAutocomplete Value="_value3"
+                         ValueChanged="@((string v) => { _value3 = v; _ = CheckAndOfferFriendRequest(v); })"
                          Label="Player 3"
                          SearchFunc="@Search1"
                          ResetValueOnEmptyText="@resetValueOnEmptyText"
@@ -115,7 +122,8 @@
                          SelectValueOnTab="@selectedOnTab"
                          AdornmentColor="Color.Primary" />
 
-        <MudAutocomplete @bind-Value="_value4"
+        <MudAutocomplete Value="_value4"
+                         ValueChanged="@((string v) => { _value4 = v; _ = CheckAndOfferFriendRequest(v); })"
                          Label="Player 4"
                          SearchFunc="@Search1"
                          ResetValueOnEmptyText="@resetValueOnEmptyText"
@@ -148,6 +156,13 @@
     </MudSelect>
 
     <MudSwitch @bind-Value="_state.UnlimitedDeuce" Label="Unlimited Deuce" Color="Color.Success" Style="margin: 10px;" />
+
+    <MudText Typo="Typo.subtitle2" Style="margin: 10px 10px 0;">Who serves first?</MudText>
+    <MudRadioGroup @bind-Value="_serverChoice" Style="margin: 0 10px;">
+        <MudRadio Value=@("random") Color="Color.Primary">Random Coin Toss</MudRadio>
+        <MudRadio Value=@("player1") Color="Color.Primary">@(Label_Switch1 ? $"{_value} & {_value2}" : _value) serves first</MudRadio>
+        <MudRadio Value=@("player2") Color="Color.Primary">@(Label_Switch1 ? $"{_value3} & {_value4}" : _value2) serves first</MudRadio>
+    </MudRadioGroup>
 
     <MudButton Variant="Variant.Filled" EndIcon="@Icons.Material.Filled.PlayArrow" Style="margin: 10px;" OnClick="ButtonOnClick">Start Match</MudButton>
 }
@@ -315,6 +330,9 @@
                 <button class="undo-btn no-zoom-element" @onclick="UndoLastPoint">
                     <MudIcon Icon="@Icons.Material.Filled.Undo" Title="Undo" Size="Size.Large" />
                 </button>
+                <button class="settings-btn no-zoom-element" @onclick="OpenScoreEditor">
+                    <MudIcon Icon="@Icons.Material.Filled.Edit" Title="Edit Score" Size="Size.Large" />
+                </button>
             </div>
         </div>
     </section>
@@ -330,6 +348,14 @@
         <MudAlert Style="margin-top: 10px;" Severity="Severity.Success">@_winner</MudAlert>
     }
     <MudButton Style="margin-top: 10px;" FullWidth=true Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.FiberNew" Color="Color.Secondary" Size="Size.Large" OnClick="@ReloadPage">Start New Match</MudButton>
+    @if (_competitionFixture != null)
+    {
+        <MudButton Style="margin-top: 10px;" FullWidth="true" Variant="Variant.Filled"
+                   StartIcon="@Icons.Material.Filled.EmojiEvents" Color="Color.Primary" Size="Size.Large"
+                   OnClick="@(() => Navigation.NavigateTo($"/competition/{_competitionFixture.CompetitionId}/view"))">
+            Back to @(_competitionFixture.Competition?.CompetitionName ?? "Competition")
+        </MudButton>
+    }
 }
 
 @code {
@@ -360,6 +386,61 @@
     private void OnExpandCollapseClick()
     {
         _expanded = !_expanded;
+    }
+
+    private async Task SaveSettings()
+    {
+        _expanded = false;
+        if (_currentUserId != null)
+        {
+            using var dbc = DbFactory.CreateDbContext();
+            var player = await dbc.Players.FirstOrDefaultAsync(p => p.UserId == _currentUserId);
+            if (player != null)
+            {
+                player.DefaultGameScoring = _state.GameScoring;
+                await dbc.SaveChangesAsync();
+                Snackbar.Add("Scoring preference saved.", Severity.Success);
+            }
+        }
+    }
+
+    private async Task CheckAndOfferFriendRequest(string displayName)
+    {
+        if (string.IsNullOrWhiteSpace(displayName)) return;
+        if (_myPlayerId == null) return;
+        if (!_playerIdByName.TryGetValue(displayName, out var selectedId)) return;
+        if (selectedId == _myPlayerId.Value) return;
+        if (_friendPlayerIds.Contains(selectedId)) return;
+
+        using var dbc = DbFactory.CreateDbContext();
+        var alreadyExists = await dbc.PlayerFriends.AnyAsync(pf =>
+            (pf.PlayerId == _myPlayerId.Value && pf.FriendPlayerId == selectedId) ||
+            (pf.PlayerId == selectedId && pf.FriendPlayerId == _myPlayerId.Value));
+        if (alreadyExists) return;
+
+        Snackbar.Add(
+            $"Add {displayName} as a friend?",
+            Severity.Info,
+            options =>
+            {
+                options.Action = "Add";
+                options.ActionColor = Color.Primary;
+                options.ActionVariant = Variant.Filled;
+                options.OnClick = async _ => await SendFriendRequest(selectedId, displayName);
+            });
+    }
+
+    private async Task SendFriendRequest(int targetPlayerId, string displayName)
+    {
+        if (_myPlayerId == null) return;
+        using var dbc = DbFactory.CreateDbContext();
+        dbc.PlayerFriends.Add(new PlayerFriend
+        {
+            PlayerId = _myPlayerId.Value,
+            FriendPlayerId = targetPlayerId
+        });
+        await dbc.SaveChangesAsync();
+        Snackbar.Add($"Friend request sent to {displayName}.", Severity.Success);
     }
 
     private readonly DialogOptions _maxWidth = new() { MaxWidth = MaxWidth.Medium, FullWidth = true };
@@ -416,6 +497,7 @@
 
     public bool Label_Switch1 { get; set; } = false;
 
+    private string _serverChoice = "random";
     private bool _showCoinToss;
     private bool _coinAnimating;
     private bool _coinTossUserServes;
@@ -436,6 +518,22 @@
             return;
         }
 
+        if (!Label_Switch1 && _value.Equals(_value2, StringComparison.OrdinalIgnoreCase))
+        {
+            Snackbar.Add("Player 1 and Player 2 must be different.", Severity.Warning);
+            return;
+        }
+
+        if (Label_Switch1)
+        {
+            var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { _value, _value2, _value3, _value4 };
+            if (names.Count < 4)
+            {
+                Snackbar.Add("All four players must be different.", Severity.Warning);
+                return;
+            }
+        }
+
         _pendingMatch = new Match
         {
             History = history,
@@ -446,17 +544,25 @@
             CourtId = _selectedCourtId
         };
 
-        _coinTossUserServes = Random.Shared.Next(2) == 0;
-        _coinTossWinnerName = _coinTossUserServes
-            ? (Label_Switch1 ? $"{_value} & {_value2}" : _value)
-            : (Label_Switch1 ? $"{_value3} & {_value4}" : _value2);
+        if (_serverChoice == "random")
+        {
+            _coinTossUserServes = Random.Shared.Next(2) == 0;
+            _coinTossWinnerName = _coinTossUserServes
+                ? (Label_Switch1 ? $"{_value} & {_value2}" : _value)
+                : (Label_Switch1 ? $"{_value3} & {_value4}" : _value2);
 
-        _showCoinToss = true;
-        _coinAnimating = true;
-        await InvokeAsync(StateHasChanged);
-        await Task.Delay(5000);
-        _coinAnimating = false;
-        await InvokeAsync(StateHasChanged);
+            _showCoinToss = true;
+            _coinAnimating = true;
+            await InvokeAsync(StateHasChanged);
+            await Task.Delay(5000);
+            _coinAnimating = false;
+            await InvokeAsync(StateHasChanged);
+        }
+        else
+        {
+            _coinTossUserServes = _serverChoice == "player1";
+            await StartAfterCoinToss();
+        }
     }
 
     private string GetUserDisplayName()
@@ -521,7 +627,9 @@
             Player3 = CurrentMatch.Player3,
             Player4 = CurrentMatch.Player4,
             CourtId = (_selectedCourtId is > 0) ? _selectedCourtId : null,
-            CreatedAt = DateTime.UtcNow
+            CreatedAt = DateTime.UtcNow,
+            UserId = _currentUserId,
+            DeviceToken = _currentUserId == null ? _deviceToken : null
         };
         dbc.SavedMatch.Add(matchToSave);
         await dbc.SaveChangesAsync();
@@ -564,6 +672,11 @@
         return _states.Where(x => x.Contains(value, StringComparison.InvariantCultureIgnoreCase));
     }
 
+    private string? _currentUserId;
+    private string? _deviceToken;
+    private int? _myPlayerId;
+    private Dictionary<string, int> _playerIdByName = [];
+    private HashSet<int> _friendPlayerIds = [];
     private TennisMatchState _state = new();
     private List<Score> scores = new();
     private HubConnection? hubConnection;
@@ -584,10 +697,50 @@
 
     protected override async Task OnInitializedAsync()
     {
-        _states = await DbContext.Players
+        var authState = await AuthStateProvider.GetAuthenticationStateAsync();
+        _currentUserId = authState.User.FindFirstValue(ClaimTypes.NameIdentifier);
+
+        if (_currentUserId != null)
+        {
+            var player = await DbContext.Players.FirstOrDefaultAsync(p => p.UserId == _currentUserId);
+            if (player?.DefaultGameScoring != null)
+                _state.GameScoring = player.DefaultGameScoring.Value;
+        }
+        else
+        {
+            _state.GameScoring = false;
+        }
+
+        var allPlayers = await DbContext.Players
             .OrderBy(p => p.DisplayName)
-            .Select(p => p.DisplayName)
+            .Select(p => new { p.PlayerId, p.DisplayName })
             .ToListAsync();
+
+        _playerIdByName = allPlayers.ToDictionary(p => p.DisplayName, p => p.PlayerId);
+
+        if (_currentUserId != null)
+        {
+            var myPlayerRecord = await DbContext.Players.AsNoTracking()
+                .FirstOrDefaultAsync(p => p.UserId == _currentUserId);
+            _myPlayerId = myPlayerRecord?.PlayerId;
+
+            if (_myPlayerId.HasValue)
+            {
+                var pid = _myPlayerId.Value;
+                _friendPlayerIds = (await DbContext.PlayerFriends
+                    .Where(pf => (pf.PlayerId == pid || pf.FriendPlayerId == pid)
+                                 && pf.Status == FriendStatus.Accepted)
+                    .Select(pf => pf.PlayerId == pid ? pf.FriendPlayerId : pf.PlayerId)
+                    .ToListAsync()).ToHashSet();
+            }
+        }
+
+        // Friends appear first in the autocomplete list
+        _states = allPlayers
+            .OrderBy(p => _friendPlayerIds.Contains(p.PlayerId) ? 0 : 1)
+            .ThenBy(p => p.DisplayName)
+            .Select(p => p.DisplayName)
+            .ToList();
 
         _courts = await DbContext.Courts
             .Include(c => c.Club)
@@ -652,13 +805,26 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (firstRender && hubConnection is null)
+        if (firstRender)
         {
-            hubConnection = new HubConnectionBuilder()
-                .WithUrl(Navigation.ToAbsoluteUri("/chathub"))
-                .Build();
+            if (_currentUserId == null)
+            {
+                _deviceToken = await JS.InvokeAsync<string?>("localStorage.getItem", "dropshot-device-token");
+                if (string.IsNullOrEmpty(_deviceToken))
+                {
+                    _deviceToken = Guid.NewGuid().ToString();
+                    await JS.InvokeVoidAsync("localStorage.setItem", "dropshot-device-token", _deviceToken);
+                }
+            }
 
-            await hubConnection.StartAsync();
+            if (hubConnection is null)
+            {
+                hubConnection = new HubConnectionBuilder()
+                    .WithUrl(Navigation.ToAbsoluteUri("/chathub"))
+                    .Build();
+
+                await hubConnection.StartAsync();
+            }
         }
     }
 
@@ -767,6 +933,41 @@
         _state.IsMatchEnded = false;
         _winner = "";
         await PersistAndBroadcast();
+    }
+
+    private async Task OpenScoreEditor()
+    {
+        var parameters = new DialogParameters<EditScoreDialog>
+        {
+            { x => x.UserSets, _state.UserSets },
+            { x => x.OppSets, _state.OppSets },
+            { x => x.UserGames, _state.UserGames },
+            { x => x.OppGames, _state.OppGames },
+            { x => x.UserPoints, _state.UserPoints },
+            { x => x.OppPoints, _state.OppPoints },
+            { x => x.IsUserServing, _state.IsUserServing },
+            { x => x.UserName, GetUserDisplayName() },
+            { x => x.OpponentName, GetOpponentDisplayName() }
+        };
+        var dialog = await DialogService.ShowAsync<EditScoreDialog>("Edit Score", parameters);
+        var result = await dialog.Result;
+        if (!result.Canceled)
+        {
+            var edited = (EditScoreDialog.EditScoreResult)result.Data!;
+            history.Clear();
+            _state.UserSets = edited.UserSets;
+            _state.OppSets = edited.OppSets;
+            _state.UserGames = edited.UserGames;
+            _state.OppGames = edited.OppGames;
+            _state.UserPoints = edited.UserPoints;
+            _state.OppPoints = edited.OppPoints;
+            _state.IsUserServing = edited.IsUserServing;
+            _state.SetScores.Clear();
+            _state.IsMatchEnded = false;
+            _state.IsTieBreak = false;
+            _state.DeuceCount = 0;
+            SaveHistory();
+        }
     }
 
     private void OpenSettings() { }

--- a/DropShot/Data/Migrations/20260331225300_AddMatchBehaviourFields.Designer.cs
+++ b/DropShot/Data/Migrations/20260331225300_AddMatchBehaviourFields.Designer.cs
@@ -4,6 +4,7 @@ using DropShot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DropShot.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260331225300_AddMatchBehaviourFields")]
+    partial class AddMatchBehaviourFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -170,38 +173,6 @@ namespace DropShot.Migrations
                     b.HasIndex("ClubId");
 
                     b.ToTable("ClubAdministrators");
-                });
-
-            modelBuilder.Entity("DropShot.Models.ClubEmailTemplate", b =>
-                {
-                    b.Property<int>("ClubEmailTemplateId")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("ClubEmailTemplateId"));
-
-                    b.Property<string>("Body")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<int>("ClubId")
-                        .HasColumnType("int");
-
-                    b.Property<string>("Name")
-                        .IsRequired()
-                        .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
-
-                    b.Property<string>("Subject")
-                        .IsRequired()
-                        .HasMaxLength(500)
-                        .HasColumnType("nvarchar(500)");
-
-                    b.HasKey("ClubEmailTemplateId");
-
-                    b.HasIndex("ClubId");
-
-                    b.ToTable("ClubEmailTemplates");
                 });
 
             modelBuilder.Entity("DropShot.Models.ClubLadder", b =>
@@ -365,24 +336,6 @@ namespace DropShot.Migrations
                     b.HasIndex("RulesSetId");
 
                     b.ToTable("Competition");
-                });
-
-            modelBuilder.Entity("DropShot.Models.CompetitionAdmin", b =>
-                {
-                    b.Property<int>("CompetitionId")
-                        .HasColumnType("int");
-
-                    b.Property<string>("UserId")
-                        .HasColumnType("nvarchar(450)");
-
-                    b.Property<DateTime>("AssignedAt")
-                        .HasColumnType("datetime2");
-
-                    b.HasKey("CompetitionId", "UserId");
-
-                    b.HasIndex("UserId");
-
-                    b.ToTable("CompetitionAdmins");
                 });
 
             modelBuilder.Entity("DropShot.Models.CompetitionFixture", b =>
@@ -564,71 +517,6 @@ namespace DropShot.Migrations
                     b.HasIndex("CompetitionId");
 
                     b.ToTable("CompetitionTeams");
-                });
-
-            modelBuilder.Entity("DropShot.Models.CompetitionTemplate", b =>
-                {
-                    b.Property<int>("CompetitionTemplateId")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("CompetitionTemplateId"));
-
-                    b.Property<int?>("BestOf")
-                        .HasColumnType("int");
-
-                    b.Property<int>("ClubId")
-                        .HasColumnType("int");
-
-                    b.Property<byte?>("EligibleSex")
-                        .HasColumnType("tinyint");
-
-                    b.Property<byte?>("Format")
-                        .HasColumnType("tinyint");
-
-                    b.Property<int?>("MaxAge")
-                        .HasColumnType("int");
-
-                    b.Property<string>("Name")
-                        .IsRequired()
-                        .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
-
-                    b.Property<int?>("RulesSetId")
-                        .HasColumnType("int");
-
-                    b.HasKey("CompetitionTemplateId");
-
-                    b.HasIndex("ClubId");
-
-                    b.ToTable("CompetitionTemplates");
-                });
-
-            modelBuilder.Entity("DropShot.Models.CompetitionTemplateWindow", b =>
-                {
-                    b.Property<int>("CompetitionTemplateWindowId")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("CompetitionTemplateWindowId"));
-
-                    b.Property<int>("CompetitionTemplateId")
-                        .HasColumnType("int");
-
-                    b.Property<int>("DayOfWeek")
-                        .HasColumnType("int");
-
-                    b.Property<TimeSpan>("EndTime")
-                        .HasColumnType("time");
-
-                    b.Property<TimeSpan>("StartTime")
-                        .HasColumnType("time");
-
-                    b.HasKey("CompetitionTemplateWindowId");
-
-                    b.HasIndex("CompetitionTemplateId");
-
-                    b.ToTable("CompetitionTemplateWindows");
                 });
 
             modelBuilder.Entity("DropShot.Models.Court", b =>
@@ -1042,17 +930,6 @@ namespace DropShot.Migrations
                     b.Navigation("User");
                 });
 
-            modelBuilder.Entity("DropShot.Models.ClubEmailTemplate", b =>
-                {
-                    b.HasOne("DropShot.Models.Club", "Club")
-                        .WithMany("EmailTemplates")
-                        .HasForeignKey("ClubId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("Club");
-                });
-
             modelBuilder.Entity("DropShot.Models.ClubLadder", b =>
                 {
                     b.HasOne("DropShot.Models.Club", "Club")
@@ -1127,25 +1004,6 @@ namespace DropShot.Migrations
                     b.Navigation("HostClub");
 
                     b.Navigation("Rules");
-                });
-
-            modelBuilder.Entity("DropShot.Models.CompetitionAdmin", b =>
-                {
-                    b.HasOne("DropShot.Models.Competition", "Competition")
-                        .WithMany("Admins")
-                        .HasForeignKey("CompetitionId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.HasOne("DropShot.Data.ApplicationUser", "User")
-                        .WithMany()
-                        .HasForeignKey("UserId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired();
-
-                    b.Navigation("Competition");
-
-                    b.Navigation("User");
                 });
 
             modelBuilder.Entity("DropShot.Models.CompetitionFixture", b =>
@@ -1265,28 +1123,6 @@ namespace DropShot.Migrations
                         .IsRequired();
 
                     b.Navigation("Competition");
-                });
-
-            modelBuilder.Entity("DropShot.Models.CompetitionTemplate", b =>
-                {
-                    b.HasOne("DropShot.Models.Club", "Club")
-                        .WithMany("CompetitionTemplates")
-                        .HasForeignKey("ClubId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("Club");
-                });
-
-            modelBuilder.Entity("DropShot.Models.CompetitionTemplateWindow", b =>
-                {
-                    b.HasOne("DropShot.Models.CompetitionTemplate", "Template")
-                        .WithMany("Windows")
-                        .HasForeignKey("CompetitionTemplateId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("Template");
                 });
 
             modelBuilder.Entity("DropShot.Models.Court", b =>
@@ -1422,13 +1258,9 @@ namespace DropShot.Migrations
                 {
                     b.Navigation("Administrators");
 
-                    b.Navigation("CompetitionTemplates");
-
                     b.Navigation("Competitions");
 
                     b.Navigation("Courts");
-
-                    b.Navigation("EmailTemplates");
 
                     b.Navigation("Ladders");
 
@@ -1449,8 +1281,6 @@ namespace DropShot.Migrations
 
             modelBuilder.Entity("DropShot.Models.Competition", b =>
                 {
-                    b.Navigation("Admins");
-
                     b.Navigation("Fixtures");
 
                     b.Navigation("MatchWindows");
@@ -1470,11 +1300,6 @@ namespace DropShot.Migrations
             modelBuilder.Entity("DropShot.Models.CompetitionTeam", b =>
                 {
                     b.Navigation("Participants");
-                });
-
-            modelBuilder.Entity("DropShot.Models.CompetitionTemplate", b =>
-                {
-                    b.Navigation("Windows");
                 });
 
             modelBuilder.Entity("DropShot.Models.Court", b =>

--- a/DropShot/Data/Migrations/20260331225300_AddMatchBehaviourFields.cs
+++ b/DropShot/Data/Migrations/20260331225300_AddMatchBehaviourFields.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropShot.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMatchBehaviourFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "DeviceToken",
+                table: "SavedMatch",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "UserId",
+                table: "SavedMatch",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "DefaultGameScoring",
+                table: "Players",
+                type: "bit",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DeviceToken",
+                table: "SavedMatch");
+
+            migrationBuilder.DropColumn(
+                name: "UserId",
+                table: "SavedMatch");
+
+            migrationBuilder.DropColumn(
+                name: "DefaultGameScoring",
+                table: "Players");
+        }
+    }
+}

--- a/DropShot/Data/Migrations/20260331233043_AddRemainingFeatures.Designer.cs
+++ b/DropShot/Data/Migrations/20260331233043_AddRemainingFeatures.Designer.cs
@@ -4,6 +4,7 @@ using DropShot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DropShot.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260331233043_AddRemainingFeatures")]
+    partial class AddRemainingFeatures
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DropShot/Data/Migrations/20260331233043_AddRemainingFeatures.cs
+++ b/DropShot/Data/Migrations/20260331233043_AddRemainingFeatures.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropShot.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRemainingFeatures : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ClubEmailTemplates",
+                columns: table => new
+                {
+                    ClubEmailTemplateId = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    ClubId = table.Column<int>(type: "int", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    Subject = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: false),
+                    Body = table.Column<string>(type: "nvarchar(max)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ClubEmailTemplates", x => x.ClubEmailTemplateId);
+                    table.ForeignKey(
+                        name: "FK_ClubEmailTemplates_Clubs_ClubId",
+                        column: x => x.ClubId,
+                        principalTable: "Clubs",
+                        principalColumn: "ClubId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "CompetitionAdmins",
+                columns: table => new
+                {
+                    CompetitionId = table.Column<int>(type: "int", nullable: false),
+                    UserId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    AssignedAt = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CompetitionAdmins", x => new { x.CompetitionId, x.UserId });
+                    table.ForeignKey(
+                        name: "FK_CompetitionAdmins_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_CompetitionAdmins_Competition_CompetitionId",
+                        column: x => x.CompetitionId,
+                        principalTable: "Competition",
+                        principalColumn: "CompetitionID",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "CompetitionTemplates",
+                columns: table => new
+                {
+                    CompetitionTemplateId = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    ClubId = table.Column<int>(type: "int", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    Format = table.Column<byte>(type: "tinyint", nullable: true),
+                    RulesSetId = table.Column<int>(type: "int", nullable: true),
+                    BestOf = table.Column<int>(type: "int", nullable: true),
+                    MaxAge = table.Column<int>(type: "int", nullable: true),
+                    EligibleSex = table.Column<byte>(type: "tinyint", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CompetitionTemplates", x => x.CompetitionTemplateId);
+                    table.ForeignKey(
+                        name: "FK_CompetitionTemplates_Clubs_ClubId",
+                        column: x => x.ClubId,
+                        principalTable: "Clubs",
+                        principalColumn: "ClubId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "CompetitionTemplateWindows",
+                columns: table => new
+                {
+                    CompetitionTemplateWindowId = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    CompetitionTemplateId = table.Column<int>(type: "int", nullable: false),
+                    DayOfWeek = table.Column<int>(type: "int", nullable: false),
+                    StartTime = table.Column<TimeSpan>(type: "time", nullable: false),
+                    EndTime = table.Column<TimeSpan>(type: "time", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CompetitionTemplateWindows", x => x.CompetitionTemplateWindowId);
+                    table.ForeignKey(
+                        name: "FK_CompetitionTemplateWindows_CompetitionTemplates_CompetitionTemplateId",
+                        column: x => x.CompetitionTemplateId,
+                        principalTable: "CompetitionTemplates",
+                        principalColumn: "CompetitionTemplateId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ClubEmailTemplates_ClubId",
+                table: "ClubEmailTemplates",
+                column: "ClubId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CompetitionAdmins_UserId",
+                table: "CompetitionAdmins",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CompetitionTemplates_ClubId",
+                table: "CompetitionTemplates",
+                column: "ClubId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CompetitionTemplateWindows_CompetitionTemplateId",
+                table: "CompetitionTemplateWindows",
+                column: "CompetitionTemplateId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ClubEmailTemplates");
+
+            migrationBuilder.DropTable(
+                name: "CompetitionAdmins");
+
+            migrationBuilder.DropTable(
+                name: "CompetitionTemplateWindows");
+
+            migrationBuilder.DropTable(
+                name: "CompetitionTemplates");
+        }
+    }
+}

--- a/DropShot/Data/MyDbContext.cs
+++ b/DropShot/Data/MyDbContext.cs
@@ -28,6 +28,10 @@ namespace DropShot.Data
         public DbSet<CompetitionMatchWindow> CompetitionMatchWindows { get; set; }
         public DbSet<ClubSchedulingTemplate> ClubSchedulingTemplates { get; set; }
         public DbSet<ClubSchedulingTemplateWindow> ClubSchedulingTemplateWindows { get; set; }
+        public DbSet<CompetitionAdmin> CompetitionAdmins { get; set; }
+        public DbSet<CompetitionTemplate> CompetitionTemplates { get; set; }
+        public DbSet<CompetitionTemplateWindow> CompetitionTemplateWindows { get; set; }
+        public DbSet<ClubEmailTemplate> ClubEmailTemplates { get; set; }
 
         protected override void OnModelCreating(ModelBuilder builder)
         {
@@ -248,6 +252,58 @@ namespace DropShot.Data
                 entity.HasOne(w => w.Template)
                       .WithMany(t => t.Windows)
                       .HasForeignKey(w => w.ClubSchedulingTemplateId)
+                      .OnDelete(DeleteBehavior.Cascade);
+            });
+
+            // ── CompetitionAdmin ─────────────────────────────────────────────────
+            builder.Entity<CompetitionAdmin>(entity =>
+            {
+                entity.HasKey(ca => new { ca.CompetitionId, ca.UserId });
+
+                entity.HasOne(ca => ca.Competition)
+                      .WithMany(c => c.Admins)
+                      .HasForeignKey(ca => ca.CompetitionId)
+                      .OnDelete(DeleteBehavior.Cascade);
+
+                entity.HasOne(ca => ca.User)
+                      .WithMany()
+                      .HasForeignKey(ca => ca.UserId)
+                      .OnDelete(DeleteBehavior.Restrict);
+            });
+
+            // ── CompetitionTemplate / CompetitionTemplateWindow ──────────────────
+            builder.Entity<CompetitionTemplate>(entity =>
+            {
+                entity.Property(t => t.Name).HasMaxLength(200).IsRequired();
+                entity.Property(t => t.Format).HasConversion<byte?>();
+                entity.Property(t => t.EligibleSex).HasConversion<byte?>();
+
+                entity.HasOne(t => t.Club)
+                      .WithMany(c => c.CompetitionTemplates)
+                      .HasForeignKey(t => t.ClubId)
+                      .OnDelete(DeleteBehavior.Cascade);
+            });
+
+            builder.Entity<CompetitionTemplateWindow>(entity =>
+            {
+                entity.Property(w => w.DayOfWeek).HasConversion<int>();
+
+                entity.HasOne(w => w.Template)
+                      .WithMany(t => t.Windows)
+                      .HasForeignKey(w => w.CompetitionTemplateId)
+                      .OnDelete(DeleteBehavior.Cascade);
+            });
+
+            // ── ClubEmailTemplate ────────────────────────────────────────────────
+            builder.Entity<ClubEmailTemplate>(entity =>
+            {
+                entity.Property(t => t.Name).HasMaxLength(200).IsRequired();
+                entity.Property(t => t.Subject).HasMaxLength(500).IsRequired();
+                entity.Property(t => t.Body).HasColumnType("nvarchar(max)").IsRequired();
+
+                entity.HasOne(t => t.Club)
+                      .WithMany(c => c.EmailTemplates)
+                      .HasForeignKey(t => t.ClubId)
                       .OnDelete(DeleteBehavior.Cascade);
             });
 

--- a/DropShot/Models/Club.cs
+++ b/DropShot/Models/Club.cs
@@ -26,6 +26,8 @@ public class Club
     public ICollection<Competition> Competitions { get; set; } = [];
     public ICollection<ClubLadder> Ladders { get; set; } = [];
     public ICollection<ClubSchedulingTemplate> SchedulingTemplates { get; set; } = [];
+    public ICollection<CompetitionTemplate> CompetitionTemplates { get; set; } = [];
+    public ICollection<ClubEmailTemplate> EmailTemplates { get; set; } = [];
 }
 
 public class Court

--- a/DropShot/Models/ClubEmailTemplate.cs
+++ b/DropShot/Models/ClubEmailTemplate.cs
@@ -1,0 +1,12 @@
+namespace DropShot.Models;
+
+public class ClubEmailTemplate
+{
+    public int ClubEmailTemplateId { get; set; }
+    public int ClubId { get; set; }
+    public string Name { get; set; } = "";
+    public string Subject { get; set; } = "";
+    public string Body { get; set; } = "";
+
+    public Club Club { get; set; } = null!;
+}

--- a/DropShot/Models/Competition.cs
+++ b/DropShot/Models/Competition.cs
@@ -31,5 +31,6 @@
         public ICollection<CompetitionStage> Stages { get; set; } = [];
         public ICollection<CompetitionTeam> Teams { get; set; } = [];
         public ICollection<CompetitionMatchWindow> MatchWindows { get; set; } = [];
+        public ICollection<CompetitionAdmin> Admins { get; set; } = [];
     }
 }

--- a/DropShot/Models/CompetitionAdmin.cs
+++ b/DropShot/Models/CompetitionAdmin.cs
@@ -1,0 +1,13 @@
+using DropShot.Data;
+
+namespace DropShot.Models;
+
+public class CompetitionAdmin
+{
+    public int CompetitionId { get; set; }
+    public string UserId { get; set; } = "";
+    public DateTime AssignedAt { get; set; } = DateTime.UtcNow;
+
+    public Competition Competition { get; set; } = null!;
+    public ApplicationUser User { get; set; } = null!;
+}

--- a/DropShot/Models/Player.cs
+++ b/DropShot/Models/Player.cs
@@ -25,6 +25,7 @@ public class Player
     public string? ProfileImagePath { get; set; }
     public string? ContactPreferences { get; set; }
     public string? MobileNumber { get; set; }
+    public bool? DefaultGameScoring { get; set; }
 
     public ICollection<CompetitionParticipant> CompetitionParticipants { get; set; } = [];
     public ICollection<PlayerFriend> Friends { get; set; } = [];

--- a/DropShot/Models/SavedMatch.cs
+++ b/DropShot/Models/SavedMatch.cs
@@ -12,4 +12,6 @@ public class SavedMatch
     public string? WinnerName { get; set; }
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public int? CourtId { get; set; }
+    public string? UserId { get; set; }
+    public string? DeviceToken { get; set; }
 }

--- a/DropShot/Models/SchedulingModels.cs
+++ b/DropShot/Models/SchedulingModels.cs
@@ -31,3 +31,29 @@ public class ClubSchedulingTemplateWindow
 
     public ClubSchedulingTemplate Template { get; set; } = null!;
 }
+
+public class CompetitionTemplate
+{
+    public int CompetitionTemplateId { get; set; }
+    public int ClubId { get; set; }
+    public string Name { get; set; } = "";
+    public CompetitionFormat? Format { get; set; }
+    public int? RulesSetId { get; set; }
+    public int? BestOf { get; set; }
+    public int? MaxAge { get; set; }
+    public PlayerSex? EligibleSex { get; set; }
+
+    public Club Club { get; set; } = null!;
+    public ICollection<CompetitionTemplateWindow> Windows { get; set; } = [];
+}
+
+public class CompetitionTemplateWindow
+{
+    public int CompetitionTemplateWindowId { get; set; }
+    public int CompetitionTemplateId { get; set; }
+    public DayOfWeek DayOfWeek { get; set; }
+    public TimeSpan StartTime { get; set; }
+    public TimeSpan EndTime { get; set; }
+
+    public CompetitionTemplate Template { get; set; } = null!;
+}

--- a/DropShot/Program.cs
+++ b/DropShot/Program.cs
@@ -76,6 +76,7 @@ builder.Services.AddScoped<ClubAuthorizationService>();
 builder.Services.AddScoped<JwtTokenService>();
 builder.Services.AddSingleton<EmailService>();
 builder.Services.AddScoped<ResultVerificationService>();
+builder.Services.AddScoped<AdminEmailService>();
 builder.Services.AddMudServices();
 
 var app = builder.Build();

--- a/DropShot/Services/AdminEmailService.cs
+++ b/DropShot/Services/AdminEmailService.cs
@@ -1,0 +1,76 @@
+using DropShot.Models;
+
+namespace DropShot.Services;
+
+public class AdminEmailService(
+    EmailService emailService,
+    IConfiguration config,
+    ILogger<AdminEmailService> logger)
+{
+    private string BaseUrl => config["App:BaseUrl"]?.TrimEnd('/') ?? "";
+
+    /// <summary>
+    /// Sends an email to all players in a fixture. The MatchLink variable resolves to the
+    /// live match URL if a SavedMatch exists, otherwise the competition view page.
+    /// </summary>
+    public async Task SendMatchEmailAsync(CompetitionFixture fixture, string subject, string body)
+    {
+        var matchLink = fixture.SavedMatchId.HasValue
+            ? $"{BaseUrl}/match/{fixture.SavedMatchId}"
+            : $"{BaseUrl}/competition/{fixture.CompetitionId}/view";
+
+        var competitionName = fixture.Competition?.CompetitionName ?? "";
+
+        var players = new[] { fixture.Player1, fixture.Player2, fixture.Player3, fixture.Player4 }
+            .Where(p => p?.Email != null)
+            .Distinct()
+            .ToList();
+
+        await Task.WhenAll(players.Select(player =>
+        {
+            var resolvedSubject = SubstituteVariables(subject, player!.DisplayName, competitionName, matchLink);
+            var resolvedBody = SubstituteVariables(body, player.DisplayName, competitionName, matchLink);
+            return SendSafe(player.Email!, resolvedSubject, resolvedBody, "match-specific admin email");
+        }));
+    }
+
+    /// <summary>
+    /// Sends an email to all competition participants who have an email address.
+    /// </summary>
+    public async Task SendCompetitionEmailAsync(
+        IEnumerable<Player> participants,
+        string competitionName,
+        string subject,
+        string body,
+        int competitionId)
+    {
+        var link = $"{BaseUrl}/competition/{competitionId}/view";
+
+        await Task.WhenAll(participants
+            .Where(p => p.Email != null)
+            .Select(player =>
+            {
+                var resolvedSubject = SubstituteVariables(subject, player.DisplayName, competitionName, link);
+                var resolvedBody = SubstituteVariables(body, player.DisplayName, competitionName, link);
+                return SendSafe(player.Email!, resolvedSubject, resolvedBody, "competition-wide admin email");
+            }));
+    }
+
+    private static string SubstituteVariables(string template, string playerName, string competitionName, string matchLink)
+        => template
+            .Replace("{PlayerName}", playerName)
+            .Replace("{CompetitionName}", competitionName)
+            .Replace("{MatchLink}", matchLink);
+
+    private async Task SendSafe(string email, string subject, string body, string context)
+    {
+        try
+        {
+            await emailService.SendEmailAsync(email, subject, body);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to send {Context} to {Email}", context, email);
+        }
+    }
+}

--- a/DropShot/Services/ClubAuthorizationService.cs
+++ b/DropShot/Services/ClubAuthorizationService.cs
@@ -59,13 +59,38 @@ public class ClubAuthorizationService(
     /// <summary>
     /// Returns true if the user can edit the given competition.
     /// Admin can edit any competition. ClubAdmin can only edit competitions
-    /// that have a host club they administer. Competitions with no host club
-    /// are Admin-only.
+    /// that have a host club they administer. CompetitionAdmins can edit
+    /// their specific competitions. Competitions with no host club
+    /// are Admin-only (unless they're a CompetitionAdmin for it).
     /// </summary>
-    public async Task<bool> CanEditCompetitionAsync(ClaimsPrincipal user, int? hostClubId)
+    public async Task<bool> CanEditCompetitionAsync(
+        ClaimsPrincipal user, int? hostClubId, int? competitionId = null)
     {
         if (await IsAdminAsync(user)) return true;
+
+        var userId = userManager.GetUserId(user);
+        if (userId != null && competitionId.HasValue)
+        {
+            await using var db = dbFactory.CreateDbContext();
+            if (await db.CompetitionAdmins.AnyAsync(ca =>
+                    ca.CompetitionId == competitionId.Value && ca.UserId == userId))
+                return true;
+        }
+
         if (hostClubId is null) return false;
         return await CanEditClubAsync(user, hostClubId.Value);
+    }
+
+    /// <summary>Returns the set of CompetitionIds the user is a per-competition admin of.</summary>
+    public async Task<HashSet<int>> GetEditableCompetitionIdsAsync(ClaimsPrincipal user)
+    {
+        var userId = userManager.GetUserId(user);
+        if (userId is null) return [];
+
+        await using var db = dbFactory.CreateDbContext();
+        return (await db.CompetitionAdmins
+            .Where(ca => ca.UserId == userId)
+            .Select(ca => ca.CompetitionId)
+            .ToListAsync()).ToHashSet();
     }
 }


### PR DESCRIPTION
## Summary

### Batch 1 — Match Behaviour & UI
- **Player validation**: distinct player check for singles (P1≠P2) and doubles (all 4 unique)
- **Server selection**: radio group for random coin toss, P1 serves, or P2 serves before match starts
- **Scoring defaults**: logged-in users persist preferred scoring mode to their Player profile; anonymous users default to point scoring
- **Direct score editing**: edit button opens `EditScoreDialog` with history-loss warning, numeric set/game/point fields, and serving toggle
- **Post-match navigation**: "View Competition" button appears after match ends if linked to a competition
- **Anonymous match scoping**: `SavedMatch` stores `UserId` or `DeviceToken`; Match history page filters by auth state so anonymous matches are device-local only

### Batch 2 — Remaining Features
- **Friends-first autocomplete**: player autocomplete in TennisScore orders accepted friends first; selecting a non-friend shows an actionable snackbar offering to send a friend request
- **Competition multiple admins**: new `CompetitionAdmin` table; `ClubAuthorizationService` extended so competition admins can edit competitions and see pending verifications; admin management UI in CompetitionPage
- **Competition templates**: club-level templates (format, rules set, best of, max age, eligible sex, time windows); apply-on-edit dropdown in CompetitionPage syncs fields and match windows
- **Admin emailing**: per-club email templates with variable substitution (`{PlayerName}`, `{CompetitionName}`, `{MatchLink}`); `AdminEmailService` supports match-specific and competition-wide sends; Send Email section in CompetitionPage

## Migrations
- `AddMatchBehaviourFields` — `Player.DefaultGameScoring`, `SavedMatch.UserId`, `SavedMatch.DeviceToken`
- `AddRemainingFeatures` — `CompetitionAdmin`, `CompetitionTemplate`, `CompetitionTemplateWindow`, `ClubEmailTemplate`

## Test plan
- [ ] Start a singles match with the same player in both slots — validation blocks it
- [ ] Start a doubles match with a duplicate across teams — validation blocks it
- [ ] Select "Player 1 serves" and confirm the coin toss shows the correct result
- [ ] Log in, change scoring mode, save as default, reload — default persists
- [ ] Open score editor mid-match, confirm warning, change scores — state updates correctly
- [ ] Complete a competition match — "View Competition" button navigates correctly
- [ ] Start a match anonymously, reload page in same browser — match appears in history; open incognito — match does not appear
- [ ] Log in with a user who has friends; open TennisScore — friends appear at top of autocomplete
- [ ] Select a non-friend player — snackbar appears; click Add — friend request sent
- [ ] Add a competition admin by email in CompetitionPage — that user can now edit the competition
- [ ] Create a competition template in Clubs — apply it when editing a competition — fields and windows populate
- [ ] Create an email template in Clubs — load it in Send Email — send to fixture players and to all participants
- [ ] Apply both migrations against the database — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)