### PR TITLE
Make scoreboard responsive and fill viewport

### DIFF
--- a/DropShot/Components/DotDigit.razor.css
+++ b/DropShot/Components/DotDigit.razor.css
@@ -1,18 +1,18 @@
-﻿.digit-grid {
+.digit-grid {
     display: flex;
     flex-direction: column;
-    gap: 4px;
-    margin: 10px;
+    gap: clamp(2px, 0.5vw, 5px);
+    margin: clamp(4px, 1vw, 12px);
 }
 
 .digit-row {
     display: flex;
-    gap: 4px;
+    gap: clamp(2px, 0.5vw, 5px);
 }
 
 .dot {
-    width: 10px;
-    height: 10px;
+    width: clamp(6px, 1.3vw, 14px);
+    height: clamp(6px, 1.3vw, 14px);
     border-radius: 50%;
     background-color: #333; /* Off state */
 }

--- a/DropShot/Components/Pages/Scoreboard.razor
+++ b/DropShot/Components/Pages/Scoreboard.razor
@@ -14,106 +14,110 @@
 
 <MudProviders />
 
-@if (!_isFullscreen)
-{
-    <div style="display: flex; gap: 12px; align-items: flex-end; flex-wrap: wrap; margin: 12px;">
-        <MudSelect T="int?" Value="_selectedCourtId" ValueChanged="OnCourtChanged" Label="Select Court"
-                   Variant="Variant.Outlined" Style="max-width: 300px;" Clearable="true">
-            @foreach (var court in _allCourts)
-            {
-                <MudSelectItem T="int?" Value="@((int?)court.CourtId)">@court.Club.Name — @court.Name</MudSelectItem>
-            }
-        </MudSelect>
-        <MudSelect T="string" Value="_selectedLayout" ValueChanged="OnLayoutChanged" Label="Layout"
-                   Variant="Variant.Outlined" Style="max-width: 180px;">
-            <MudSelectItem T="string" Value=@("default")>Default</MudSelectItem>
-            <MudSelectItem T="string" Value=@("wimbledon")>Wimbledon</MudSelectItem>
-        </MudSelect>
-        <MudIconButton Icon="@Icons.Material.Filled.Fullscreen" aria-label="Enter fullscreen"
-                       OnClick="EnterFullscreenAsync" Size="Size.Large" />
-    </div>
-}
-else
-{
-    <MudIconButton Icon="@Icons.Material.Filled.FullscreenExit" aria-label="Exit fullscreen (ESC)"
-                   OnClick="ExitFullscreenAsync"
-                   Style="position: fixed; top: 8px; right: 8px; z-index: 9999; opacity: 0.3;"
-                   Size="Size.Large" />
-}
-
-@if (_selectedLayout == "wimbledon")
-{
-    <WimbledonScoreboard Score="currentScore" ActiveMatch="_activeMatch" SelectedCourt="_selectedCourt" ActiveFixture="_activeFixture" />
-}
-else
-{
-    @if (_selectedCourt != null)
+<div class="scoreboard-page">
+    @if (!_isFullscreen)
     {
-        <MudText Typo="Typo.h5" Align="Align.Center" Style="margin-top: 8px; letter-spacing: 2px; text-transform: uppercase;">
-            @_selectedCourt.Club.Name — @_selectedCourt.Name
-        </MudText>
-    }
-
-    @if (_activeFixture?.Competition != null)
-    {
-        <MudText Typo="Typo.caption" Align="Align.Center" Style="letter-spacing:1px; text-transform:uppercase; color:#FFD700; margin-top:4px;">
-            @_activeFixture.Competition.CompetitionName
-            @if (!string.IsNullOrEmpty(_activeFixture.FixtureLabel))
-            {
-                <span> — @_activeFixture.FixtureLabel</span>
-            }
-        </MudText>
-    }
-    @if (_activeMatch != null)
-    {
-        <MudText Typo="Typo.subtitle1" Align="Align.Center" Style="margin-bottom: 4px;">
-            @PlayerLabel(_activeMatch)
-        </MudText>
-    }
-
-    @if (!currentScore.isComplete)
-    {
-        <div style="display: flex; justify-content: center; gap: 40px; margin-top: 8px; margin-bottom: 4px; align-items: center;">
-            <div style="display: flex; align-items: center; gap: 6px;">
-                <span style="font-size: 1.4rem; visibility: @(currentScore.IsUserServing ? "visible" : "hidden");">🎾</span>
-                <MudText Typo="Typo.h3" Style="font-weight: bold;">@PointDisplay(currentScore.UserPts, currentScore.OppPts, currentScore.DeuceCount, currentScore.TieBreak, true)</MudText>
-            </div>
-            <div style="display: flex; align-items: center; gap: 6px;">
-                <MudText Typo="Typo.h3" Style="font-weight: bold;">@PointDisplay(currentScore.OppPts, currentScore.UserPts, currentScore.DeuceCount, currentScore.TieBreak, false)</MudText>
-                <span style="font-size: 1.4rem; visibility: @(!currentScore.IsUserServing ? "visible" : "hidden");">🎾</span>
-            </div>
+        <div class="scoreboard-toolbar">
+            <MudSelect T="int?" Value="_selectedCourtId" ValueChanged="OnCourtChanged" Label="Select Court"
+                       Variant="Variant.Outlined" Style="max-width: min(300px, 45vw);" Clearable="true">
+                @foreach (var court in _allCourts)
+                {
+                    <MudSelectItem T="int?" Value="@((int?)court.CourtId)">@court.Club.Name — @court.Name</MudSelectItem>
+                }
+            </MudSelect>
+            <MudSelect T="string" Value="_selectedLayout" ValueChanged="OnLayoutChanged" Label="Layout"
+                       Variant="Variant.Outlined" Style="max-width: min(180px, 30vw);">
+                <MudSelectItem T="string" Value=@("default")>Default</MudSelectItem>
+                <MudSelectItem T="string" Value=@("wimbledon")>Wimbledon</MudSelectItem>
+            </MudSelect>
+            <MudIconButton Icon="@Icons.Material.Filled.Fullscreen" aria-label="Enter fullscreen"
+                           OnClick="EnterFullscreenAsync" Size="Size.Large" />
         </div>
     }
-
-    @if (currentScore.TieBreak)
+    else
     {
-        <div class="scoreboard-tiebreak">TIE BREAK</div>
+        <MudIconButton Icon="@Icons.Material.Filled.FullscreenExit" aria-label="Exit fullscreen (ESC)"
+                       OnClick="ExitFullscreenAsync"
+                       Style="position: fixed; top: 8px; right: 8px; z-index: 9999; opacity: 0.3;"
+                       Size="Size.Large" />
     }
 
-    <div style="display: flex; justify-content: center; margin-top: 4px; align-items: center;">
-        @foreach (var set in currentScore.SetScores ?? Enumerable.Empty<SetScore>())
+    <div class="scoreboard-content">
+        @if (_selectedLayout == "wimbledon")
         {
-            <DotDigit Number="@set.UserGames" />
+            <WimbledonScoreboard Score="currentScore" ActiveMatch="_activeMatch" SelectedCourt="_selectedCourt" ActiveFixture="_activeFixture" />
         }
-        <DotDigit Number="@currentScore.UserG" />
-        @for (int i = 0; i < 5 - (currentScore.SetScores?.Count() ?? 0) - 1; i++)
+        else
         {
-            <DotDigit Number="0" />
-        }
-    </div>
+            @if (_selectedCourt != null)
+            {
+                <div class="score-court-name">
+                    @_selectedCourt.Club.Name — @_selectedCourt.Name
+                </div>
+            }
 
-    <div style="display: flex; justify-content: center; align-items: center;">
-        @foreach (var set in currentScore.SetScores ?? Enumerable.Empty<SetScore>())
-        {
-            <DotDigit Number="@set.OpponentGames" />
-        }
-        <DotDigit Number="@currentScore.OppG" />
-        @for (int i = 0; i < 5 - (currentScore.SetScores?.Count() ?? 0) - 1; i++)
-        {
-            <DotDigit Number="0" />
+            @if (_activeFixture?.Competition != null)
+            {
+                <div class="score-competition">
+                    @_activeFixture.Competition.CompetitionName
+                    @if (!string.IsNullOrEmpty(_activeFixture.FixtureLabel))
+                    {
+                        <span> — @_activeFixture.FixtureLabel</span>
+                    }
+                </div>
+            }
+            @if (_activeMatch != null)
+            {
+                <div class="score-player-label">
+                    @PlayerLabel(_activeMatch)
+                </div>
+            }
+
+            @if (!currentScore.isComplete)
+            {
+                <div class="score-points-row">
+                    <div class="score-point-group">
+                        <span class="score-serve-indicator" style="visibility: @(currentScore.IsUserServing ? "visible" : "hidden");">🎾</span>
+                        <span class="score-point-value">@PointDisplay(currentScore.UserPts, currentScore.OppPts, currentScore.DeuceCount, currentScore.TieBreak, true)</span>
+                    </div>
+                    <div class="score-point-group">
+                        <span class="score-point-value">@PointDisplay(currentScore.OppPts, currentScore.UserPts, currentScore.DeuceCount, currentScore.TieBreak, false)</span>
+                        <span class="score-serve-indicator" style="visibility: @(!currentScore.IsUserServing ? "visible" : "hidden");">🎾</span>
+                    </div>
+                </div>
+            }
+
+            @if (currentScore.TieBreak)
+            {
+                <div class="scoreboard-tiebreak">TIE BREAK</div>
+            }
+
+            <div class="score-dot-row">
+                @foreach (var set in currentScore.SetScores ?? Enumerable.Empty<SetScore>())
+                {
+                    <DotDigit Number="@set.UserGames" />
+                }
+                <DotDigit Number="@currentScore.UserG" />
+                @for (int i = 0; i < 5 - (currentScore.SetScores?.Count() ?? 0) - 1; i++)
+                {
+                    <DotDigit Number="0" />
+                }
+            </div>
+
+            <div class="score-dot-row">
+                @foreach (var set in currentScore.SetScores ?? Enumerable.Empty<SetScore>())
+                {
+                    <DotDigit Number="@set.OpponentGames" />
+                }
+                <DotDigit Number="@currentScore.OppG" />
+                @for (int i = 0; i < 5 - (currentScore.SetScores?.Count() ?? 0) - 1; i++)
+                {
+                    <DotDigit Number="0" />
+                }
+            </div>
         }
     </div>
-}
+</div>
 
 @code {
     private HubConnection? hubConnection;

--- a/DropShot/Components/Pages/Scoreboard.razor.css
+++ b/DropShot/Components/Pages/Scoreboard.razor.css
@@ -1,0 +1,80 @@
+/* ── Full-viewport scoreboard page ──────────────────────────── */
+.scoreboard-page {
+    display: flex;
+    flex-direction: column;
+    min-height: calc(100vh - 3.5rem);
+}
+
+.scoreboard-toolbar {
+    display: flex;
+    gap: 12px;
+    align-items: flex-end;
+    flex-wrap: wrap;
+    padding: 8px 12px;
+    flex-shrink: 0;
+}
+
+.scoreboard-content {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    min-height: 0;
+    padding: 0 8px;
+}
+
+/* ── Default layout text styles (fluid) ────────────────────── */
+.score-court-name {
+    margin-top: 8px;
+    letter-spacing: 2px;
+    text-transform: uppercase;
+    text-align: center;
+    font-size: clamp(1.2rem, 3vw, 2rem);
+    font-weight: 500;
+}
+
+.score-competition {
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    color: #FFD700;
+    margin-top: 4px;
+    text-align: center;
+    font-size: clamp(0.65rem, 1.5vw, 1rem);
+}
+
+.score-player-label {
+    margin-bottom: 4px;
+    text-align: center;
+    font-size: clamp(1rem, 2.5vw, 1.5rem);
+}
+
+.score-points-row {
+    display: flex;
+    justify-content: center;
+    gap: clamp(20px, 5vw, 60px);
+    margin-top: 8px;
+    margin-bottom: 4px;
+    align-items: center;
+}
+
+.score-point-group {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.score-point-value {
+    font-size: clamp(2.5rem, 6vw, 4.5rem);
+    font-weight: bold;
+}
+
+.score-serve-indicator {
+    font-size: clamp(1.2rem, 2.5vw, 2rem);
+}
+
+.score-dot-row {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}

--- a/DropShot/Components/WimbledonScoreboard.razor.css
+++ b/DropShot/Components/WimbledonScoreboard.razor.css
@@ -3,8 +3,9 @@
     background-color: #0d1117;
     color: #ffffff;
     font-family: Georgia, 'Times New Roman', serif;
-    max-width: 700px;
-    margin: 20px auto;
+    width: 100%;
+    max-width: 1200px;
+    margin: 0 auto;
     border: 1px solid #2a2a3a;
     border-radius: 4px;
     overflow: hidden;
@@ -15,7 +16,7 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 6px 16px;
+    padding: clamp(4px, 0.8vh, 8px) clamp(8px, 1.5vw, 20px);
     background-color: #0a0e15;
     border-bottom: 1px solid #2a2a3a;
 }
@@ -23,7 +24,7 @@
 .wb-clock,
 .wb-elapsed {
     font-family: Georgia, 'Times New Roman', serif;
-    font-size: 1.4rem;
+    font-size: clamp(1rem, 2.2vw, 2rem);
     font-weight: bold;
     color: #ffffff;
     letter-spacing: 0.05em;
@@ -37,7 +38,7 @@
 /* ── Court label ──────────────────────────────────────────────── */
 .wb-court-label {
     text-align: center;
-    font-size: 0.7rem;
+    font-size: clamp(0.55rem, 1.1vw, 0.85rem);
     font-family: 'Helvetica Neue', Arial, sans-serif;
     letter-spacing: 0.15em;
     color: #888888;
@@ -52,16 +53,16 @@
     align-items: center;
     background-color: #0a0e15;
     border-bottom: 2px solid #2a2a3a;
-    padding: 6px 12px;
+    padding: clamp(4px, 0.8vh, 8px) clamp(8px, 1.5vw, 16px);
 }
 
 .wb-prev-sets-label {
-    font-size: 0.62rem;
+    font-size: clamp(0.5rem, 1vw, 0.75rem);
     font-family: 'Helvetica Neue', Arial, sans-serif;
     letter-spacing: 0.14em;
     color: #c9a84c;
     text-transform: uppercase;
-    min-width: 150px;
+    min-width: clamp(80px, 18vw, 180px);
     flex-shrink: 0;
 }
 
@@ -71,9 +72,9 @@
 
 .wb-live-headers {
     display: flex;
-    min-width: 195px;
+    min-width: clamp(120px, 24vw, 240px);
     justify-content: space-around;
-    font-size: 0.62rem;
+    font-size: clamp(0.5rem, 1vw, 0.75rem);
     font-family: 'Helvetica Neue', Arial, sans-serif;
     letter-spacing: 0.14em;
     color: #c9a84c;
@@ -85,9 +86,9 @@
 .wb-player-row {
     display: flex;
     align-items: center;
-    padding: 10px 12px;
+    padding: clamp(6px, 1.2vh, 14px) clamp(8px, 1.5vw, 16px);
     border-bottom: 1px solid #1c1c2e;
-    min-height: 56px;
+    min-height: clamp(36px, 7vh, 72px);
 }
 
 .wb-player-row.wb-serving {
@@ -98,23 +99,23 @@
 .wb-prev-sets {
     display: flex;
     gap: 4px;
-    min-width: 150px;
+    min-width: clamp(80px, 18vw, 180px);
     flex-shrink: 0;
     align-items: center;
 }
 
 .wb-prev-score {
     display: inline-block;
-    width: 26px;
+    width: clamp(18px, 3.5vw, 32px);
     text-align: center;
-    font-size: 1.25rem;
+    font-size: clamp(0.9rem, 1.8vw, 1.5rem);
     color: #cccccc;
 }
 
 /* Player name */
 .wb-name {
     flex: 1;
-    font-size: 1.2rem;
+    font-size: clamp(0.85rem, 2vw, 1.6rem);
     font-weight: bold;
     letter-spacing: 0.03em;
     padding: 0 12px;
@@ -126,7 +127,7 @@
 /* Serve indicator dot */
 .wb-serve-dot {
     color: #c9a84c;
-    font-size: 0.65rem;
+    font-size: clamp(0.45rem, 0.9vw, 0.75rem);
     margin-right: 7px;
     vertical-align: middle;
 }
@@ -134,7 +135,7 @@
 /* Live score columns */
 .wb-live-scores {
     display: flex;
-    min-width: 195px;
+    min-width: clamp(120px, 24vw, 240px);
     justify-content: space-around;
     flex-shrink: 0;
     align-items: center;
@@ -142,9 +143,9 @@
 
 .wb-live-scores span {
     display: inline-block;
-    width: 65px;
+    width: clamp(40px, 8vw, 80px);
     text-align: center;
-    font-size: 1.5rem;
+    font-size: clamp(1rem, 2.5vw, 2.2rem);
     font-weight: bold;
 }
 
@@ -152,25 +153,25 @@
 .wb-separator {
     display: flex;
     align-items: center;
-    padding: 2px 12px;
+    padding: 2px clamp(8px, 1.5vw, 16px);
     border-bottom: 1px solid #1c1c2e;
 }
 
 .wb-prev-sets-spacer {
-    min-width: 150px;
+    min-width: clamp(80px, 18vw, 180px);
     flex-shrink: 0;
 }
 
 .wb-vs {
     flex: 1;
-    font-size: 0.8rem;
+    font-size: clamp(0.6rem, 1.2vw, 1rem);
     color: #777777;
     padding-left: 12px;
     font-style: italic;
 }
 
 .wb-live-scores-spacer {
-    min-width: 195px;
+    min-width: clamp(120px, 24vw, 240px);
     flex-shrink: 0;
 }
 
@@ -178,11 +179,20 @@
 .wb-tiebreak-badge {
     text-align: center;
     padding: 6px;
-    font-size: 0.72rem;
+    font-size: clamp(0.55rem, 1.1vw, 0.85rem);
     font-family: 'Helvetica Neue', Arial, sans-serif;
     letter-spacing: 0.16em;
     color: #c9a84c;
     text-transform: uppercase;
     background-color: #0a0e15;
     border-top: 1px solid #2a2a3a;
+}
+
+/* ── Mobile: hide previous sets column ───────────────────────── */
+@media (max-width: 480px) {
+    .wb-prev-sets,
+    .wb-prev-sets-label,
+    .wb-prev-sets-spacer {
+        display: none;
+    }
 }

--- a/DropShot/wwwroot/app.css
+++ b/DropShot/wwwroot/app.css
@@ -65,11 +65,12 @@ h1:focus {
 }
 
 .scoreboard-tiebreak {
-    margin-top: 16px;
-    font-size: 2rem;
+    margin-top: clamp(8px, 1.5vh, 16px);
+    font-size: clamp(1.2rem, 2.5vw, 2rem);
     font-weight: bold;
     color: gold;
     letter-spacing: 0.1em;
+    text-align: center;
 }
 
 /* Scoreboard fullscreen mode — hides sidebar and content padding */


### PR DESCRIPTION
## Summary
- Both Wimbledon and Default scoreboard layouts now scale to fill the available viewport height and width, like a TV display
- Replaced all hard-coded sizes with CSS `clamp()` for fluid scaling across mobile, tablet, desktop, and large screens
- Wimbledon board: removed 700px max-width cap (now up to 1200px), fluid column widths and font sizes, previous-sets column hides on mobile (<480px)
- Default layout: restructured into full-height flex container with vertically centered content, fluid point display and LED dot sizes
- DotDigit LED dots scale from 6px to 14px based on viewport width

## Test plan
- [ ] Open `/score` on desktop — both layouts should fill the screen and not leave large empty areas
- [ ] Resize browser to mobile width — content should scale down gracefully, no horizontal overflow
- [ ] Test Wimbledon layout on narrow screens (<480px) — previous sets column should hide
- [ ] Verify court/layout dropdowns remain functional at all sizes
- [ ] Check Default layout LED dots scale proportionally on different screen sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)