### PR TITLE
Add input validation to Player endpoints

### DIFF
--- a/DropShot/Controllers/PlayersController.cs
+++ b/DropShot/Controllers/PlayersController.cs
@@ -32,6 +32,13 @@ public class PlayersController(IDbContextFactory<MyDbContext> dbFactory) : Contr
     [Authorize(Roles = "Admin")]
     public async Task<ActionResult<PlayerDto>> Create([FromBody] CreatePlayerRequest req)
     {
+        if (string.IsNullOrWhiteSpace(req.DisplayName))
+            return BadRequest(new { message = "DisplayName is required." });
+        if (req.DisplayName.Length > 100)
+            return BadRequest(new { message = "DisplayName must be 100 characters or less." });
+        if (req.Email != null && !req.Email.Contains('@'))
+            return BadRequest(new { message = "Invalid email format." });
+
         await using var db = dbFactory.CreateDbContext();
         var player = new Player
         {
@@ -53,6 +60,13 @@ public class PlayersController(IDbContextFactory<MyDbContext> dbFactory) : Contr
     [Authorize(Roles = "Admin")]
     public async Task<ActionResult<PlayerDto>> Update(int id, [FromBody] UpdatePlayerRequest req)
     {
+        if (string.IsNullOrWhiteSpace(req.DisplayName))
+            return BadRequest(new { message = "DisplayName is required." });
+        if (req.DisplayName.Length > 100)
+            return BadRequest(new { message = "DisplayName must be 100 characters or less." });
+        if (req.Email != null && !req.Email.Contains('@'))
+            return BadRequest(new { message = "Invalid email format." });
+
         await using var db = dbFactory.CreateDbContext();
         var p = await db.Players.FindAsync(id);
         if (p is null) return NotFound();


### PR DESCRIPTION
## Summary
- `DisplayName.Trim()` threw NullReferenceException if DisplayName was null
- No length validation despite DB MaxLength(100), no email format check
- Added null/whitespace, length, and email format validation to both Create and Update

## Test plan
- [ ] Create a player with valid data — verify success
- [ ] Create a player with null DisplayName — verify 400 response
- [ ] Create a player with a 200-character name — verify 400 response
- [ ] Create a player with invalid email — verify 400 response

https://claude.ai/code/session_01QQdzsLPVkQ85fVNyhvwc8B