### PR TITLE
Handle odd number of winners in bracket advancement

### DIFF
--- a/DropShot/Services/CompetitionProgressionService.cs
+++ b/DropShot/Services/CompetitionProgressionService.cs
@@ -200,6 +200,15 @@ public static class CompetitionProgressionService
     internal static void AssignWinners(List<CompetitionFixture> targets, List<int> winners)
     {
         int n = targets.Count;
+        if (winners.Count <= n)
+        {
+            // Not enough winners for seeded pairing — assign sequentially
+            for (int i = 0; i < n; i++)
+                targets[i].Player1Id = i < winners.Count ? winners[i] : null;
+            return;
+        }
+
+        // Standard seeded pairing: seed[i] vs seed[2n-1-i]
         for (int i = 0; i < n; i++)
         {
             int p2Idx = 2 * n - 1 - i;


### PR DESCRIPTION
## Summary
- `AssignWinners` assumed winners count was always 2x target fixtures
- With walkovers producing odd winners, seeded pairing misassigned players
- Now falls back to sequential assignment when there aren't enough winners for pairing

## Test plan
- [ ] Advance a normal round (4 winners to 2 fixtures) — verify correct seeded pairing
- [ ] Advance with 3 winners (one walkover) — verify sequential assignment without crash
- [ ] Verify single-winner advancement to final still works

https://claude.ai/code/session_01QQdzsLPVkQ85fVNyhvwc8B