### PR TITLE
Fix tiebreak serve rotation after set ends

### DIFF
--- a/DropShot/Services/TennisScoreService.cs
+++ b/DropShot/Services/TennisScoreService.cs
@@ -21,6 +21,7 @@ public class TennisScoreService
                     s.OppGames++;
                 }
                 EndSet(s);
+                return;
             }
 
             var dsd = (s.UserPoints + s.OppPoints) % 2;


### PR DESCRIPTION
## Summary
- After a tiebreak ended via `EndSet()`, the serve-toggle logic still executed, incorrectly flipping the serve one extra time
- Added early `return` after `EndSet(s)` to skip the rotation when the tiebreak is over

## Test plan
- [ ] Play a match to a tiebreak, win it — verify correct server for next set
- [ ] Verify serve rotation during an ongoing tiebreak still alternates correctly
- [ ] Verify non-tiebreak games are unaffected

https://claude.ai/code/session_01QQdzsLPVkQ85fVNyhvwc8B