### PR TITLE
Remove spinner and waiting message from QR login panel

### DIFF
--- a/DropShot/Components/QrLoginPanel.razor
+++ b/DropShot/Components/QrLoginPanel.razor
@@ -24,12 +24,6 @@
             <div class="qr-code-wrapper">
                 <QrCodeDisplay Url="@_qrUrl" CssClass="qr-code-login" />
             </div>
-            <MudStack Row="true" Justify="Justify.Center" AlignItems="AlignItems.Center" Spacing="2" Class="mt-3">
-                <MudProgressCircular Indeterminate="true" Size="Size.Small" Color="Color.Primary" />
-                <MudText Typo="Typo.caption" Color="Color.Secondary">
-                    Waiting for mobile login...
-                </MudText>
-            </MudStack>
         </div>
     }
     else if (_status == "confirmed")


### PR DESCRIPTION
## Summary
- Remove the spinner and "Waiting for mobile login..." text from below the QR code
- The QR code speaks for itself — heading + subtitle + code is all that's needed

## Test plan
- [ ] Open login page — QR panel shows heading, subtitle, and QR code only (no spinner/text below)
- [ ] Complete mobile auth flow — confirm desktop still redirects correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)