### PR TITLE
Use fresh DbContext after save in Friends page

### DIFF
--- a/DropShot/Components/Pages/Friends.razor
+++ b/DropShot/Components/Pages/Friends.razor
@@ -188,7 +188,8 @@ else
         await db.SaveChangesAsync();
         Snackbar.Add($"Friend request sent to {_selectedPlayer.DisplayName}.", Severity.Success);
         _selectedPlayer = null;
-        await LoadAll(db);
+        await using var freshDb = DbFactory.CreateDbContext();
+        await LoadAll(freshDb);
     }
 
     private async Task AcceptRequest(PlayerFriend req)
@@ -197,7 +198,8 @@ else
         var pf = await db.PlayerFriends.FindAsync(req.PlayerId, req.FriendPlayerId);
         if (pf != null) { pf.Status = FriendStatus.Accepted; await db.SaveChangesAsync(); }
         Snackbar.Add("Friend request accepted.", Severity.Success);
-        await LoadAll(db);
+        await using var freshDb = DbFactory.CreateDbContext();
+        await LoadAll(freshDb);
     }
 
     private async Task DeclineRequest(PlayerFriend req)
@@ -206,7 +208,8 @@ else
         var pf = await db.PlayerFriends.FindAsync(req.PlayerId, req.FriendPlayerId);
         if (pf != null) { db.PlayerFriends.Remove(pf); await db.SaveChangesAsync(); }
         Snackbar.Add("Request declined.", Severity.Warning);
-        await LoadAll(db);
+        await using var freshDb = DbFactory.CreateDbContext();
+        await LoadAll(freshDb);
     }
 
     private async Task CancelRequest(PlayerFriend req)
@@ -215,7 +218,8 @@ else
         var pf = await db.PlayerFriends.FindAsync(req.PlayerId, req.FriendPlayerId);
         if (pf != null) { db.PlayerFriends.Remove(pf); await db.SaveChangesAsync(); }
         Snackbar.Add("Request cancelled.", Severity.Warning);
-        await LoadAll(db);
+        await using var freshDb = DbFactory.CreateDbContext();
+        await LoadAll(freshDb);
     }
 
     private async Task RemoveFriend(PlayerFriend pf)
@@ -224,6 +228,7 @@ else
         var record = await db.PlayerFriends.FindAsync(pf.PlayerId, pf.FriendPlayerId);
         if (record != null) { db.PlayerFriends.Remove(record); await db.SaveChangesAsync(); }
         Snackbar.Add("Friend removed.", Severity.Warning);
-        await LoadAll(db);
+        await using var freshDb = DbFactory.CreateDbContext();
+        await LoadAll(freshDb);
     }
 }


### PR DESCRIPTION
## Summary
- Five methods in Friends.razor reused the same DbContext after SaveChangesAsync for reload queries
- EF change tracker could return stale cached entities
- Now creates a fresh DbContext for LoadAll after each save operation

## Test plan
- [ ] Send a friend request — verify the list refreshes correctly
- [ ] Accept/decline a request — verify status updates immediately
- [ ] Remove a friend — verify they disappear from the list

https://claude.ai/code/session_01QQdzsLPVkQ85fVNyhvwc8B