### PR TITLE
Guard SupplyParameterFromForm against null on GET requests

### DIFF
--- a/DropShot/Components/Account/Pages/ExternalLogin.razor
+++ b/DropShot/Components/Account/Pages/ExternalLogin.razor
@@ -53,8 +53,10 @@
     [CascadingParameter]
     private HttpContext HttpContext { get; set; } = default!;
 
+    private InputModel _input = new();
+
     [SupplyParameterFromForm]
-    private InputModel Input { get; set; } = default!;
+    private InputModel Input { get => _input; set => _input = value ?? _input; }
 
     [SupplyParameterFromQuery]
     private string? RemoteError { get; set; }

--- a/DropShot/Components/Account/Pages/ForgotPassword.razor
+++ b/DropShot/Components/Account/Pages/ForgotPassword.razor
@@ -34,8 +34,10 @@
 </div>
 
 @code {
+    private InputModel _input = new();
+
     [SupplyParameterFromForm]
-    private InputModel Input { get; set; } = default!;
+    private InputModel Input { get => _input; set => _input = value ?? _input; }
 
     private async Task OnValidSubmitAsync()
     {

--- a/DropShot/Components/Account/Pages/Login.razor
+++ b/DropShot/Components/Account/Pages/Login.razor
@@ -70,8 +70,10 @@
     [CascadingParameter]
     private HttpContext HttpContext { get; set; } = default!;
 
+    private InputModel _input = new();
+
     [SupplyParameterFromForm]
-    private InputModel Input { get; set; } = default!;
+    private InputModel Input { get => _input; set => _input = value ?? _input; }
 
     [SupplyParameterFromQuery]
     private string? ReturnUrl { get; set; }

--- a/DropShot/Components/Account/Pages/LoginWith2fa.razor
+++ b/DropShot/Components/Account/Pages/LoginWith2fa.razor
@@ -48,8 +48,10 @@
     private string? message;
     private ApplicationUser user = default!;
 
+    private InputModel _input = new();
+
     [SupplyParameterFromForm]
-    private InputModel Input { get; set; } = default!;
+    private InputModel Input { get => _input; set => _input = value ?? _input; }
 
     [SupplyParameterFromQuery]
     private string? ReturnUrl { get; set; }

--- a/DropShot/Components/Account/Pages/LoginWithRecoveryCode.razor
+++ b/DropShot/Components/Account/Pages/LoginWithRecoveryCode.razor
@@ -37,8 +37,10 @@
     private string? message;
     private ApplicationUser user = default!;
 
+    private InputModel _input = new();
+
     [SupplyParameterFromForm]
-    private InputModel Input { get; set; } = default!;
+    private InputModel Input { get => _input; set => _input = value ?? _input; }
 
     [SupplyParameterFromQuery]
     private string? ReturnUrl { get; set; }

--- a/DropShot/Components/Account/Pages/Manage/ChangePassword.razor
+++ b/DropShot/Components/Account/Pages/Manage/ChangePassword.razor
@@ -47,8 +47,10 @@
     [CascadingParameter]
     private HttpContext HttpContext { get; set; } = default!;
 
+    private InputModel _input = new();
+
     [SupplyParameterFromForm]
-    private InputModel Input { get; set; } = default!;
+    private InputModel Input { get => _input; set => _input = value ?? _input; }
 
     protected override async Task OnInitializedAsync()
     {

--- a/DropShot/Components/Account/Pages/Manage/DeletePersonalData.razor
+++ b/DropShot/Components/Account/Pages/Manage/DeletePersonalData.razor
@@ -46,8 +46,10 @@
     [CascadingParameter]
     private HttpContext HttpContext { get; set; } = default!;
 
+    private InputModel _input = new();
+
     [SupplyParameterFromForm]
-    private InputModel Input { get; set; } = default!;
+    private InputModel Input { get => _input; set => _input = value ?? _input; }
 
     protected override async Task OnInitializedAsync()
     {

--- a/DropShot/Components/Account/Pages/Manage/Email.razor
+++ b/DropShot/Components/Account/Pages/Manage/Email.razor
@@ -62,8 +62,10 @@
     [CascadingParameter]
     private HttpContext HttpContext { get; set; } = default!;
 
+    private InputModel _input = new();
+
     [SupplyParameterFromForm(FormName = "change-email")]
-    private InputModel Input { get; set; } = default!;
+    private InputModel Input { get => _input; set => _input = value ?? _input; }
 
     protected override async Task OnInitializedAsync()
     {

--- a/DropShot/Components/Account/Pages/Manage/EnableAuthenticator.razor
+++ b/DropShot/Components/Account/Pages/Manage/EnableAuthenticator.razor
@@ -78,8 +78,10 @@ else
     [CascadingParameter]
     private HttpContext HttpContext { get; set; } = default!;
 
+    private InputModel _input = new();
+
     [SupplyParameterFromForm]
-    private InputModel Input { get; set; } = default!;
+    private InputModel Input { get => _input; set => _input = value ?? _input; }
 
     protected override async Task OnInitializedAsync()
     {

--- a/DropShot/Components/Account/Pages/Manage/Index.razor
+++ b/DropShot/Components/Account/Pages/Manage/Index.razor
@@ -41,8 +41,10 @@
     [CascadingParameter]
     private HttpContext HttpContext { get; set; } = default!;
 
+    private InputModel _input = new();
+
     [SupplyParameterFromForm]
-    private InputModel Input { get; set; } = default!;
+    private InputModel Input { get => _input; set => _input = value ?? _input; }
 
     protected override async Task OnInitializedAsync()
     {

--- a/DropShot/Components/Account/Pages/Manage/SetPassword.razor
+++ b/DropShot/Components/Account/Pages/Manage/SetPassword.razor
@@ -44,8 +44,10 @@
     [CascadingParameter]
     private HttpContext HttpContext { get; set; } = default!;
 
+    private InputModel _input = new();
+
     [SupplyParameterFromForm]
-    private InputModel Input { get; set; } = default!;
+    private InputModel Input { get => _input; set => _input = value ?? _input; }
 
     protected override async Task OnInitializedAsync()
     {

--- a/DropShot/Components/Account/Pages/Register.razor
+++ b/DropShot/Components/Account/Pages/Register.razor
@@ -59,8 +59,10 @@
 @code {
     private IEnumerable<IdentityError>? identityErrors;
 
+    private InputModel _input = new();
+
     [SupplyParameterFromForm]
-    private InputModel Input { get; set; } = default!;
+    private InputModel Input { get => _input; set => _input = value ?? _input; }
 
     [SupplyParameterFromQuery]
     private string? ReturnUrl { get; set; }

--- a/DropShot/Components/Account/Pages/ResendEmailConfirmation.razor
+++ b/DropShot/Components/Account/Pages/ResendEmailConfirmation.razor
@@ -36,8 +36,10 @@
 @code {
     private string? message;
 
+    private InputModel _input = new();
+
     [SupplyParameterFromForm]
-    private InputModel Input { get; set; } = default!;
+    private InputModel Input { get => _input; set => _input = value ?? _input; }
 
     private async Task OnValidSubmitAsync()
     {

--- a/DropShot/Components/Account/Pages/ResetPassword.razor
+++ b/DropShot/Components/Account/Pages/ResetPassword.razor
@@ -45,8 +45,10 @@
 @code {
     private IEnumerable<IdentityError>? identityErrors;
 
+    private InputModel _input = new();
+
     [SupplyParameterFromForm]
-    private InputModel Input { get; set; } = default!;
+    private InputModel Input { get => _input; set => _input = value ?? _input; }
 
     [SupplyParameterFromQuery]
     private string? Code { get; set; }


### PR DESCRIPTION
## Summary
- In .NET 10, `[SupplyParameterFromForm]` can set `Input` to `null` on GET requests during SSR, overriding the `= new()` field initializer
- This causes `EditForm` to throw `InvalidOperationException: EditForm requires either a Model parameter, or an EditContext parameter`
- Fixed by using a backing field with a null-coalescing setter (`set => _input = value ?? _input`) across all 14 Account pages

## Test plan
- [ ] Navigate to `/Account/Login?ReturnUrl=%2Fcompetitions` — verify no error
- [ ] Submit login form — verify form data binds correctly
- [ ] Check Register, ForgotPassword, and Manage pages load without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)