### PR TITLE
Revert deploy pipeline to unblock deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
       - main  # or your deployment branch
 
 jobs:
-  build-and-test:
+  build-and-deploy:
     runs-on: ubuntu-latest
 
     steps:
@@ -19,26 +19,10 @@ jobs:
         dotnet-version: '10.0.x'
 
     - name: Restore dependencies
-      run: dotnet restore
+      run: dotnet restore DropShot/DropShot.csproj
 
     - name: Build
-      run: dotnet build --configuration Release
-
-    - name: Run bUnit tests
-      run: dotnet test DropShot.Tests/DropShot.Tests.csproj --configuration Release --no-build --verbosity normal
-
-  deploy:
-    needs: build-and-test
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: '10.0.x'
+      run: dotnet build DropShot/DropShot.csproj --configuration Release
 
     - name: Publish
       run: dotnet publish DropShot/DropShot.csproj -c Release -o ./publish
@@ -49,32 +33,3 @@ jobs:
         app-name: DropShot
         publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
         package: ./publish
-
-  e2e-tests:
-    needs: deploy
-    runs-on: ubuntu-latest
-    if: vars.STAGING_URL != ''
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: '10.0.x'
-
-    - name: Build E2E tests
-      run: dotnet build DropShot.E2E/DropShot.E2E.csproj --configuration Release
-
-    - name: Install Playwright browsers
-      run: pwsh DropShot.E2E/bin/Release/net10.0/playwright.ps1 install --with-deps chromium
-
-    - name: Run E2E tests
-      run: dotnet test DropShot.E2E/DropShot.E2E.csproj --configuration Release --no-build --verbosity normal
-      env:
-        PLAYWRIGHT_BASE_URL: ${{ vars.STAGING_URL }}
-        TEST_USER_EMAIL: ${{ secrets.TEST_USER_EMAIL }}
-        TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
-        TEST_ADMIN_EMAIL: ${{ secrets.TEST_ADMIN_EMAIL }}
-        TEST_ADMIN_PASSWORD: ${{ secrets.TEST_ADMIN_PASSWORD }}


### PR DESCRIPTION
## Summary
- Removes bUnit test gate and E2E test jobs from the deploy pipeline
- Scopes restore/build back to `DropShot/DropShot.csproj` only (avoids MAUI workload issues)
- Restores single `build-and-deploy` job for straightforward deployment

Previous PR was overwritten by a concurrent merge — this re-applies the fix.

## Test plan
- [ ] Merge and verify GitHub Actions deploy workflow runs successfully
- [ ] Confirm Azure deployment completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)