### PR TITLE
Add club-level authorization to scoreboard settings

### DIFF
--- a/DropShot/Components/Pages/Scoreboard.razor
+++ b/DropShot/Components/Pages/Scoreboard.razor
@@ -322,6 +322,12 @@
 
     private async Task OnCourtChanged(int? courtId)
     {
+        // Verify the user is authorized for this court's club.
+        // _allCourts is already filtered to clubs the user can admin,
+        // so reject any courtId not in that list to prevent query-string bypass.
+        if (courtId.HasValue && !_allCourts.Any(c => c.CourtId == courtId.Value))
+            return;
+
         // Leave old court group
         if (_selectedCourtId.HasValue && hubConnection?.State == HubConnectionState.Connected)
             await hubConnection.SendAsync("LeaveCourtGroup", _selectedCourtId.Value);
@@ -379,6 +385,10 @@
 
     private async Task SaveDisplaySettingToDbAsync(int courtId, Action<ScoreboardDisplaySetting> update)
     {
+        // Verify club-level authorization before persisting display settings
+        if (!_allCourts.Any(c => c.CourtId == courtId))
+            return;
+
         using var db = DbFactory.CreateDbContext();
         var setting = await db.ScoreboardDisplaySettings.FirstOrDefaultAsync(s => s.CourtId == courtId);
         if (setting is null)


### PR DESCRIPTION
## Summary
- Scoreboard display settings were loaded without verifying admin access to the court's club
- An admin of Club A could view/control courts of Club B via query string manipulation
- Now validates selected court is in the user's authorized court list before loading settings or saving changes

## Test plan
- [ ] As Club A admin — verify you can view and control Club A courts
- [ ] As Club A admin — verify Club B courts are not accessible
- [ ] Verify score viewing (non-admin functionality) is unaffected

https://claude.ai/code/session_01QQdzsLPVkQ85fVNyhvwc8B