### PR TITLE
Move role switcher below username and above logout

### DIFF
--- a/DropShot/Components/Layout/NavMenu.razor
+++ b/DropShot/Components/Layout/NavMenu.razor
@@ -91,9 +91,6 @@
         <AuthorizeView>
             <Authorized>
                 <div class="nav-item px-3">
-                    <DropShot.Components.Shared.RoleSwitcher />
-                </div>
-                <div class="nav-item px-3">
                     <NavLink class="nav-link" href="upgrade">
                         <MudIcon Icon="@Icons.Material.Filled.Star" Class="nav-icon" /> Upgrade
                     </NavLink>
@@ -107,6 +104,9 @@
                     <a class="nav-link" href="Account/Manage" data-enhance-nav="false">
                         <MudIcon Icon="@Icons.Material.Filled.Person" Class="nav-icon" /> @context.User.Identity?.Name
                     </a>
+                </div>
+                <div class="nav-item px-3">
+                    <DropShot.Components.Shared.RoleSwitcher />
                 </div>
                 <div class="nav-item px-3">
                     <form action="Account/Logout" method="post">


### PR DESCRIPTION
## Summary
- Move the role switcher dropdown from above Upgrade to between the username link and the Logout button

🤖 Generated with [Claude Code](https://claude.com/claude-code)