### PR TITLE
Add active role switching for admin users

### DIFF
--- a/DropShot.Maui/Services/AuthService.cs
+++ b/DropShot.Maui/Services/AuthService.cs
@@ -18,8 +18,10 @@ public class AuthService : AuthenticationStateProvider
     public AuthService(HttpClient http) => _http = http;
 
     public LoginResponse? Session => _session;
-    public bool IsAdmin => _session?.Roles.Contains("Admin") ?? false;
-    public bool IsClubAdmin => _session?.Roles.Contains("ClubAdmin") ?? false;
+    public string ActiveRole => _session?.ActiveRole ?? "";
+    public List<string> GrantedRoles => _session?.GrantedRoles ?? [];
+    public bool IsAdmin => _session?.ActiveRole is "Admin" or "SuperAdmin";
+    public bool IsClubAdmin => _session?.ActiveRole == "ClubAdmin";
     public List<int> AdminClubIds => _session?.AdminClubIds ?? [];
 
     public bool CanEditClub(int clubId) =>
@@ -94,12 +96,46 @@ public class AuthService : AuthenticationStateProvider
             var info = await _http.GetFromJsonAsync<UserInfoDto>("api/auth/me");
             if (info is null) { await LogoutAsync(); return; }
 
-            _session = new LoginResponse(token, info.UserName, info.Email, info.Roles, info.AdminClubIds);
+            _session = new LoginResponse(token, info.UserName, info.Email, info.Roles, info.AdminClubIds, info.ActiveRole, info.GrantedRoles);
             NotifyAuthenticationStateChanged(GetAuthenticationStateAsync());
         }
         catch
         {
             await LogoutAsync();
+        }
+    }
+
+    /// <summary>Switch active role via the API. Returns true on success.</summary>
+    public async Task<bool> SwitchRoleAsync(string role)
+    {
+        try
+        {
+            var response = await _http.PostAsJsonAsync("api/auth/switch-role",
+                new SwitchRoleRequest(role));
+
+            if (!response.IsSuccessStatusCode) return false;
+
+            var result = await response.Content.ReadFromJsonAsync<SwitchRoleResponse>();
+            if (result is null || _session is null) return false;
+
+            // Update session with new token and active role
+            _session = _session with
+            {
+                AccessToken = result.AccessToken,
+                ActiveRole = result.ActiveRole,
+                GrantedRoles = result.GrantedRoles
+            };
+
+            await SecureStorage.SetAsync("access_token", result.AccessToken);
+            _http.DefaultRequestHeaders.Authorization =
+                new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", result.AccessToken);
+
+            NotifyAuthenticationStateChanged(GetAuthenticationStateAsync());
+            return true;
+        }
+        catch
+        {
+            return false;
         }
     }
 

--- a/DropShot.Shared/Dtos/AuthDtos.cs
+++ b/DropShot.Shared/Dtos/AuthDtos.cs
@@ -7,11 +7,22 @@ public record LoginResponse(
     string UserName,
     string Email,
     List<string> Roles,
-    List<int> AdminClubIds);
+    List<int> AdminClubIds,
+    string ActiveRole,
+    List<string> GrantedRoles);
 
 public record UserInfoDto(
     string UserId,
     string UserName,
     string Email,
     List<string> Roles,
-    List<int> AdminClubIds);
+    List<int> AdminClubIds,
+    string ActiveRole,
+    List<string> GrantedRoles);
+
+public record SwitchRoleRequest(string Role);
+
+public record SwitchRoleResponse(
+    string AccessToken,
+    string ActiveRole,
+    List<string> GrantedRoles);

--- a/DropShot/Authorization/RequireActiveRoleAttribute.cs
+++ b/DropShot/Authorization/RequireActiveRoleAttribute.cs
@@ -1,0 +1,38 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace DropShot.Authorization;
+
+/// <summary>
+/// Action filter that checks the active role from the JWT's "active_role" claim.
+/// Use on API controllers instead of [Authorize(Roles=...)] when you want to
+/// enforce role checks against the active role specifically.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+public class RequireActiveRoleAttribute(params string[] roles) : Attribute, IAuthorizationFilter
+{
+    public void OnAuthorization(AuthorizationFilterContext context)
+    {
+        var user = context.HttpContext.User;
+        if (user.Identity?.IsAuthenticated != true)
+        {
+            context.Result = new UnauthorizedResult();
+            return;
+        }
+
+        var activeRole = user.FindFirst("active_role")?.Value;
+
+        // Fall back to standard role claim if no active_role claim present
+        // (e.g., tokens issued before this feature was deployed)
+        if (string.IsNullOrEmpty(activeRole))
+        {
+            activeRole = user.FindFirst(System.Security.Claims.ClaimTypes.Role)?.Value;
+        }
+
+        if (string.IsNullOrEmpty(activeRole) ||
+            !roles.Any(r => r.Equals(activeRole, StringComparison.OrdinalIgnoreCase)))
+        {
+            context.Result = new ForbidResult();
+        }
+    }
+}

