### PR TITLE
Restyle role switcher as a compact dropdown

### DIFF
--- a/DropShot/Components/Shared/RoleSwitcher.razor
+++ b/DropShot/Components/Shared/RoleSwitcher.razor
@@ -1,7 +1,6 @@
-@* Pure SSR component — uses a form POST like logout, no interactive circuit needed *@
+@* Pure SSR — native <select> auto-submits on change via inline JS *@
 
 @using System.Security.Claims
-@using Microsoft.AspNetCore.Identity
 @using Microsoft.EntityFrameworkCore
 @using DropShot.Data
 
@@ -11,22 +10,19 @@
 
 @if (_grantedRoles.Count > 1)
 {
-    <div class="role-switcher-section">
-        <span class="role-switcher-label nav-link" style="font-size: 0.75rem; opacity: 0.7; padding-bottom: 0;">
-            <MudIcon Icon="@Icons.Material.Filled.SwapHoriz" Class="nav-icon" /> Role: @_activeRole
-        </span>
-        @foreach (var role in _grantedRoles.Where(r => r != _activeRole))
-        {
-            <form action="Account/SwitchRole" method="post" data-enhance-nav="false">
-                <AntiforgeryToken />
-                <input type="hidden" name="role" value="@role" />
-                <input type="hidden" name="returnUrl" value="@_currentUrl" />
-                <button type="submit" class="nav-link role-switch-btn">
-                    <MudIcon Icon="@Icons.Material.Filled.ArrowForward" Class="nav-icon" /> Switch to @role
-                </button>
-            </form>
-        }
-    </div>
+    <form action="Account/SwitchRole" method="post" data-enhance-nav="false">
+        <AntiforgeryToken />
+        <input type="hidden" name="returnUrl" value="@_currentUrl" />
+        <div class="role-switcher-row">
+            <MudIcon Icon="@Icons.Material.Filled.SwapHoriz" Class="nav-icon" />
+            <select name="role" class="role-switcher-select" onchange="this.form.submit()">
+                @foreach (var role in _grantedRoles)
+                {
+                    <option value="@role" selected="@(role == _activeRole)">@role</option>
+                }
+            </select>
+        </div>
+    </form>
 }
 
 @code {
@@ -44,7 +40,6 @@
         var userId = httpContext.User.FindFirstValue(ClaimTypes.NameIdentifier);
         if (userId is null) return;
 
-        // Use a dedicated DbContext to avoid concurrency with other SSR components
         await using var db = DbFactory.CreateDbContext();
         _grantedRoles = await db.UserRoles
             .Where(ur => ur.UserId == userId)

--- a/DropShot/Components/Shared/RoleSwitcher.razor.css
+++ b/DropShot/Components/Shared/RoleSwitcher.razor.css
@@ -1,0 +1,34 @@
+.role-switcher-row {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    height: 3rem;
+    padding-left: 10px;
+}
+
+.role-switcher-select {
+    background: rgba(255, 255, 255, 0.1);
+    color: #d7d7d7;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 4px;
+    padding: 4px 8px;
+    font-size: 0.85rem;
+    cursor: pointer;
+    flex: 1;
+    min-width: 0;
+}
+
+    .role-switcher-select:hover {
+        background: rgba(255, 255, 255, 0.2);
+        color: white;
+    }
+
+    .role-switcher-select:focus {
+        outline: none;
+        border-color: rgba(255, 255, 255, 0.5);
+    }
+
+    .role-switcher-select option {
+        background: #1e1e2e;
+        color: #d7d7d7;
+    }


### PR DESCRIPTION
## Summary
- Replace label + per-role buttons with a single `<select>` dropdown
- Auto-submits on change via `onchange="this.form.submit()"`
- Scoped CSS styles the dropdown to match the sidebar theme
- Compact single-line layout with swap icon + dropdown

## Test plan
- [ ] Verify dropdown appears in sidebar for multi-role users
- [ ] Select a different role — page reloads with new active role
- [ ] Verify dropdown shows current role as selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)