### PR TITLE
Add scoreboard fullscreen mode and remote admin display control

### DIFF
--- a/DropShot/Components/Layout/MainLayout.razor
+++ b/DropShot/Components/Layout/MainLayout.razor
@@ -1,18 +1,20 @@
 ﻿ <meta name="viewport" content="width=device-width, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
 @inherits LayoutComponentBase
+@inject DropShot.Services.LayoutState LayoutState
+@implements IDisposable
 <MudThemeProvider IsDarkMode="true" Theme="_theme" />
 @* Popover/Dialog/Snackbar providers are intentionally NOT here.
    Each @rendermode InteractiveServer page injects <MudProviders /> directly
    so the providers share the page's circuit DI scope.  Having them here too
    caused "duplicate subscriber" errors because SSR and circuit both rendered
    a MudPopoverProvider for the same page. *@
-<div class="page">
+<div class="page @(LayoutState.IsFullscreen ? "fullscreen" : "")">
     <div class="sidebar">
         <NavMenu />
     </div>
 
     <main>
-        
+
         <article class="content px-4">
             @Body
         </article>
@@ -27,4 +29,19 @@
 
 @code {
     private MudTheme _theme = new();
+
+    protected override void OnInitialized()
+    {
+        LayoutState.OnChange += OnLayoutStateChanged;
+    }
+
+    private void OnLayoutStateChanged()
+    {
+        InvokeAsync(StateHasChanged);
+    }
+
+    public void Dispose()
+    {
+        LayoutState.OnChange -= OnLayoutStateChanged;
+    }
 }

--- a/DropShot/Components/Layout/MainLayout.razor.css
+++ b/DropShot/Components/Layout/MainLayout.razor.css
@@ -103,3 +103,15 @@ main {
         top: 0.5rem;
     }
 
+.page.fullscreen .sidebar {
+    display: none !important;
+}
+
+.page.fullscreen main {
+    width: 100%;
+}
+
+.page.fullscreen .content {
+    padding: 0 !important;
+}
+

--- a/DropShot/Components/Layout/NavMenu.razor
+++ b/DropShot/Components/Layout/NavMenu.razor
@@ -63,6 +63,14 @@
             </NavLink>
         </div>
 
+        <AuthorizeView Roles="Admin,SuperAdmin,ClubAdmin">
+            <div class="nav-item px-3">
+                <NavLink class="nav-link" href="display-control">
+                    <MudIcon Icon="@Icons.Material.Filled.ScreenShare" Class="nav-icon" /> Display Control
+                </NavLink>
+            </div>
+        </AuthorizeView>
+
         <AuthorizeView Roles="Admin,SuperAdmin">
             <div class="nav-item px-3">
                 <NavLink class="nav-link" href="admin/users">

