### PR TITLE
Overhaul results validation with detailed review and audit trail

### DIFF
--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -501,6 +501,7 @@
                         <MudTh>Date / Time</MudTh>
                         <MudTh>Players</MudTh>
                         <MudTh>Court</MudTh>
+                        <MudTh>Result</MudTh>
                         <MudTh>Status</MudTh>
                         <MudTh></MudTh>
                     </HeaderContent>
@@ -510,6 +511,22 @@
                         <MudTd>@(context.ScheduledAt?.ToString("dd MMM yyyy HH:mm") ?? "—")</MudTd>
                         <MudTd>@FixturePlayers(context)</MudTd>
                         <MudTd>@(context.Court?.Name ?? "—")</MudTd>
+                        <MudTd>
+                            @if (!string.IsNullOrEmpty(context.ResultSummary))
+                            {
+                                <MudText Typo="Typo.body2">@context.ResultSummary</MudText>
+                                @if (context.ResultModifiedByAdmin)
+                                {
+                                    <MudTooltip Text="@($"Original: {context.OriginalResultSummary}")">
+                                        <MudChip T="string" Size="Size.Small" Color="Color.Warning" Variant="Variant.Text">Modified</MudChip>
+                                    </MudTooltip>
+                                }
+                            }
+                            else
+                            {
+                                <MudText Typo="Typo.caption" Color="Color.Secondary">—</MudText>
+                            }
+                        </MudTd>
                         <MudTd>
                             <MudChip T="string" Size="Size.Small" Color="@StatusColor(context.Status)">
                                 @context.Status

--- a/DropShot/Components/Pages/Competitions.razor
+++ b/DropShot/Components/Pages/Competitions.razor
@@ -12,20 +12,82 @@
 @inject IDbContextFactory<MyDbContext> DbFactory
 @inject ClubAuthorizationService AuthzService
 @inject AuthenticationStateProvider AuthStateProvider
+@inject IDialogService DialogService
+@inject ISnackbar Snackbar
 
-@if (_pendingVerifications.Count > 0)
+@if (_pendingFixtures.Count > 0)
 {
-    <MudAlert Severity="Severity.Warning" Class="mb-4">
-        <MudText><strong>Results awaiting verification (@_pendingVerifications.Count)</strong></MudText>
-        <MudList T="string" Dense="true">
-            @foreach (var (label, compId) in _pendingVerifications)
-            {
-                <MudListItem T="string">
-                    <MudLink Href="@($"/competition/{compId}")">@label</MudLink>
-                </MudListItem>
-            }
-        </MudList>
-    </MudAlert>
+    <MudCard Class="mb-4" Elevation="2">
+        <MudCardHeader>
+            <CardHeaderContent>
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                    <MudIcon Icon="@Icons.Material.Filled.RateReview" Color="Color.Warning" />
+                    <MudText Typo="Typo.h6">Results Awaiting Verification (@_pendingFixtures.Count)</MudText>
+                </MudStack>
+            </CardHeaderContent>
+        </MudCardHeader>
+        <MudCardContent Class="pa-0">
+            <MudTable Items="@_pendingFixtures" Dense="true" Hover="true" Breakpoint="Breakpoint.Sm"
+                      GroupBy="@(new TableGroupDefinition<CompetitionFixture>
+                      {
+                          GroupName = "Competition",
+                          Selector = f => f.Competition?.CompetitionName ?? "Unknown",
+                          Expandable = true,
+                          IsInitiallyExpanded = true
+                      })">
+                <HeaderContent>
+                    <MudTh>Match</MudTh>
+                    <MudTh>Players</MudTh>
+                    <MudTh>Submitted Score</MudTh>
+                    <MudTh>Winner</MudTh>
+                    <MudTh Style="width:180px"></MudTh>
+                </HeaderContent>
+                <GroupHeaderTemplate>
+                    <MudTh colspan="5">
+                        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                            <MudIcon Icon="@Icons.Material.Filled.EmojiEvents" Size="Size.Small" Color="Color.Primary" />
+                            <MudText Typo="Typo.subtitle1" Style="font-weight:600">@context.Key</MudText>
+                            <MudChip T="string" Size="Size.Small" Color="Color.Warning">@context.Items.Count() pending</MudChip>
+                        </MudStack>
+                    </MudTh>
+                </GroupHeaderTemplate>
+                <RowTemplate>
+                    <MudTd DataLabel="Match">
+                        <MudText Typo="Typo.body2">@(context.FixtureLabel ?? "Match")</MudText>
+                        @if (context.ScheduledAt.HasValue)
+                        {
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">@context.ScheduledAt.Value.ToString("dd MMM yyyy")</MudText>
+                        }
+                    </MudTd>
+                    <MudTd DataLabel="Players">
+                        <MudText Typo="Typo.body2">@FixturePlayers(context)</MudText>
+                    </MudTd>
+                    <MudTd DataLabel="Score">
+                        <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Color="Color.Dark">
+                            @(context.ResultSummary ?? "—")
+                        </MudChip>
+                    </MudTd>
+                    <MudTd DataLabel="Winner">
+                        <MudText Typo="Typo.body2" Style="font-weight:500">@FixtureWinnerName(context)</MudText>
+                    </MudTd>
+                    <MudTd>
+                        <MudStack Row="true" Spacing="1">
+                            <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Success"
+                                       StartIcon="@Icons.Material.Filled.CheckCircle"
+                                       OnClick="@(() => QuickApproveAsync(context))">
+                                Approve
+                            </MudButton>
+                            <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Warning"
+                                       StartIcon="@Icons.Material.Filled.Edit"
+                                       OnClick="@(() => OpenReviewDialogAsync(context))">
+                                Review
+                            </MudButton>
+                        </MudStack>
+                    </MudTd>
+                </RowTemplate>
+            </MudTable>
+        </MudCardContent>
+    </MudCard>
 }
 
 <MudTextField @bind-Value="_searchText" Placeholder="Search competitions..."
