### PR TITLE
Fix async void methods in TennisScore component

### DIFF
--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -815,7 +815,7 @@
         }
     }
 
-    private async void SaveHistory()
+    private async Task SaveHistory()
     {
         var snapshotList = _state.SetScores.Select(s => s.Clone()).ToList();
 
@@ -846,7 +846,7 @@
         SaveHistory();
     }
 
-    private async void UndoLastPoint()
+    private async Task UndoLastPoint()
     {
         if (history.Any())
             history.Pop();


### PR DESCRIPTION
## Summary
- `SaveHistory()` and `UndoLastPoint()` in TennisScore.razor were `async void`
- Exceptions in async void methods crash the process and can't be caught
- Changed both to `async Task` — Blazor event handlers accept both return types

## Test plan
- [ ] Use the undo/history features during a match — verify they still work
- [ ] Verify no unhandled exception warnings in browser console

https://claude.ai/code/session_01QQdzsLPVkQ85fVNyhvwc8B