### PR TITLE
HTML-encode email template substitution values

### DIFF
--- a/DropShot/Services/AdminEmailService.cs
+++ b/DropShot/Services/AdminEmailService.cs
@@ -58,9 +58,9 @@ public class AdminEmailService(
 
     private static string SubstituteVariables(string template, string playerName, string competitionName, string matchLink)
         => template
-            .Replace("{PlayerName}", playerName)
-            .Replace("{CompetitionName}", competitionName)
-            .Replace("{MatchLink}", matchLink);
+            .Replace("{PlayerName}", System.Net.WebUtility.HtmlEncode(playerName))
+            .Replace("{CompetitionName}", System.Net.WebUtility.HtmlEncode(competitionName))
+            .Replace("{MatchLink}", System.Net.WebUtility.HtmlEncode(matchLink));
 
     private async Task SendSafe(string email, string subject, string body, string context)
     {


### PR DESCRIPTION
## Summary
- `AdminEmailService.SubstituteVariables` inserted user-controlled values (player name, competition name, match link) into HTML templates without encoding
- A competition named `Test<script>alert(1)</script>` would inject into emails
- Now wraps all substituted values with `System.Net.WebUtility.HtmlEncode()`

## Test plan
- [ ] Create a competition with HTML characters in the name — verify emails escape them
- [ ] Verify normal admin notification emails render correctly

https://claude.ai/code/session_01QQdzsLPVkQ85fVNyhvwc8B