### PR TITLE
Validate stage belongs to competition in fixture endpoints

### DIFF
--- a/DropShot/Controllers/CompetitionsController.cs
+++ b/DropShot/Controllers/CompetitionsController.cs
@@ -282,6 +282,13 @@ public class CompetitionsController(
         if (comp is null) return NotFound();
         if (!await authzService.CanEditCompetitionAsync(User, comp.HostClubId)) return Forbid();
 
+        if (req.CompetitionStageId.HasValue)
+        {
+            var stage = await db.CompetitionStages.FindAsync(req.CompetitionStageId.Value);
+            if (stage is null || stage.CompetitionId != id)
+                return BadRequest(new { message = "Stage does not belong to this competition." });
+        }
+
         var fixture = new CompetitionFixture { CompetitionId = id };
         ApplyFixture(fixture, req);
         db.CompetitionFixtures.Add(fixture);
@@ -296,6 +303,13 @@ public class CompetitionsController(
         var comp = await db.Competition.FindAsync(id);
         if (comp is null) return NotFound();
         if (!await authzService.CanEditCompetitionAsync(User, comp.HostClubId)) return Forbid();
+
+        if (req.CompetitionStageId.HasValue)
+        {
+            var stage = await db.CompetitionStages.FindAsync(req.CompetitionStageId.Value);
+            if (stage is null || stage.CompetitionId != id)
+                return BadRequest(new { message = "Stage does not belong to this competition." });
+        }
 
         var fixture = await db.CompetitionFixtures.FindAsync(fixtureId);
         if (fixture is null || fixture.CompetitionId != id) return NotFound();


### PR DESCRIPTION
## Summary
- Fixtures could be assigned a `CompetitionStageId` from a different competition
- Added validation in both `AddFixture` and `UpdateFixture` to verify the stage belongs to the target competition

## Test plan
- [ ] Create a fixture with a valid stage — verify success
- [ ] Create a fixture with a stage from another competition — verify 400 response

https://claude.ai/code/session_01QQdzsLPVkQ85fVNyhvwc8B