--- a/DropShot/Components/Account/ActiveRoleAuthenticationStateProvider.cs
+++ b/DropShot/Components/Account/ActiveRoleAuthenticationStateProvider.cs
@@ -1,0 +1,87 @@
+using System.Security.Claims;
+using DropShot.Data;
+using DropShot.Services;
+using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.AspNetCore.Components.Server;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+
+namespace DropShot.Components.Account;
+
+/// <summary>
+/// Wraps the Identity revalidating auth state provider to filter role claims
+/// based on the user's active role. This ensures [Authorize(Roles=...)] and
+/// AuthorizeView automatically respect the active role selection.
+/// </summary>
+internal sealed class ActiveRoleAuthenticationStateProvider(
+    ILoggerFactory loggerFactory,
+    IServiceScopeFactory scopeFactory,
+    IOptions<IdentityOptions> options,
+    ActiveRoleService activeRoleService)
+    : RevalidatingServerAuthenticationStateProvider(loggerFactory)
+{
+    protected override TimeSpan RevalidationInterval => TimeSpan.FromMinutes(30);
+
+    protected override async Task<bool> ValidateAuthenticationStateAsync(
+        AuthenticationState authenticationState, CancellationToken cancellationToken)
+    {
+        await using var scope = scopeFactory.CreateAsyncScope();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+        return await ValidateSecurityStampAsync(userManager, authenticationState.User);
+    }
+
+    private async Task<bool> ValidateSecurityStampAsync(
+        UserManager<ApplicationUser> userManager, ClaimsPrincipal principal)
+    {
+        var user = await userManager.GetUserAsync(principal);
+        if (user is null) return false;
+        if (!userManager.SupportsUserSecurityStamp) return true;
+
+        var principalStamp = principal.FindFirstValue(
+            options.Value.ClaimsIdentity.SecurityStampClaimType);
+        var userStamp = await userManager.GetSecurityStampAsync(user);
+        return principalStamp == userStamp;
+    }
+
+    public override async Task<AuthenticationState> GetAuthenticationStateAsync()
+    {
+        var state = await base.GetAuthenticationStateAsync();
+        var user = state.User;
+
+        if (user.Identity?.IsAuthenticated != true)
+            return state;
+
+        // Initialize the active role service with all granted roles
+        var allRoleClaims = user.FindAll(ClaimTypes.Role).Select(c => c.Value).ToList();
+        if (allRoleClaims.Count > 0)
+            activeRoleService.Initialize(allRoleClaims);
+
+        // If there's only one role (or none), no filtering needed
+        if (allRoleClaims.Count <= 1)
+            return state;
+
+        // Build a new identity with only the active role claim
+        var activeRole = activeRoleService.ActiveRole;
+        var filteredClaims = user.Claims
+            .Where(c => c.Type != ClaimTypes.Role)
+            .Append(new Claim(ClaimTypes.Role, activeRole))
+            .ToList();
+
+        var filteredIdentity = new ClaimsIdentity(
+            filteredClaims,
+            user.Identity.AuthenticationType,
+            ClaimsIdentity.DefaultNameClaimType,
+            ClaimTypes.Role);
+
+        return new AuthenticationState(new ClaimsPrincipal(filteredIdentity));
+    }
+
+    /// <summary>
+    /// Call this after a role switch to force all Blazor components
+    /// to re-evaluate authorization.
+    /// </summary>
+    public void NotifyRoleChanged()
+    {
+        NotifyAuthenticationStateChanged(GetAuthenticationStateAsync());
+    }
+}

--- a/DropShot/Components/Layout/MainLayout.razor
+++ b/DropShot/Components/Layout/MainLayout.razor
@@ -12,7 +12,7 @@
     </div>
 
     <main>
-
+        <DropShot.Components.Shared.RoleBanner />
         <article class="content px-4">
             @Body
         </article>

--- a/DropShot/Components/Layout/NavMenu.razor
+++ b/DropShot/Components/Layout/NavMenu.razor
@@ -91,6 +91,9 @@
         <AuthorizeView>
             <Authorized>
                 <div class="nav-item px-3">
+                    <DropShot.Components.Shared.RoleSwitcher />
+                </div>
+                <div class="nav-item px-3">
                     <NavLink class="nav-link" href="upgrade">
                         <MudIcon Icon="@Icons.Material.Filled.Star" Class="nav-icon" /> Upgrade
                     </NavLink>

