### PR TITLE
Add error context to MAUI login failures

### DIFF
--- a/DropShot.Maui/Services/AuthService.cs
+++ b/DropShot.Maui/Services/AuthService.cs
@@ -28,10 +28,17 @@ public class AuthService : AuthenticationStateProvider
     public bool CanEditCompetition(int? hostClubId) =>
         IsAdmin || (hostClubId.HasValue && AdminClubIds.Contains(hostClubId.Value));
 
+    /// <summary>
+    /// Contains the error message from the last failed login attempt, or null if the last login succeeded.
+    /// </summary>
+    public string? LastError { get; private set; }
+
     // ── Login / Logout ───────────────────────────────────────────────────────
 
     public async Task<bool> LoginAsync(string email, string password)
     {
+        LastError = null;
+
         try
         {
             var response = await _http.PostAsJsonAsync("api/auth/login",
@@ -52,8 +59,14 @@ public class AuthService : AuthenticationStateProvider
             NotifyAuthenticationStateChanged(GetAuthenticationStateAsync());
             return true;
         }
-        catch
+        catch (HttpRequestException)
         {
+            LastError = "Network error. Please check your connection.";
+            return false;
+        }
+        catch (Exception)
+        {
+            LastError = "An unexpected error occurred.";
             return false;
         }
     }


### PR DESCRIPTION
## Summary
- `LoginAsync` caught all exceptions returning `false` with no context
- Users couldn't distinguish network errors from bad credentials
- Added `LastError` property with specific messages for `HttpRequestException` vs general errors

## Test plan
- [ ] Log in with correct credentials — verify success and LastError is null
- [ ] Log in with wrong password — verify appropriate error
- [ ] Disable network and attempt login — verify "Network error" message appears

https://claude.ai/code/session_01QQdzsLPVkQ85fVNyhvwc8B