--- a/DropShot/Components/Pages/DisplayControl.razor
+++ b/DropShot/Components/Pages/DisplayControl.razor
@@ -1,0 +1,123 @@
+@page "/display-control"
+@rendermode InteractiveServer
+@attribute [Authorize(Roles = "Admin,SuperAdmin,ClubAdmin")]
+@using DropShot.Data
+@using DropShot.Models
+@using DropShot.Services
+@using Microsoft.AspNetCore.Authorization
+@using Microsoft.AspNetCore.SignalR.Client
+@using Microsoft.EntityFrameworkCore
+@using MudBlazor
+@inject NavigationManager Navigation
+@inject IDbContextFactory<MyDbContext> DbFactory
+@inject ClubAuthorizationService AuthzService
+@inject AuthenticationStateProvider AuthStateProvider
+
+<MudProviders />
+
+<MudText Typo="Typo.h4" Class="mb-2">Display Control</MudText>
+<MudText Typo="Typo.body2" Class="mb-4" Style="color: var(--mud-palette-text-secondary);">
+    Control the scoreboard display for courts you manage. Changes are pushed live to all scoreboard screens showing that court.
+</MudText>
+
+@if (_courts.Count == 0 && _loaded)
+{
+    <MudAlert Severity="Severity.Info">No courts available for your account.</MudAlert>
+}
+
+<MudGrid>
+    @foreach (var court in _courts)
+    {
+        <MudItem xs="12" sm="6" md="4">
+            <MudCard Elevation="2">
+                <MudCardHeader>
+                    <CardHeaderContent>
+                        <MudText Typo="Typo.h6">@court.Club.Name</MudText>
+                        <MudText Typo="Typo.subtitle2" Style="color: var(--mud-palette-text-secondary);">@court.Name</MudText>
+                    </CardHeaderContent>
+                    <CardHeaderActions>
+                        <MudIcon Icon="@Icons.Material.Filled.Tv" />
+                    </CardHeaderActions>
+                </MudCardHeader>
+                <MudCardContent>
+                    <MudSwitch T="bool" Value="GetFullscreen(court.CourtId)"
+                               ValueChanged="@(v => ToggleFullscreen(court.CourtId, v))"
+                               Label="Fullscreen" Color="Color.Primary" />
+                    <MudSelect T="string" Value="GetLayout(court.CourtId)"
+                               ValueChanged="@(v => ChangeLayout(court.CourtId, v))"
+                               Label="Layout" Variant="Variant.Outlined" Class="mt-2">
+                        <MudSelectItem T="string" Value=@("default")>Default</MudSelectItem>
+                        <MudSelectItem T="string" Value=@("wimbledon")>Wimbledon</MudSelectItem>
+                    </MudSelect>
+                </MudCardContent>
+            </MudCard>
+        </MudItem>
+    }
+</MudGrid>
+
+@code {
+    private HubConnection? _hub;
+    private List<Court> _courts = [];
+    private Dictionary<int, bool> _fullscreenState = new();
+    private Dictionary<int, string> _layoutState = new();
+    private bool _loaded;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var authState = await AuthStateProvider.GetAuthenticationStateAsync();
+        var isAdmin = await AuthzService.IsAdminAsync(authState.User);
+
+        await using var db = DbFactory.CreateDbContext();
+
+        if (isAdmin)
+        {
+            _courts = await db.Courts.Include(c => c.Club)
+                .OrderBy(c => c.Club.Name).ThenBy(c => c.Name)
+                .ToListAsync();
+        }
+        else
+        {
+            var clubIds = await AuthzService.GetAdminClubIdsAsync(authState.User);
+            _courts = await db.Courts.Include(c => c.Club)
+                .Where(c => clubIds.Contains(c.ClubId))
+                .OrderBy(c => c.Club.Name).ThenBy(c => c.Name)
+                .ToListAsync();
+        }
+
+        foreach (var court in _courts)
+        {
+            _fullscreenState[court.CourtId] = false;
+            _layoutState[court.CourtId] = "default";
+        }
+
+        _loaded = true;
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _hub = new HubConnectionBuilder()
+                .WithUrl(Navigation.ToAbsoluteUri("/chathub"))
+                .Build();
+            await _hub.StartAsync();
+        }
+    }
+
+    private bool GetFullscreen(int courtId) => _fullscreenState.GetValueOrDefault(courtId);
+    private string GetLayout(int courtId) => _layoutState.GetValueOrDefault(courtId, "default");
+
+    private async Task ToggleFullscreen(int courtId, bool value)
+    {
+        _fullscreenState[courtId] = value;
+        if (_hub?.State == HubConnectionState.Connected)
+            await _hub.SendAsync("SendDisplayCommand", courtId, "setFullscreen", value.ToString().ToLower());
+    }
+
+    private async Task ChangeLayout(int courtId, string layout)
+    {
+        _layoutState[courtId] = layout;
+        if (_hub?.State == HubConnectionState.Connected)
+            await _hub.SendAsync("SendDisplayCommand", courtId, "setLayout", layout);
+    }
+}

--- a/DropShot/Components/Pages/Scoreboard.razor
+++ b/DropShot/Components/Pages/Scoreboard.razor
@@ -2,6 +2,7 @@
 @rendermode InteractiveServer
 @using DropShot.Data
 @using DropShot.Models
+@using DropShot.Services
 @using Microsoft.AspNetCore.SignalR.Client
 @using Microsoft.EntityFrameworkCore
 @using Newtonsoft.Json
@@ -10,23 +11,37 @@
 @inject MyDbContext DbContext
 @inject IDbContextFactory<MyDbContext> DbFactory
 @inject IJSRuntime JS
+@inject LayoutState LayoutState
+@implements IAsyncDisposable
 
 <MudProviders />
 
