### PR TITLE
Fix .gitignore excluding test project directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,8 @@ ipch/
 
 # Visual Studio Trace Files
 *.e2e
+!DropShot.E2E/
+!DropShot.Tests/
 
 # TFS 2012 Local Workspace
 $tf/


### PR DESCRIPTION
## Changes

- Added exceptions to `.gitignore` to prevent excluding test project directories
- Negated patterns for `DropShot.E2E/` and `DropShot.Tests/` directories

## Details

The `.gitignore` was previously configured to ignore all `*.e2e` files, which inadvertently excluded the entire `DropShot.E2E/` and `DropShot.Tests/` project directories. This fix adds explicit negation patterns to ensure these test projects are tracked in version control.