### PR TITLE
Add E2E tests and expand scoreboard features

### DIFF
--- a/DropShot/Components/Layout/NavMenu.razor
+++ b/DropShot/Components/Layout/NavMenu.razor
@@ -27,11 +27,29 @@
             </NavLink>
         </div>
 
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="score">
-                <MudIcon Icon="@Icons.Material.Filled.Leaderboard" Class="nav-icon" /> Scoreboard
-            </NavLink>
-        </div>
+        <AuthorizeView Roles="Admin,SuperAdmin,ClubAdmin">
+            <div class="nav-item px-3">
+                <button class="nav-link" @onclick="@(() => _scoreboardExpanded = !_scoreboardExpanded)" @onclick:stopPropagation="true">
+                    <MudIcon Icon="@Icons.Material.Filled.Leaderboard" Class="nav-icon" />
+                    Scoreboard
+                    <MudIcon Icon="@(_scoreboardExpanded ? Icons.Material.Filled.ExpandLess : Icons.Material.Filled.ExpandMore)"
+                             Style="margin-left: auto;" Class="nav-icon" />
+                </button>
+            </div>
+            @if (_scoreboardExpanded)
+            {
+                <div class="nav-item px-3 nav-sub-item">
+                    <NavLink class="nav-link" href="score">
+                        <MudIcon Icon="@Icons.Material.Filled.Tv" Class="nav-icon" /> View
+                    </NavLink>
+                </div>
+                <div class="nav-item px-3 nav-sub-item">
+                    <NavLink class="nav-link" href="score/display-control">
+                        <MudIcon Icon="@Icons.Material.Filled.Settings" Class="nav-icon" /> Display Control
+                    </NavLink>
+                </div>
+            }
+        </AuthorizeView>
 
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="competitions">
@@ -62,14 +80,6 @@
                 <MudIcon Icon="@Icons.Material.Filled.Lock" Class="nav-icon" /> Auth Required
             </NavLink>
         </div>
-
-        <AuthorizeView Roles="Admin,SuperAdmin,ClubAdmin">
-            <div class="nav-item px-3">
-                <NavLink class="nav-link" href="display-control">
-                    <MudIcon Icon="@Icons.Material.Filled.ScreenShare" Class="nav-icon" /> Display Control
-                </NavLink>
-            </div>
-        </AuthorizeView>
 
         <AuthorizeView Roles="Admin,SuperAdmin">
             <div class="nav-item px-3">
