### PR TITLE
Add duplicate participant check to AddParticipant

### DIFF
--- a/DropShot/Controllers/CompetitionsController.cs
+++ b/DropShot/Controllers/CompetitionsController.cs
@@ -142,6 +142,11 @@ public class CompetitionsController(
         if (comp is null) return NotFound();
         if (!await authzService.CanEditCompetitionAsync(User, comp.HostClubId)) return Forbid();
 
+        var alreadyRegistered = await db.CompetitionParticipants
+            .AnyAsync(cp => cp.CompetitionId == id && cp.PlayerId == req.PlayerId);
+        if (alreadyRegistered)
+            return Conflict(new { message = "Player is already registered in this competition." });
+
         var cp = new CompetitionParticipant
         {
             CompetitionId = id, PlayerId = req.PlayerId,


### PR DESCRIPTION
## Summary
- `AddParticipant` API endpoint allowed the same player to be registered multiple times in a competition
- Now checks for existing registration and returns 409 Conflict with a descriptive message

## Test plan
- [ ] Add a player to a competition — verify success
- [ ] Add the same player again — verify 409 Conflict response
- [ ] Verify the Blazor UI (which already had a client-side guard) still works

https://claude.ai/code/session_01QQdzsLPVkQ85fVNyhvwc8B