### PR TITLE
Remove Auth Required menu item

### DIFF
--- a/DropShot/Components/Layout/NavMenu.razor
+++ b/DropShot/Components/Layout/NavMenu.razor
@@ -80,12 +80,6 @@
             </NavLink>
         </div>
 
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="auth">
-                <MudIcon Icon="@Icons.Material.Filled.Lock" Class="nav-icon" /> Auth Required
-            </NavLink>
-        </div>
-
         <AuthorizeView Roles="Admin,SuperAdmin">
             <div class="nav-item px-3">
                 <NavLink class="nav-link" href="admin/users">


### PR DESCRIPTION
## Summary
- Removes the "Auth Required" nav menu item from the sidebar navigation

## Test plan
- [ ] Verify the nav menu no longer shows the "Auth Required" link
- [ ] Confirm other menu items are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)