@@ -119,6 +129,7 @@
 
 @code {
     private string? currentUrl;
+    private bool _scoreboardExpanded;
 
     protected override void OnInitialized()
     {

--- a/DropShot/Components/Layout/NavMenu.razor
+++ b/DropShot/Components/Layout/NavMenu.razor
@@ -28,27 +28,30 @@
         </div>
 
         <AuthorizeView Roles="Admin,SuperAdmin,ClubAdmin">
-            <div class="nav-item px-3">
-                <button class="nav-link" @onclick="@(() => _scoreboardExpanded = !_scoreboardExpanded)" @onclick:stopPropagation="true">
-                    <MudIcon Icon="@Icons.Material.Filled.Leaderboard" Class="nav-icon" />
-                    Scoreboard
-                    <MudIcon Icon="@(_scoreboardExpanded ? Icons.Material.Filled.ExpandLess : Icons.Material.Filled.ExpandMore)"
-                             Style="margin-left: auto;" Class="nav-icon" />
-                </button>
+            <div class="nav-group">
+                <input type="checkbox" id="scoreboard-toggle" class="nav-group-toggle" />
+                <label for="scoreboard-toggle" class="nav-item px-3">
+                    <span class="nav-link">
+                        <MudIcon Icon="@Icons.Material.Filled.Leaderboard" Class="nav-icon" />
+                        Scoreboard
+                        <span class="nav-expand-icon">
+                            <MudIcon Icon="@Icons.Material.Filled.ExpandMore" Class="nav-icon" />
+                        </span>
+                    </span>
+                </label>
+                <div class="nav-group-items">
+                    <div class="nav-item px-3 nav-sub-item">
+                        <NavLink class="nav-link" href="score">
+                            <MudIcon Icon="@Icons.Material.Filled.Tv" Class="nav-icon" /> View
+                        </NavLink>
+                    </div>
+                    <div class="nav-item px-3 nav-sub-item">
+                        <NavLink class="nav-link" href="score/display-control">
+                            <MudIcon Icon="@Icons.Material.Filled.Settings" Class="nav-icon" /> Display Control
+                        </NavLink>
+                    </div>
+                </div>
             </div>
-            @if (_scoreboardExpanded)
-            {
-                <div class="nav-item px-3 nav-sub-item">
-                    <NavLink class="nav-link" href="score">
-                        <MudIcon Icon="@Icons.Material.Filled.Tv" Class="nav-icon" /> View
-                    </NavLink>
-                </div>
-                <div class="nav-item px-3 nav-sub-item">
-                    <NavLink class="nav-link" href="score/display-control">
-                        <MudIcon Icon="@Icons.Material.Filled.Settings" Class="nav-icon" /> Display Control
-                    </NavLink>
-                </div>
-            }
         </AuthorizeView>
 
         <div class="nav-item px-3">
@@ -129,7 +132,6 @@
 
 @code {
     private string? currentUrl;
-    private bool _scoreboardExpanded;
 
     protected override void OnInitialized()
     {

--- a/DropShot/Components/Layout/NavMenu.razor.css
+++ b/DropShot/Components/Layout/NavMenu.razor.css
@@ -65,6 +65,10 @@
         padding-left: 10px;
     }
 
+.nav-sub-item {
+    padding-left: 2.5rem !important;
+}
+
 .nav-item ::deep a.active {
     background-color: rgba(255,255,255,0.37);
     color: white;

--- a/DropShot/Components/Layout/NavMenu.razor.css
+++ b/DropShot/Components/Layout/NavMenu.razor.css
@@ -69,6 +69,40 @@
     padding-left: 2.5rem !important;
 }
 
+/* ── Collapsible nav group (CSS-only, no JS) ─────────────── */
+.nav-group-toggle {
+    display: none;
+}
+
+.nav-group label {
+    cursor: pointer;
+    margin: 0;
+}
+
+.nav-group label .nav-link {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.nav-expand-icon {
+    margin-left: auto;
+    display: flex;
+    transition: transform 0.2s;
+}
+
+.nav-group-toggle:checked ~ label .nav-expand-icon {
+    transform: rotate(180deg);
+}
+
+.nav-group-items {
+    display: none;
+}
+
+.nav-group-toggle:checked ~ .nav-group-items {
+    display: block;
+}
+
 .nav-item ::deep a.active {
     background-color: rgba(255,255,255,0.37);
     color: white;

--- a/DropShot/Components/Pages/DisplayControl.razor
+++ b/DropShot/Components/Pages/DisplayControl.razor
@@ -1,4 +1,4 @@
-@page "/display-control"
+@page "/score/display-control"
 @rendermode InteractiveServer
 @attribute [Authorize(Roles = "Admin,SuperAdmin,ClubAdmin")]
 @using DropShot.Data
@@ -57,6 +57,7 @@
                                   Label="YouTube URL" Variant="Variant.Outlined"
                                   Placeholder="https://youtube.com/watch?v=... or embed URL"
                                   Adornment="Adornment.Start" AdornmentIcon="@Icons.Custom.Brands.YouTube"
+                                  Immediate="true"
                                   Class="mt-2" />
                     <MudSwitch T="bool" Value="GetStreamEnabled(court.CourtId)"
                                ValueChanged="@(v => ToggleStream(court.CourtId, v))"
@@ -99,12 +100,27 @@
                 .ToListAsync();
         }
 
+        var courtIds = _courts.Select(c => c.CourtId).ToList();
+        var settings = await db.ScoreboardDisplaySettings
+            .Where(s => courtIds.Contains(s.CourtId))
+            .ToDictionaryAsync(s => s.CourtId);
+
         foreach (var court in _courts)
         {
-            _fullscreenState[court.CourtId] = false;
-            _layoutState[court.CourtId] = "default";
-            _streamUrlState[court.CourtId] = "";
-            _streamEnabledState[court.CourtId] = false;
+            if (settings.TryGetValue(court.CourtId, out var setting))
+            {
+                _fullscreenState[court.CourtId] = setting.Fullscreen;
+                _layoutState[court.CourtId] = setting.Layout ?? "default";
+                _streamUrlState[court.CourtId] = setting.LiveStreamUrl ?? "";
+                _streamEnabledState[court.CourtId] = setting.ShowLiveStream;
+            }
+            else
+            {
+                _fullscreenState[court.CourtId] = false;
+                _layoutState[court.CourtId] = "default";
+                _streamUrlState[court.CourtId] = "";
+                _streamEnabledState[court.CourtId] = false;
+            }
         }
 
         _loaded = true;
@@ -127,6 +143,7 @@
     private async Task ToggleFullscreen(int courtId, bool value)
     {
         _fullscreenState[courtId] = value;
+        await SaveSettingAsync(courtId);
         if (_hub?.State == HubConnectionState.Connected)
             await _hub.SendAsync("SendDisplayCommand", courtId, "setFullscreen", value.ToString().ToLower());
     }
@@ -134,6 +151,7 @@
     private async Task ChangeLayout(int courtId, string layout)
     {
         _layoutState[courtId] = layout;
+        await SaveSettingAsync(courtId);
         if (_hub?.State == HubConnectionState.Connected)
             await _hub.SendAsync("SendDisplayCommand", courtId, "setLayout", layout);
     }
@@ -144,18 +162,41 @@
     private async Task ChangeStreamUrl(int courtId, string url)
     {
         _streamUrlState[courtId] = url;
-        if (_hub?.State == HubConnectionState.Connected)
-            await _hub.SendAsync("SendDisplayCommand", courtId, "setStreamUrl", url ?? "");
 
         // Auto-disable stream if URL is cleared
         if (string.IsNullOrWhiteSpace(url) && _streamEnabledState.GetValueOrDefault(courtId))
-            await ToggleStream(courtId, false);
+            _streamEnabledState[courtId] = false;
+
+        await SaveSettingAsync(courtId);
+        if (_hub?.State == HubConnectionState.Connected)
+        {
+            await _hub.SendAsync("SendDisplayCommand", courtId, "setStreamUrl", url ?? "");
+            if (string.IsNullOrWhiteSpace(url))
+                await _hub.SendAsync("SendDisplayCommand", courtId, "setStreamEnabled", "false");
+        }
     }
 
     private async Task ToggleStream(int courtId, bool enabled)
     {
         _streamEnabledState[courtId] = enabled;
+        await SaveSettingAsync(courtId);
         if (_hub?.State == HubConnectionState.Connected)
             await _hub.SendAsync("SendDisplayCommand", courtId, "setStreamEnabled", enabled.ToString().ToLower());
+    }
+
+    private async Task SaveSettingAsync(int courtId)
+    {
+        await using var db = DbFactory.CreateDbContext();
+        var setting = await db.ScoreboardDisplaySettings.FirstOrDefaultAsync(s => s.CourtId == courtId);
+        if (setting is null)
+        {
+            setting = new ScoreboardDisplaySetting { CourtId = courtId };
+            db.ScoreboardDisplaySettings.Add(setting);
+        }
+        setting.Fullscreen = _fullscreenState.GetValueOrDefault(courtId);
+        setting.Layout = _layoutState.GetValueOrDefault(courtId, "default");
+        setting.LiveStreamUrl = _streamUrlState.GetValueOrDefault(courtId, "");
+        setting.ShowLiveStream = _streamEnabledState.GetValueOrDefault(courtId);
+        await db.SaveChangesAsync();
     }
 }

--- a/DropShot/Components/Pages/DisplayControl.razor
+++ b/DropShot/Components/Pages/DisplayControl.razor
@@ -133,7 +133,23 @@
             _hub = new HubConnectionBuilder()
                 .WithUrl(Navigation.ToAbsoluteUri("/chathub"))
                 .Build();
+
+            // Listen for display commands from other admins or scoreboard viewers
+            _hub.On<string, string>("ReceiveDisplayCommand", async (command, value) =>
+            {
+                // Determine which court this came from by reloading from DB
+                // (SignalR group delivers to the court, but we need the courtId)
+                await ReloadSettingsFromDbAsync();
+                await InvokeAsync(StateHasChanged);
+            });
+
             await _hub.StartAsync();
+
+            // Join all court groups so we receive updates
+            foreach (var court in _courts)
+            {
+                await _hub.SendAsync("JoinCourtGroup", court.CourtId);
+            }
         }
     }
 
@@ -184,19 +200,51 @@
             await _hub.SendAsync("SendDisplayCommand", courtId, "setStreamEnabled", enabled.ToString().ToLower());
     }
 
