### PR TITLE
Fix EditForm null Model error on Account pages

### DIFF
--- a/DropShot/Components/Layout/NavMenu.razor
+++ b/DropShot/Components/Layout/NavMenu.razor
@@ -79,9 +79,9 @@
                     </NavLink>
                 </div>
                 <div class="nav-item px-3">
-                    <NavLink class="nav-link" href="Account/Manage">
+                    <a class="nav-link" href="Account/Manage" data-enhance-nav="false">
                         <MudIcon Icon="@Icons.Material.Filled.Person" Class="nav-icon" /> @context.User.Identity?.Name
-                    </NavLink>
+                    </a>
                 </div>
                 <div class="nav-item px-3">
                     <form action="Account/Logout" method="post">
@@ -95,14 +95,14 @@
             </Authorized>
             <NotAuthorized>
                 <div class="nav-item px-3">
-                    <NavLink class="nav-link" href="Account/Register">
+                    <a class="nav-link" href="Account/Register" data-enhance-nav="false">
                         <MudIcon Icon="@Icons.Material.Filled.PersonAdd" Class="nav-icon" /> Register
-                    </NavLink>
+                    </a>
                 </div>
                 <div class="nav-item px-3">
-                    <NavLink class="nav-link" href="Account/Login">
+                    <a class="nav-link" href="Account/Login" data-enhance-nav="false">
                         <MudIcon Icon="@Icons.Material.Filled.Login" Class="nav-icon" /> Login
-                    </NavLink>
+                    </a>
                 </div>
             </NotAuthorized>
         </AuthorizeView>


### PR DESCRIPTION
## Summary
- Account pages (Login, Register, Manage) require SSR for `HttpContext` and `[SupplyParameterFromForm]` to work
- `NavLink` in `NavMenu.razor` triggered Blazor enhanced navigation, rendering these pages inside an interactive circuit where `Model` became `null`
- Replaced with plain `<a>` tags using `data-enhance-nav="false"` to force full page reloads

## Test plan
- [ ] Navigate to `/competitions` while logged out — verify redirect to Login page works without error
- [ ] Click Login/Register links in the nav menu from an interactive page — verify no `InvalidOperationException`
- [ ] Verify login form submits successfully
- [ ] Click Account/Manage link while logged in from an interactive page — verify profile page loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)