### PR TITLE
Fix scoreboard reverting to old score when navigating back

### DIFF
--- a/DropShot/Components/Pages/Scoreboard.razor
+++ b/DropShot/Components/Pages/Scoreboard.razor
@@ -185,7 +185,7 @@ else
             if (_activeMatch?.MatchJson is { } json)
             {
                 var match = JsonConvert.DeserializeObject<DropShot.Models.Match>(json);
-                var latest = match?.HistoryList?.FirstOrDefault();
+                var latest = match?.HistoryList?.LastOrDefault();
                 if (latest != null)
                     currentScore = latest;
             }


### PR DESCRIPTION
## Summary
- Fixed `Scoreboard.razor` using `FirstOrDefault()` on `HistoryList`, which returned the oldest (initial 0-0) state instead of the current score
- Changed to `LastOrDefault()` to correctly load the most recent score when returning to the scoreboard

## Test plan
- [ ] Start a match and score several points
- [ ] Navigate away from the scoreboard page
- [ ] Return to the scoreboard and verify the current score is displayed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)