### PR TITLE
Fix match query showing other users' matches

### DIFF
--- a/DropShot/Components/Pages/Match.razor
+++ b/DropShot/Components/Pages/Match.razor
@@ -65,9 +65,9 @@ else if (_loaded)
 
             if (_userId != null)
             {
-                // Logged-in users see all authenticated matches + their own
+                // Logged-in users see only their own matches
                 _matches = await db.SavedMatch
-                    .Where(m => !m.Complete && (m.UserId != null || (m.UserId == null && m.DeviceToken == null)))
+                    .Where(m => !m.Complete && m.UserId == _userId)
                     .OrderByDescending(m => m.CreatedAt)
                     .ToListAsync();
             }


### PR DESCRIPTION
## Summary
- The match listing query for authenticated users included orphaned matches (null UserId and DeviceToken) visible to all users
- Changed to filter strictly by `m.UserId == _userId` so users only see their own matches

## Test plan
- [ ] Log in as User A, create a match — verify it appears in the list
- [ ] Log in as User B — verify User A's matches are not visible
- [ ] Verify unauthenticated device-token matches still work for anonymous users

https://claude.ai/code/session_01QQdzsLPVkQ85fVNyhvwc8B