-<div style="display: flex; gap: 12px; align-items: flex-end; flex-wrap: wrap; margin: 12px;">
-    <MudSelect T="int?" Value="_selectedCourtId" ValueChanged="OnCourtChanged" Label="Select Court"
-               Variant="Variant.Outlined" Style="max-width: 300px;" Clearable="true">
-        @foreach (var court in _allCourts)
-        {
-            <MudSelectItem T="int?" Value="@((int?)court.CourtId)">@court.Club.Name — @court.Name</MudSelectItem>
-        }
-    </MudSelect>
-    <MudSelect T="string" Value="_selectedLayout" ValueChanged="OnLayoutChanged" Label="Layout"
-               Variant="Variant.Outlined" Style="max-width: 180px;">
-        <MudSelectItem T="string" Value=@("default")>Default</MudSelectItem>
-        <MudSelectItem T="string" Value=@("wimbledon")>Wimbledon</MudSelectItem>
-    </MudSelect>
-</div>
+@if (!_isFullscreen)
+{
+    <div style="display: flex; gap: 12px; align-items: flex-end; flex-wrap: wrap; margin: 12px;">
+        <MudSelect T="int?" Value="_selectedCourtId" ValueChanged="OnCourtChanged" Label="Select Court"
+                   Variant="Variant.Outlined" Style="max-width: 300px;" Clearable="true">
+            @foreach (var court in _allCourts)
+            {
+                <MudSelectItem T="int?" Value="@((int?)court.CourtId)">@court.Club.Name — @court.Name</MudSelectItem>
+            }
+        </MudSelect>
+        <MudSelect T="string" Value="_selectedLayout" ValueChanged="OnLayoutChanged" Label="Layout"
+                   Variant="Variant.Outlined" Style="max-width: 180px;">
+            <MudSelectItem T="string" Value=@("default")>Default</MudSelectItem>
+            <MudSelectItem T="string" Value=@("wimbledon")>Wimbledon</MudSelectItem>
+        </MudSelect>
+        <MudIconButton Icon="@Icons.Material.Filled.Fullscreen" Title="Enter fullscreen"
+                       OnClick="EnterFullscreen" Size="Size.Large" />
+    </div>
+}
+else
+{
+    <MudIconButton Icon="@Icons.Material.Filled.FullscreenExit" Title="Exit fullscreen (ESC)"
+                   OnClick="ExitFullscreen"
+                   Style="position: fixed; top: 8px; right: 8px; z-index: 9999; opacity: 0.3;"
+                   Size="Size.Large" />
+}
 
 @if (_selectedLayout == "wimbledon")
 {
@@ -112,27 +127,57 @@ else
     private CompetitionFixture? _activeFixture;
     GameState currentScore = new(0, 0, 0, 0, 0, 0, false, 0, true, 0, 0, new List<SetScore>(), DateTime.Now, false, "", "");
 
+    private bool _isFullscreen;
+    private DotNetObjectReference<Scoreboard>? _dotNetRef;
+    private IJSObjectReference? _jsModule;
+
     protected override async Task OnInitializedAsync()
     {
         _allCourts = await DbContext.Courts
             .Include(c => c.Club)
             .OrderBy(c => c.Club.Name).ThenBy(c => c.Name)
             .ToListAsync();
+
+        // Parse query string for kiosk mode
+        var uri = new Uri(Navigation.Uri);
+        var query = System.Web.HttpUtility.ParseQueryString(uri.Query);
+
+        if (query["layout"] is string layout && (layout == "default" || layout == "wimbledon"))
+            _selectedLayout = layout;
+
+        if (int.TryParse(query["court"], out int qsCourtId))
+            await OnCourtChanged(qsCourtId);
+
+        if (query["fullscreen"] == "true")
+            EnterFullscreen();
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)
         {
-            var savedLayout = await JS.InvokeAsync<string?>("localStorage.getItem", "scoreboard-layout");
-            if (!string.IsNullOrEmpty(savedLayout))
-                _selectedLayout = savedLayout;
+            // Restore saved preferences (only if not overridden by query string)
+            var uri = new Uri(Navigation.Uri);
+            var query = System.Web.HttpUtility.ParseQueryString(uri.Query);
+            bool hasQueryParams = query["fullscreen"] != null || query["court"] != null || query["layout"] != null;
 
-            var savedCourt = await JS.InvokeAsync<string?>("localStorage.getItem", "scoreboard-court");
-            if (int.TryParse(savedCourt, out int courtId))
-                await OnCourtChanged(courtId);
+            if (!hasQueryParams)
+            {
+                var savedLayout = await JS.InvokeAsync<string?>("localStorage.getItem", "scoreboard-layout");
+                if (!string.IsNullOrEmpty(savedLayout))
+                    _selectedLayout = savedLayout;
+
+                var savedCourt = await JS.InvokeAsync<string?>("localStorage.getItem", "scoreboard-court");
+                if (int.TryParse(savedCourt, out int courtId))
+                    await OnCourtChanged(courtId);
+            }
 
             StateHasChanged();
+
+            // Register ESC key handler
+            _jsModule = await JS.InvokeAsync<IJSObjectReference>("import", "./js/scoreboard.js");
+            _dotNetRef = DotNetObjectReference.Create(this);
+            await _jsModule.InvokeVoidAsync("registerEscHandler", _dotNetRef);
         }
 
         if (firstRender && hubConnection is null)
@@ -153,7 +198,7 @@ else
                 if (gameState != null)
                     currentScore = gameState;
 
-                // Refresh match details when scoring starts (e.g. a new match just began on this court)
+                // Refresh match details when scoring starts
                 if (_activeMatch == null && _selectedCourtId.HasValue)
                 {
                     using var dbc = DbFactory.CreateDbContext();
@@ -165,12 +210,46 @@ else
                 await InvokeAsync(StateHasChanged);
             });
 