--- a/DropShot/Components/Shared/RoleBanner.razor
+++ b/DropShot/Components/Shared/RoleBanner.razor
@@ -1,0 +1,88 @@
+@using DropShot.Components.Account
+@using DropShot.Services
+
+@inject ActiveRoleService ActiveRoleService
+@inject RoleSwitchService RoleSwitchService
+@inject AuthenticationStateProvider AuthStateProvider
+@inject IHttpContextAccessor HttpContextAccessor
+
+@implements IDisposable
+
+@if (_showBanner)
+{
+    <MudAlert Severity="Severity.Info"
+              Variant="Variant.Filled"
+              Dense="true"
+              Class="role-banner"
+              NoIcon="false">
+        <div class="d-flex align-center justify-space-between flex-wrap gap-2">
+            <MudText Typo="Typo.body2">
+                You are browsing as a standard user
+            </MudText>
+            <MudButton Variant="Variant.Text"
+                       Color="Color.Inherit"
+                       Size="Size.Small"
+                       OnClick="SwitchToAdmin"
+                       StartIcon="@Icons.Material.Filled.AdminPanelSettings">
+                Switch to @_highestAdminRole
+            </MudButton>
+        </div>
+    </MudAlert>
+}
+
+@code {
+    [CascadingParameter]
+    private Task<AuthenticationState>? AuthState { get; set; }
+
+    private bool _showBanner;
+    private string? _userId;
+    private string _highestAdminRole = "Admin";
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (AuthState is not null)
+        {
+            var state = await AuthState;
+            _userId = state.User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
+        }
+
+        ActiveRoleService.OnChange += UpdateBanner;
+        UpdateBanner();
+    }
+
+    private void UpdateBanner()
+    {
+        var granted = ActiveRoleService.GrantedRoles;
+        var active = ActiveRoleService.ActiveRole;
+
+        // Show the banner when the user has an admin-level granted role
+        // but is currently operating in a non-admin role
+        var hasAdminRole = granted.Any(r => r is "SuperAdmin" or "Admin");
+        var isInAdminRole = active is "SuperAdmin" or "Admin";
+
+        _showBanner = hasAdminRole && !isInAdminRole && ActiveRoleService.CanSwitchRole;
+
+        if (_showBanner)
+        {
+            _highestAdminRole = granted.Contains("SuperAdmin") ? "SuperAdmin" : "Admin";
+        }
+
+        InvokeAsync(StateHasChanged);
+    }
+
+    private async Task SwitchToAdmin()
+    {
+        if (_userId is null) return;
+
+        var ip = HttpContextAccessor.HttpContext?.Connection.RemoteIpAddress?.ToString();
+        await RoleSwitchService.SwitchRoleAsync(_userId, _highestAdminRole, ip);
+
+        if (AuthStateProvider is ActiveRoleAuthenticationStateProvider activeProvider)
+            activeProvider.NotifyRoleChanged();
+    }
+
+    public void Dispose()
+    {
+        ActiveRoleService.OnChange -= UpdateBanner;
+    }
+}

--- a/DropShot/Components/Shared/RoleSwitcher.razor
+++ b/DropShot/Components/Shared/RoleSwitcher.razor
@@ -1,0 +1,85 @@
+@using DropShot.Components.Account
+@using DropShot.Services
+
+@inject ActiveRoleService ActiveRoleService
+@inject RoleSwitchService RoleSwitchService
+@inject AuthenticationStateProvider AuthStateProvider
+@inject IHttpContextAccessor HttpContextAccessor
+
+@implements IDisposable
+
+@if (ActiveRoleService.CanSwitchRole)
+{
+    <div class="role-switcher">
+        <MudMenu Icon="@Icons.Material.Filled.SwapHoriz"
+                 Color="Color.Inherit"
+                 Dense="true"
+                 AnchorOrigin="Origin.BottomLeft">
+            <ActivatorContent>
+                <MudChip T="string"
+                         Size="Size.Small"
+                         Color="@GetRoleColor(ActiveRoleService.ActiveRole)"
+                         Variant="Variant.Filled"
+                         Icon="@Icons.Material.Filled.SwapHoriz">
+                    @ActiveRoleService.ActiveRole
+                </MudChip>
+            </ActivatorContent>
+            <ChildContent>
+                @foreach (var role in ActiveRoleService.GrantedRoles)
+                {
+                    <MudMenuItem OnClick="@(() => SwitchToRole(role))"
+                                 Disabled="@(role == ActiveRoleService.ActiveRole)">
+                        <div class="d-flex align-center gap-2">
+                            <MudIcon Icon="@(role == ActiveRoleService.ActiveRole ? Icons.Material.Filled.RadioButtonChecked : Icons.Material.Filled.RadioButtonUnchecked)"
+                                     Size="Size.Small" />
+                            <MudText>@role</MudText>
+                        </div>
+                    </MudMenuItem>
+                }
+            </ChildContent>
+        </MudMenu>
+    </div>
+}
+
+@code {
+    [CascadingParameter]
+    private Task<AuthenticationState>? AuthState { get; set; }
+
+    private string? _userId;
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (AuthState is not null)
+        {
+            var state = await AuthState;
+            _userId = state.User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
+        }
+
+        ActiveRoleService.OnChange += StateHasChanged;
+    }
+
+    private async Task SwitchToRole(string role)
+    {
+        if (_userId is null || role == ActiveRoleService.ActiveRole) return;
+
+        var ip = HttpContextAccessor.HttpContext?.Connection.RemoteIpAddress?.ToString();
+        await RoleSwitchService.SwitchRoleAsync(_userId, role, ip);
+
+        // Notify the auth state provider so all AuthorizeView components re-evaluate
+        if (AuthStateProvider is ActiveRoleAuthenticationStateProvider activeProvider)
+            activeProvider.NotifyRoleChanged();
+    }
+
+    private Color GetRoleColor(string role) => role switch
+    {
+        "SuperAdmin" => Color.Error,
+        "Admin" => Color.Warning,
+        "ClubAdmin" => Color.Info,
+        _ => Color.Default
+    };
+
+    public void Dispose()
+    {
+        ActiveRoleService.OnChange -= StateHasChanged;
+    }
+}

