### PR TITLE
Add head-to-head tiebreaker for round-robin standings

### DIFF
--- a/DropShot/Controllers/CompetitionsController.cs
+++ b/DropShot/Controllers/CompetitionsController.cs
@@ -564,6 +564,17 @@ public class CompetitionsController(
             }
         }
 
+        // Build head-to-head lookup for tiebreaking
+        var h2h = new HashSet<(int winner, int loser)>();
+        foreach (var f in fixtures)
+        {
+            var loserIds = new[] { f.Player1Id, f.Player2Id }
+                .Where(pid => pid.HasValue && pid.Value != f.WinnerPlayerId!.Value)
+                .Select(pid => pid!.Value);
+            foreach (var lid in loserIds)
+                h2h.Add((f.WinnerPlayerId!.Value, lid));
+        }
+
         var entries = participants
             .Select(cp => new LeagueTableEntryDto(
                 cp.PlayerId,
@@ -574,6 +585,7 @@ public class CompetitionsController(
                 won[cp.PlayerId] * 3))
             .OrderByDescending(e => e.Points)
             .ThenByDescending(e => e.Won)
+            .ThenByDescending(e => h2h.Count(h => h.winner == e.PlayerId))
             .ThenBy(e => e.Lost)
             .ToList();
 

--- a/DropShot/Services/CompetitionProgressionService.cs
+++ b/DropShot/Services/CompetitionProgressionService.cs
@@ -103,9 +103,21 @@ public static class CompetitionProgressionService
             }
         }
 
+        // Build head-to-head lookup: (winnerPid, loserPid) pairs
+        var h2h = new HashSet<(int winner, int loser)>();
+        foreach (var f in rrFixtures.Where(f => f.Status == FixtureStatus.Completed && f.WinnerPlayerId.HasValue))
+        {
+            var loserIds = new[] { f.Player1Id, f.Player2Id }
+                .Where(pid => pid.HasValue && pid.Value != f.WinnerPlayerId!.Value)
+                .Select(pid => pid!.Value);
+            foreach (var lid in loserIds)
+                h2h.Add((f.WinnerPlayerId!.Value, lid));
+        }
+
         var seeded = pts
             .OrderByDescending(kv => kv.Value.Points)
             .ThenByDescending(kv => kv.Value.Won)
+            .ThenByDescending(kv => h2h.Count(h => h.winner == kv.Key))
             .Take(targetFixtures.Count * 2)
             .Select(kv => kv.Key)
             .ToList();


### PR DESCRIPTION
## Summary
- Round-robin standings only ranked by points then wins, with no head-to-head tiebreaker
- Added h2h win count as a secondary sort in both `CompetitionProgressionService` (bracket advancement) and `GetLeagueTable` (API response)
- Players tied on points and wins are now ranked by direct match results

## Test plan
- [ ] Create a 3-player RR where two players tie on points/wins — verify h2h winner ranks higher
- [ ] Verify league table display reflects the new ordering
- [ ] Verify bracket advancement uses h2h when advancing from RR to knockout

https://claude.ai/code/session_01QQdzsLPVkQ85fVNyhvwc8B