### PR TITLE
Redirect to home page on role switch

### DIFF
--- a/DropShot/Components/Shared/RoleSwitcher.razor
+++ b/DropShot/Components/Shared/RoleSwitcher.razor
@@ -12,7 +12,7 @@
 {
     <form action="Account/SwitchRole" method="post" data-enhance-nav="false">
         <AntiforgeryToken />
-        <input type="hidden" name="returnUrl" value="@_currentUrl" />
+        <input type="hidden" name="returnUrl" value="/" />
         <div class="role-switcher-row">
             <MudIcon Icon="@Icons.Material.Filled.SwapHoriz" Class="nav-icon" />
             <select name="role" class="role-switcher-select" onchange="this.form.submit()">


### PR DESCRIPTION
## Summary
- Role switcher now always redirects to `/` instead of back to the current page
- Prevents 404 when switching to a lower-privilege role while on an admin-only page

## Test plan
- [ ] Navigate to an admin page, switch to User role — should land on home page
- [ ] Switch roles from the home page — should stay on home page

🤖 Generated with [Claude Code](https://claude.com/claude-code)