+            // Listen for display commands from admin
+            hubConnection.On<string, string>("ReceiveDisplayCommand", async (command, value) =>
+            {
+                switch (command)
+                {
+                    case "setFullscreen":
+                        if (value == "true")
+                            EnterFullscreen();
+                        else
+                            ExitFullscreen();
+                        break;
+                    case "setLayout":
+                        _selectedLayout = value;
+                        await JS.InvokeVoidAsync("localStorage.setItem", "scoreboard-layout", value);
+                        break;
+                }
+                await InvokeAsync(StateHasChanged);
+            });
+
+            // Re-join court group on reconnection
+            hubConnection.Reconnected += async _ =>
+            {
+                if (_selectedCourtId.HasValue)
+                    await hubConnection.SendAsync("JoinCourtGroup", _selectedCourtId.Value);
+            };
+
             await hubConnection.StartAsync();
+
+            // Join initial court group
+            if (_selectedCourtId.HasValue)
+                await hubConnection.SendAsync("JoinCourtGroup", _selectedCourtId.Value);
         }
     }
 
     private async Task OnCourtChanged(int? courtId)
     {
+        // Leave old court group
+        if (_selectedCourtId.HasValue && hubConnection?.State == HubConnectionState.Connected)
+            await hubConnection.SendAsync("LeaveCourtGroup", _selectedCourtId.Value);
+
         _selectedCourtId = courtId;
         await JS.InvokeVoidAsync("localStorage.setItem", "scoreboard-court", courtId?.ToString() ?? "");
         currentScore = new GameState(0, 0, 0, 0, 0, 0, false, 0, true, 0, 0, new List<SetScore>(), DateTime.Now, false, "", "");
@@ -191,6 +270,10 @@ else
             }
 
             _activeFixture = await LoadFixtureForMatchAsync(_activeMatch);
+
+            // Join new court group
+            if (hubConnection?.State == HubConnectionState.Connected)
+                await hubConnection.SendAsync("JoinCourtGroup", courtId.Value);
         }
     }
 
@@ -208,6 +291,28 @@ else
     {
         _selectedLayout = layout;
         await JS.InvokeVoidAsync("localStorage.setItem", "scoreboard-layout", layout);
+    }
+
+    private void EnterFullscreen()
+    {
+        _isFullscreen = true;
+        LayoutState.SetFullscreen(true);
+    }
+
+    private void ExitFullscreen()
+    {
+        _isFullscreen = false;
+        LayoutState.SetFullscreen(false);
+    }
+
+    [JSInvokable]
+    public void ExitFullscreenFromJs()
+    {
+        if (_isFullscreen)
+        {
+            ExitFullscreen();
+            InvokeAsync(StateHasChanged);
+        }
     }
 
     private static string PointDisplay(int myPts, int oppPts, int deuceCount, bool tieBreak, bool isUser)
