### PR TITLE
Add QR code mobile login system

### DIFF
--- a/DropShot/Components/Account/Pages/Login.razor
+++ b/DropShot/Components/Account/Pages/Login.razor
@@ -55,11 +55,18 @@
             </EditForm>
         </section>
     </div>
-    <div class="col-md-6 col-md-offset-2">
+    <div class="col-md-4">
         <section>
             <h3>Use another service to log in.</h3>
             <hr />
             <ExternalLoginPicker />
+        </section>
+    </div>
+    <div class="col-md-4">
+        <section>
+            <h3>Scan QR code to log in</h3>
+            <hr />
+            <QrLoginPanel />
         </section>
     </div>
 </div>

--- a/DropShot/Components/Pages/Home.razor
+++ b/DropShot/Components/Pages/Home.razor
@@ -44,6 +44,26 @@
     </MudAlert>
 }
 
+@if (!_isAuthenticated)
+{
+    <MudCard Class="mb-4">
+        <MudCardContent>
+            <MudGrid>
+                <MudItem xs="12" sm="6">
+                    <MudText Typo="Typo.h5">Welcome to DropShot</MudText>
+                    <MudText Typo="Typo.body1" Class="mt-2">
+                        Scan the QR code with your phone to log in, or
+                        <MudLink Href="/Account/Login">use email and password</MudLink>.
+                    </MudText>
+                </MudItem>
+                <MudItem xs="12" sm="6">
+                    <QrLoginPanel />
+                </MudItem>
+            </MudGrid>
+        </MudCardContent>
+    </MudCard>
+}
+
 @if (_pendingReviews.Count > 0)
 {
     <MudCard Class="mb-4" Elevation="2">
@@ -212,12 +232,14 @@
     private List<CompetitionFixture> _upcomingFixtures = [];
     private List<CompetitionFixture> _pendingReviews = [];
     private bool _showUpgradeBanner;
+    private bool _isAuthenticated;
 
     protected override async Task OnInitializedAsync()
     {
         var authState = await AuthStateProvider.GetAuthenticationStateAsync();
         var userId = authState.User.FindFirstValue(ClaimTypes.NameIdentifier);
-        if (string.IsNullOrEmpty(userId)) return;
+        _isAuthenticated = !string.IsNullOrEmpty(userId);
+        if (!_isAuthenticated) return;
 
         await using var db = DbFactory.CreateDbContext();
 

--- a/DropShot/Components/Pages/MobileAuth.razor
+++ b/DropShot/Components/Pages/MobileAuth.razor
@@ -1,0 +1,206 @@
+@page "/mobile-auth"
+@rendermode InteractiveServer
+@using DropShot.Data
+@using DropShot.Hubs
+@using DropShot.Models
+@using DropShot.Services
+@using Microsoft.AspNetCore.Identity
+@using Microsoft.AspNetCore.SignalR
+@using Microsoft.EntityFrameworkCore
+@using System.ComponentModel.DataAnnotations
+@inject QrLoginService QrLoginService
+@inject SignInManager<ApplicationUser> SignInManager
+@inject UserManager<ApplicationUser> UserManager
+@inject IDbContextFactory<MyDbContext> DbFactory
+@inject IHubContext<QrAuthHub> HubContext
+@inject NavigationManager Navigation
+
+<MudProviders />
+
+<div class="mobile-auth-container pa-4" style="max-width: 400px; margin: 0 auto;">
+    <MudText Typo="Typo.h5" Align="Align.Center" Class="mb-4">Mobile Login</MudText>
+
+    @if (_state == MobileAuthState.InvalidToken)
+    {
+        <MudAlert Severity="Severity.Error">
+            This login link is invalid or has expired. Please scan a new QR code.
+        </MudAlert>
+    }
+    else if (_state == MobileAuthState.LoginForm)
+    {
+        <MudCard>
+            <MudCardContent>
+                <MudText Typo="Typo.body2" Class="mb-3" Color="Color.Secondary">
+                    Log in to authenticate the desktop session.
+                </MudText>
+                <MudTextField @bind-Value="_email" Label="Email" Variant="Variant.Outlined"
+                              InputType="InputType.Email" Required="true" Class="mb-3" />
+                <MudTextField @bind-Value="_password" Label="Password" Variant="Variant.Outlined"
+                              InputType="InputType.Password" Required="true" Class="mb-3" />
+                @if (!string.IsNullOrEmpty(_errorMessage))
+                {
+                    <MudAlert Severity="Severity.Error" Class="mb-3">@_errorMessage</MudAlert>
+                }
+                <MudButton Variant="Variant.Filled" Color="Color.Primary" FullWidth="true"
+                           OnClick="LoginAsync" Disabled="_isLoading">
+                    @if (_isLoading)
+                    {
+                        <MudProgressCircular Indeterminate="true" Size="Size.Small" Class="mr-2" />
+                    }
+                    Log in
+                </MudButton>
+            </MudCardContent>
+        </MudCard>
+    }
+    else if (_state == MobileAuthState.CourtSelection)
+    {
+        <MudCard>
+            <MudCardContent>
+                <MudText Typo="Typo.body1" Class="mb-2">
+                    Welcome, @_userName!
+                </MudText>
+                <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mb-3">
+                    Select a court to direct the desktop to its scoreboard, or skip to go to the home page.
+                </MudText>
+                <MudSelect T="int?" @bind-Value="_selectedCourtId" Label="Select Court"
+                           Variant="Variant.Outlined" Clearable="true" Class="mb-3">
+                    @foreach (var court in _courts)
+                    {
+                        <MudSelectItem T="int?" Value="@((int?)court.CourtId)">
+                            @court.Club.Name — @court.Name
+                        </MudSelectItem>
+                    }
+                </MudSelect>
+                <MudStack Row="true" Spacing="2">
+                    <MudButton Variant="Variant.Outlined" Color="Color.Default" FullWidth="true"
+                               OnClick="() => ConfirmAsync(null)">
+                        Skip
+                    </MudButton>
+                    <MudButton Variant="Variant.Filled" Color="Color.Primary" FullWidth="true"
+                               OnClick="() => ConfirmAsync(_selectedCourtId)" Disabled="_selectedCourtId is null">
+                        Confirm
+                    </MudButton>
+                </MudStack>
+            </MudCardContent>
+        </MudCard>
+    }
+    else if (_state == MobileAuthState.Success)
+    {
+        <MudAlert Severity="Severity.Success" Variant="Variant.Filled">
+            <MudText Typo="Typo.h6">You are now logged in on the other device.</MudText>
+            <MudText Typo="Typo.body2" Class="mt-1">You can close this page.</MudText>
+        </MudAlert>
+    }
+</div>
+
+@code {
+    private enum MobileAuthState { Loading, InvalidToken, LoginForm, CourtSelection, Success }
+
+    [SupplyParameterFromQuery(Name = "session")]
+    private string? SessionToken { get; set; }
+
+    private MobileAuthState _state = MobileAuthState.Loading;
+    private string _email = "";
+    private string _password = "";
+    private string? _errorMessage;
+    private bool _isLoading;
+    private string? _userId;
+    private string? _userName;
+    private List<string> _roles = [];
+    private List<Court> _courts = [];
+    private int? _selectedCourtId;
+
+    protected override void OnInitialized()
+    {
+        if (string.IsNullOrEmpty(SessionToken))
+        {
+            _state = MobileAuthState.InvalidToken;
+            return;
+        }
+
+        var session = QrLoginService.GetSession(SessionToken);
+        if (session is null || session.Status != QrSessionStatus.Pending || session.IsExpired)
+        {
+            _state = MobileAuthState.InvalidToken;
+            return;
+        }
+
+        _state = MobileAuthState.LoginForm;
+    }
+
+    private async Task LoginAsync()
+    {
+        _errorMessage = null;
+        _isLoading = true;
+
+        if (string.IsNullOrWhiteSpace(_email) || string.IsNullOrWhiteSpace(_password))
+        {
+            _errorMessage = "Email and password are required.";
+            _isLoading = false;
+            return;
+        }
+
+        // Re-validate token before proceeding
+        var session = QrLoginService.GetSession(SessionToken!);
+        if (session is null || session.Status != QrSessionStatus.Pending || session.IsExpired)
+        {
+            _state = MobileAuthState.InvalidToken;
+            _isLoading = false;
+            return;
+        }
+
+        var user = await UserManager.FindByEmailAsync(_email);
+        if (user is null)
+        {
+            _errorMessage = "Invalid email or password.";
+            _isLoading = false;
+            return;
+        }
+
+        var result = await SignInManager.CheckPasswordSignInAsync(user, _password, lockoutOnFailure: true);
+        if (!result.Succeeded)
+        {
+            _errorMessage = "Invalid email or password.";
+            _isLoading = false;
+            return;
+        }
+
+        _userId = user.Id;
+        _userName = user.UserName;
+        _roles = (await UserManager.GetRolesAsync(user)).ToList();
+        _isLoading = false;
+
+        var isAdmin = _roles.Any(r => r is "Admin" or "SuperAdmin" or "ClubAdmin");
+        if (isAdmin)
+        {
+            await using var db = DbFactory.CreateDbContext();
+            _courts = await db.Courts.Include(c => c.Club).OrderBy(c => c.Club.Name).ThenBy(c => c.Name).ToListAsync();
+            _state = MobileAuthState.CourtSelection;
+        }
+        else
+        {
+            await ConfirmAsync(null);
+        }
+    }
+
+    private async Task ConfirmAsync(int? courtId)
+    {
+        var confirmed = QrLoginService.ConfirmSession(SessionToken!, _userId!, _userName!, _roles, courtId);
+        if (!confirmed)
+        {
+            _state = MobileAuthState.InvalidToken;
+            return;
+        }
+
+        await HubContext.Clients.Group($"qr-{SessionToken}")
+            .SendAsync("QrAuthConfirmed", new
+            {
+                userId = _userId,
+                userName = _userName,
+                roles = _roles,
+                courtId
+            });
+
+        _state = MobileAuthState.Success;
+    }
+}

--- a/DropShot/Components/QrLoginPanel.razor
+++ b/DropShot/Components/QrLoginPanel.razor
@@ -1,0 +1,144 @@
+@rendermode InteractiveServer
+@using Microsoft.AspNetCore.SignalR.Client
+@using DropShot.Services
+@inject QrLoginService QrLoginService
+@inject NavigationManager Navigation
+@inject IConfiguration Configuration
+@implements IAsyncDisposable
+
+<div class="qr-login-panel">
+    @if (_status == "loading")
+    {
+        <div class="qr-loading">
+            <MudProgressCircular Indeterminate="true" Size="Size.Large" />
+            <MudText Typo="Typo.body2" Class="mt-2">Generating QR code...</MudText>
+        </div>
+    }
+    else if (_status == "pending")
+    {
+        <div class="qr-waiting">
+            <MudText Typo="Typo.h6" Align="Align.Center" Class="mb-2">Scan to log in</MudText>
+            <MudText Typo="Typo.body2" Color="Color.Secondary" Align="Align.Center" Class="mb-3">
+                Use your phone camera to scan this QR code
+            </MudText>
+            <div class="qr-code-wrapper">
+                <QrCodeDisplay Url="@_qrUrl" CssClass="qr-code-login" />
+            </div>
+            <div class="qr-status-indicator mt-3">
+                <MudProgressLinear Indeterminate="true" Color="Color.Primary" Size="Size.Small" />
+                <MudText Typo="Typo.caption" Color="Color.Secondary" Align="Align.Center" Class="mt-1">
+                    Waiting for mobile login...
+                </MudText>
+            </div>
+            <MudText Typo="Typo.caption" Color="Color.Tertiary" Align="Align.Center" Class="mt-2">
+                Expires in @_remainingSeconds seconds
+            </MudText>
+        </div>
+    }
+    else if (_status == "expired")
+    {
+        <div class="qr-expired">
+            <MudIcon Icon="@Icons.Material.Filled.TimerOff" Size="Size.Large" Color="Color.Warning" />
+            <MudText Typo="Typo.body2" Class="mt-2">QR code expired</MudText>
+            <MudButton Variant="Variant.Outlined" Color="Color.Primary" OnClick="GenerateNewSession" Class="mt-2">
+                Generate new QR code
+            </MudButton>
+        </div>
+    }
+    else if (_status == "confirmed")
+    {
+        <div class="qr-success">
+            <MudIcon Icon="@Icons.Material.Filled.CheckCircle" Size="Size.Large" Color="Color.Success" />
+            <MudText Typo="Typo.body1" Class="mt-2">Login confirmed! Redirecting...</MudText>
+        </div>
+    }
+</div>
+
+@code {
+    private HubConnection? _hubConnection;
+    private string _status = "loading";
+    private string? _currentToken;
+    private string _qrUrl = "";
+    private int _remainingSeconds = 300;
+    private System.Threading.Timer? _expiryTimer;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            await GenerateNewSession();
+        }
+    }
+
+    private async Task GenerateNewSession()
+    {
+        _status = "loading";
+        StateHasChanged();
+
+        // Clean up previous hub connection
+        if (_hubConnection is not null)
+        {
+            if (_currentToken is not null)
+                await _hubConnection.InvokeAsync("LeaveSession", _currentToken);
+            await _hubConnection.DisposeAsync();
+            _hubConnection = null;
+        }
+
+        _expiryTimer?.Dispose();
+
+        // Generate a new session
+        var session = QrLoginService.GenerateSession();
+        _currentToken = session.Token;
+
+        var baseUrl = (Configuration["App:BaseUrl"] ?? Navigation.BaseUri).TrimEnd('/');
+        _qrUrl = $"{baseUrl}/mobile-auth?session={_currentToken}";
+
+        // Connect to SignalR hub
+        _hubConnection = new HubConnectionBuilder()
+            .WithUrl(Navigation.ToAbsoluteUri("/qrauthub"))
+            .WithAutomaticReconnect()
+            .Build();
+
+        _hubConnection.On<object>("QrAuthConfirmed", async (data) =>
+        {
+            _status = "confirmed";
+            await InvokeAsync(StateHasChanged);
+
+            // Navigate to the cookie-setting endpoint which will redirect appropriately
+            var redirectUrl = $"/Account/QrLogin?token={_currentToken}";
+            await InvokeAsync(() => Navigation.NavigateTo(redirectUrl, forceLoad: true));
+        });
+
+        await _hubConnection.StartAsync();
+        await _hubConnection.InvokeAsync("JoinSession", _currentToken);
+
+        // Start expiry countdown
+        _remainingSeconds = 300;
+        _status = "pending";
+        StateHasChanged();
+
+        _expiryTimer = new System.Threading.Timer(async _ =>
+        {
+            _remainingSeconds--;
+            if (_remainingSeconds <= 0)
+            {
+                _status = "expired";
+                _expiryTimer?.Dispose();
+            }
+            await InvokeAsync(StateHasChanged);
+        }, null, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _expiryTimer?.Dispose();
+        if (_hubConnection is not null)
+        {
+            if (_currentToken is not null)
+            {
+                try { await _hubConnection.InvokeAsync("LeaveSession", _currentToken); } catch { }
+            }
+            await _hubConnection.DisposeAsync();
+        }
+    }
+}

--- a/DropShot/Controllers/QrAuthController.cs
+++ b/DropShot/Controllers/QrAuthController.cs
@@ -1,0 +1,85 @@
+using DropShot.Data;
+using DropShot.Hubs;
+using DropShot.Models;
+using DropShot.Services;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.SignalR;
+
+namespace DropShot.Controllers;
+
+[ApiController]
+[Route("api/auth/qr")]
+public class QrAuthController(
+    QrLoginService qrLoginService,
+    SignInManager<ApplicationUser> signInManager,
+    UserManager<ApplicationUser> userManager,
+    IHubContext<QrAuthHub> hubContext) : ControllerBase
+{
+    [HttpPost("generate")]
+    public ActionResult Generate()
+    {
+        var session = qrLoginService.GenerateSession();
+        return Ok(new { session.Token });
+    }
+
+    [HttpGet("status")]
+    public ActionResult GetStatus([FromQuery] string session)
+    {
+        var qrSession = qrLoginService.GetSession(session);
+        if (qrSession is null)
+            return NotFound(new { status = "not_found" });
+
+        return Ok(new
+        {
+            status = qrSession.Status.ToString().ToLowerInvariant(),
+            userId = qrSession.UserId,
+            userName = qrSession.UserName,
+            roles = qrSession.Roles,
+            courtId = qrSession.CourtId
+        });
+    }
+
+    [HttpPost("confirm")]
+    public async Task<IActionResult> Confirm([FromBody] QrConfirmRequest request)
+    {
+        var session = qrLoginService.GetSession(request.Token);
+        if (session is null)
+            return NotFound(new { message = "Session not found." });
+
+        if (session.Status == QrSessionStatus.Expired || session.IsExpired)
+            return BadRequest(new { message = "Session has expired." });
+
+        if (session.Status != QrSessionStatus.Pending)
+            return BadRequest(new { message = "Session already used." });
+
+        var user = await userManager.FindByEmailAsync(request.Email);
+        if (user is null)
+            return Unauthorized(new { message = "Invalid email or password." });
+
+        var result = await signInManager.CheckPasswordSignInAsync(user, request.Password, lockoutOnFailure: true);
+        if (!result.Succeeded)
+            return Unauthorized(new { message = "Invalid email or password." });
+
+        var roles = (await userManager.GetRolesAsync(user)).ToList();
+
+        var confirmed = qrLoginService.ConfirmSession(
+            request.Token, user.Id, user.UserName!, roles, request.CourtId);
+
+        if (!confirmed)
+            return BadRequest(new { message = "Failed to confirm session." });
+
+        await hubContext.Clients.Group($"qr-{request.Token}")
+            .SendAsync("QrAuthConfirmed", new
+            {
+                userId = user.Id,
+                userName = user.UserName,
+                roles,
+                courtId = request.CourtId
+            });
+
+        return Ok(new { message = "Login confirmed." });
+    }
+}
+
+public record QrConfirmRequest(string Token, string Email, string Password, int? CourtId);

--- a/DropShot/Hubs/QrAuthHub.cs
+++ b/DropShot/Hubs/QrAuthHub.cs
@@ -1,0 +1,16 @@
+using Microsoft.AspNetCore.SignalR;
+
+namespace DropShot.Hubs;
+
+public class QrAuthHub : Hub
+{
+    public async Task JoinSession(string token)
+    {
+        await Groups.AddToGroupAsync(Context.ConnectionId, $"qr-{token}");
+    }
+
+    public async Task LeaveSession(string token)
+    {
+        await Groups.RemoveFromGroupAsync(Context.ConnectionId, $"qr-{token}");
+    }
+}

--- a/DropShot/Models/QrLoginSession.cs
+++ b/DropShot/Models/QrLoginSession.cs
@@ -1,0 +1,21 @@
+namespace DropShot.Models;
+
+public enum QrSessionStatus
+{
+    Pending,
+    Authenticated,
+    Expired
+}
+
+public class QrLoginSession
+{
+    public required string Token { get; set; }
+    public QrSessionStatus Status { get; set; } = QrSessionStatus.Pending;
+    public string? UserId { get; set; }
+    public string? UserName { get; set; }
+    public int? CourtId { get; set; }
+    public List<string> Roles { get; set; } = [];
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    public bool IsExpired => DateTime.UtcNow - CreatedAt > TimeSpan.FromMinutes(5);
+}

--- a/DropShot/Program.cs
+++ b/DropShot/Program.cs
@@ -1,6 +1,7 @@
 using DropShot.Components;
 using DropShot.Components.Account;
 using DropShot.Data;
+using DropShot.Hubs;
 using DropShot.Models;
 using DropShot.Services;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -80,6 +81,8 @@ builder.Services.AddSingleton<EmailService>();
 builder.Services.AddScoped<ResultVerificationService>();
 builder.Services.AddScoped<AdminEmailService>();
 builder.Services.AddScoped<FuzzySearchService>();
+builder.Services.AddSingleton<QrLoginService>();
+builder.Services.AddHostedService<QrSessionCleanupService>();
 builder.Services.AddMudServices();
 
 var app = builder.Build();
@@ -104,6 +107,31 @@ app.MapControllers();
 app.MapRazorComponents<App>().AddInteractiveServerRenderMode();
 app.MapAdditionalIdentityEndpoints();
 app.MapHub<ChatHub>("/chathub");
+app.MapHub<QrAuthHub>("/qrauthub");
+
+// ── QR code login callback (sets identity cookie, redirects desktop) ─────────
+app.MapGet("/Account/QrLogin", async (
+    string token,
+    QrLoginService qrLoginService,
+    UserManager<ApplicationUser> userManager,
+    SignInManager<ApplicationUser> signInManager) =>
+{
+    var session = qrLoginService.GetSession(token);
+    if (session is null || session.Status != QrSessionStatus.Authenticated || string.IsNullOrEmpty(session.UserId))
+        return Results.Redirect("/Account/Login");
+
+    var user = await userManager.FindByIdAsync(session.UserId);
+    if (user is null)
+        return Results.Redirect("/Account/Login");
+
+    await signInManager.SignInAsync(user, isPersistent: false);
+    qrLoginService.RemoveSession(token);
+
+    if (session.CourtId.HasValue)
+        return Results.Redirect($"/score?courtId={session.CourtId.Value}");
+
+    return Results.Redirect("/");
+});
 
 // ── Seed roles ────────────────────────────────────────────────────────────────
 using (var scope = app.Services.CreateScope())

--- a/DropShot/Services/QrLoginService.cs
+++ b/DropShot/Services/QrLoginService.cs
@@ -1,0 +1,60 @@
+using System.Collections.Concurrent;
+using DropShot.Models;
+
+namespace DropShot.Services;
+
+public class QrLoginService
+{
+    private readonly ConcurrentDictionary<string, QrLoginSession> _sessions = new();
+
+    public QrLoginSession GenerateSession()
+    {
+        var session = new QrLoginSession { Token = Guid.NewGuid().ToString("N") };
+        _sessions[session.Token] = session;
+        return session;
+    }
+
+    public QrLoginSession? GetSession(string token)
+    {
+        if (!_sessions.TryGetValue(token, out var session))
+            return null;
+
+        if (session.IsExpired && session.Status == QrSessionStatus.Pending)
+        {
+            session.Status = QrSessionStatus.Expired;
+        }
+
+        return session;
+    }
+
+    public bool ConfirmSession(string token, string userId, string userName, List<string> roles, int? courtId)
+    {
+        if (!_sessions.TryGetValue(token, out var session))
+            return false;
+
+        if (session.Status != QrSessionStatus.Pending || session.IsExpired)
+            return false;
+
+        session.UserId = userId;
+        session.UserName = userName;
+        session.Roles = roles;
+        session.CourtId = courtId;
+        session.Status = QrSessionStatus.Authenticated;
+        return true;
+    }
+
+    public void RemoveSession(string token)
+    {
+        _sessions.TryRemove(token, out _);
+    }
+
+    public void CleanupExpiredSessions()
+    {
+        var cutoff = DateTime.UtcNow.AddMinutes(-6); // keep a bit longer than 5 min for status checks
+        foreach (var kvp in _sessions)
+        {
+            if (kvp.Value.CreatedAt < cutoff)
+                _sessions.TryRemove(kvp.Key, out _);
+        }
+    }
+}

--- a/DropShot/Services/QrSessionCleanupService.cs
+++ b/DropShot/Services/QrSessionCleanupService.cs
@@ -1,0 +1,13 @@
+namespace DropShot.Services;
+
+public class QrSessionCleanupService(QrLoginService qrLoginService) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await Task.Delay(TimeSpan.FromSeconds(60), stoppingToken);
+            qrLoginService.CleanupExpiredSessions();
+        }
+    }
+}

