### PR TITLE
Add QR codes, direct match links, and court-aware scheduling

### DIFF
--- a/DropShot/Components/App.razor
+++ b/DropShot/Components/App.razor
@@ -19,6 +19,8 @@
     <script src="_content/MudBlazor/MudBlazor.min.js?v=@(MudBlazor.Metadata.Version)"></script>
     <script src="https://cdn.jsdelivr.net/npm/fuse.js@7.0.0/dist/fuse.min.js"></script>
     <script src="js/fuzzySearch.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/qrcode-generator@1.4.4/qrcode.min.js"></script>
+    <script src="js/qrcode-helper.js"></script>
     <script src="_framework/blazor.web.js"></script>
 </body>
 

--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -16,6 +16,8 @@
 @inject AuthenticationStateProvider AuthStateProvider
 @inject IDialogService DialogService
 @inject AdminEmailService AdminEmailSvc
+@inject IConfiguration Configuration
+@inject IJSRuntime JS
 
 <MudProviders />
 
@@ -170,7 +172,7 @@
                 <MudText Typo="Typo.h6" Class="mb-3">Match Windows</MudText>
 
                 <MudGrid Spacing="1" Class="mb-2">
-                    <MudItem xs="4">
+                    <MudItem xs="3">
                         <MudSelect @bind-Value="_newMatchWindowDay" Label="Day" Variant="Variant.Outlined" Margin="Margin.Dense">
                             @foreach (DayOfWeek d in Enum.GetValues<DayOfWeek>())
                             {
@@ -179,10 +181,19 @@
                         </MudSelect>
                     </MudItem>
                     <MudItem xs="3">
+                        <MudSelect @bind-Value="_newMatchWindowCourtId" Label="Court" Variant="Variant.Outlined"
+                                   Margin="Margin.Dense" Clearable="true">
+                            @foreach (var c in _courts)
+                            {
+                                <MudSelectItem T="int?" Value="@((int?)c.CourtId)">@c.Name</MudSelectItem>
+                            }
+                        </MudSelect>
+                    </MudItem>
+                    <MudItem xs="2">
                         <MudTimePicker @bind-Time="_newMatchWindowStart" Label="From" Variant="Variant.Outlined"
                                        Margin="Margin.Dense" AmPm="false" />
                     </MudItem>
-                    <MudItem xs="3">
+                    <MudItem xs="2">
                         <MudTimePicker @bind-Time="_newMatchWindowEnd" Label="To" Variant="Variant.Outlined"
                                        Margin="Margin.Dense" AmPm="false" />
                     </MudItem>
@@ -196,13 +207,14 @@
                 {
                     <MudSimpleTable Dense="true" Class="mb-2">
                         <thead>
-                            <tr><th>Day</th><th>From</th><th>To</th><th></th></tr>
+                            <tr><th>Day</th><th>Court</th><th>From</th><th>To</th><th></th></tr>
                         </thead>
                         <tbody>
                             @foreach (var w in _matchWindows)
                             {
                                 <tr>
                                     <td>@w.DayOfWeek</td>
+                                    <td>@(w.Court?.Name ?? "All courts")</td>
                                     <td>@w.StartTime.ToString(@"hh\:mm")</td>
                                     <td>@w.EndTime.ToString(@"hh\:mm")</td>
                                     <td>
@@ -517,6 +529,12 @@
                                                Color="Color.Warning" aria-label="Override / Enter Result"
                                                OnClick="@(() => OpenOverrideResultAsync(context))" />
                             }
+                            @if (context.Player1Id.HasValue && context.Player2Id.HasValue)
+                            {
+                                <MudIconButton Icon="@Icons.Material.Filled.QrCode2" Size="Size.Small"
+                                               Color="Color.Info" aria-label="QR Code"
+                                               OnClick="@(() => ShowQrCode(context))" />
+                            }
                             <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="Size.Small"
                                            OnClick="@(() => OpenEditFixtureDialog(context))" />
                             <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small"
@@ -711,6 +729,34 @@
     </DialogActions>
 </MudDialog>
 
+@* ── QR Code Dialog ──────────────────────────────────────── *@
+<MudDialog @bind-Visible="_showQrDialog" Options="@(new DialogOptions { MaxWidth = MaxWidth.Small, FullWidth = true })">
+    <TitleContent>Match QR Code</TitleContent>
+    <DialogContent>
+        @if (_qrFixture != null)
+        {
+            <MudStack AlignItems="AlignItems.Center" Spacing="3">
+                <MudText Typo="Typo.subtitle1">@FixturePlayers(_qrFixture)</MudText>
+                @if (_qrFixture.ScheduledAt.HasValue)
+                {
+                    <MudText Typo="Typo.body2" Color="Color.Secondary">@_qrFixture.ScheduledAt.Value.ToString("dd MMM yyyy HH:mm")</MudText>
+                }
+                @if (_qrFixture.Court != null)
+                {
+                    <MudText Typo="Typo.body2" Color="Color.Secondary">@_qrFixture.Court.Name</MudText>
+                }
+                <QrCodeDisplay Url="@_qrUrl" CssClass="d-flex justify-center" />
+                <MudTextField Value="@_qrUrl" ReadOnly="true" Variant="Variant.Outlined" Margin="Margin.Dense"
+                              Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.ContentCopy"
+                              OnAdornmentClick="CopyQrUrl" FullWidth="true" />
+            </MudStack>
+        }
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@(() => _showQrDialog = false)">Close</MudButton>
+    </DialogActions>
+</MudDialog>
+
 @code {
     [Parameter] public int Id { get; set; }
 
@@ -733,6 +779,11 @@
     private List<CompetitionTeam> _teams = [];
     private List<Court> _courts = [];
 
+    // QR code dialog
+    private bool _showQrDialog;
+    private CompetitionFixture? _qrFixture;
+    private string _qrUrl = "";
+
     // Stage dialog
     private bool _showStageDialog;
     private StageForm _stageForm = new();
@@ -754,6 +805,7 @@
     // Match windows
     private List<CompetitionMatchWindow> _matchWindows = [];
     private DayOfWeek _newMatchWindowDay = DayOfWeek.Monday;
+    private int? _newMatchWindowCourtId;
     private TimeSpan? _newMatchWindowStart;
     private TimeSpan? _newMatchWindowEnd;
     private List<ClubSchedulingTemplate> _clubTemplates = [];
@@ -844,7 +896,7 @@
                 .Include(c => c.Fixtures).ThenInclude(f => f.Player3)
                 .Include(c => c.Fixtures).ThenInclude(f => f.Player4)
                 .Include(c => c.Teams)
-                .Include(c => c.MatchWindows)
+                .Include(c => c.MatchWindows).ThenInclude(w => w.Court)
                 .AsNoTracking()
                 .FirstOrDefaultAsync(c => c.CompetitionID == Id);
 
@@ -1246,6 +1298,20 @@
             await OnParametersSetAsync();
     }
 
+    private void ShowQrCode(CompetitionFixture fixture)
+    {
+        _qrFixture = fixture;
+        var baseUrl = (Configuration["App:BaseUrl"] ?? "").TrimEnd('/');
+        _qrUrl = $"{baseUrl}/match/0?fixtureId={fixture.CompetitionFixtureId}&autostart=true";
+        _showQrDialog = true;
+    }
+
+    private async Task CopyQrUrl()
+    {
+        await JS.InvokeVoidAsync("copyToClipboard", _qrUrl);
+        Snackbar.Add("Link copied to clipboard.", Severity.Success);
+    }
+
     private async Task DeleteFixture(CompetitionFixture fixture)
     {
         await using var db = DbFactory.CreateDbContext();
@@ -1262,14 +1328,17 @@
         var w = new CompetitionMatchWindow
         {
             CompetitionId = Id,
+            CourtId       = _newMatchWindowCourtId,
             DayOfWeek     = _newMatchWindowDay,
             StartTime     = _newMatchWindowStart.Value,
             EndTime       = _newMatchWindowEnd.Value
         };
         db.CompetitionMatchWindows.Add(w);
         await db.SaveChangesAsync();
+        w.Court = _courts.FirstOrDefault(c => c.CourtId == _newMatchWindowCourtId);
         _matchWindows.Add(w);
         _matchWindows = [.. _matchWindows.OrderBy(x => x.DayOfWeek).ThenBy(x => x.StartTime)];
+        _newMatchWindowCourtId = null;
         _newMatchWindowStart = null;
         _newMatchWindowEnd = null;
         Snackbar.Add("Window added.", Severity.Success);

--- a/DropShot/Components/QrCodeDisplay.razor
+++ b/DropShot/Components/QrCodeDisplay.razor
@@ -1,0 +1,20 @@
+@inject IJSRuntime JS
+
+<div id="@_elementId" class="@CssClass"></div>
+
+@code {
+    [Parameter, EditorRequired] public string Url { get; set; } = "";
+    [Parameter] public string? CssClass { get; set; }
+
+    private readonly string _elementId = $"qr-{Guid.NewGuid():N}";
+    private string? _renderedUrl;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!string.IsNullOrEmpty(Url) && Url != _renderedUrl)
+        {
+            _renderedUrl = Url;
+            await JS.InvokeVoidAsync("generateQrCode", _elementId, Url);
+        }
+    }
+}

--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -574,8 +574,10 @@
 
     [Parameter] public int MatchId { get; set; }
     [SupplyParameterFromQuery] public int? FixtureId { get; set; }
+    [SupplyParameterFromQuery] public bool? AutoStart { get; set; }
     private int _savedMatchId;
     private CompetitionFixture? _competitionFixture;
+    private bool _autoStartPending;
 
     private List<string> _states = [];
     private List<Court> _courts = [];
@@ -713,6 +715,19 @@
             }
         }
 
