### PR TITLE
Fix DbContext concurrency in role switcher components

### DIFF
--- a/DropShot/Components/Shared/RoleBanner.razor
+++ b/DropShot/Components/Shared/RoleBanner.razor
@@ -2,9 +2,11 @@
 
 @using System.Security.Claims
 @using Microsoft.AspNetCore.Identity
+@using Microsoft.EntityFrameworkCore
+@using DropShot.Data
 
 @inject IHttpContextAccessor HttpContextAccessor
-@inject UserManager<DropShot.Data.ApplicationUser> UserManager
+@inject IDbContextFactory<MyDbContext> DbFactory
 @inject NavigationManager NavigationManager
 
 @if (_showBanner)
@@ -34,10 +36,16 @@
 
         _currentUrl = NavigationManager.ToBaseRelativePath(NavigationManager.Uri);
 
-        var user = await UserManager.GetUserAsync(httpContext.User);
-        if (user is null) return;
+        var userId = httpContext.User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (userId is null) return;
 
-        var grantedRoles = (await UserManager.GetRolesAsync(user)).ToList();
+        // Use a dedicated DbContext to avoid concurrency with other SSR components
+        await using var db = DbFactory.CreateDbContext();
+        var grantedRoles = await db.UserRoles
+            .Where(ur => ur.UserId == userId)
+            .Join(db.Roles, ur => ur.RoleId, r => r.Id, (ur, r) => r.Name!)
+            .ToListAsync();
+
         if (grantedRoles.Count <= 1) return;
 
         var hasAdminRole = grantedRoles.Any(r => r is "SuperAdmin" or "Admin");

--- a/DropShot/Components/Shared/RoleSwitcher.razor
+++ b/DropShot/Components/Shared/RoleSwitcher.razor
@@ -2,9 +2,11 @@
 
 @using System.Security.Claims
 @using Microsoft.AspNetCore.Identity
+@using Microsoft.EntityFrameworkCore
+@using DropShot.Data
 
 @inject IHttpContextAccessor HttpContextAccessor
-@inject UserManager<DropShot.Data.ApplicationUser> UserManager
+@inject IDbContextFactory<MyDbContext> DbFactory
 @inject NavigationManager NavigationManager
 
 @if (_grantedRoles.Count > 1)
@@ -39,13 +41,18 @@
 
         _currentUrl = NavigationManager.ToBaseRelativePath(NavigationManager.Uri);
 
-        var user = await UserManager.GetUserAsync(httpContext.User);
-        if (user is null) return;
+        var userId = httpContext.User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (userId is null) return;
 
-        _grantedRoles = (await UserManager.GetRolesAsync(user)).ToList();
+        // Use a dedicated DbContext to avoid concurrency with other SSR components
+        await using var db = DbFactory.CreateDbContext();
+        _grantedRoles = await db.UserRoles
+            .Where(ur => ur.UserId == userId)
+            .Join(db.Roles, ur => ur.RoleId, r => r.Id, (ur, r) => r.Name!)
+            .ToListAsync();
+
         if (_grantedRoles.Count <= 1) return;
 
-        // Read active role from cookie, default to first granted role
         _activeRole = httpContext.Request.Cookies["ActiveRole"] ?? _grantedRoles[0];
         if (!_grantedRoles.Contains(_activeRole, StringComparer.OrdinalIgnoreCase))
             _activeRole = _grantedRoles[0];


### PR DESCRIPTION
## Summary
- Replace `UserManager` injection with `IDbContextFactory` in RoleSwitcher and RoleBanner
- Each component creates its own short-lived `DbContext` via the factory
- Queries `UserRoles`/`Roles` tables directly instead of `UserManager.GetRolesAsync()`

**Root cause:** Both components injected `UserManager<ApplicationUser>` which internally uses the scoped `DbContext`. During SSR, the layout renders components concurrently, so two `GetRolesAsync` calls hit the same `DbContext` simultaneously.

## Test plan
- [ ] Page loads without `InvalidOperationException`
- [ ] Role switcher still shows correctly for multi-role users
- [ ] Role switching still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)