@@ -71,7 +133,7 @@
     private List<Competition> _competitions = [];
     private string _searchText = "";
     private bool _isAdmin;
-    private List<(string Label, int CompetitionId)> _pendingVerifications = [];
+    private List<CompetitionFixture> _pendingFixtures = [];
     private HashSet<int> _editableClubIds = [];
     private HashSet<int> _competitionAdminIds = [];
 
@@ -101,21 +163,19 @@
         // Load pending verifications for admins / club admins / competition admins
         if (_isAdmin || _editableClubIds.Count > 0 || _competitionAdminIds.Count > 0)
         {
-            _pendingVerifications = (await dbc.CompetitionFixtures
+            _pendingFixtures = await dbc.CompetitionFixtures
+                .Include(f => f.Competition)
+                .Include(f => f.Player1)
+                .Include(f => f.Player2)
+                .Include(f => f.Player3)
+                .Include(f => f.Player4)
                 .Where(f => f.Status == FixtureStatus.AwaitingVerification
                     && (_isAdmin
                         || (f.Competition.HostClubId.HasValue && _editableClubIds.Contains(f.Competition.HostClubId.Value))
                         || _competitionAdminIds.Contains(f.CompetitionId)))
-                .Select(f => new
-                {
-                    f.CompetitionId,
-                    Label = f.FixtureLabel != null
-                        ? f.Competition.CompetitionName + " — " + f.FixtureLabel
-                        : f.Competition.CompetitionName
-                })
-                .ToListAsync())
-                .Select(f => (f.Label, f.CompetitionId))
-                .ToList();
+                .OrderBy(f => f.Competition.CompetitionName)
+                .ThenBy(f => f.ScheduledAt)
+                .ToListAsync();
         }
     }
 
@@ -123,4 +183,59 @@
         _isAdmin ||
         (c.HostClubId.HasValue && _editableClubIds.Contains(c.HostClubId.Value)) ||
         _competitionAdminIds.Contains(c.CompetitionID);
+
+    private static string FixturePlayers(CompetitionFixture f)
+    {
+        var s1 = new[] { f.Player1?.DisplayName, f.Player3?.DisplayName }
+            .Where(n => n != null).DefaultIfEmpty("TBD");
+        var s2 = new[] { f.Player2?.DisplayName, f.Player4?.DisplayName }
+            .Where(n => n != null).DefaultIfEmpty("TBD");
+        return $"{string.Join(" & ", s1)} vs {string.Join(" & ", s2)}";
+    }
+
+    private static string FixtureWinnerName(CompetitionFixture f)
+    {
+        if (f.WinnerPlayerId == f.Player1Id) return f.Player1?.DisplayName ?? "Player 1";
+        if (f.WinnerPlayerId == f.Player2Id) return f.Player2?.DisplayName ?? "Player 2";
+        if (f.WinnerPlayerId == f.Player3Id) return f.Player3?.DisplayName ?? "Player 3";
+        if (f.WinnerPlayerId == f.Player4Id) return f.Player4?.DisplayName ?? "Player 4";
+        return "—";
+    }
+
+    private async Task QuickApproveAsync(CompetitionFixture fixture)
+    {
+        await using var db = DbFactory.CreateDbContext();
+        var fx = await db.CompetitionFixtures.FindAsync(fixture.CompetitionFixtureId);
+        if (fx == null) return;
+
+        fx.Status = FixtureStatus.Completed;
+        fx.VerificationToken = null;
+        await db.SaveChangesAsync();
+
+        await CompetitionProgressionService.TryAdvanceAsync(db, fx.CompetitionId, fx.CompetitionFixtureId);
+
+        _pendingFixtures.Remove(fixture);
+        Snackbar.Add("Result approved.", Severity.Success);
+    }
+
+    private async Task OpenReviewDialogAsync(CompetitionFixture fixture)
+    {
+        await using var db = DbFactory.CreateDbContext();
+        var loaded = await db.CompetitionFixtures
+            .Include(f => f.Competition)
+            .Include(f => f.Player1).Include(f => f.Player2)
+            .Include(f => f.Player3).Include(f => f.Player4)
+            .FirstOrDefaultAsync(f => f.CompetitionFixtureId == fixture.CompetitionFixtureId);
+        if (loaded == null) return;
+
+        var parameters = new DialogParameters<ReviewResultDialog> { { x => x.Fixture, loaded } };
+        var dialog = await DialogService.ShowAsync<ReviewResultDialog>("Review Result", parameters,
+            new DialogOptions { MaxWidth = MaxWidth.Small, FullWidth = true });
+        var result = await dialog.Result;
+        if (result is not null && !result.Canceled)
+        {
+            _pendingFixtures.Remove(fixture);
+            Snackbar.Add("Result verified.", Severity.Success);
+        }
+    }
 }

--- a/DropShot/Components/Pages/Home.razor
+++ b/DropShot/Components/Pages/Home.razor
@@ -10,9 +10,12 @@
 @inject IDbContextFactory<MyDbContext> DbFactory
 @inject AuthenticationStateProvider AuthStateProvider
 @inject IDialogService DialogService
+@inject ClubAuthorizationService AuthzService
+@inject ISnackbar Snackbar
 
 @using System.Text.RegularExpressions
 @using System.ComponentModel.DataAnnotations
+@using DropShot.Services
 
 <MudProviders />
 
@@ -21,6 +24,81 @@
     <MudAlert Severity="Severity.Info" Class="mb-4" ShowCloseIcon="true" CloseIconClicked="@(() => LinkedPlayer = false)">
         Your account has been linked to an existing player profile with this email address.
     </MudAlert>
