### PR TITLE
Add missing authorization to participant endpoints

### DIFF
--- a/DropShot/Controllers/CompetitionsController.cs
+++ b/DropShot/Controllers/CompetitionsController.cs
@@ -157,6 +157,10 @@ public class CompetitionsController(
         int id, int playerId, [FromBody] UpdateParticipantStatusRequest req)
     {
         await using var db = dbFactory.CreateDbContext();
+        var comp = await db.Competition.FindAsync(id);
+        if (comp is null) return NotFound();
+        if (!await authzService.CanEditCompetitionAsync(User, comp.HostClubId)) return Forbid();
+
         var cp = await db.CompetitionParticipants.FindAsync(id, playerId);
         if (cp is null) return NotFound();
         cp.Status = (DropShot.Models.ParticipantStatus)req.Status;
@@ -168,6 +172,10 @@ public class CompetitionsController(
     public async Task<IActionResult> RemoveParticipant(int id, int playerId)
     {
         await using var db = dbFactory.CreateDbContext();
+        var comp = await db.Competition.FindAsync(id);
+        if (comp is null) return NotFound();
+        if (!await authzService.CanEditCompetitionAsync(User, comp.HostClubId)) return Forbid();
+
         var cp = await db.CompetitionParticipants.FindAsync(id, playerId);
         if (cp is null) return NotFound();
         db.CompetitionParticipants.Remove(cp);


### PR DESCRIPTION
## Summary
- `UpdateParticipantStatus` and `RemoveParticipant` were missing `CanEditCompetitionAsync` authorization checks
- Any authenticated user could change any participant's status or remove participants from any competition
- Both endpoints now follow the same authorization pattern as `AddParticipant` and `AssignParticipantTeam`

## Test plan
- [ ] As an admin — verify updating/removing participants still works
- [ ] As a club admin for the host club — verify access is granted
- [ ] As an unrelated authenticated user — verify 403 Forbid is returned
- [ ] Verify MAUI client handles the new auth checks correctly

https://claude.ai/code/session_01QQdzsLPVkQ85fVNyhvwc8B