### PR TITLE
Add external OAuth login for Google, Facebook, Twitter, and Microsoft

### DIFF
--- a/DropShot/Components/Account/Shared/ExternalLoginPicker.razor
+++ b/DropShot/Components/Account/Shared/ExternalLoginPicker.razor
@@ -17,15 +17,20 @@
 else
 {
     <form class="form-horizontal" action="Account/PerformExternalLogin" method="post">
-        <div>
-            <AntiforgeryToken />
-            <input type="hidden" name="ReturnUrl" value="@ReturnUrl" />
-            <p>
-                @foreach (var provider in externalLogins)
-                {
-                    <button type="submit" class="btn btn-primary" name="provider" value="@provider.Name" title="Log in using your @provider.DisplayName account">@provider.DisplayName</button>
-                }
-            </p>
+        <AntiforgeryToken />
+        <input type="hidden" name="ReturnUrl" value="@ReturnUrl" />
+        <div class="d-grid gap-2">
+            @foreach (var provider in externalLogins)
+            {
+                var (icon, bg) = GetProviderStyle(provider.Name);
+                <button type="submit" class="btn text-white d-flex align-items-center justify-content-center gap-2"
+                        style="background-color:@bg;"
+                        name="provider" value="@provider.Name"
+                        title="Log in using your @provider.DisplayName account">
+                    @((MarkupString)icon)
+                    <span>@provider.DisplayName</span>
+                </button>
+            }
         </div>
     </form>
 }
@@ -40,4 +45,23 @@ else
     {
         externalLogins = (await SignInManager.GetExternalAuthenticationSchemesAsync()).ToArray();
     }
+
+    private static (string Icon, string Background) GetProviderStyle(string providerName) => providerName switch
+    {
+        "Google" => (
+            """<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 48 48"><path fill="#FFC107" d="M43.611 20.083H42V20H24v8h11.303c-1.649 4.657-6.08 8-11.303 8-6.627 0-12-5.373-12-12s5.373-12 12-12c3.059 0 5.842 1.154 7.961 3.039l5.657-5.657C34.046 6.053 29.268 4 24 4 12.955 4 4 12.955 4 24s8.955 20 20 20 20-8.955 20-20c0-1.341-.138-2.65-.389-3.917z"/><path fill="#FF3D00" d="m6.306 14.691 6.571 4.819C14.655 15.108 18.961 12 24 12c3.059 0 5.842 1.154 7.961 3.039l5.657-5.657C34.046 6.053 29.268 4 24 4 16.318 4 9.656 8.337 6.306 14.691z"/><path fill="#4CAF50" d="M24 44c5.166 0 9.86-1.977 13.409-5.192l-6.19-5.238A11.91 11.91 0 0 1 24 36c-5.202 0-9.619-3.317-11.283-7.946l-6.522 5.025C9.505 39.556 16.227 44 24 44z"/><path fill="#1976D2" d="M43.611 20.083H42V20H24v8h11.303a12.04 12.04 0 0 1-4.087 5.571l.003-.002 6.19 5.238C36.971 39.205 44 34 44 24c0-1.341-.138-2.65-.389-3.917z"/></svg>""",
+            "#4285F4"),
+        "Facebook" => (
+            """<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="white" viewBox="0 0 24 24"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg>""",
+            "#1877F2"),
+        "Twitter" => (
+            """<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="white" viewBox="0 0 24 24"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>""",
+            "#000000"),
+        "Microsoft" => (
+            """<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 21 21"><rect x="1" y="1" width="9" height="9" fill="#f25022"/><rect x="1" y="11" width="9" height="9" fill="#00a4ef"/><rect x="11" y="1" width="9" height="9" fill="#7fba00"/><rect x="11" y="11" width="9" height="9" fill="#ffb900"/></svg>""",
+            "#2f2f2f"),
+        _ => (
+            """<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="white" viewBox="0 0 16 16"><path d="M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0zm3.669 11.538a.498.498 0 0 1-.686.165c-1.879-1.147-4.243-1.407-7.028-.77a.499.499 0 0 1-.222-.973c3.048-.696 5.662-.397 7.77.892a.5.5 0 0 1 .166.686z"/></svg>""",
+            "#6c757d")
+    };
 }