+}
+
+@if (_pendingReviews.Count > 0)
+{
+    <MudCard Class="mb-4" Elevation="2">
+        <MudCardHeader>
+            <CardHeaderContent>
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                    <MudIcon Icon="@Icons.Material.Filled.RateReview" Color="Color.Warning" />
+                    <MudText Typo="Typo.h6">Pending Result Reviews (@_pendingReviews.Count)</MudText>
+                </MudStack>
+            </CardHeaderContent>
+        </MudCardHeader>
+        <MudCardContent Class="pa-0">
+            <MudTable Items="@_pendingReviews" Dense="true" Hover="true" Breakpoint="Breakpoint.Sm"
+                      GroupBy="@(new TableGroupDefinition<CompetitionFixture>
+                      {
+                          GroupName = "Competition",
+                          Selector = f => f.Competition?.CompetitionName ?? "Unknown",
+                          Expandable = true,
+                          IsInitiallyExpanded = true
+                      })">
+                <HeaderContent>
+                    <MudTh>Match</MudTh>
+                    <MudTh>Players</MudTh>
+                    <MudTh>Submitted Score</MudTh>
+                    <MudTh>Winner</MudTh>
+                    <MudTh Style="width:180px"></MudTh>
+                </HeaderContent>
+                <GroupHeaderTemplate>
+                    <MudTh colspan="5">
+                        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                            <MudIcon Icon="@Icons.Material.Filled.EmojiEvents" Size="Size.Small" Color="Color.Primary" />
+                            <MudText Typo="Typo.subtitle1" Style="font-weight:600">@context.Key</MudText>
+                            <MudChip T="string" Size="Size.Small" Color="Color.Warning">@context.Items.Count() pending</MudChip>
+                        </MudStack>
+                    </MudTh>
+                </GroupHeaderTemplate>
+                <RowTemplate>
+                    <MudTd DataLabel="Match">
+                        <MudText Typo="Typo.body2">@(context.FixtureLabel ?? "Match")</MudText>
+                        @if (context.ScheduledAt.HasValue)
+                        {
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">@context.ScheduledAt.Value.ToString("dd MMM yyyy")</MudText>
+                        }
+                    </MudTd>
+                    <MudTd DataLabel="Players">
+                        <MudText Typo="Typo.body2">@ReviewFixturePlayers(context)</MudText>
+                    </MudTd>
+                    <MudTd DataLabel="Score">
+                        <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Color="Color.Dark">
+                            @(context.ResultSummary ?? "—")
+                        </MudChip>
+                    </MudTd>
+                    <MudTd DataLabel="Winner">
+                        <MudText Typo="Typo.body2" Style="font-weight:500">@ReviewWinnerName(context)</MudText>
+                    </MudTd>
+                    <MudTd>
+                        <MudStack Row="true" Spacing="1">
+                            <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Success"
+                                       StartIcon="@Icons.Material.Filled.CheckCircle"
+                                       OnClick="@(() => QuickApproveReviewAsync(context))">
+                                Approve
+                            </MudButton>
+                            <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Warning"
+                                       StartIcon="@Icons.Material.Filled.Edit"
+                                       OnClick="@(() => OpenReviewDialogAsync(context))">
+                                Review
+                            </MudButton>
+                        </MudStack>
+                    </MudTd>
+                </RowTemplate>
+            </MudTable>
+        </MudCardContent>
+    </MudCard>
 }
 
 <MudCarousel Class="mud-width-full" Style="height:400px;" ShowArrows="@arrows" ShowBullets="@bullets" EnableSwipeGesture="@enableSwipeGesture" AutoCycle="@autocycle" TData="object">
@@ -114,6 +192,7 @@
     private bool LinkedPlayer { get; set; }
 
     private List<CompetitionFixture> _upcomingFixtures = [];
+    private List<CompetitionFixture> _pendingReviews = [];
 
     protected override async Task OnInitializedAsync()
     {
@@ -122,6 +201,28 @@
         if (string.IsNullOrEmpty(userId)) return;
 
         await using var db = DbFactory.CreateDbContext();
+
+        // Load pending reviews for admins
+        var isAdmin = await AuthzService.IsAdminAsync(authState.User);
+        var editableClubIds = new HashSet<int>(await AuthzService.GetAdminClubIdsAsync(authState.User));
+        var competitionAdminIds = await AuthzService.GetEditableCompetitionIdsAsync(authState.User);
+
+        if (isAdmin || editableClubIds.Count > 0 || competitionAdminIds.Count > 0)
+        {
+            _pendingReviews = await db.CompetitionFixtures
+                .Include(f => f.Competition)
+                .Include(f => f.Player1).Include(f => f.Player2)
+                .Include(f => f.Player3).Include(f => f.Player4)
+                .Where(f => f.Status == FixtureStatus.AwaitingVerification
+                    && (isAdmin
+                        || (f.Competition.HostClubId.HasValue && editableClubIds.Contains(f.Competition.HostClubId.Value))
+                        || competitionAdminIds.Contains(f.CompetitionId)))
+                .OrderBy(f => f.Competition.CompetitionName)
+                .ThenBy(f => f.ScheduledAt)
+                .ToListAsync();
+        }
+
+        // Load upcoming matches for player
         var player = await db.Players.FirstOrDefaultAsync(p => p.UserId == userId);
         if (player == null) return;
 
@@ -167,4 +268,59 @@
         FixtureStatus.Walkover => Color.Info,
         _ => Color.Default
     };