+        // Auto-start: skip wizard and go straight to match when all info is available
+        if (AutoStart == true && _competitionFixture != null
+            && !string.IsNullOrEmpty(_value) && !string.IsNullOrEmpty(_value2))
+        {
+            _state.BestOf = _competitionFixture.Competition?.BestOf ?? 3;
+            _state.GameScoring = true;
+            _state.UnlimitedDeuce = true;
+            _state.GamesFirstTo = 6;
+            _selectedCourtId = _competitionFixture.CourtId;
+            _serverChoice = "random";
+            _autoStartPending = true;
+        }
+
         _courts = await DbContext.Courts
             .Include(c => c.Club)
             .Where(c => c.CourtId == _selectedCourtId
@@ -748,6 +763,13 @@
                     .Build();
 
                 await hubConnection.StartAsync();
+            }
+
+            if (_autoStartPending)
+            {
+                _autoStartPending = false;
+                await ButtonOnClick();
+                await InvokeAsync(StateHasChanged);
             }
         }
     }

--- a/DropShot/Controllers/CompetitionsController.cs
+++ b/DropShot/Controllers/CompetitionsController.cs
@@ -395,7 +395,7 @@ public class CompetitionsController(
         var comp = await db.Competition
             .Include(c => c.Stages.OrderBy(s => s.StageOrder))
             .Include(c => c.Participants)
-            .Include(c => c.MatchWindows)
+            .Include(c => c.MatchWindows).ThenInclude(w => w.Court)
             .FirstOrDefaultAsync(c => c.CompetitionID == id);
         if (comp is null) return NotFound();
         if (!await authzService.CanEditCompetitionAsync(User, comp.HostClubId)) return Forbid();
@@ -421,9 +421,30 @@ public class CompetitionsController(
 
         var rng = new Random();
         IReadOnlyList<DropShot.Models.CompetitionMatchWindow> matchWindows = comp.MatchWindows.ToList();
+        var courts = comp.HostClubId.HasValue
+            ? await db.Courts.Where(c => c.ClubId == comp.HostClubId.Value).ToListAsync()
+            : new List<DropShot.Models.Court>();
+        var occupied = new HashSet<(DateTime, int?)>();
 
-        DateTime RandomSlot() =>
-            SchedulingSlotPicker.PickSlot(matchWindows, startDate, endDate, rng);
+        (DateTime, int?) RandomCourtSlot()
+        {
+            var result = SchedulingSlotPicker.PickCourtSlot(matchWindows, courts, occupied, startDate, endDate, rng);
+            occupied.Add(result);
+            return result;
+        }
+
+        CompetitionFixture NewFixture(int compId, int stageId)
+        {
+            var (slot, courtId) = RandomCourtSlot();
+            return new CompetitionFixture
+            {
+                CompetitionId = compId,
+                CompetitionStageId = stageId,
+                ScheduledAt = slot,
+                CourtId = courtId,
+                Status = DropShot.Models.FixtureStatus.Scheduled
+            };
+        }
 
         foreach (var stage in comp.Stages)
         {
@@ -436,15 +457,10 @@ public class CompetitionsController(
                     {
                         for (int j = i + 1; j < players.Count; j++)
                         {
-                            db.CompetitionFixtures.Add(new CompetitionFixture
-                            {
-                                CompetitionId = id,
-                                CompetitionStageId = stage.CompetitionStageId,
-                                Player1Id = players[i],
-                                Player2Id = players[j],
-                                ScheduledAt = RandomSlot(),
-                                Status = DropShot.Models.FixtureStatus.Scheduled
-                            });
+                            var fixture = NewFixture(id, stage.CompetitionStageId);
+                            fixture.Player1Id = players[i];
+                            fixture.Player2Id = players[j];
+                            db.CompetitionFixtures.Add(fixture);
                         }
                     }
                     break;
@@ -470,29 +486,19 @@ public class CompetitionsController(
                         // ── Quarter-Finals (players assigned automatically when RR completes) ──
                         for (int m = 0; m < 4; m++)
                         {
-                            db.CompetitionFixtures.Add(new CompetitionFixture
-                            {
-                                CompetitionId = id,
-                                CompetitionStageId = stage.CompetitionStageId,
-                                FixtureLabel = $"Quarter-Final {m + 1}",
-                                RoundNumber = 1,
-                                ScheduledAt = RandomSlot(),
-                                Status = DropShot.Models.FixtureStatus.Scheduled
-                            });
+                            var qf = NewFixture(id, stage.CompetitionStageId);
+                            qf.FixtureLabel = $"Quarter-Final {m + 1}";
+                            qf.RoundNumber = 1;
+                            db.CompetitionFixtures.Add(qf);
                         }
 
                         // ── Semi-Finals (players assigned automatically when QF completes) ───
                         for (int m = 0; m < 2; m++)
                         {
-                            db.CompetitionFixtures.Add(new CompetitionFixture
-                            {
-                                CompetitionId = id,
-                                CompetitionStageId = stage.CompetitionStageId,
-                                FixtureLabel = $"Semi-Final {m + 1}",
-                                RoundNumber = 2,
-                                ScheduledAt = RandomSlot(),
-                                Status = DropShot.Models.FixtureStatus.Scheduled
-                            });
+                            var sf = NewFixture(id, stage.CompetitionStageId);
+                            sf.FixtureLabel = $"Semi-Final {m + 1}";
+                            sf.RoundNumber = 2;
+                            db.CompetitionFixtures.Add(sf);
                         }
                     }
                     else
@@ -500,42 +506,27 @@ public class CompetitionsController(
                         // ── Semi-Finals (players assigned automatically when RR completes) ────
                         for (int m = 0; m < 2; m++)
                         {
-                            db.CompetitionFixtures.Add(new CompetitionFixture
-                            {
-                                CompetitionId = id,
-                                CompetitionStageId = stage.CompetitionStageId,
-                                FixtureLabel = $"Semi-Final {m + 1}",
-                                RoundNumber = 1,
-                                ScheduledAt = RandomSlot(),
-                                Status = DropShot.Models.FixtureStatus.Scheduled
-                            });
+                            var sf = NewFixture(id, stage.CompetitionStageId);
+                            sf.FixtureLabel = $"Semi-Final {m + 1}";
+                            sf.RoundNumber = 1;
+                            db.CompetitionFixtures.Add(sf);
                         }
                     }
 
                     // ── Final (always a placeholder) ─────────────────────────────
-                    db.CompetitionFixtures.Add(new CompetitionFixture
-                    {
-                        CompetitionId = id,
-                        CompetitionStageId = stage.CompetitionStageId,
-                        FixtureLabel = "Final",
-                        RoundNumber = n >= 8 ? 3 : 2,
-                        ScheduledAt = RandomSlot(),
-                        Status = DropShot.Models.FixtureStatus.Scheduled
-                    });
+                    var final1 = NewFixture(id, stage.CompetitionStageId);
+                    final1.FixtureLabel = "Final";
+                    final1.RoundNumber = n >= 8 ? 3 : 2;
+                    db.CompetitionFixtures.Add(final1);
                     break;
                 }
 
                 case DropShot.Models.StageType.Final:
                 {
-                    db.CompetitionFixtures.Add(new CompetitionFixture
-                    {
-                        CompetitionId = id,
-                        CompetitionStageId = stage.CompetitionStageId,
-                        FixtureLabel = "Final",
-                        RoundNumber = 1,
-                        ScheduledAt = RandomSlot(),
-                        Status = DropShot.Models.FixtureStatus.Scheduled
-                    });
+                    var final2 = NewFixture(id, stage.CompetitionStageId);
+                    final2.FixtureLabel = "Final";
+                    final2.RoundNumber = 1;
+                    db.CompetitionFixtures.Add(final2);
                     break;
                 }
 
@@ -543,15 +534,10 @@ public class CompetitionsController(
                 {
                     for (int m = 0; m < 4; m++)
                     {
-                        db.CompetitionFixtures.Add(new CompetitionFixture
-                        {
-                            CompetitionId = id,
-                            CompetitionStageId = stage.CompetitionStageId,
-                            FixtureLabel = $"Quarter-Final {m + 1}",
-                            RoundNumber = 1,
-                            ScheduledAt = RandomSlot(),
-                            Status = DropShot.Models.FixtureStatus.Scheduled
-                        });
+                        var qf = NewFixture(id, stage.CompetitionStageId);
+                        qf.FixtureLabel = $"Quarter-Final {m + 1}";
+                        qf.RoundNumber = 1;
+                        db.CompetitionFixtures.Add(qf);
                     }
                     break;
                 }
@@ -560,15 +546,10 @@ public class CompetitionsController(
                 {
                     for (int m = 0; m < 2; m++)
                     {
-                        db.CompetitionFixtures.Add(new CompetitionFixture
-                        {
-                            CompetitionId = id,
-                            CompetitionStageId = stage.CompetitionStageId,
-                            FixtureLabel = $"Semi-Final {m + 1}",
-                            RoundNumber = 1,
-                            ScheduledAt = RandomSlot(),
-                            Status = DropShot.Models.FixtureStatus.Scheduled
-                        });
+                        var sf = NewFixture(id, stage.CompetitionStageId);
+                        sf.FixtureLabel = $"Semi-Final {m + 1}";
+                        sf.RoundNumber = 1;
+                        db.CompetitionFixtures.Add(sf);
                     }
                     break;
                 }

--- a/DropShot/Data/Migrations/20260404020215_AddCourtToMatchWindow.Designer.cs
+++ b/DropShot/Data/Migrations/20260404020215_AddCourtToMatchWindow.Designer.cs
@@ -4,6 +4,7 @@ using DropShot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DropShot.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260404020215_AddCourtToMatchWindow")]
+    partial class AddCourtToMatchWindow
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DropShot/Data/Migrations/20260404020215_AddCourtToMatchWindow.cs
+++ b/DropShot/Data/Migrations/20260404020215_AddCourtToMatchWindow.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropShot.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCourtToMatchWindow : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "CourtId",
+                table: "CompetitionMatchWindows",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CompetitionMatchWindows_CourtId",
+                table: "CompetitionMatchWindows",
+                column: "CourtId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CompetitionMatchWindows_Courts_CourtId",
+                table: "CompetitionMatchWindows",
+                column: "CourtId",
+                principalTable: "Courts",
+                principalColumn: "CourtId",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_CompetitionMatchWindows_Courts_CourtId",
+                table: "CompetitionMatchWindows");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CompetitionMatchWindows_CourtId",
+                table: "CompetitionMatchWindows");
+
+            migrationBuilder.DropColumn(
+                name: "CourtId",
+                table: "CompetitionMatchWindows");
+        }
+    }
+}

