### PR TITLE
Fix GetMaxSetsToWin returning 0 for unexpected BestOf

### DIFF
--- a/DropShot/Services/TennisScoreService.cs
+++ b/DropShot/Services/TennisScoreService.cs
@@ -214,6 +214,6 @@ public class TennisScoreService
         3 => 2,
         5 => 3,
         7 => 4,
-        _ => 0
+        _ => Math.Max(1, (bestOf + 1) / 2)
     };
 }


### PR DESCRIPTION
## Summary
- `GetMaxSetsToWin` returned 0 for any `BestOf` value outside {3, 5, 7}, making matches impossible to end
- Now falls back to `Math.Max(1, (bestOf + 1) / 2)` which correctly handles BestOf=1 (reachable via the Clubs page) and any other odd value

## Test plan
- [ ] Start a match with BestOf=1 — verify it ends after 1 set
- [ ] Start a match with BestOf=3 — verify it still ends after 2 sets (unchanged)
- [ ] Start a match with BestOf=5 — verify it still ends after 3 sets (unchanged)

https://claude.ai/code/session_01QQdzsLPVkQ85fVNyhvwc8B