### PR TITLE
Fix XSS vulnerability in email HTML body

### DIFF
--- a/DropShot/Models/EmailService.cs
+++ b/DropShot/Models/EmailService.cs
@@ -17,7 +17,7 @@ public class EmailService
         var emailContent = new EmailContent(subject)
         {
             PlainText = body,
-            Html = $"<html><body><p>{body}</p></body></html>"
+            Html = $"<html><body><p>{System.Net.WebUtility.HtmlEncode(body)}</p></body></html>"
         };
 
         var recipients = new EmailRecipients(new List<EmailAddress> { new EmailAddress(recipient) });


### PR DESCRIPTION
## Summary
- `EmailService.SendEmailAsync` interpolated the `body` parameter directly into HTML without encoding
- User-controlled content (competition names, result summaries) could inject scripts into emails
- Now uses `System.Net.WebUtility.HtmlEncode(body)` before interpolation

## Test plan
- [ ] Send a test email with HTML characters in the body (e.g. `<script>`) — verify they are escaped
- [ ] Verify normal emails still render correctly

https://claude.ai/code/session_01QQdzsLPVkQ85fVNyhvwc8B