### PR TITLE
Add scoring type selection and court change in match settings

### DIFF
--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -716,12 +716,6 @@
             .Select(p => p.DisplayName)
             .ToList();
 
-        _courts = await DbContext.Courts
-            .Include(c => c.Club)
-            .Where(c => !DbContext.SavedMatch.Any(m => !m.Complete && m.CourtId == c.CourtId))
-            .OrderBy(c => c.Club.Name).ThenBy(c => c.Name)
-            .ToListAsync();
-
         if (MatchId > 0)
         {
             var savedMatch = await DbContext.SavedMatch
@@ -770,6 +764,13 @@
                 Label_Switch1 = _competitionFixture.Player3 != null;
             }
         }
+
+        _courts = await DbContext.Courts
+            .Include(c => c.Club)
+            .Where(c => c.CourtId == _selectedCourtId
+                        || !DbContext.SavedMatch.Any(m => !m.Complete && m.CourtId == c.CourtId))
+            .OrderBy(c => c.Club.Name).ThenBy(c => c.Name)
+            .ToListAsync();
 
         // Mark as loaded after DB queries so content renders immediately.
         // The hub connection is deferred to OnAfterRenderAsync so it only


### PR DESCRIPTION
## Summary
- Add a **Game Scoring** toggle to the pre-match setup form so users can choose between point scoring (0/15/30/40) and game scoring before starting
- Persist `GameScoring` on the `Match` model so the setting survives page reloads
- Add a **court selector** to the in-match settings panel, allowing court changes mid-match
- Fix court dropdown to include the currently assigned court (previously excluded by the active-match filter)

## Test plan
- [ ] Start a new match with Game Scoring toggled off, verify point scoring displays (0/15/30/40)
- [ ] Navigate away and back to `/match/{id}`, confirm scoring type persists
- [ ] Open settings during a match, change court, save — verify court header updates
- [ ] Open settings on a match with a court already assigned — verify it shows the display name, not the ID
- [ ] Change to a different court then change back — verify the original court is still in the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)