### PR TITLE
Fix Elo calculator division by zero

### DIFF
--- a/DropShot/Models/EloCalculator.cs
+++ b/DropShot/Models/EloCalculator.cs
@@ -24,9 +24,10 @@
             double pointsA, double pointsB, double ratingA, double ratingB)
         {
             double PD = pointsA - pointsB;
-            double diff = Math.Abs(PD);
-            double factor = 2.2 / ((Math.Min(ratingA, ratingB) - Math.Max(ratingA, ratingB)) * 0.001 + 2.2);
-            return Math.Log(diff + 1) * factor;
+            double pointDiff = Math.Abs(PD);
+            double ratingDiff = Math.Abs(ratingA - ratingB);
+            double factor = 2.2 / (ratingDiff * 0.001 + 2.2);
+            return Math.Log(pointDiff + 1) * factor;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Fix `MarginOfVictoryMultiplier` in `EloCalculator.cs` where `Math.Min - Math.Max` produced a always-negative value, causing division by zero at 2200 rating difference and negative factors beyond that
- Replace with `Math.Abs(ratingA - ratingB)` to keep the factor safely in (0, 1]

## Test plan
- [ ] Verify Elo calculations with equal ratings (factor should be 1.0)
- [ ] Verify with large rating differences (e.g. 2200+) no longer crashes
- [ ] Verify upsets still receive a higher multiplier than expected wins

https://claude.ai/code/session_01QQdzsLPVkQ85fVNyhvwc8B