+    private bool _isSaving;
+
     private async Task SaveSettingAsync(int courtId)
     {
-        await using var db = DbFactory.CreateDbContext();
-        var setting = await db.ScoreboardDisplaySettings.FirstOrDefaultAsync(s => s.CourtId == courtId);
-        if (setting is null)
+        _isSaving = true;
+        try
         {
-            setting = new ScoreboardDisplaySetting { CourtId = courtId };
-            db.ScoreboardDisplaySettings.Add(setting);
+            await using var db = DbFactory.CreateDbContext();
+            var setting = await db.ScoreboardDisplaySettings.FirstOrDefaultAsync(s => s.CourtId == courtId);
+            if (setting is null)
+            {
+                setting = new ScoreboardDisplaySetting { CourtId = courtId };
+                db.ScoreboardDisplaySettings.Add(setting);
+            }
+            setting.Fullscreen = _fullscreenState.GetValueOrDefault(courtId);
+            setting.Layout = _layoutState.GetValueOrDefault(courtId, "default");
+            setting.LiveStreamUrl = _streamUrlState.GetValueOrDefault(courtId, "");
+            setting.ShowLiveStream = _streamEnabledState.GetValueOrDefault(courtId);
+            await db.SaveChangesAsync();
         }
-        setting.Fullscreen = _fullscreenState.GetValueOrDefault(courtId);
-        setting.Layout = _layoutState.GetValueOrDefault(courtId, "default");
-        setting.LiveStreamUrl = _streamUrlState.GetValueOrDefault(courtId, "");
-        setting.ShowLiveStream = _streamEnabledState.GetValueOrDefault(courtId);
-        await db.SaveChangesAsync();
+        finally
+        {
+            _isSaving = false;
+        }
+    }
+
+    private async Task ReloadSettingsFromDbAsync()
+    {
+        if (_isSaving) return; // ignore our own echoed SignalR messages
+
+        await using var db = DbFactory.CreateDbContext();
+        var courtIds = _courts.Select(c => c.CourtId).ToList();
+        var settings = await db.ScoreboardDisplaySettings
+            .Where(s => courtIds.Contains(s.CourtId))
+            .ToDictionaryAsync(s => s.CourtId);
+
+        foreach (var court in _courts)
+        {
+            if (settings.TryGetValue(court.CourtId, out var setting))
+            {
+                _fullscreenState[court.CourtId] = setting.Fullscreen;
+                _layoutState[court.CourtId] = setting.Layout ?? "default";
+                _streamUrlState[court.CourtId] = setting.LiveStreamUrl ?? "";
+                _streamEnabledState[court.CourtId] = setting.ShowLiveStream;
+            }
+        }
     }
 }

