### PR TITLE
Remove unused variable in GetLeagueTable

### DIFF
--- a/DropShot/Controllers/CompetitionsController.cs
+++ b/DropShot/Controllers/CompetitionsController.cs
@@ -538,10 +538,6 @@ public class CompetitionsController(
             .Include(cp => cp.Player)
             .ToListAsync();
 
-        var table = participants.ToDictionary(
-            cp => cp.PlayerId,
-            cp => new { Name = cp.Player?.DisplayName ?? "", Played = 0, Won = 0, Lost = 0 });
-
         // Mutable counters
         var played = participants.ToDictionary(cp => cp.PlayerId, _ => 0);
         var won = participants.ToDictionary(cp => cp.PlayerId, _ => 0);


### PR DESCRIPTION
## Summary
- Remove dead `table` dictionary allocation in `GetLeagueTable` that was computed but never read
- The actual counting uses separate `played`/`won`/`lost` dictionaries

## Test plan
- [ ] Verify league table endpoint still returns correct standings
- [ ] Verify no regression in round-robin competition views

https://claude.ai/code/session_01QQdzsLPVkQ85fVNyhvwc8B