### PR TITLE
Add try-catch around JSON deserialization in Scoreboard

### DIFF
--- a/DropShot/Components/Pages/Scoreboard.razor
+++ b/DropShot/Components/Pages/Scoreboard.razor
@@ -263,7 +263,9 @@
                             return;
                     }
 
-                    GameState? gameState = JsonConvert.DeserializeObject<GameState>(user);
+                    GameState? gameState;
+                    try { gameState = JsonConvert.DeserializeObject<GameState>(user); }
+                    catch (JsonException) { return; }
                     if (gameState != null)
                         currentScore = gameState;
 
@@ -359,7 +361,9 @@
 
             if (_activeMatch?.MatchJson is { } json)
             {
-                var match = JsonConvert.DeserializeObject<DropShot.Models.Match>(json);
+                DropShot.Models.Match? match;
+                try { match = JsonConvert.DeserializeObject<DropShot.Models.Match>(json); }
+                catch (JsonException) { match = null; }
                 var latest = match?.HistoryList?.LastOrDefault();
                 if (latest != null)
                     currentScore = latest;


### PR DESCRIPTION
## Summary
- `JsonConvert.DeserializeObject()` calls in Scoreboard.razor had no error handling
- Malformed JSON from database or SignalR would crash the component
- Wrapped both call sites in try-catch for `JsonException`, skipping gracefully on failure

## Test plan
- [ ] Verify scoreboard displays correctly with valid match data
- [ ] Manually corrupt a SavedMatch.MatchJson value — verify scoreboard handles it without crashing

https://claude.ai/code/session_01QQdzsLPVkQ85fVNyhvwc8B