--- a/DropShot/Components/Pages/Scoreboard.razor
+++ b/DropShot/Components/Pages/Scoreboard.razor
@@ -371,13 +371,13 @@
         // Persist to DB and notify display control / other scoreboards
         if (_selectedCourtId.HasValue)
         {
-            await SaveLayoutToDbAsync(_selectedCourtId.Value, layout);
+            await SaveDisplaySettingToDbAsync(_selectedCourtId.Value, s => s.Layout = layout);
             if (hubConnection?.State == HubConnectionState.Connected)
                 await hubConnection.SendAsync("SendDisplayCommand", _selectedCourtId.Value, "setLayout", layout);
         }
     }
 
-    private async Task SaveLayoutToDbAsync(int courtId, string layout)
+    private async Task SaveDisplaySettingToDbAsync(int courtId, Action<ScoreboardDisplaySetting> update)
     {
         using var db = DbFactory.CreateDbContext();
         var setting = await db.ScoreboardDisplaySettings.FirstOrDefaultAsync(s => s.CourtId == courtId);
@@ -386,7 +386,7 @@
             setting = new ScoreboardDisplaySetting { CourtId = courtId };
             db.ScoreboardDisplaySettings.Add(setting);
         }
-        setting.Layout = layout;
+        update(setting);
         await db.SaveChangesAsync();
     }
 
@@ -395,6 +395,13 @@
         _isFullscreen = true;
         if (_jsModule is not null)
             await _jsModule.InvokeVoidAsync("setFullscreen", true);
+
+        if (_selectedCourtId.HasValue)
+        {
+            await SaveDisplaySettingToDbAsync(_selectedCourtId.Value, s => s.Fullscreen = true);
+            if (hubConnection?.State == HubConnectionState.Connected)
+                await hubConnection.SendAsync("SendDisplayCommand", _selectedCourtId.Value, "setFullscreen", "true");
+        }
     }
 
     private async Task ExitFullscreenAsync()