--- a/DropShot/Controllers/AuthController.cs
+++ b/DropShot/Controllers/AuthController.cs
@@ -1,6 +1,8 @@
 using DropShot.Data;
+using DropShot.Models;
 using DropShot.Services;
 using DropShot.Shared.Dtos;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -13,7 +15,8 @@ public class AuthController(
     SignInManager<ApplicationUser> signInManager,
     UserManager<ApplicationUser> userManager,
     JwtTokenService jwtTokenService,
-    IDbContextFactory<MyDbContext> dbFactory) : ControllerBase
+    IDbContextFactory<MyDbContext> dbFactory,
+    ILogger<AuthController> logger) : ControllerBase
 {
     [HttpPost("login")]
     public async Task<ActionResult<LoginResponse>> Login([FromBody] LoginRequest request)
@@ -27,7 +30,8 @@ public class AuthController(
             return Unauthorized(new { message = "Invalid email or password." });
 
         var roles = (await userManager.GetRolesAsync(user)).ToList();
-        var token = await jwtTokenService.GenerateTokenAsync(user);
+        var activeRole = roles.FirstOrDefault() ?? "";
+        var token = jwtTokenService.GenerateTokenWithActiveRole(user, roles, activeRole);
 
         await using var db = dbFactory.CreateDbContext();
         var adminClubIds = await db.ClubAdministrators
@@ -35,17 +39,21 @@ public class AuthController(
             .Select(ca => ca.ClubId)
             .ToListAsync();
 
-        return Ok(new LoginResponse(token, user.UserName!, user.Email!, roles, adminClubIds));
+        return Ok(new LoginResponse(token, user.UserName!, user.Email!, roles, adminClubIds, activeRole, roles));
     }
 
     [HttpGet("me")]
-    [Microsoft.AspNetCore.Authorization.Authorize(AuthenticationSchemes = "Bearer")]
+    [Authorize(AuthenticationSchemes = "Bearer")]
     public async Task<ActionResult<UserInfoDto>> Me()
     {
         var user = await userManager.GetUserAsync(User);
         if (user is null) return Unauthorized();
 
-        var roles = (await userManager.GetRolesAsync(user)).ToList();
+        var grantedRoles = (await userManager.GetRolesAsync(user)).ToList();
+
+        // Read active role from JWT claim, fall back to first granted role
+        var activeRole = User.FindFirst("active_role")?.Value
+                         ?? grantedRoles.FirstOrDefault() ?? "";
 
         await using var db = dbFactory.CreateDbContext();
         var adminClubIds = await db.ClubAdministrators
@@ -53,6 +61,45 @@ public class AuthController(
             .Select(ca => ca.ClubId)
             .ToListAsync();
 
-        return Ok(new UserInfoDto(user.Id, user.UserName!, user.Email!, roles, adminClubIds));
+        return Ok(new UserInfoDto(user.Id, user.UserName!, user.Email!, grantedRoles, adminClubIds, activeRole, grantedRoles));
+    }
+
+    [HttpPost("switch-role")]
+    [Authorize(AuthenticationSchemes = "Bearer")]
+    public async Task<ActionResult<SwitchRoleResponse>> SwitchRole([FromBody] SwitchRoleRequest request)
+    {
+        var user = await userManager.GetUserAsync(User);
+        if (user is null) return Unauthorized();
+
+        var grantedRoles = (await userManager.GetRolesAsync(user)).ToList();
+
+        // Validate the requested role is in the user's granted roles
+        if (!grantedRoles.Contains(request.Role, StringComparer.OrdinalIgnoreCase))
+            return BadRequest(new { message = $"Role '{request.Role}' is not in your granted roles." });
+
+        var previousRole = User.FindFirst("active_role")?.Value
+                           ?? grantedRoles.FirstOrDefault() ?? "";
+
+        // Log the role switch
+        var ip = HttpContext.Connection.RemoteIpAddress?.ToString();
+        await using var db = dbFactory.CreateDbContext();
+        db.RoleSwitchLogs.Add(new RoleSwitchLog
+        {
+            UserId = user.Id,
+            FromRole = previousRole,
+            ToRole = request.Role,
+            Timestamp = DateTime.UtcNow,
+            IpAddress = ip
+        });
+        await db.SaveChangesAsync();
+
+        logger.LogInformation(
+            "Role switch: User {UserId} switched from {FromRole} to {ToRole} (IP: {Ip})",
+            user.Id, previousRole, request.Role, ip);
+
+        // Issue a new token with the requested active role
+        var token = jwtTokenService.GenerateTokenWithActiveRole(user, grantedRoles, request.Role);
+
+        return Ok(new SwitchRoleResponse(token, request.Role, grantedRoles));
     }
 }

--- a/DropShot/Data/Migrations/20260405185253_AddRoleSwitchLog.Designer.cs
+++ b/DropShot/Data/Migrations/20260405185253_AddRoleSwitchLog.Designer.cs
@@ -4,6 +4,7 @@ using DropShot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DropShot.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260405185253_AddRoleSwitchLog")]
+    partial class AddRoleSwitchLog
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DropShot/Data/Migrations/20260405185253_AddRoleSwitchLog.cs
+++ b/DropShot/Data/Migrations/20260405185253_AddRoleSwitchLog.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropShot.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRoleSwitchLog : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "RoleSwitchLogs",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    UserId = table.Column<string>(type: "nvarchar(450)", maxLength: 450, nullable: false),
+                    FromRole = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    ToRole = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    Timestamp = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    IpAddress = table.Column<string>(type: "nvarchar(45)", maxLength: 45, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RoleSwitchLogs", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RoleSwitchLogs_Timestamp",
+                table: "RoleSwitchLogs",
+                column: "Timestamp");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RoleSwitchLogs_UserId",
+                table: "RoleSwitchLogs",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "RoleSwitchLogs");
+        }
+    }
+}