+
+    // ── Pending review helpers ───────────────────────────────────────────────
+
+    private static string ReviewFixturePlayers(CompetitionFixture f)
+    {
+        var s1 = new[] { f.Player1?.DisplayName, f.Player3?.DisplayName }
+            .Where(n => n != null).DefaultIfEmpty("TBD");
+        var s2 = new[] { f.Player2?.DisplayName, f.Player4?.DisplayName }
+            .Where(n => n != null).DefaultIfEmpty("TBD");
+        return $"{string.Join(" & ", s1)} vs {string.Join(" & ", s2)}";
+    }
+
+    private static string ReviewWinnerName(CompetitionFixture f)
+    {
+        if (f.WinnerPlayerId == f.Player1Id) return f.Player1?.DisplayName ?? "Player 1";
+        if (f.WinnerPlayerId == f.Player2Id) return f.Player2?.DisplayName ?? "Player 2";
+        return "—";
+    }
+
+    private async Task QuickApproveReviewAsync(CompetitionFixture fixture)
+    {
+        await using var db = DbFactory.CreateDbContext();
+        var fx = await db.CompetitionFixtures.FindAsync(fixture.CompetitionFixtureId);
+        if (fx == null) return;
+
+        fx.Status = FixtureStatus.Completed;
+        fx.VerificationToken = null;
+        await db.SaveChangesAsync();
+
+        await CompetitionProgressionService.TryAdvanceAsync(db, fx.CompetitionId, fx.CompetitionFixtureId);
+
+        _pendingReviews.Remove(fixture);
+        Snackbar.Add("Result approved.", Severity.Success);
+    }
+
+    private async Task OpenReviewDialogAsync(CompetitionFixture fixture)
+    {
+        await using var db = DbFactory.CreateDbContext();
+        var loaded = await db.CompetitionFixtures
+            .Include(f => f.Competition)
+            .Include(f => f.Player1).Include(f => f.Player2)
+            .Include(f => f.Player3).Include(f => f.Player4)
+            .FirstOrDefaultAsync(f => f.CompetitionFixtureId == fixture.CompetitionFixtureId);
+        if (loaded == null) return;
+
+        var parameters = new DialogParameters<ReviewResultDialog> { { x => x.Fixture, loaded } };
+        var dialog = await DialogService.ShowAsync<ReviewResultDialog>("Review Result", parameters,
+            new DialogOptions { MaxWidth = MaxWidth.Small, FullWidth = true });
+        var result = await dialog.Result;
+        if (result is not null && !result.Canceled)
+        {
+            _pendingReviews.Remove(fixture);
+            Snackbar.Add("Result verified.", Severity.Success);
+        }
+    }
 }

--- a/DropShot/Components/Pages/VerifyResult.razor
+++ b/DropShot/Components/Pages/VerifyResult.razor
@@ -1,4 +1,5 @@
 @page "/verify-result/{Token}"
+@rendermode InteractiveServer
 @using DropShot.Data
 @using DropShot.Models
 @using DropShot.Services