@@ -234,4 +339,28 @@ else
 
     public bool IsConnected =>
         hubConnection?.State == HubConnectionState.Connected;
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_isFullscreen)
+            LayoutState.SetFullscreen(false);
+
+        if (_jsModule is not null)
+        {
+            try
+            {
+                await _jsModule.InvokeVoidAsync("unregisterEscHandler");
+                await _jsModule.DisposeAsync();
+            }
+            catch { }
+        }
+
+        _dotNetRef?.Dispose();
+
+        if (hubConnection is not null)
+        {
+            try { await hubConnection.DisposeAsync(); }
+            catch { }
+        }
+    }
 }

--- a/DropShot/Models/ChatHub.cs
+++ b/DropShot/Models/ChatHub.cs
@@ -9,5 +9,20 @@
         {
             await Clients.All.SendAsync("ReceiveMessage", user, message);
         }
+
+        public async Task JoinCourtGroup(int courtId)
+        {
+            await Groups.AddToGroupAsync(Context.ConnectionId, $"court-{courtId}");
+        }
+
+        public async Task LeaveCourtGroup(int courtId)
+        {
+            await Groups.RemoveFromGroupAsync(Context.ConnectionId, $"court-{courtId}");
+        }
+
+        public async Task SendDisplayCommand(int courtId, string command, string value)
+        {
+            await Clients.Group($"court-{courtId}").SendAsync("ReceiveDisplayCommand", command, value);
+        }
     }
 }

--- a/DropShot/Program.cs
+++ b/DropShot/Program.cs
@@ -73,6 +73,7 @@ builder.Services.AddIdentityCore<ApplicationUser>(options => options.SignIn.Requ
 builder.Services.AddScoped<UserState>();
 builder.Services.AddScoped<TennisScoreService>();
 builder.Services.AddScoped<ClubAuthorizationService>();
+builder.Services.AddScoped<LayoutState>();
 builder.Services.AddScoped<JwtTokenService>();
 builder.Services.AddSingleton<EmailService>();
 builder.Services.AddScoped<ResultVerificationService>();

--- a/DropShot/Services/LayoutState.cs
+++ b/DropShot/Services/LayoutState.cs
@@ -1,0 +1,13 @@
+namespace DropShot.Services;
+
+public class LayoutState
+{
+    public bool IsFullscreen { get; private set; }
+    public event Action? OnChange;
+
+    public void SetFullscreen(bool fullscreen)
+    {
+        IsFullscreen = fullscreen;
+        OnChange?.Invoke();
+    }
+}

--- a/DropShot/wwwroot/js/scoreboard.js
+++ b/DropShot/wwwroot/js/scoreboard.js
@@ -1,0 +1,18 @@
+let _handler = null;
+
+export function registerEscHandler(dotNetRef) {
+    unregisterEscHandler();
+    _handler = function (e) {
+        if (e.key === 'Escape') {
+            dotNetRef.invokeMethodAsync('ExitFullscreenFromJs');
+        }
+    };
+    document.addEventListener('keydown', _handler);
+}
+
+export function unregisterEscHandler() {
+    if (_handler) {
+        document.removeEventListener('keydown', _handler);
+        _handler = null;
+    }
+}


### PR DESCRIPTION
## Summary
- Add fullscreen toggle button to scoreboard page that hides the sidebar, court selection, and layout controls for clean display on dedicated screens
- ESC key and overlay exit button to leave fullscreen mode
- Kiosk URL support (`/score?fullscreen=true&court=5&layout=wimbledon`) for bookmarked display screens
- New **Display Control** admin page (`/display-control`) where Admin/ClubAdmin can remotely toggle fullscreen and change layout for any court's scoreboard via SignalR
- Extended ChatHub with court groups for targeted display commands

## Test plan
- [ ] Navigate to `/score`, select a court, click fullscreen button — verify sidebar and controls hide
- [ ] Press ESC or click exit button — verify normal view restores
- [ ] Open `/score?fullscreen=true&court={id}&layout=wimbledon` — verify kiosk mode loads correctly
- [ ] Log in as ClubAdmin, navigate to `/display-control` — verify only managed courts appear
- [ ] Toggle fullscreen/layout on admin page — verify scoreboard client updates live
- [ ] Navigate away from scoreboard — verify sidebar restores (dispose cleanup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)