### PR TITLE
Add development fallback for email service

### DIFF
--- a/DropShot/Models/EmailService.cs
+++ b/DropShot/Models/EmailService.cs
@@ -2,18 +2,30 @@
 
 public class EmailService
 {
-    private readonly EmailClient _emailClient;
-    private readonly string _sender;
+    private readonly EmailClient? _emailClient;
+    private readonly string? _sender;
 
     public EmailService(IConfiguration config)
     {
-        var connectionString = config["ACS:ConnectionString"] ?? throw new InvalidOperationException("ACS:ConnectionString not configured");
+        var connectionString = config["ACS:ConnectionString"];
+        if (string.IsNullOrEmpty(connectionString))
+        {
+            Console.WriteLine("[Email] ACS:ConnectionString not configured. Email sending will be simulated.");
+            return;
+        }
+
         _sender = config["ACS:SenderAddress"] ?? throw new InvalidOperationException("ACS:SenderAddress not configured");
         _emailClient = new EmailClient(connectionString);
     }
 
     public async Task SendEmailAsync(string recipient, string subject, string body)
     {
+        if (_emailClient is null || _sender is null)
+        {
+            Console.WriteLine($"[Email] ACS not configured. Would send to {recipient}: {subject}");
+            return;
+        }
+
         var emailContent = new EmailContent(subject)
         {
             PlainText = body,


### PR DESCRIPTION
## Summary
- Missing `ACS:ConnectionString` threw at runtime, making local development without Azure impossible
- Now logs emails to console when ACS is not configured instead of crashing
- Production behavior unchanged since the connection string is always present

## Test plan
- [ ] Run locally without ACS config — verify app starts and emails are logged to console
- [ ] Run with ACS config — verify emails send normally
- [ ] Verify result verification and admin notification flows work in both modes

https://claude.ai/code/session_01QQdzsLPVkQ85fVNyhvwc8B