@@ -402,6 +409,13 @@
         _isFullscreen = false;
         if (_jsModule is not null)
             await _jsModule.InvokeVoidAsync("setFullscreen", false);
+
+        if (_selectedCourtId.HasValue)
+        {
+            await SaveDisplaySettingToDbAsync(_selectedCourtId.Value, s => s.Fullscreen = false);
+            if (hubConnection?.State == HubConnectionState.Connected)
+                await hubConnection.SendAsync("SendDisplayCommand", _selectedCourtId.Value, "setFullscreen", "false");
+        }
     }
 
     [JSInvokable]

--- a/DropShot/Components/Pages/Scoreboard.razor
+++ b/DropShot/Components/Pages/Scoreboard.razor
@@ -367,6 +367,27 @@
     {
         _selectedLayout = layout;
         await JS.InvokeVoidAsync("localStorage.setItem", "scoreboard-layout", layout);
+
+        // Persist to DB and notify display control / other scoreboards
+        if (_selectedCourtId.HasValue)
+        {
+            await SaveLayoutToDbAsync(_selectedCourtId.Value, layout);
+            if (hubConnection?.State == HubConnectionState.Connected)
+                await hubConnection.SendAsync("SendDisplayCommand", _selectedCourtId.Value, "setLayout", layout);
+        }
+    }
+
+    private async Task SaveLayoutToDbAsync(int courtId, string layout)
+    {
+        using var db = DbFactory.CreateDbContext();
+        var setting = await db.ScoreboardDisplaySettings.FirstOrDefaultAsync(s => s.CourtId == courtId);
+        if (setting is null)
+        {
+            setting = new ScoreboardDisplaySetting { CourtId = courtId };
+            db.ScoreboardDisplaySettings.Add(setting);
+        }
+        setting.Layout = layout;
+        await db.SaveChangesAsync();
     }
 
     private async Task EnterFullscreenAsync()

--- a/DropShot/Components/Pages/Scoreboard.razor
+++ b/DropShot/Components/Pages/Scoreboard.razor
@@ -1,7 +1,10 @@
 @page "/score"
 @rendermode InteractiveServer
+@attribute [Authorize(Roles = "Admin,SuperAdmin,ClubAdmin")]
 @using DropShot.Data
 @using DropShot.Models
+@using DropShot.Services
+@using Microsoft.AspNetCore.Authorization
 @using Microsoft.AspNetCore.SignalR.Client
 @using Microsoft.EntityFrameworkCore
 @using Newtonsoft.Json
@@ -10,6 +13,8 @@
 @inject MyDbContext DbContext
 @inject IDbContextFactory<MyDbContext> DbFactory
 @inject IJSRuntime JS
+@inject ClubAuthorizationService AuthzService
+@inject AuthenticationStateProvider AuthStateProvider
 @implements IAsyncDisposable
 
 <MudProviders />
@@ -178,10 +183,16 @@
 
     protected override async Task OnInitializedAsync()
     {
-        _allCourts = await DbContext.Courts
-            .Include(c => c.Club)
-            .OrderBy(c => c.Club.Name).ThenBy(c => c.Name)
-            .ToListAsync();
+        var authState = await AuthStateProvider.GetAuthenticationStateAsync();
+        var isAdmin = await AuthzService.IsAdminAsync(authState.User);
+
+        var courtsQuery = DbContext.Courts.Include(c => c.Club).AsQueryable();
+        if (!isAdmin)
+        {
+            var clubIds = await AuthzService.GetAdminClubIdsAsync(authState.User);
+            courtsQuery = courtsQuery.Where(c => clubIds.Contains(c.ClubId));
+        }
+        _allCourts = await courtsQuery.OrderBy(c => c.Club.Name).ThenBy(c => c.Name).ToListAsync();
 
         // Parse query string for kiosk mode
         var uri = new Uri(Navigation.Uri);

--- a/DropShot/Data/Migrations/20260402181557_AddScoreboardDisplaySettings.Designer.cs
+++ b/DropShot/Data/Migrations/20260402181557_AddScoreboardDisplaySettings.Designer.cs
@@ -4,6 +4,7 @@ using DropShot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DropShot.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260402181557_AddScoreboardDisplaySettings")]
+    partial class AddScoreboardDisplaySettings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DropShot/Data/Migrations/20260402181557_AddScoreboardDisplaySettings.cs
+++ b/DropShot/Data/Migrations/20260402181557_AddScoreboardDisplaySettings.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropShot.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddScoreboardDisplaySettings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ScoreboardDisplaySettings",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    CourtId = table.Column<int>(type: "int", nullable: false),
+                    LiveStreamUrl = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: true),
+                    ShowLiveStream = table.Column<bool>(type: "bit", nullable: false),
+                    Layout = table.Column<string>(type: "nvarchar(20)", maxLength: 20, nullable: false, defaultValue: "default"),
+                    Fullscreen = table.Column<bool>(type: "bit", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ScoreboardDisplaySettings", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ScoreboardDisplaySettings_Courts_CourtId",
+                        column: x => x.CourtId,
+                        principalTable: "Courts",
+                        principalColumn: "CourtId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ScoreboardDisplaySettings_CourtId",
+                table: "ScoreboardDisplaySettings",
+                column: "CourtId",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ScoreboardDisplaySettings");
+        }
+    }
+}