--- a/DropShot/Data/MyDbContext.cs
+++ b/DropShot/Data/MyDbContext.cs
@@ -34,6 +34,7 @@ namespace DropShot.Data
         public DbSet<ClubEmailTemplate> ClubEmailTemplates { get; set; }
         public DbSet<ScoreboardDisplaySetting> ScoreboardDisplaySettings { get; set; }
         public DbSet<UserPlayer> UserPlayers { get; set; }
+        public DbSet<RoleSwitchLog> RoleSwitchLogs { get; set; }
 
         protected override void OnModelCreating(ModelBuilder builder)
         {
@@ -410,6 +411,17 @@ namespace DropShot.Data
                       .WithMany()
                       .HasForeignKey(up => up.PlayerId)
                       .OnDelete(DeleteBehavior.Cascade);
+            });
+
+            // ── RoleSwitchLog ───────────────────────────────────────────────────
+            builder.Entity<RoleSwitchLog>(entity =>
+            {
+                entity.Property(r => r.UserId).HasMaxLength(450).IsRequired();
+                entity.Property(r => r.FromRole).HasMaxLength(50).IsRequired();
+                entity.Property(r => r.ToRole).HasMaxLength(50).IsRequired();
+                entity.Property(r => r.IpAddress).HasMaxLength(45);
+                entity.HasIndex(r => r.UserId);
+                entity.HasIndex(r => r.Timestamp);
             });
         }
     }

--- a/DropShot/Models/RoleSwitchLog.cs
+++ b/DropShot/Models/RoleSwitchLog.cs
@@ -1,0 +1,11 @@
+namespace DropShot.Models;
+
+public class RoleSwitchLog
+{
+    public int Id { get; set; }
+    public string UserId { get; set; } = null!;
+    public string FromRole { get; set; } = null!;
+    public string ToRole { get; set; } = null!;
+    public DateTime Timestamp { get; set; }
+    public string? IpAddress { get; set; }
+}

