### PR TITLE
Preserve active fixtures when rescheduling

### DIFF
--- a/DropShot/Controllers/CompetitionsController.cs
+++ b/DropShot/Controllers/CompetitionsController.cs
@@ -331,9 +331,12 @@ public class CompetitionsController(
         if (comp is null) return NotFound();
         if (!await authzService.CanEditCompetitionAsync(User, comp.HostClubId)) return Forbid();
 
-        // Delete existing non-completed fixtures
+        // Delete existing fixtures that are not completed, in progress, or awaiting verification
         var existing = await db.CompetitionFixtures
-            .Where(f => f.CompetitionId == id && f.Status != DropShot.Models.FixtureStatus.Completed)
+            .Where(f => f.CompetitionId == id
+                && f.Status != DropShot.Models.FixtureStatus.Completed
+                && f.Status != DropShot.Models.FixtureStatus.AwaitingVerification
+                && f.Status != DropShot.Models.FixtureStatus.InProgress)
             .ToListAsync();
         db.CompetitionFixtures.RemoveRange(existing);
 


### PR DESCRIPTION
## Summary
- `ScheduleFixtures` was deleting all non-completed fixtures, including those with `AwaitingVerification` and `InProgress` status
- Now excludes these statuses from deletion so matches being played or pending admin review are preserved

## Test plan
- [ ] Create fixtures in InProgress and AwaitingVerification states, run schedule — verify they survive
- [ ] Verify Scheduled and Cancelled fixtures are still replaced as expected
- [ ] Verify completed fixtures remain untouched

https://claude.ai/code/session_01QQdzsLPVkQ85fVNyhvwc8B