### PR TITLE
Add EF Core migrations step to CI pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,14 @@ jobs:
     - name: Build
       run: dotnet build DropShot/DropShot.csproj --configuration Release
 
+    - name: Install EF Core tools
+      run: dotnet tool install --global dotnet-ef
+
+    - name: Apply EF migrations
+      run: dotnet ef database update --project DropShot/DropShot.csproj --configuration Release
+      env:
+        ConnectionStrings__DefaultConnection: ${{ secrets.AZURE_SQL_CONNECTION_STRING }}
+
     - name: Publish
       run: dotnet publish DropShot/DropShot.csproj -c Release -o ./publish
 


### PR DESCRIPTION
Applies pending migrations to the production database before deploying
the app, preventing schema mismatches that could break the site.

https://claude.ai/code/session_0115aY3R4RY2i36gt8CJ3vDP