@@ -15,19 +16,115 @@
             {
                 <MudStack AlignItems="AlignItems.Center" Spacing="3">
                     <MudProgressCircular Indeterminate="true" />
-                    <MudText>Verifying result…</MudText>
+                    <MudText>Loading result details…</MudText>
                 </MudStack>
             }
             else if (_success)
             {
                 <MudStack Spacing="3">
-                    <MudAlert Severity="Severity.Success">Result verified — competition updated.</MudAlert>
+                    <MudAlert Severity="Severity.Success">
+                        Result verified@(_wasModified ? " (score was updated)" : "") — competition updated.
+                    </MudAlert>
                     @if (_competitionId.HasValue)
                     {
-                        <MudButton Href="@($"/competitions/{_competitionId}")" Variant="Variant.Filled" Color="Color.Primary">
+                        <MudButton Href="@($"/competition/{_competitionId}/view")" Variant="Variant.Filled" Color="Color.Primary">
                             View Competition
                         </MudButton>
                     }
+                </MudStack>
+            }
+            else if (_fixture != null)
+            {
+                @* Show fixture details for review *@
+                <MudStack Spacing="3">
+                    <MudText Typo="Typo.h6">Review Submitted Result</MudText>
+
+                    <MudText Typo="Typo.subtitle2" Color="Color.Primary">
+                        @(_fixture.Competition?.CompetitionName ?? "Competition")
+                    </MudText>
+                    @if (!string.IsNullOrEmpty(_fixture.FixtureLabel))
+                    {
+                        <MudText Typo="Typo.caption" Color="Color.Secondary">@_fixture.FixtureLabel</MudText>
+                    }
+
+                    <MudDivider />
+
+                    <MudText Typo="Typo.body1">
+                        <strong>@_side1</strong> vs <strong>@_side2</strong>
+                    </MudText>
+
+                    <MudAlert Severity="Severity.Info" Dense="true" NoIcon="true">
+                        <MudText Typo="Typo.subtitle2">Submitted Score</MudText>
+                        <MudText Typo="Typo.h6">@_fixture.ResultSummary</MudText>
+                        <MudText Typo="Typo.body2">
+                            Winner: <strong>@WinnerName()</strong>
+                        </MudText>
+                    </MudAlert>
+
+                    <MudSwitch @bind-Value="_editing" Label="Modify score" Color="Color.Warning" />
+
+                    @if (_editing)
+                    {
+                        <MudAlert Severity="Severity.Warning" Dense="true">
+                            The original submission will be preserved for audit purposes.
+                        </MudAlert>
+
+                        <MudText Typo="Typo.subtitle2">Updated Set Scores</MudText>
+                        <MudSimpleTable Dense="true" Style="max-width:300px">
+                            <thead>
+                                <tr>
+                                    <th style="width:50px"></th>
+                                    <th style="text-align:center; font-size:0.8rem">@_side1</th>
+                                    <th style="width:20px"></th>
+                                    <th style="text-align:center; font-size:0.8rem">@_side2</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @for (int i = 0; i < _bestOf; i++)
+                                {
+                                    int idx = i;
+                                    <tr>
+                                        <td style="color:#888; font-size:0.8rem; padding-right:8px">Set @(idx + 1)</td>
+                                        <td>
+                                            <MudNumericField T="int?" @bind-Value="_score1[idx]"
+                                                            Min="0" Max="13" Variant="Variant.Outlined"
+                                                            Style="width:65px" HideSpinButtons="true" />
+                                        </td>
+                                        <td style="text-align:center; padding:0 4px; font-weight:bold">-</td>
+                                        <td>
+                                            <MudNumericField T="int?" @bind-Value="_score2[idx]"
+                                                            Min="0" Max="13" Variant="Variant.Outlined"
+                                                            Style="width:65px" HideSpinButtons="true" />
+                                        </td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </MudSimpleTable>
+
+                        <MudSelect T="int?" @bind-Value="_winnerPlayerId" Label="Winner" Variant="Variant.Outlined">
+                            @if (_fixture.Player1Id.HasValue)
+                            {
+                                <MudSelectItem T="int?" Value="@_fixture.Player1Id">@_side1</MudSelectItem>
+                            }
+                            @if (_fixture.Player2Id.HasValue)
+                            {
+                                <MudSelectItem T="int?" Value="@_fixture.Player2Id">@_side2</MudSelectItem>
+                            }
+                        </MudSelect>
+                    }
+
+                    @if (!string.IsNullOrEmpty(_error))
+                    {
+                        <MudAlert Severity="Severity.Error">@_error</MudAlert>
+                    }
+
+                    <MudStack Row="true" Spacing="2" Justify="Justify.FlexEnd">
+                        <MudButton Color="Color.Success" Variant="Variant.Filled"
+                                   StartIcon="@Icons.Material.Filled.CheckCircle"
+                                   OnClick="ApproveAsync" Disabled="_saving">
+                            @(_editing ? "Approve with Changes" : "Approve Result")
+                        </MudButton>
+                    </MudStack>
                 </MudStack>
             }
             else
@@ -43,8 +140,20 @@
 
     private bool _loading = true;
     private bool _success;
+    private bool _wasModified;
     private string _message = "";
     private int? _competitionId;
+
+    private CompetitionFixture? _fixture;
+    private string _side1 = "";
+    private string _side2 = "";
+    private int _bestOf = 3;
+    private int?[] _score1 = new int?[3];
+    private int?[] _score2 = new int?[3];
+    private int? _winnerPlayerId;
+    private bool _editing;
+    private bool _saving;
+    private string? _error;
 
     protected override async Task OnInitializedAsync()
     {
@@ -57,25 +166,109 @@
 
         await using var db = DbFactory.CreateDbContext();
 
-        var fixture = await db.CompetitionFixtures
+        _fixture = await db.CompetitionFixtures
             .Include(f => f.Competition)
+            .Include(f => f.Player1).Include(f => f.Player2)
+            .Include(f => f.Player3).Include(f => f.Player4)
             .FirstOrDefaultAsync(f => f.VerificationToken == token && f.Status == FixtureStatus.AwaitingVerification);
 
-        if (fixture == null)
+        if (_fixture == null)
         {
             _message = "This link has already been used or could not be found.";
             _loading = false;
             return;
         }
 
-        fixture.Status = FixtureStatus.Completed;
-        fixture.VerificationToken = null;
-        await db.SaveChangesAsync();
+        _bestOf = Math.Max(1, _fixture.Competition?.BestOf ?? 3);
+        _score1 = new int?[_bestOf];
+        _score2 = new int?[_bestOf];
 
-        await CompetitionProgressionService.TryAdvanceAsync(db, fixture.CompetitionId, fixture.CompetitionFixtureId);
+        var s1Parts = new[] { _fixture.Player1?.DisplayName, _fixture.Player3?.DisplayName }.Where(n => n != null).ToList();
+        var s2Parts = new[] { _fixture.Player2?.DisplayName, _fixture.Player4?.DisplayName }.Where(n => n != null).ToList();
+        _side1 = s1Parts.Any() ? string.Join(" & ", s1Parts) : "Player 1";
+        _side2 = s2Parts.Any() ? string.Join(" & ", s2Parts) : "Player 2";
 
-        _competitionId = fixture.CompetitionId;
-        _success = true;
+        _winnerPlayerId = _fixture.WinnerPlayerId;
+        ParseResultSummary(_fixture.ResultSummary);
+
         _loading = false;
+    }
+
+    private void ParseResultSummary(string? summary)
+    {
+        if (string.IsNullOrEmpty(summary)) return;
+        var sets = summary.Split(',', StringSplitOptions.TrimEntries);
+        for (int i = 0; i < Math.Min(sets.Length, _bestOf); i++)
+        {
+            var parts = sets[i].Split(new[] { '-', '\u2013' }, StringSplitOptions.TrimEntries);
+            if (parts.Length == 2 && int.TryParse(parts[0], out var s1) && int.TryParse(parts[1], out var s2))
+            {
+                _score1[i] = s1;
+                _score2[i] = s2;
+            }
+        }
+    }
+
+    private string WinnerName()
+    {
+        if (_fixture?.WinnerPlayerId == _fixture?.Player1Id) return _side1;
+        if (_fixture?.WinnerPlayerId == _fixture?.Player2Id) return _side2;
+        return "Unknown";
+    }
+
+    private async Task ApproveAsync()
+    {
+        _error = null;
+
+        if (_editing)
+        {
+            var enteredSets = Enumerable.Range(0, _bestOf)
+                .Where(i => _score1[i].HasValue || _score2[i].HasValue)
+                .ToList();
+
+            if (!enteredSets.Any()) { _error = "Please enter at least one set score."; return; }
+            if (_winnerPlayerId == null) { _error = "Please select a winner."; return; }
+        }
+
+        _saving = true;
+        try
+        {
+            await using var db = DbFactory.CreateDbContext();
+            var fx = await db.CompetitionFixtures
+                .FirstOrDefaultAsync(f => f.CompetitionFixtureId == _fixture!.CompetitionFixtureId);
+            if (fx == null) { _error = "Fixture not found."; return; }
+
+            if (_editing)
+            {
+                var newSummary = string.Join(", ", Enumerable.Range(0, _bestOf)
+                    .Where(i => _score1[i].HasValue || _score2[i].HasValue)
+                    .Select(i => $"{_score1[i] ?? 0}\u2013{_score2[i] ?? 0}"));
+
+                fx.OriginalResultSummary = fx.ResultSummary;
+                fx.OriginalWinnerPlayerId = fx.WinnerPlayerId;
+                fx.ResultModifiedByAdmin = true;
+                fx.ResultSummary = newSummary;
+                fx.WinnerPlayerId = _winnerPlayerId;
+                _wasModified = true;
+            }
+
+            fx.Status = FixtureStatus.Completed;
+            fx.VerificationToken = null;
+            await db.SaveChangesAsync();
+
+            await CompetitionProgressionService.TryAdvanceAsync(db, fx.CompetitionId, fx.CompetitionFixtureId);
+
+            _competitionId = fx.CompetitionId;
+            _fixture = null;
+            _success = true;
+        }
+        catch (Exception)
+        {
+            _error = "Failed to save. Please try again.";
+        }
+        finally
+        {
+            _saving = false;
+        }
     }
 }

