### PR TITLE
Register AdminEmailService mock in test context

### DIFF
--- a/DropShot.Tests/Helpers/DropShotTestContext.cs
+++ b/DropShot.Tests/Helpers/DropShotTestContext.cs
@@ -93,6 +93,10 @@ public class DropShotTestContext : BunitContext
             emailService, config, NullLogger<ResultVerificationService>.Instance);
         Services.AddScoped(_ => resultVerification);
 
+        var adminEmailSvc = Substitute.For<AdminEmailService>(
+            emailService, config, NullLogger<AdminEmailService>.Instance);
+        Services.AddScoped(_ => adminEmailSvc);
+
         Services.AddScoped(_ => Substitute.For<JwtTokenService>(config, userManager));
 
         // Logging


### PR DESCRIPTION
## Summary
- Adds `AdminEmailService` mock registration to `DropShotTestContext` so CompetitionPage tests resolve the injected service
- Fixes 2 test failures: `CompetitionPage_New_Renders_Without_Exception` and `CompetitionPage_Existing_Renders_With_Data`

## Test plan
- [x] All 29 bUnit tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)