--- a/DropShot/DropShot.csproj
+++ b/DropShot/DropShot.csproj
@@ -10,7 +10,11 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Communication.Email" Version="1.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="10.0.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="10.0.*" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="10.0.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Twitter" Version="10.0.*" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.*" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.*" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.*" />

--- a/DropShot/Program.cs
+++ b/DropShot/Program.cs
@@ -50,7 +50,7 @@ builder.Services.AddAuthentication(options =>
 
 // JWT bearer — used by the MAUI app (separate AddAuthentication call)
 var jwtCfg = builder.Configuration.GetSection("Jwt");
-builder.Services.AddAuthentication()
+var authBuilder = builder.Services.AddAuthentication()
     .AddJwtBearer(JwtBearerDefaults.AuthenticationScheme, options =>
     {
         options.TokenValidationParameters = new TokenValidationParameters
@@ -64,6 +64,38 @@ builder.Services.AddAuthentication()
             IssuerSigningKey = new SymmetricSecurityKey(
                 Encoding.UTF8.GetBytes(jwtCfg["Key"]!))
         };
+    });
+
+// ── External OAuth providers (only registered when credentials are configured) ──
+var authCfg = builder.Configuration.GetSection("Authentication");
+
+if (!string.IsNullOrEmpty(authCfg["Google:ClientId"]))
+    authBuilder.AddGoogle(options =>
+    {
+        options.ClientId = authCfg["Google:ClientId"]!;
+        options.ClientSecret = authCfg["Google:ClientSecret"]!;
+    });
+
+if (!string.IsNullOrEmpty(authCfg["Facebook:AppId"]))
+    authBuilder.AddFacebook(options =>
+    {
+        options.AppId = authCfg["Facebook:AppId"]!;
+        options.AppSecret = authCfg["Facebook:AppSecret"]!;
+    });
+
+if (!string.IsNullOrEmpty(authCfg["Twitter:ConsumerKey"]))
+    authBuilder.AddTwitter(options =>
+    {
+        options.ConsumerKey = authCfg["Twitter:ConsumerKey"]!;
+        options.ConsumerSecret = authCfg["Twitter:ConsumerSecret"]!;
+        options.RetrieveUserDetails = true;
+    });
+
+if (!string.IsNullOrEmpty(authCfg["Microsoft:ClientId"]))
+    authBuilder.AddMicrosoftAccount(options =>
+    {
+        options.ClientId = authCfg["Microsoft:ClientId"]!;
+        options.ClientSecret = authCfg["Microsoft:ClientSecret"]!;
     });
 
 builder.Services.AddIdentityCore<ApplicationUser>(options => options.SignIn.RequireConfirmedAccount = true)

--- a/DropShot/appsettings.json
+++ b/DropShot/appsettings.json
@@ -22,6 +22,24 @@
     "Audience": "DropShot",
     "ExpiryHours": 24
   },
+  "Authentication": {
+    "Google": {
+      "ClientId": "",
+      "ClientSecret": ""
+    },
+    "Facebook": {
+      "AppId": "",
+      "AppSecret": ""
+    },
+    "Twitter": {
+      "ConsumerKey": "",
+      "ConsumerSecret": ""
+    },
+    "Microsoft": {
+      "ClientId": "",
+      "ClientSecret": ""
+    }
+  },
   "PayPal": {
     "ClientId": "YOUR_PAYPAL_CLIENT_ID",
     "ClientSecret": "YOUR_PAYPAL_CLIENT_SECRET",


### PR DESCRIPTION
## Summary
- Add NuGet packages and `Program.cs` registration for Google, Facebook, Twitter/X, and Microsoft OAuth providers
- Providers only activate when credentials are configured (empty by default in `appsettings.json`)
- Update `ExternalLoginPicker.razor` with branded buttons (provider logos + brand colors)

## Test plan
- [ ] Verify app builds and starts with empty credentials (no providers shown)
- [ ] Configure one provider's credentials, confirm its button appears on `/Account/Login`
- [ ] Click a provider button, verify OAuth redirect and callback flow works
- [ ] New external user is prompted to associate an email, existing user signs in directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)