### PR TITLE
Fix league table counting losses on null winner

### DIFF
--- a/DropShot/Controllers/CompetitionsController.cs
+++ b/DropShot/Controllers/CompetitionsController.cs
@@ -559,8 +559,10 @@ public class CompetitionsController(
             foreach (var pid in ids)
             {
                 played[pid]++;
-                if (pid == f.WinnerPlayerId) won[pid]++;
-                else lost[pid]++;
+                if (pid == f.WinnerPlayerId)
+                    won[pid]++;
+                else if (f.WinnerPlayerId.HasValue)
+                    lost[pid]++;
             }
         }
 


### PR DESCRIPTION
## Summary
- If a fixture had null `WinnerPlayerId`, all participants were incorrectly counted as losers
- Added defensive `WinnerPlayerId.HasValue` guard so only the `played` counter increments when winner is unknown

## Test plan
- [ ] View league table with completed fixtures — verify correct win/loss counts
- [ ] Verify walkovers or cancelled fixtures don't inflate loss counts

https://claude.ai/code/session_01QQdzsLPVkQ85fVNyhvwc8B