### PR TITLE
Add pagination to list API endpoints

### DIFF
--- a/DropShot/Controllers/ClubsController.cs
+++ b/DropShot/Controllers/ClubsController.cs
@@ -16,10 +16,14 @@ public class ClubsController(
     ClubAuthorizationService authzService) : ControllerBase
 {
     [HttpGet]
-    public async Task<ActionResult<List<ClubDto>>> GetAll()
+    public async Task<ActionResult<List<ClubDto>>> GetAll([FromQuery] int skip = 0, [FromQuery] int take = 50)
     {
         await using var db = dbFactory.CreateDbContext();
-        var clubs = await db.Clubs.Include(c => c.Courts).OrderBy(c => c.Name).ToListAsync();
+        var clubs = await db.Clubs.Include(c => c.Courts)
+            .OrderBy(c => c.Name)
+            .Skip(skip)
+            .Take(Math.Min(take, 200))
+            .ToListAsync();
         return clubs.Select(c => new ClubDto(
             c.ClubId, c.Name, c.AddressLine1, c.AddressLine2,
             c.Town, c.Postcode, c.Phone, c.Email, c.Website,

--- a/DropShot/Controllers/CompetitionsController.cs
+++ b/DropShot/Controllers/CompetitionsController.cs
@@ -16,13 +16,15 @@ public class CompetitionsController(
     ClubAuthorizationService authzService) : ControllerBase
 {
     [HttpGet]
-    public async Task<ActionResult<List<CompetitionDto>>> GetAll()
+    public async Task<ActionResult<List<CompetitionDto>>> GetAll([FromQuery] int skip = 0, [FromQuery] int take = 50)
     {
         await using var db = dbFactory.CreateDbContext();
         var comps = await db.Competition
             .Include(c => c.HostClub)
             .Include(c => c.Rules)
             .OrderBy(c => c.CompetitionName)
+            .Skip(skip)
+            .Take(Math.Min(take, 200))
             .ToListAsync();
         return comps.Select(ToDto).ToList();
     }

--- a/DropShot/Controllers/PlayersController.cs
+++ b/DropShot/Controllers/PlayersController.cs
@@ -13,10 +13,14 @@ namespace DropShot.Controllers;
 public class PlayersController(IDbContextFactory<MyDbContext> dbFactory) : ControllerBase
 {
     [HttpGet]
-    public async Task<ActionResult<List<PlayerDto>>> GetAll()
+    public async Task<ActionResult<List<PlayerDto>>> GetAll([FromQuery] int skip = 0, [FromQuery] int take = 50)
     {
         await using var db = dbFactory.CreateDbContext();
-        var players = await db.Players.OrderBy(p => p.DisplayName).ToListAsync();
+        var players = await db.Players
+            .OrderBy(p => p.DisplayName)
+            .Skip(skip)
+            .Take(Math.Min(take, 200))
+            .ToListAsync();
         return players.Select(ToDto).ToList();
     }
 


### PR DESCRIPTION
## Summary
- `GetAll` endpoints in CompetitionsController, PlayersController, and ClubsController returned all records with no limit
- Added `skip` (default 0) and `take` (default 50, max 200) query parameters to all three

## Test plan
- [ ] Call `/api/competitions` with no params — verify max 50 results
- [ ] Call with `?skip=10&take=5` — verify correct offset/limit
- [ ] Call with `?take=999` — verify capped at 200
- [ ] Verify MAUI client still works (uses default pagination)

https://claude.ai/code/session_01QQdzsLPVkQ85fVNyhvwc8B