### PR TITLE
Tighten score value limits in EditScoreDialog

### DIFF
--- a/DropShot/Components/EditScoreDialog.razor
+++ b/DropShot/Components/EditScoreDialog.razor
@@ -11,16 +11,16 @@
 
         <MudText Typo="Typo.subtitle2" Class="mb-2">@UserName</MudText>
         <MudStack Row="true" Spacing="2" Class="mb-3">
-            <MudNumericField @bind-Value="UserSets" Label="Sets" Min="0" Max="9" Variant="Variant.Outlined" Style="max-width:100px;" />
+            <MudNumericField @bind-Value="UserSets" Label="Sets" Min="0" Max="3" Variant="Variant.Outlined" Style="max-width:100px;" />
             <MudNumericField @bind-Value="UserGames" Label="Games" Min="0" Max="13" Variant="Variant.Outlined" Style="max-width:100px;" />
-            <MudNumericField @bind-Value="UserPoints" Label="Points" Min="0" Max="99" Variant="Variant.Outlined" Style="max-width:100px;" />
+            <MudNumericField @bind-Value="UserPoints" Label="Points" Min="0" Max="20" Variant="Variant.Outlined" Style="max-width:100px;" />
         </MudStack>
 
         <MudText Typo="Typo.subtitle2" Class="mb-2">@OpponentName</MudText>
         <MudStack Row="true" Spacing="2" Class="mb-3">
-            <MudNumericField @bind-Value="OppSets" Label="Sets" Min="0" Max="9" Variant="Variant.Outlined" Style="max-width:100px;" />
+            <MudNumericField @bind-Value="OppSets" Label="Sets" Min="0" Max="3" Variant="Variant.Outlined" Style="max-width:100px;" />
             <MudNumericField @bind-Value="OppGames" Label="Games" Min="0" Max="13" Variant="Variant.Outlined" Style="max-width:100px;" />
-            <MudNumericField @bind-Value="OppPoints" Label="Points" Min="0" Max="99" Variant="Variant.Outlined" Style="max-width:100px;" />
+            <MudNumericField @bind-Value="OppPoints" Label="Points" Min="0" Max="20" Variant="Variant.Outlined" Style="max-width:100px;" />
         </MudStack>
 
         <MudSwitch @bind-Value="IsUserServing" Label="@($"{UserName} is serving")" Color="Color.Primary" />


### PR DESCRIPTION
## Summary
- Point fields allowed 0-99 and set fields allowed unrealistic values
- Reduced points max to 20 (covers extended tiebreaks) and sets max to 3 (best-of-5 maximum)
- Games max left at 13 which is already reasonable

## Test plan
- [ ] Open edit score dialog — verify field limits are applied
- [ ] Enter a tiebreak score (e.g. 12-10) — verify it's accepted
- [ ] Try to enter points > 20 — verify it's rejected

https://claude.ai/code/session_01QQdzsLPVkQ85fVNyhvwc8B