--- a/DropShot/Components/Pages/ViewCompetition.razor
+++ b/DropShot/Components/Pages/ViewCompetition.razor
@@ -94,11 +94,21 @@ else
                         <MudChip T="string" Size="Size.Small" Color="@StatusColor(context.Status)">@context.Status</MudChip>
                     </MudTd>
                     <MudTd DataLabel="Result">
-                        @if (context.Status == FixtureStatus.Completed)
+                        @if (context.Status == FixtureStatus.Completed || context.Status == FixtureStatus.AwaitingVerification)
                         {
                             <MudText Typo="Typo.body2" Style="font-weight:500">
                                 @(context.ResultSummary ?? WinnerName(context))
                             </MudText>
+                            @if (context.ResultModifiedByAdmin)
+                            {
+                                <MudTooltip Text="@($"Original: {context.OriginalResultSummary}")">
+                                    <MudChip T="string" Size="Size.Small" Color="Color.Warning" Variant="Variant.Text">Modified</MudChip>
+                                </MudTooltip>
+                            }
+                            @if (context.Status == FixtureStatus.AwaitingVerification)
+                            {
+                                <MudChip T="string" Size="Size.Small" Color="Color.Secondary" Variant="Variant.Text">Pending</MudChip>
+                            }
                         }
                         else
                         {

--- a/DropShot/Components/ReviewResultDialog.razor
+++ b/DropShot/Components/ReviewResultDialog.razor
@@ -1,0 +1,231 @@
+@using DropShot.Data
+@using DropShot.Models
+@using DropShot.Services
+@using Microsoft.EntityFrameworkCore
+
+@inject IDbContextFactory<MyDbContext> DbFactory
+
+<MudDialog>
+    <TitleContent>
+        Review Result
+    </TitleContent>
+    <DialogContent>
+        <MudStack Spacing="3">
+            @* Competition & fixture info *@
+            <MudText Typo="Typo.subtitle2" Color="Color.Primary">
+                @(Fixture.Competition?.CompetitionName ?? "Competition")
+            </MudText>
+            @if (!string.IsNullOrEmpty(Fixture.FixtureLabel))
+            {
+                <MudText Typo="Typo.caption" Color="Color.Secondary">@Fixture.FixtureLabel</MudText>
+            }
+
+            <MudDivider />
+
+            @* Players *@
+            <MudText Typo="Typo.body1">
+                <strong>@_side1</strong> vs <strong>@_side2</strong>
+            </MudText>
+
+            @* Submitted score display *@
+            <MudAlert Severity="Severity.Info" Dense="true" NoIcon="true">
+                <MudText Typo="Typo.subtitle2">Submitted Score</MudText>
+                <MudText Typo="Typo.h6">@Fixture.ResultSummary</MudText>
+                <MudText Typo="Typo.body2">
+                    Winner: <strong>@WinnerName()</strong>
+                </MudText>
+            </MudAlert>
+
+            @* Edit toggle *@
+            <MudSwitch @bind-Value="_editing" Label="Modify score" Color="Color.Warning" />
+
+            @if (_editing)
+            {
+                <MudAlert Severity="Severity.Warning" Dense="true">
+                    The original submission will be preserved for audit purposes.
+                </MudAlert>
+
+                <MudText Typo="Typo.subtitle2">Updated Set Scores</MudText>
+                <MudSimpleTable Dense="true" Style="max-width:300px">
+                    <thead>
+                        <tr>
+                            <th style="width:50px"></th>
+                            <th style="text-align:center; font-size:0.8rem">@_side1</th>
+                            <th style="width:20px"></th>
+                            <th style="text-align:center; font-size:0.8rem">@_side2</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @for (int i = 0; i < _bestOf; i++)
+                        {
+                            int idx = i;
+                            <tr>
+                                <td style="color:#888; font-size:0.8rem; padding-right:8px">Set @(idx + 1)</td>
+                                <td>
+                                    <MudNumericField T="int?" @bind-Value="_score1[idx]"
+                                                    Min="0" Max="13" Variant="Variant.Outlined"
+                                                    Style="width:65px" HideSpinButtons="true" />
+                                </td>
+                                <td style="text-align:center; padding:0 4px; font-weight:bold">-</td>
+                                <td>
+                                    <MudNumericField T="int?" @bind-Value="_score2[idx]"
+                                                    Min="0" Max="13" Variant="Variant.Outlined"
+                                                    Style="width:65px" HideSpinButtons="true" />
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </MudSimpleTable>
+
+                <MudSelect T="int?" @bind-Value="_winnerPlayerId" Label="Winner" Variant="Variant.Outlined">
+                    @if (Fixture.Player1Id.HasValue)
+                    {
+                        <MudSelectItem T="int?" Value="@Fixture.Player1Id">@_side1</MudSelectItem>
+                    }
+                    @if (Fixture.Player2Id.HasValue)
+                    {
+                        <MudSelectItem T="int?" Value="@Fixture.Player2Id">@_side2</MudSelectItem>
+                    }
+                </MudSelect>
+            }
+
+            @if (!string.IsNullOrEmpty(_error))
+            {
+                <MudAlert Severity="Severity.Error">@_error</MudAlert>
+            }
+        </MudStack>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel">Cancel</MudButton>
+        <MudButton Color="Color.Success" Variant="Variant.Filled"
+                   OnClick="ApproveAsync" Disabled="_saving"
+                   StartIcon="@Icons.Material.Filled.CheckCircle">
+            @(_editing ? "Approve with Changes" : "Approve")
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = default!;
+
+    [Parameter] public CompetitionFixture Fixture { get; set; } = default!;
+
+    private int _bestOf = 3;
+    private int?[] _score1 = new int?[3];
+    private int?[] _score2 = new int?[3];
+    private int? _winnerPlayerId;
+    private bool _editing;
+    private bool _saving;
+    private string? _error;
+    private string _side1 = "";
+    private string _side2 = "";
+
+    protected override void OnParametersSet()
+    {
+        _bestOf = Math.Max(1, Fixture.Competition?.BestOf ?? 3);
+        _score1 = new int?[_bestOf];
+        _score2 = new int?[_bestOf];
+
+        var s1Parts = new[] { Fixture.Player1?.DisplayName, Fixture.Player3?.DisplayName }
+            .Where(n => n != null).ToList();
+        var s2Parts = new[] { Fixture.Player2?.DisplayName, Fixture.Player4?.DisplayName }
+            .Where(n => n != null).ToList();
+        _side1 = s1Parts.Any() ? string.Join(" & ", s1Parts) : "Player 1";
+        _side2 = s2Parts.Any() ? string.Join(" & ", s2Parts) : "Player 2";
+
+        // Pre-fill edit fields from submitted result
+        _winnerPlayerId = Fixture.WinnerPlayerId;
+        ParseResultSummary(Fixture.ResultSummary);
+    }
+
+    private void ParseResultSummary(string? summary)
+    {
+        if (string.IsNullOrEmpty(summary)) return;
+        var sets = summary.Split(',', StringSplitOptions.TrimEntries);
+        for (int i = 0; i < Math.Min(sets.Length, _bestOf); i++)
+        {
+            // Expect format "6-4" or "6\u20134"
+            var parts = sets[i].Split(new[] { '-', '\u2013' }, StringSplitOptions.TrimEntries);
+            if (parts.Length == 2 && int.TryParse(parts[0], out var s1) && int.TryParse(parts[1], out var s2))
+            {
+                _score1[i] = s1;
+                _score2[i] = s2;
+            }
+        }
+    }
+
+    private string WinnerName()
+    {
+        if (Fixture.WinnerPlayerId == Fixture.Player1Id) return _side1;
+        if (Fixture.WinnerPlayerId == Fixture.Player2Id) return _side2;
+        return "Unknown";
+    }
+
+    private async Task ApproveAsync()
+    {
+        _error = null;
+
+        if (_editing)
+        {
+            var enteredSets = Enumerable.Range(0, _bestOf)
+                .Where(i => _score1[i].HasValue || _score2[i].HasValue)
+                .Select(i => $"{_score1[i] ?? 0}\u2013{_score2[i] ?? 0}")
+                .ToList();
+
+            if (!enteredSets.Any())
+            {
+                _error = "Please enter at least one set score.";
+                return;
+            }
+
+            if (_winnerPlayerId == null)
+            {
+                _error = "Please select a winner.";
+                return;
+            }
+        }
+
+        _saving = true;
+        try
+        {
+            await using var db = DbFactory.CreateDbContext();
+            var fx = await db.CompetitionFixtures
+                .Include(f => f.Competition)
+                .FirstOrDefaultAsync(f => f.CompetitionFixtureId == Fixture.CompetitionFixtureId);
+            if (fx == null) { _error = "Fixture not found."; return; }
+
+            if (_editing)
+            {
+                var newSummary = string.Join(", ", Enumerable.Range(0, _bestOf)
+                    .Where(i => _score1[i].HasValue || _score2[i].HasValue)
+                    .Select(i => $"{_score1[i] ?? 0}\u2013{_score2[i] ?? 0}"));
+
+                // Store original before overwriting
+                fx.OriginalResultSummary = fx.ResultSummary;
+                fx.OriginalWinnerPlayerId = fx.WinnerPlayerId;
+                fx.ResultModifiedByAdmin = true;
+                fx.ResultSummary = newSummary;
+                fx.WinnerPlayerId = _winnerPlayerId;
+            }
+
+            fx.Status = FixtureStatus.Completed;
+            fx.VerificationToken = null;
+
+            await db.SaveChangesAsync();
+            await CompetitionProgressionService.TryAdvanceAsync(db, fx.CompetitionId, fx.CompetitionFixtureId);
+        }
+        catch (Exception)
+        {
+            _error = "Failed to save. Please try again.";
+            return;
+        }
+        finally
+        {
+            _saving = false;
+        }
+
+        MudDialog.Close(DialogResult.Ok(true));
+    }
+
+    private void Cancel() => MudDialog.Cancel();
+}

--- a/DropShot/Components/SubmitScoreDialog.razor
+++ b/DropShot/Components/SubmitScoreDialog.razor
@@ -204,6 +204,14 @@
             var fx = await db.CompetitionFixtures.FindAsync(Fixture.CompetitionFixtureId);
             if (fx != null)
             {
+                // If admin is overriding an existing result, preserve the original for audit
+                if (AdminOverride && fx.ResultSummary != null)
+                {
+                    fx.OriginalResultSummary = fx.ResultSummary;
+                    fx.OriginalWinnerPlayerId = fx.WinnerPlayerId;
+                    fx.ResultModifiedByAdmin = true;
+                }
+
                 fx.ResultSummary  = resultSummary;
                 fx.WinnerPlayerId = _winnerPlayerId;
 

--- a/DropShot/Data/Migrations/20260404120000_AddResultVerificationAudit.cs
+++ b/DropShot/Data/Migrations/20260404120000_AddResultVerificationAudit.cs
@@ -1,0 +1,50 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropShot.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddResultVerificationAudit : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "OriginalResultSummary",
+                table: "CompetitionFixtures",
+                type: "nvarchar(200)",
+                maxLength: 200,
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "OriginalWinnerPlayerId",
+                table: "CompetitionFixtures",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "ResultModifiedByAdmin",
+                table: "CompetitionFixtures",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "OriginalResultSummary",
+                table: "CompetitionFixtures");
+
+            migrationBuilder.DropColumn(
+                name: "OriginalWinnerPlayerId",
+                table: "CompetitionFixtures");
+
+            migrationBuilder.DropColumn(
+                name: "ResultModifiedByAdmin",
+                table: "CompetitionFixtures");
+        }
+    }
+}

