### PR TITLE
Fix scoreboard fullscreen toggle infinite loop

### DIFF
--- a/DropShot/Models/ChatHub.cs
+++ b/DropShot/Models/ChatHub.cs
@@ -22,7 +22,7 @@
 
         public async Task SendDisplayCommand(int courtId, string command, string value)
         {
-            await Clients.Group($"court-{courtId}").SendAsync("ReceiveDisplayCommand", command, value);
+            await Clients.OthersInGroup($"court-{courtId}").SendAsync("ReceiveDisplayCommand", command, value);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Fixed infinite loop when toggling fullscreen on the scoreboard screen
- `SendDisplayCommand` in `ChatHub` was using `Clients.Group()` which broadcasts to **all** clients in the group, including the sender
- The sender's `ReceiveDisplayCommand` handler would call `EnterFullscreenAsync()`/`ExitFullscreenAsync()` again, re-sending the command — causing an endless loop
- Changed to `Clients.OthersInGroup()` so the sender is excluded from its own broadcast

## Test plan
- [ ] Toggle fullscreen on the scoreboard page — verify it enters/exits cleanly without looping
- [ ] Open the scoreboard on two browser tabs for the same court — verify toggling on one updates the other
- [ ] Use the Display Control admin page to toggle fullscreen — verify the scoreboard responds correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)