--- a/DropShot/wwwroot/app.css
+++ b/DropShot/wwwroot/app.css
@@ -90,3 +90,44 @@ body.scoreboard-fullscreen main {
 body.scoreboard-fullscreen .content {
     padding: 0 !important;
 }
+
+/* ── QR Login Panel ──────────────────────────────────────────────────────── */
+.qr-login-panel {
+    text-align: center;
+    padding: 1rem;
+}
+
+.qr-loading,
+.qr-expired,
+.qr-success {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 2rem 1rem;
+}
+
+.qr-code-wrapper {
+    display: inline-block;
+    padding: 12px;
+    background: white;
+    border-radius: 8px;
+    border: 3px solid var(--mud-palette-primary, #1b6ec2);
+    animation: qr-pulse 2s ease-in-out infinite;
+}
+
+@keyframes qr-pulse {
+    0%, 100% { border-color: var(--mud-palette-primary, #1b6ec2); }
+    50% { border-color: var(--mud-palette-primary-lighten, #4a9aea); }
+}
+
+.qr-code-login svg {
+    display: block;
+}
+
+/* ── Mobile Auth Page ────────────────────────────────────────────────────── */
+.mobile-auth-container {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}


### PR DESCRIPTION
## Summary
- Add QR code mobile login: desktop shows scannable QR code on login and home pages, user authenticates on phone, desktop session logs in automatically via SignalR push
- Admin users get a court selector on mobile that redirects the desktop to the selected court's scoreboard
- In-memory session store with 5-minute token expiry and background cleanup service

## New files
- `Models/QrLoginSession.cs` — session data with token, status, user/court info
- `Services/QrLoginService.cs` — singleton ConcurrentDictionary-backed session store
- `Services/QrSessionCleanupService.cs` �� background service purging expired sessions
- `Hubs/QrAuthHub.cs` — SignalR hub for desktop push notifications
- `Controllers/QrAuthController.cs` — API: generate, status, confirm endpoints
- `Components/QrLoginPanel.razor` — desktop QR display with auto-refresh and SignalR subscription
- `Components/Pages/MobileAuth.razor` — mobile login page with admin court selection

## Modified files
- `Program.cs` — register services, hub, and `/Account/QrLogin` cookie-setting endpoint
- `Login.razor` — added QR panel column
- `Home.razor` — added QR card for unauthenticated users
- `app.css` — QR panel and mobile auth styles

## Test plan
- [ ] Open login page — verify QR code renders with "Waiting for mobile login..." indicator
- [ ] Open home page while unauthenticated — verify QR card appears above carousel
- [ ] Scan QR code / open `/mobile-auth?session={token}` — verify login form appears
- [ ] Submit valid credentials on mobile — verify desktop auto-redirects to home
- [ ] Test admin flow: login as admin on mobile — verify court selector, then desktop redirects to `/score?courtId={id}`
- [ ] Wait 5 minutes — verify QR code shows expired state with refresh button
- [ ] Test invalid/expired token — verify mobile page shows error
- [ ] Run `dotnet build` — verify zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)