### PR TITLE
Enforce MaxParticipants limit on registration

### DIFF
--- a/DropShot/Controllers/CompetitionsController.cs
+++ b/DropShot/Controllers/CompetitionsController.cs
@@ -149,6 +149,14 @@ public class CompetitionsController(
         if (alreadyRegistered)
             return Conflict(new { message = "Player is already registered in this competition." });
 
+        if (comp.MaxParticipants.HasValue)
+        {
+            var currentCount = await db.CompetitionParticipants
+                .CountAsync(p => p.CompetitionId == id);
+            if (currentCount >= comp.MaxParticipants.Value)
+                return BadRequest(new { message = "Competition has reached its maximum number of participants." });
+        }
+
         var cp = new CompetitionParticipant
         {
             CompetitionId = id, PlayerId = req.PlayerId,


### PR DESCRIPTION
## Summary
- `AddParticipant` endpoint never checked `MaxParticipants`, allowing unlimited registrations
- Now returns 400 BadRequest when the competition has reached its participant cap

## Test plan
- [ ] Set MaxParticipants to 2, add 2 players — verify success
- [ ] Attempt to add a 3rd player — verify 400 response with message
- [ ] Verify competitions with null MaxParticipants still allow unlimited registration

https://claude.ai/code/session_01QQdzsLPVkQ85fVNyhvwc8B