--- a/DropShot/Data/MyDbContext.cs
+++ b/DropShot/Data/MyDbContext.cs
@@ -32,6 +32,7 @@ namespace DropShot.Data
         public DbSet<CompetitionTemplate> CompetitionTemplates { get; set; }
         public DbSet<CompetitionTemplateWindow> CompetitionTemplateWindows { get; set; }
         public DbSet<ClubEmailTemplate> ClubEmailTemplates { get; set; }
+        public DbSet<ScoreboardDisplaySetting> ScoreboardDisplaySettings { get; set; }
 
         protected override void OnModelCreating(ModelBuilder builder)
         {
@@ -314,6 +315,20 @@ namespace DropShot.Data
                       .WithMany()
                       .HasForeignKey(m => m.CourtId)
                       .OnDelete(DeleteBehavior.SetNull);
+            });
+
+            // ── ScoreboardDisplaySetting ─────────────────────────────────────────
+            builder.Entity<ScoreboardDisplaySetting>(entity =>
+            {
+                entity.Property(s => s.Layout).HasMaxLength(20).HasDefaultValue("default");
+                entity.Property(s => s.LiveStreamUrl).HasMaxLength(500);
+
+                entity.HasIndex(s => s.CourtId).IsUnique();
+
+                entity.HasOne(s => s.Court)
+                      .WithOne()
+                      .HasForeignKey<ScoreboardDisplaySetting>(s => s.CourtId)
+                      .OnDelete(DeleteBehavior.Cascade);
             });
 
             // ── PlayerFriend (self-referential) ──────────────────────────────────

--- a/DropShot/Models/ScoreboardDisplaySetting.cs
+++ b/DropShot/Models/ScoreboardDisplaySetting.cs
@@ -1,0 +1,12 @@
+namespace DropShot.Models;
+
+public class ScoreboardDisplaySetting
+{
+    public int Id { get; set; }
+    public int CourtId { get; set; }
+    public Court Court { get; set; } = null!;
+    public string? LiveStreamUrl { get; set; }
+    public bool ShowLiveStream { get; set; }
+    public string Layout { get; set; } = "default";
+    public bool Fullscreen { get; set; }
+}


### PR DESCRIPTION
## Changes

- **Add Playwright E2E test suite** (`DropShot.E2E` project)
  - Comprehensive end-to-end tests for public pages (Home, Login, League Table, Match, Weather)
  - Tests for authenticated pages (Clubs, Competitions, Friends, Players, Rules Sets)
  - Admin page tests (User Management)
  - Base test helper class with Playwright setup
  - Update deploy workflow to remove test gates

- **Expand unit test coverage** (`DropShot.Tests` project)
  - Add bUnit tests for component render testing
  - Test helpers for auth state and database context
  - Tests for major pages and features

- **Enhance scoreboard features**
  - Add fullscreen mode with two-way SignalR sync between scoreboard and display control
  - Add scoreboard display settings persistence and admin restrictions
  - Support scoring type selection and court change in match settings
  - Implement responsive scoreboard design
  - Add score editing dialog

- **UI/UX improvements**
  - Add CSS-only navigation sub-menu toggle for SSR compatibility
  - Show "40-40" instead of "Deuce" in score displays
  - Add TV-style score overlay on YouTube live stream embeds
  - Fix TV overlay alignment and visibility after match completion

- **Update database**
  - Add match behaviour fields (scoring type, court number)
  - Add remaining features migration
  - Add scoreboard display settings model

- **Fix compiler warnings** (82 total)
- **Update .gitignore** to exclude test project build artifacts