### PR TITLE
Restrict CORS to configured origins

### DIFF
--- a/DropShot/Program.cs
+++ b/DropShot/Program.cs
@@ -20,9 +20,11 @@ builder.Services.AddRazorComponents()
 builder.Services.AddControllers();
 
 // ── CORS (allow MAUI app to call the API) ────────────────────────────────────
+var allowedOrigins = builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>()
+    ?? ["https://localhost:7000", "https://localhost:5001"];
 builder.Services.AddCors(options =>
     options.AddPolicy("MauiPolicy", policy =>
-        policy.AllowAnyOrigin().AllowAnyHeader().AllowAnyMethod()));
+        policy.WithOrigins(allowedOrigins).AllowAnyHeader().AllowAnyMethod()));
 
 // ── Database ─────────────────────────────────────────────────────────────────
 builder.Services.AddDbContextFactory<MyDbContext>(options =>

--- a/DropShot/appsettings.json
+++ b/DropShot/appsettings.json
@@ -10,6 +10,9 @@
     }
   },
   "AllowedHosts": "*",
+  "Cors": {
+    "AllowedOrigins": ["https://localhost:7000", "https://localhost:5001"]
+  },
   "App": {
     "BaseUrl": "https://localhost:7000"
   },


### PR DESCRIPTION
## Summary
- CORS was configured with `AllowAnyOrigin()`, allowing any domain to make API requests
- Replaced with `WithOrigins()` reading from `Cors:AllowedOrigins` in appsettings.json
- Falls back to localhost origins for development

## Test plan
- [ ] Verify MAUI client can still connect (add its origin to config)
- [ ] Verify cross-origin requests from unlisted domains are rejected
- [ ] Verify local development still works with default localhost origins

https://claude.ai/code/session_01QQdzsLPVkQ85fVNyhvwc8B