--- a/DropShot/Data/MyDbContext.cs
+++ b/DropShot/Data/MyDbContext.cs
@@ -243,6 +243,11 @@ namespace DropShot.Data
                       .WithMany(c => c.MatchWindows)
                       .HasForeignKey(w => w.CompetitionId)
                       .OnDelete(DeleteBehavior.Cascade);
+
+                entity.HasOne(w => w.Court)
+                      .WithMany()
+                      .HasForeignKey(w => w.CourtId)
+                      .OnDelete(DeleteBehavior.SetNull);
             });
 
             // ── ClubSchedulingTemplate / ClubSchedulingTemplateWindow ────────────

--- a/DropShot/Models/SchedulingModels.cs
+++ b/DropShot/Models/SchedulingModels.cs
@@ -4,11 +4,13 @@ public class CompetitionMatchWindow
 {
     public int CompetitionMatchWindowId { get; set; }
     public int CompetitionId { get; set; }
+    public int? CourtId { get; set; }
     public DayOfWeek DayOfWeek { get; set; }
     public TimeSpan StartTime { get; set; }
     public TimeSpan EndTime { get; set; }
 
     public Competition Competition { get; set; } = null!;
+    public Court? Court { get; set; }
 }
 
 public class ClubSchedulingTemplate

--- a/DropShot/Services/SchedulingSlotPicker.cs
+++ b/DropShot/Services/SchedulingSlotPicker.cs
@@ -43,6 +43,77 @@ public static class SchedulingSlotPicker
         return FallbackSlot(windowStart, windowEnd, rng, fallbackTimeSlots ?? DefaultTimeSlots);
     }
 