--- a/DropShot/Program.cs
+++ b/DropShot/Program.cs
@@ -39,7 +39,8 @@ builder.Services.AddDatabaseDeveloperPageExceptionFilter();
 builder.Services.AddCascadingAuthenticationState();
 builder.Services.AddScoped<IdentityUserAccessor>();
 builder.Services.AddScoped<IdentityRedirectManager>();
-builder.Services.AddScoped<AuthenticationStateProvider, IdentityRevalidatingAuthenticationStateProvider>();
+builder.Services.AddScoped<ActiveRoleService>();
+builder.Services.AddScoped<AuthenticationStateProvider, ActiveRoleAuthenticationStateProvider>();
 
 builder.Services.AddAuthentication(options =>
     {
@@ -105,6 +106,8 @@ builder.Services.AddIdentityCore<ApplicationUser>(options => options.SignIn.Requ
     .AddDefaultTokenProviders();
 
 // ── App services ─────────────────────────────────────────────────────────────
+builder.Services.AddHttpContextAccessor();
+builder.Services.AddScoped<RoleSwitchService>();
 builder.Services.AddScoped<UserState>();
 builder.Services.AddScoped<TennisScoreService>();
 builder.Services.AddScoped<ClubAuthorizationService>();

--- a/DropShot/Services/ActiveRoleService.cs
+++ b/DropShot/Services/ActiveRoleService.cs
@@ -1,0 +1,62 @@
+namespace DropShot.Services;
+
+/// <summary>
+/// Scoped service that tracks the active role for the current Blazor circuit.
+/// Each user session gets its own instance. The active role defaults to the
+/// highest-privilege granted role on first access.
+/// </summary>
+public class ActiveRoleService
+{
+    private string? _activeRole;
+    private List<string> _grantedRoles = [];
+
+    public event Action? OnChange;
+
+    /// <summary>All roles the user has been granted via ASP.NET Identity.</summary>
+    public IReadOnlyList<string> GrantedRoles => _grantedRoles;
+
+    /// <summary>The currently active role used for authorization checks.</summary>
+    public string ActiveRole => _activeRole ?? (_grantedRoles.Count > 0 ? _grantedRoles[0] : "");
+
+    /// <summary>True when the user has more than one granted role (show role switcher).</summary>
+    public bool CanSwitchRole => _grantedRoles.Count > 1;
+
+    /// <summary>
+    /// Initialize with the user's granted roles. Ordered by privilege descending:
+    /// SuperAdmin > Admin > ClubAdmin > others.
+    /// </summary>
+    public void Initialize(IList<string> grantedRoles)
+    {
+        _grantedRoles = grantedRoles
+            .OrderBy(r => r switch
+            {
+                "SuperAdmin" => 0,
+                "Admin" => 1,
+                "ClubAdmin" => 2,
+                _ => 3
+            })
+            .ToList();
+
+        // Default to highest-privilege role
+        _activeRole ??= _grantedRoles.FirstOrDefault();
+    }
+
+    /// <summary>
+    /// Switch to a different role. Returns false if the role is not in granted roles.
+    /// </summary>
+    public bool TrySwitch(string newRole)
+    {
+        if (!_grantedRoles.Contains(newRole, StringComparer.OrdinalIgnoreCase))
+            return false;
+
+        _activeRole = _grantedRoles.First(r => r.Equals(newRole, StringComparison.OrdinalIgnoreCase));
+        OnChange?.Invoke();
+        return true;
+    }
+
+    /// <summary>
+    /// Returns the previous active role (before the last switch), or the current one if not yet switched.
+    /// Stored transiently to support logging.
+    /// </summary>
+    public string PreviousRole { get; set; } = "";
+}

--- a/DropShot/Services/ClubAuthorizationService.cs
+++ b/DropShot/Services/ClubAuthorizationService.cs
@@ -8,32 +8,42 @@ namespace DropShot.Services;
 /// <summary>
 /// Provides fine-grained authorization checks for club and competition editing.
 /// Inject into Blazor pages and pass the current ClaimsPrincipal.
+///
+/// Role checks read from the ClaimsPrincipal's Role claims, which are filtered
+/// by ActiveRoleAuthenticationStateProvider to contain only the active role.
+/// This means all checks automatically respect the user's active role selection.
 /// </summary>
 public class ClubAuthorizationService(
     UserManager<ApplicationUser> userManager,
     IDbContextFactory<MyDbContext> dbFactory)
 {
-    private async Task<(ApplicationUser? user, IList<string> roles)> GetUserAndRolesAsync(ClaimsPrincipal principal)
+    private (string? userId, IList<string> roles) GetUserAndRoles(ClaimsPrincipal principal)
     {
-        var user = await userManager.GetUserAsync(principal);
-        if (user is null) return (null, Array.Empty<string>());
-        var roles = await userManager.GetRolesAsync(user);
-        return (user, roles);
+        var userId = userManager.GetUserId(principal);
+        if (userId is null) return (null, Array.Empty<string>());
+
+        // Read roles from claims (filtered to active role by the auth state provider)
+        var roles = principal.FindAll(ClaimTypes.Role).Select(c => c.Value).ToList();
+        return (userId, roles);
     }
 
-    /// <summary>Returns true if the user holds the SuperAdmin role.</summary>
-    public async Task<bool> IsSuperAdminAsync(ClaimsPrincipal user)
+    /// <summary>Returns true if the user's active role is SuperAdmin.</summary>
+    public bool IsSuperAdmin(ClaimsPrincipal user)
     {
-        var (appUser, roles) = await GetUserAndRolesAsync(user);
-        return appUser is not null && roles.Contains("SuperAdmin");
+        var (userId, roles) = GetUserAndRoles(user);
+        return userId is not null && roles.Contains("SuperAdmin");
     }
 
-    /// <summary>Returns true if the user holds the Admin or SuperAdmin role.</summary>
-    public async Task<bool> IsAdminAsync(ClaimsPrincipal user)
+    /// <summary>Returns true if the user's active role is Admin or SuperAdmin.</summary>
+    public bool IsAdmin(ClaimsPrincipal user)
     {
-        var (appUser, roles) = await GetUserAndRolesAsync(user);
-        return appUser is not null && (roles.Contains("Admin") || roles.Contains("SuperAdmin"));
+        var (userId, roles) = GetUserAndRoles(user);
+        return userId is not null && (roles.Contains("Admin") || roles.Contains("SuperAdmin"));
     }
+
+    // Keep async overloads for backward compatibility with existing callers
+    public Task<bool> IsSuperAdminAsync(ClaimsPrincipal user) => Task.FromResult(IsSuperAdmin(user));
+    public Task<bool> IsAdminAsync(ClaimsPrincipal user) => Task.FromResult(IsAdmin(user));
 
     /// <summary>Returns the list of ClubIds the user is an administrator of.</summary>
     public async Task<List<int>> GetAdminClubIdsAsync(ClaimsPrincipal user)
@@ -48,16 +58,16 @@ public class ClubAuthorizationService(
             .ToListAsync();
     }
 
-    /// <summary>Returns true if the user can edit the given club (Admin or assigned ClubAdmin).</summary>
+    /// <summary>Returns true if the user can edit the given club (Admin active role or assigned ClubAdmin).</summary>
     public async Task<bool> CanEditClubAsync(ClaimsPrincipal user, int clubId)
     {
-        var (appUser, roles) = await GetUserAndRolesAsync(user);
-        if (appUser is null) return false;
+        var (userId, roles) = GetUserAndRoles(user);
+        if (userId is null) return false;
         if (roles.Contains("Admin") || roles.Contains("SuperAdmin")) return true;
 
         await using var db = dbFactory.CreateDbContext();
         return await db.ClubAdministrators
-            .AnyAsync(ca => ca.UserId == appUser.Id && ca.ClubId == clubId);
+            .AnyAsync(ca => ca.UserId == userId && ca.ClubId == clubId);
     }
 
     /// <summary>
@@ -70,15 +80,15 @@ public class ClubAuthorizationService(
     public async Task<bool> CanEditCompetitionAsync(
         ClaimsPrincipal user, int? hostClubId, int? competitionId = null)
     {
-        var (appUser, roles) = await GetUserAndRolesAsync(user);
-        if (appUser is null) return false;
+        var (userId, roles) = GetUserAndRoles(user);
+        if (userId is null) return false;
         if (roles.Contains("Admin") || roles.Contains("SuperAdmin")) return true;
 
         if (competitionId.HasValue)
         {
             await using var db = dbFactory.CreateDbContext();
             if (await db.CompetitionAdmins.AnyAsync(ca =>
-                    ca.CompetitionId == competitionId.Value && ca.UserId == appUser.Id))
+                    ca.CompetitionId == competitionId.Value && ca.UserId == userId))
                 return true;
         }
 
@@ -86,7 +96,7 @@ public class ClubAuthorizationService(
 
         await using var db2 = dbFactory.CreateDbContext();
         return await db2.ClubAdministrators
-            .AnyAsync(ca => ca.UserId == appUser.Id && ca.ClubId == hostClubId.Value);
+            .AnyAsync(ca => ca.UserId == userId && ca.ClubId == hostClubId.Value);
     }
 
     /// <summary>Returns the set of CompetitionIds the user is a per-competition admin of.</summary>

--- a/DropShot/Services/JwtTokenService.cs
+++ b/DropShot/Services/JwtTokenService.cs
@@ -9,19 +9,37 @@ namespace DropShot.Services;
 
 public class JwtTokenService(IConfiguration config, UserManager<ApplicationUser> userManager)
 {
+    /// <summary>
+    /// Generate a JWT with all the user's roles (default behavior).
+    /// The first role in the list is set as the active role.
+    /// </summary>
     public async Task<string> GenerateTokenAsync(ApplicationUser user)
     {
         var roles = await userManager.GetRolesAsync(user);
+        var activeRole = roles.FirstOrDefault() ?? "";
+        return GenerateTokenWithActiveRole(user, roles, activeRole);
+    }
 
+    /// <summary>
+    /// Generate a JWT with a specific active role. The token carries all granted
+    /// roles in "granted_role" claims but only the active role in the standard
+    /// Role claim, so [Authorize(Roles=...)] checks respect the active role.
+    /// </summary>
+    public string GenerateTokenWithActiveRole(
+        ApplicationUser user, IList<string> grantedRoles, string activeRole)
+    {
         var claims = new List<Claim>
         {
             new(JwtRegisteredClaimNames.Sub, user.Id),
             new(JwtRegisteredClaimNames.Email, user.Email ?? ""),
             new(JwtRegisteredClaimNames.UniqueName, user.UserName ?? ""),
-            new(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString())
+            new(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
+            new(ClaimTypes.Role, activeRole),
+            new("active_role", activeRole)
         };
 
-        claims.AddRange(roles.Select(r => new Claim(ClaimTypes.Role, r)));
+        // Store all granted roles as separate claims for reference
+        claims.AddRange(grantedRoles.Select(r => new Claim("granted_role", r)));
 
         var jwtCfg = config.GetSection("Jwt");
         var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtCfg["Key"]!));

--- a/DropShot/Services/RoleSwitchService.cs
+++ b/DropShot/Services/RoleSwitchService.cs
@@ -1,0 +1,43 @@
+using DropShot.Data;
+using DropShot.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace DropShot.Services;
+
+/// <summary>
+/// Handles the server-side logic for role switching in Blazor Server circuits.
+/// Coordinates between ActiveRoleService (in-memory state) and the database (audit log).
+/// </summary>
+public class RoleSwitchService(
+    ActiveRoleService activeRoleService,
+    IDbContextFactory<MyDbContext> dbFactory,
+    ILogger<RoleSwitchService> logger)
+{
+    public async Task<bool> SwitchRoleAsync(string userId, string newRole, string? ipAddress)
+    {
+        var previousRole = activeRoleService.ActiveRole;
+
+        if (!activeRoleService.TrySwitch(newRole))
+            return false;
+
+        activeRoleService.PreviousRole = previousRole;
+
+        // Log to database
+        await using var db = dbFactory.CreateDbContext();
+        db.RoleSwitchLogs.Add(new RoleSwitchLog
+        {
+            UserId = userId,
+            FromRole = previousRole,
+            ToRole = newRole,
+            Timestamp = DateTime.UtcNow,
+            IpAddress = ipAddress
+        });
+        await db.SaveChangesAsync();
+
+        logger.LogInformation(
+            "Role switch: User {UserId} switched from {FromRole} to {ToRole} (IP: {Ip})",
+            userId, previousRole, newRole, ipAddress);
+
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary
- Users with multiple granted roles can switch their active role without re-authenticating
- All authorization checks (Blazor `[Authorize]`, `AuthorizeView`, `ClubAuthorizationService`, JWT `[Authorize(Roles=...)]`) now use `activeRole` instead of all granted roles
- New `POST /api/auth/switch-role` API endpoint for MAUI clients, with new JWT issued per switch
- Blazor Server uses scoped `ActiveRoleService` + custom `AuthenticationStateProvider` that filters role claims
- `RoleSwitcher` component in sidebar (visible only to multi-role users) with color-coded role chip
- `RoleBanner` at top of page when admin users are browsing as a standard user
- All role switches logged to `RoleSwitchLogs` table with userId, fromRole, toRole, timestamp, IP
- `[RequireActiveRole("Admin")]` attribute available for API controllers
- EF migration included for `RoleSwitchLogs` table

## Test plan
- [ ] Log in as a user with multiple roles (e.g. Admin + ClubAdmin)
- [ ] Verify the role switcher chip appears in the sidebar
- [ ] Switch to a non-admin role and verify admin-only pages/nav items are hidden
- [ ] Verify the "browsing as standard user" banner appears with switch-back link
- [ ] Switch back to admin and verify full access is restored
- [ ] Verify `RoleSwitchLogs` table records each switch
- [ ] Test the `/api/auth/switch-role` endpoint from MAUI or API client
- [ ] Verify a user with only one role does NOT see the role switcher
- [ ] Verify switching to a role not in grantedRoles returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)