### PR TITLE
Replace QR countdown timer with calm waiting state

### DIFF
--- a/DropShot/Components/QrLoginPanel.razor
+++ b/DropShot/Components/QrLoginPanel.razor
@@ -24,25 +24,12 @@
             <div class="qr-code-wrapper">
                 <QrCodeDisplay Url="@_qrUrl" CssClass="qr-code-login" />
             </div>
-            <div class="qr-status-indicator mt-3">
-                <MudProgressLinear Indeterminate="true" Color="Color.Primary" Size="Size.Small" />
-                <MudText Typo="Typo.caption" Color="Color.Secondary" Align="Align.Center" Class="mt-1">
+            <MudStack Row="true" Justify="Justify.Center" AlignItems="AlignItems.Center" Spacing="2" Class="mt-3">
+                <MudProgressCircular Indeterminate="true" Size="Size.Small" Color="Color.Primary" />
+                <MudText Typo="Typo.caption" Color="Color.Secondary">
                     Waiting for mobile login...
                 </MudText>
-            </div>
-            <MudText Typo="Typo.caption" Color="Color.Tertiary" Align="Align.Center" Class="mt-2">
-                Expires in @_remainingSeconds seconds
-            </MudText>
-        </div>
-    }
-    else if (_status == "expired")
-    {
-        <div class="qr-expired">
-            <MudIcon Icon="@Icons.Material.Filled.TimerOff" Size="Size.Large" Color="Color.Warning" />
-            <MudText Typo="Typo.body2" Class="mt-2">QR code expired</MudText>
-            <MudButton Variant="Variant.Outlined" Color="Color.Primary" OnClick="GenerateNewSession" Class="mt-2">
-                Generate new QR code
-            </MudButton>
+            </MudStack>
         </div>
     }
     else if (_status == "confirmed")
@@ -59,7 +46,6 @@
     private string _status = "loading";
     private string? _currentToken;
     private string _qrUrl = "";
-    private int _remainingSeconds = 300;
     private System.Threading.Timer? _expiryTimer;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -112,21 +98,14 @@
         await _hubConnection.StartAsync();
         await _hubConnection.InvokeAsync("JoinSession", _currentToken);
 
-        // Start expiry countdown
-        _remainingSeconds = 300;
         _status = "pending";
         StateHasChanged();
 
+        // Silently refresh the QR code when the token expires
         _expiryTimer = new System.Threading.Timer(async _ =>
         {
-            _remainingSeconds--;
-            if (_remainingSeconds <= 0)
-            {
-                _status = "expired";
-                _expiryTimer?.Dispose();
-            }
-            await InvokeAsync(StateHasChanged);
-        }, null, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
+            await InvokeAsync(GenerateNewSession);
+        }, null, TimeSpan.FromMinutes(5), Timeout.InfiniteTimeSpan);
     }
 
     public async ValueTask DisposeAsync()

--- a/DropShot/wwwroot/app.css
+++ b/DropShot/wwwroot/app.css
@@ -98,7 +98,6 @@ body.scoreboard-fullscreen .content {
 }
 
 .qr-loading,
-.qr-expired,
 .qr-success {
     display: flex;
     flex-direction: column;
@@ -111,13 +110,7 @@ body.scoreboard-fullscreen .content {
     padding: 12px;
     background: white;
     border-radius: 8px;
-    border: 3px solid var(--mud-palette-primary, #1b6ec2);
-    animation: qr-pulse 2s ease-in-out infinite;
-}
-
-@keyframes qr-pulse {
-    0%, 100% { border-color: var(--mud-palette-primary, #1b6ec2); }
-    50% { border-color: var(--mud-palette-primary-lighten, #4a9aea); }
+    border: 2px solid var(--mud-palette-lines-default, #e0e0e0);
 }
 
 .qr-code-login svg {


### PR DESCRIPTION
## Summary
- Remove countdown timer and animated progress bar from QR login panel — they created unnecessary urgency
- Replace with a small spinner and static "Waiting for mobile login..." text
- Remove pulsing border animation on QR code wrapper (now a subtle static border)
- QR code silently auto-refreshes after 5 minutes instead of showing an expired state

## Test plan
- [ ] Open login page — QR code displays with small spinner, no countdown or flashing elements
- [ ] Wait 5+ minutes — QR code silently refreshes (no "expired" message shown)
- [ ] Complete mobile auth flow — confirm desktop still redirects correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)