### PR TITLE
Enforce active role via middleware for SSR and controllers

### DIFF
--- a/DropShot/Program.cs
+++ b/DropShot/Program.cs
@@ -134,6 +134,42 @@ app.UseHttpsRedirection();
 app.UseCors("MauiPolicy");
 app.UseStaticFiles();
 app.UseAuthentication();
+
+// ── Active-role middleware ────────────────────────────────────────────────────
+// Reads the ActiveRole cookie and rebuilds HttpContext.User with only that role
+// claim, so SSR AuthorizeView, [Authorize(Roles=...)], and all downstream checks
+// see the active role instead of all granted roles.
+app.Use(async (context, next) =>
+{
+    var user = context.User;
+    if (user.Identity?.IsAuthenticated == true)
+    {
+        var activeRole = context.Request.Cookies["ActiveRole"];
+        var allRoles = user.FindAll(System.Security.Claims.ClaimTypes.Role)
+            .Select(c => c.Value).ToList();
+
+        if (!string.IsNullOrEmpty(activeRole) && allRoles.Count > 1 &&
+            allRoles.Contains(activeRole, StringComparer.OrdinalIgnoreCase))
+        {
+            var filteredClaims = user.Claims
+                .Where(c => c.Type != System.Security.Claims.ClaimTypes.Role)
+                .Append(new System.Security.Claims.Claim(
+                    System.Security.Claims.ClaimTypes.Role, activeRole))
+                .ToList();
+
+            var identity = new System.Security.Claims.ClaimsIdentity(
+                filteredClaims,
+                user.Identity.AuthenticationType,
+                System.Security.Claims.ClaimsIdentity.DefaultNameClaimType,
+                System.Security.Claims.ClaimTypes.Role);
+
+            context.User = new System.Security.Claims.ClaimsPrincipal(identity);
+        }
+    }
+
+    await next();
+});
+
 app.UseAuthorization();
 app.UseAntiforgery();
 


### PR DESCRIPTION
## Summary
- Add middleware between `UseAuthentication()` and `UseAuthorization()` that filters `HttpContext.User` role claims based on the `ActiveRole` cookie
- When a user has multiple roles and an active role cookie, the principal is rebuilt with only that one role
- This makes SSR `AuthorizeView`, `[Authorize(Roles=...)]` on controllers, and `ClubAuthorizationService` all respect the active role

**Root cause:** The Identity cookie contains all granted roles. SSR reads `HttpContext.User` directly from the cookie — the `ActiveRoleAuthenticationStateProvider` only runs in interactive circuits, not SSR.

## Test plan
- [ ] Switch to User role — admin nav items (User Management, Scoreboard) should disappear
- [ ] Visit `/admin/users` directly while in User role — should be denied
- [ ] Switch back to Admin — full admin access restored
- [ ] API `[Authorize(Roles="Admin")]` endpoints should also respect the active role

🤖 Generated with [Claude Code](https://claude.com/claude-code)