### PR TITLE
Add base User role so admins can switch to normal user

### DIFF
--- a/DropShot/Components/Account/Pages/Register.razor
+++ b/DropShot/Components/Account/Pages/Register.razor
@@ -96,6 +96,9 @@
 
         Logger.LogInformation("User created a new account with password.");
 
+        // Assign the base "User" role to every new account
+        await UserManager.AddToRoleAsync(user, "User");
+
         // Auto-link to an existing unlinked Player record with the same email
         var linkedPlayer = false;
         await using (var db = await DbFactory.CreateDbContextAsync())

--- a/DropShot/Program.cs
+++ b/DropShot/Program.cs
@@ -221,9 +221,16 @@ app.MapPost("/Account/SwitchRole", async (
 using (var scope = app.Services.CreateScope())
 {
     var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<IdentityRole>>();
-    foreach (var roleName in new[] { "SuperAdmin", "Admin", "ClubAdmin" })
+    foreach (var roleName in new[] { "SuperAdmin", "Admin", "ClubAdmin", "User" })
         if (!await roleManager.RoleExistsAsync(roleName))
             await roleManager.CreateAsync(new IdentityRole(roleName));
+
+    // Ensure every existing user has the base "User" role
+    var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+    var usersWithoutRole = (await userManager.GetUsersInRoleAsync("User")).Select(u => u.Id).ToHashSet();
+    var allUsers = userManager.Users.ToList();
+    foreach (var user in allUsers.Where(u => !usersWithoutRole.Contains(u.Id)))
+        await userManager.AddToRoleAsync(user, "User");
 }
 
 app.Run();

--- a/DropShot/Services/ActiveRoleService.cs
+++ b/DropShot/Services/ActiveRoleService.cs
@@ -33,7 +33,8 @@ public class ActiveRoleService
                 "SuperAdmin" => 0,
                 "Admin" => 1,
                 "ClubAdmin" => 2,
-                _ => 3
+                "User" => 3,
+                _ => 4
             })
             .ToList();
 


### PR DESCRIPTION
## Summary
- Seed a `User` role alongside SuperAdmin, Admin, ClubAdmin
- On startup, assign `User` to all existing users who don't have it yet
- New registrations get `User` role automatically
- Admin users now see "Switch to User" in the role switcher

## Test plan
- [ ] Run the app — verify no startup errors
- [ ] Log in as an admin — verify "Switch to User" appears in the role switcher
- [ ] Switch to User — verify admin nav items disappear and the banner shows
- [ ] Register a new account — verify the User role is assigned

🤖 Generated with [Claude Code](https://claude.com/claude-code)