+    /// <summary>
+    /// Picks a random valid (DateTime, CourtId) pair that does not collide with
+    /// already-occupied slots. Two fixtures may share the same time only when
+    /// they are on different courts.
+    /// Falls back to <see cref="PickSlot"/> with no court when no courts are
+    /// provided or all court-specific candidates are exhausted.
+    /// </summary>
+    public static (DateTime slot, int? courtId) PickCourtSlot(
+        IReadOnlyList<CompetitionMatchWindow> windows,
+        IReadOnlyList<Court> courts,
+        HashSet<(DateTime, int?)> occupied,
+        DateTime windowStart,
+        DateTime windowEnd,
+        Random rng)
+    {
+        if (courts.Count == 0)
+            return (PickSlot(windows, windowStart, windowEnd, rng), null);
+
+        var candidates = new List<(DateTime time, int courtId)>();
+
+        for (var d = windowStart.Date; d <= windowEnd.Date; d = d.AddDays(1))
+        {
+            foreach (var court in courts)
+            {
+                // Court-specific windows for this court and day
+                var courtWindows = windows
+                    .Where(w => w.DayOfWeek == d.DayOfWeek && w.CourtId == court.CourtId)
+                    .ToList();
+
+                // If no court-specific windows, use global windows (CourtId == null)
+                if (courtWindows.Count == 0)
+                {
+                    courtWindows = windows
+                        .Where(w => w.DayOfWeek == d.DayOfWeek && w.CourtId == null)
+                        .ToList();
+                }
+
+                foreach (var w in courtWindows)
+                {
+                    for (var t = w.StartTime; t < w.EndTime; t = t.Add(TimeSpan.FromMinutes(30)))
+                        candidates.Add((d + t, court.CourtId));
+                }
+            }
+        }
+
+        // Fall back to default slots per court when no windows defined
+        if (candidates.Count == 0 && windows.Count == 0)
+        {
+            foreach (var court in courts)
+            {
+                for (var d = windowStart.Date; d <= windowEnd.Date; d = d.AddDays(1))
+                {
+                    foreach (var mins in DefaultTimeSlots)
+                        candidates.Add((d.AddMinutes(mins), court.CourtId));
+                }
+            }
+        }
+
+        // Remove occupied slots
+        var available = candidates.Where(c => !occupied.Contains((c.time, c.courtId))).ToList();
+
+        if (available.Count > 0)
+        {
+            var pick = available[rng.Next(available.Count)];
+            return (pick.time, pick.courtId);
+        }
+
+        // All court slots exhausted — fall back to time-only
+        return (PickSlot(windows, windowStart, windowEnd, rng), null);
+    }
+
     private static DateTime FallbackSlot(DateTime start, DateTime end, Random rng, int[] timeSlots)
     {
         var days = Math.Max(0, (end.Date - start.Date).Days);

--- a/DropShot/wwwroot/js/qrcode-helper.js
+++ b/DropShot/wwwroot/js/qrcode-helper.js
@@ -1,0 +1,11 @@
+window.generateQrCode = function (elementId, url) {
+    var qr = qrcode(0, 'M');
+    qr.addData(url);
+    qr.make();
+    var el = document.getElementById(elementId);
+    if (el) el.innerHTML = qr.createSvgTag({ cellSize: 6, margin: 4 });
+};
+
+window.copyToClipboard = function (text) {
+    return navigator.clipboard.writeText(text);
+};


### PR DESCRIPTION
## Summary
- **QR codes per fixture**: Each fixture with assigned players gets a QR code button that opens a dialog with a scannable QR code and copyable direct link. Scanning/clicking the link auto-starts the match, skipping the setup wizard entirely.
- **Court-aware auto-scheduling**: `ScheduleFixtures` now assigns courts from the host club and avoids time+court collisions. Matches can overlap in time if on different courts. New `PickCourtSlot` method in `SchedulingSlotPicker` handles collision detection.
- **Court-specific match windows**: `CompetitionMatchWindow` gains an optional `CourtId` — when set, the window applies only to that court; when null, it applies to all courts. The CompetitionPage UI now includes a court dropdown when adding match windows.

## Test plan
- [ ] Create a competition with 2+ courts and court-specific match windows, run auto-schedule, verify fixtures get court assignments with no same-court-same-time collisions
- [ ] Open a fixture's QR dialog, verify QR renders and URL contains `autostart=true`
- [ ] Navigate to `/match/0?fixtureId=X&autostart=true` — verify wizard is skipped, coin toss plays, match starts with correct players and BestOf from competition
- [ ] Navigate to `/match/0?fixtureId=X` (without autostart) — verify normal wizard flow still works
- [ ] Add match windows with and without court selection, verify table shows "All courts" vs court name
- [ ] Run `dotnet build` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)