### PR TITLE
Add EF Core migrations to CI pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,14 @@ jobs:
     - name: Build
       run: dotnet build DropShot/DropShot.csproj --configuration Release
 
+    - name: Install EF Core tools
+      run: dotnet tool install --global dotnet-ef
+
+    - name: Apply EF migrations
+      run: dotnet ef database update --project DropShot/DropShot.csproj --configuration Release
+      env:
+        ConnectionStrings__DefaultConnection: ${{ secrets.AZURE_SQL_CONNECTION_STRING }}
+
     - name: Publish
       run: dotnet publish DropShot/DropShot.csproj -c Release -o ./publish
 

--- a/DropShot/Data/Migrations/20260404120000_AddResultVerificationAudit.Designer.cs
+++ b/DropShot/Data/Migrations/20260404120000_AddResultVerificationAudit.Designer.cs
@@ -4,6 +4,7 @@ using DropShot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DropShot.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260404120000_AddResultVerificationAudit")]
+    partial class AddResultVerificationAudit
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -482,9 +485,6 @@ namespace DropShot.Migrations
                     b.Property<int>("CompetitionId")
                         .HasColumnType("int");
 
-                    b.Property<int?>("CourtId")
-                        .HasColumnType("int");
-
                     b.Property<int>("DayOfWeek")
                         .HasColumnType("int");
 
@@ -497,8 +497,6 @@ namespace DropShot.Migrations
                     b.HasKey("CompetitionMatchWindowId");
 
                     b.HasIndex("CompetitionId");
-
-                    b.HasIndex("CourtId");
 
                     b.ToTable("CompetitionMatchWindows");
                 });
@@ -1296,14 +1294,7 @@ namespace DropShot.Migrations
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
-                    b.HasOne("DropShot.Models.Court", "Court")
-                        .WithMany()
-                        .HasForeignKey("CourtId")
-                        .OnDelete(DeleteBehavior.SetNull);
-
                     b.Navigation("Competition");
-
-                    b.Navigation("Court");
                 });
 
             modelBuilder.Entity("DropShot.Models.CompetitionParticipant", b =>


### PR DESCRIPTION
## Summary
- Adds an EF Core migrations step (`dotnet ef database update`) to the GitHub Actions deploy workflow, running after build but before publish/deploy so the database schema is always in sync with the deployed code
- Fixes the incomplete `AddResultVerificationAudit` migration by adding its missing `.Designer.cs` file and updating the `ApplicationDbContextModelSnapshot.cs` with the 3 new `CompetitionFixture` columns

## Setup required
- Add a GitHub secret called `AZURE_SQL_CONNECTION_STRING` containing the production Azure SQL connection string (`Settings > Secrets and variables > Actions`)

## Test plan
- [ ] Verify the `AZURE_SQL_CONNECTION_STRING` secret is configured in the repo
- [ ] Merge and confirm the deploy workflow runs `dotnet ef database update` successfully
- [ ] Confirm the site loads without database schema errors after deployment

https://claude.ai/code/session_0115aY3R4RY2i36gt8CJ3vDP