--- a/DropShot/Data/MyDbContext.cs
+++ b/DropShot/Data/MyDbContext.cs
@@ -205,6 +205,7 @@ namespace DropShot.Data
             {
                 entity.Property(f => f.Status).HasConversion<byte>();
                 entity.Property(f => f.ResultSummary).HasMaxLength(200);
+                entity.Property(f => f.OriginalResultSummary).HasMaxLength(200);
                 entity.Property(f => f.FixtureLabel).HasMaxLength(50);
 
                 entity.HasOne(f => f.Competition)

--- a/DropShot/Models/CompetitionFixture.cs
+++ b/DropShot/Models/CompetitionFixture.cs
@@ -32,6 +32,11 @@ public class CompetitionFixture
     public int? WinnerPlayerId { get; set; }
     public Guid? VerificationToken { get; set; }
 
+    // Audit trail for admin-modified results
+    public string? OriginalResultSummary { get; set; }
+    public int? OriginalWinnerPlayerId { get; set; }
+    public bool ResultModifiedByAdmin { get; set; }
+
     public Competition Competition { get; set; } = null!;
     public CompetitionStage? Stage { get; set; }
     public Court? Court { get; set; }


### PR DESCRIPTION
## Summary
- Pending verification lists now show full match details: competition name, fixture label, players, submitted score, and winner
- Admins can **Approve** results directly from the list or open a **Review** dialog to inspect and optionally modify the score
- When a score is modified by an admin, the original submission (`OriginalResultSummary`, `OriginalWinnerPlayerId`) is preserved and the fixture is flagged as `ResultModifiedByAdmin`
- The email verification page (`/verify-result/{token}`) now shows full fixture details instead of auto-approving on load, with the option to modify the score before approving
- Admins see a **Pending Result Reviews** section on their Home screen, grouped by competition, with inline approve/review actions
- Fixture tables in CompetitionPage and ViewCompetition show a "Modified" chip with tooltip showing the original score when results have been admin-modified

### Files changed (10)
- **New:** `ReviewResultDialog.razor` — review dialog with approve/modify flow
- **New:** `20260404120000_AddResultVerificationAudit.cs` — migration for audit columns
- **Modified:** `CompetitionFixture.cs` — added 3 audit trail fields
- **Modified:** `MyDbContext.cs` — field constraints for new columns
- **Modified:** `Competitions.razor` — full detail table replacing simple label list
- **Modified:** `Home.razor` — pending reviews section for admins
- **Modified:** `VerifyResult.razor` — complete rewrite with review UI
- **Modified:** `SubmitScoreDialog.razor` — preserve original on admin override
- **Modified:** `CompetitionPage.razor` — Result column with modified indicator
- **Modified:** `ViewCompetition.razor` — Result column with modified indicator

## Test plan
- [ ] Submit a score for a competition with `RequireVerification` enabled — verify it shows as AwaitingVerification
- [ ] Navigate to Competitions page as admin — verify pending list shows players, score, winner grouped by competition
- [ ] Click Approve on a pending result — verify it transitions to Completed and disappears from the list
- [ ] Click Review on a pending result — verify dialog shows submitted score with option to modify
- [ ] Toggle "Modify score", change the score, approve — verify original is preserved and "Modified" chip appears
- [ ] Hover over "Modified" chip — verify tooltip shows original score
- [ ] Navigate to Home page as admin — verify Pending Result Reviews section appears grouped by competition
- [ ] Click email verification link — verify it shows details instead of auto-approving, with approve/modify options
- [ ] Verify non-admin users do not see the pending reviews sections

https://claude.ai/code/session_01QQdzsLPVkQ85fVNyhvwc8B