### PR TITLE
Improve match page layout and functionality

### DIFF
--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -30,23 +30,23 @@
 
 <MudProviders />
 
-<MudCollapse Expanded="_expanded" Style="margin-top: 10px;">
-    <MudPaper Class="pa-4">
-        <MudStack Spacing="2">
-            <MudText>Settings</MudText>
-            <MudDivider />
-            <MudSwitch @bind-Value="_state.GameScoring" Label="Game Scoring" LabelPlacement="Placement.Start" Color="Color.Success" />
-            <MudSelect T="int?" @bind-Value="_selectedCourtId" Label="Court (optional)" Variant="Variant.Outlined" Clearable="true">
-                @foreach (var court in _courts)
-                {
-                    <MudSelectItem T="int?" Value="@((int?)court.CourtId)">@court.Club.Name — @court.Name</MudSelectItem>
-                }
-            </MudSelect>
-            <MudButton Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Save" Color="Color.Info" Size="Size.Small" OnClick="@SaveSettings">Save</MudButton>
-            <MudButton Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Cancel" Color="Color.Error" Size="Size.Small" OnClick="@(() => OpenDialogAsync(_fullScreen))">End Match</MudButton>
-        </MudStack>
-    </MudPaper>
-</MudCollapse>
+@* #8 — Settings as a slide-out drawer instead of a collapse that pushes content *@
+<MudDrawer @bind-Open="_expanded" Anchor="Anchor.End" Variant="DrawerVariant.Temporary" Width="320px" Elevation="4">
+    <MudDrawerHeader>
+        <MudText Typo="Typo.h6">Settings</MudText>
+    </MudDrawerHeader>
+    <MudStack Spacing="2" Class="pa-4">
+        <MudSwitch @bind-Value="_state.GameScoring" Label="Game Scoring" LabelPlacement="Placement.Start" Color="Color.Success" />
+        <MudSelect T="int?" @bind-Value="_selectedCourtId" Label="Court (optional)" Variant="Variant.Outlined" Clearable="true">
+            @foreach (var court in _courts)
+            {
+                <MudSelectItem T="int?" Value="@((int?)court.CourtId)">@court.Club.Name — @court.Name</MudSelectItem>
+            }
+        </MudSelect>
+        <MudButton Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Save" Color="Color.Info" Size="Size.Small" OnClick="@SaveSettings">Save</MudButton>
+        <MudButton Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Cancel" Color="Color.Error" Size="Size.Small" OnClick="@(() => OpenDialogAsync(_fullScreen))">End Match</MudButton>
+    </MudStack>
+</MudDrawer>
 
 @if (_showCoinToss)
 {
@@ -84,14 +84,14 @@
 {
     <section class="bg-tennis overlay-dark">
         <div class="score-container">
-            <!-- Match Header -->
+            @* #3 — Match header with CSS classes instead of inline styles *@
             @{
                 var _headerCourt = _courts.FirstOrDefault(c => c.CourtId == _selectedCourtId);
             }
-            <div style="text-align: center; padding: 4px 8px;">
+            <div class="match-header">
                 @if (_competitionFixture?.Competition != null)
                 {
-                    <div style="font-size: 0.75rem; color: #FFD700; letter-spacing: 1px; text-transform: uppercase; font-weight: bold;">
+                    <div class="match-header-competition">
                         @_competitionFixture.Competition.CompetitionName
                         @if (!string.IsNullOrEmpty(_competitionFixture.FixtureLabel))
                         {
@@ -101,175 +101,197 @@
                 }
                 @if (_headerCourt != null)
                 {
-                    <div style="font-size: 0.85rem; color: #aaa; letter-spacing: 1px; text-transform: uppercase;">
+                    <div class="match-header-court">
                         @_headerCourt.Club.Name — @_headerCourt.Name
                     </div>
                 }
-                <div style="font-size: 1rem; color: white; font-weight: bold;">
-                    @GetUserDisplayName() <span style="color: #aaa;">vs</span> @GetOpponentDisplayName()
+                <div class="match-header-players">
+                    @GetUserDisplayName() <span class="match-header-vs">vs</span> @GetOpponentDisplayName()
                 </div>
+                @* #7 — Match elapsed timer *@
+                <div class="match-timer">@_elapsedDisplay</div>
             </div>
 
+            @* #2 — Larger tap targets (80px avatars) + #9 tap feedback + #10 doubles badge *@
             <!-- Top Player Button -->
-            <div style="display: flex">
+            <div class="player-row">
                 <MudAvatarGroup Max="3" Spacing="2" MaxColor="Color.Primary">
-                    <MudAvatar @onclick="UserWinsPoint" disabled="@_state.IsMatchEnded" Class="no-zoom-element" Style="border: solid 1px lightseagreen; width:60px; height: 60px;">
+                    <MudAvatar @onclick="UserWinsPoint" disabled="@_state.IsMatchEnded"
+                               Class="@($"no-zoom-element {(_userTapAnim ? "avatar-tap" : "")}")"
+                               Style="border: solid 2px lightseagreen; width:80px; height: 80px;">
                         <MudImage Class="no-zoom-element" Src="images/me.png"></MudImage>
-                        <div Class="no-zoom-element" style="position:absolute; top:50%; left:50%; transform:translate(-50%, -50%);
-                                        color:white; font-size:20px; font-weight:bold;">
+                        <div class="no-zoom-element" style="position:absolute; top:50%; left:50%; transform:translate(-50%, -50%);
+                                        color:white; font-size:22px; font-weight:bold;">
                             @CurrentMatch.Player1.GetInitials()
                         </div>
-                    </MudAvatar>
-                    <MudAvatar @onclick="UserWinsPoint" Class="no-zoom-element" Style="border: solid 1px lightseagreen; width:60px; height: 60px;">
-                        <MudIcon Icon="@Icons.Material.Filled.KeyboardDoubleArrowUp" />
                     </MudAvatar>
                 </MudAvatarGroup>
 
                 @if (Label_Switch1)
                 {
-                    <MudAvatar @onclick="UserWinsPoint" Class="no-zoom-element" disabled="@_state.IsMatchEnded" Style="border: solid 2px lightseagreen; width:60px; height: 60px; margin-left: -15px;">
-                        <MudImage Class="no-zoom-element" Src="images/me.png" @onclick="UserWinsPoint"></MudImage>
-                        <div Class="no-zoom-element" style="position:absolute; top:50%; left:50%; transform:translate(-50%, -50%);
-                                                    color:white; font-size:20px; font-weight:bold;">
+                    <span class="doubles-partner-badge">&</span>
+                    <MudAvatar @onclick="UserWinsPoint" Class="no-zoom-element" disabled="@_state.IsMatchEnded"
+                               Style="border: solid 2px lightseagreen; width:80px; height: 80px;">
+                        <MudImage Class="no-zoom-element" Src="images/me.png"></MudImage>
+                        <div class="no-zoom-element" style="position:absolute; top:50%; left:50%; transform:translate(-50%, -50%);
+                                                    color:white; font-size:22px; font-weight:bold;">
                             @CurrentMatch.Player2.GetInitials()
                         </div>
                     </MudAvatar>
                 }
             </div>
-            <!-- Score Display -->
+
+            @* #1 + #5 + #6 — Score display with visual hierarchy, set dividers, styled serve indicator *@
             <div class="score-display">
                 <div class="score-row">
-
+                    @* #6 — Serve indicator as pulsing dot *@
                     @if (_state.IsUserServing)
                     {
-                        <span class="sets serve-indicator">🎾</span>
+                        <span class="serve-indicator"><span class="serve-dot"></span></span>
                     }
                     else
                     {
-                        <span class="sets serve-indicator"></span>
+                        <span class="serve-indicator-empty"></span>
                     }
 
+                    @* Completed set scores (muted) *@
                     @foreach (var set in _state.SetScores)
                     {
-                        <span class="sets">@set.UserGames</span>
+                        <span class="set-score">@set.UserGames</span>
                     }
+
+                    @* #5 — Divider between completed sets and live score *@
+                    @if (_state.SetScores.Any() && !_state.IsMatchEnded)
+                    {
+                        <span class="set-divider"></span>
+                    }
+
+                    @* #1 — Current games larger *@
                     @if (!_state.IsMatchEnded)
                     {
-                        <span class="sets">@_state.UserGames</span>
+                        <span class="current-games">@_state.UserGames</span>
                     }
                     @if (!_state.GameScoring || _state.IsTieBreak)
                     {
-                        <span class="sets">@ScoreService.GetScoreDisplayUser(_state)</span>
+                        <span class="current-points">@ScoreService.GetScoreDisplayUser(_state)</span>
                     }
                 </div>
                 <div class="score-row">
-
                     @if (!_state.IsUserServing)
                     {
-                        <span class="sets serve-indicator">🎾</span>
+                        <span class="serve-indicator"><span class="serve-dot"></span></span>
                     }
                     else
                     {
-                        <span class="sets serve-indicator"></span>
+                        <span class="serve-indicator-empty"></span>
                     }
 
                     @foreach (var set in _state.SetScores)
                     {
-                        <span class="sets">@set.OpponentGames </span>
+                        <span class="set-score">@set.OpponentGames</span>
+                    }
+
+                    @if (_state.SetScores.Any() && !_state.IsMatchEnded)
+                    {
+                        <span class="set-divider"></span>
                     }
 
                     @if (!_state.IsMatchEnded)
                     {
-                        <span class="sets">@_state.OppGames</span>
+                        <span class="current-games">@_state.OppGames</span>
                     }
 
                     @if (!_state.GameScoring || _state.IsTieBreak)
                     {
-                        <span class="sets">@ScoreService.GetScoreDisplayOpp(_state)</span>
+                        <span class="current-points">@ScoreService.GetScoreDisplayOpp(_state)</span>
                     }
                 </div>
             </div>
 
-            <!-- Bottom Player Button -->
-            <div style="display: flex">
+            @* #2 + #9 + #10 — Bottom Player with larger avatars, tap feedback, doubles badge *@
+            <div class="player-row">
                 @if (Label_Switch1)
                 {
                     <MudAvatarGroup Max="3" Spacing="2" MaxColor="Color.Primary">
-                        <MudAvatar @onclick="OpponentWinsPoint" Class="no-zoom-element" disabled="@_state.IsMatchEnded" Style="border: solid 2px orangered; width:60px; height: 60px;">
+                        <MudAvatar @onclick="OpponentWinsPoint" Class="@($"no-zoom-element {(_oppTapAnim ? "avatar-tap" : "")}")"
+                                   disabled="@_state.IsMatchEnded"
+                                   Style="border: solid 2px orangered; width:80px; height: 80px;">
                             <MudImage Class="no-zoom-element" Src="images/me.png"></MudImage>
-                            <div Class="no-zoom-element" style="position:absolute; top:50%; left:50%; transform:translate(-50%, -50%);
-                                        color:white; font-size:20px; font-weight:bold;">
+                            <div class="no-zoom-element" style="position:absolute; top:50%; left:50%; transform:translate(-50%, -50%);
+                                        color:white; font-size:22px; font-weight:bold;">
                                 @CurrentMatch.Player3.GetInitials()
                             </div>
                         </MudAvatar>
-                        <MudAvatar @onclick="OpponentWinsPoint" Class="no-zoom-element" Style="border: solid 1px lightseagreen; width:60px; height: 60px;">
-                            <MudIcon Icon="@Icons.Material.Filled.KeyboardDoubleArrowUp" />
-                        </MudAvatar>
-                        <MudAvatar @onclick="OpponentWinsPoint" Class="no-zoom-element" disabled="@_state.IsMatchEnded" Style="border: solid 2px orangered; width:60px; height: 60px; margin-left: -15px;">
-                            <MudImage Class="no-zoom-element" Src="images/me.png"></MudImage>
-                            <div Class="no-zoom-element" style="position:absolute; top:50%; left:50%; transform:translate(-50%, -50%);
-                                        color:white; font-size:20px; font-weight:bold;">
-                                @CurrentMatch.Player4.GetInitials()
-                            </div>
-                        </MudAvatar>
                     </MudAvatarGroup>
+                    <span class="doubles-partner-badge">&</span>
+                    <MudAvatar @onclick="OpponentWinsPoint" Class="no-zoom-element" disabled="@_state.IsMatchEnded"
+                               Style="border: solid 2px orangered; width:80px; height: 80px;">
+                        <MudImage Class="no-zoom-element" Src="images/me.png"></MudImage>
+                        <div class="no-zoom-element" style="position:absolute; top:50%; left:50%; transform:translate(-50%, -50%);
+                                    color:white; font-size:22px; font-weight:bold;">
+                            @CurrentMatch.Player4.GetInitials()
+                        </div>
+                    </MudAvatar>
                 }
                 else
                 {
                     <MudAvatarGroup Max="3" Spacing="2" MaxColor="Color.Primary">
-                        <MudAvatar @onclick="OpponentWinsPoint" Class="no-zoom-element" disabled="@_state.IsMatchEnded" Style="border: solid 2px orangered; width:60px; height: 60px;">
+                        <MudAvatar @onclick="OpponentWinsPoint" Class="@($"no-zoom-element {(_oppTapAnim ? "avatar-tap" : "")}")"
+                                   disabled="@_state.IsMatchEnded"
+                                   Style="border: solid 2px orangered; width:80px; height: 80px;">
                             <MudImage Class="no-zoom-element" Src="images/me.png"></MudImage>
-                            <div Class="no-zoom-element" style="position:absolute; top:50%; left:50%; transform:translate(-50%, -50%);
-                                color:white; font-size:20px; font-weight:bold;">
+                            <div class="no-zoom-element" style="position:absolute; top:50%; left:50%; transform:translate(-50%, -50%);
+                                color:white; font-size:22px; font-weight:bold;">
                                 @CurrentMatch.Player2.GetInitials()
                             </div>
                         </MudAvatar>
-                        <MudAvatar @onclick="OpponentWinsPoint" Class="no-zoom-element" Style="border: solid 1px lightseagreen; width:60px; height: 60px;">
-                            <MudIcon Icon="@Icons.Material.Filled.KeyboardDoubleArrowUp" />
-                        </MudAvatar>
                     </MudAvatarGroup>
-                    @*   <button name="btnOppWinsPoint" class="initial-circle" style="color: lightseagreen; border-color: lightseagreen" >
-                    <MudImage Src="images/me.png" Alt="Mony the dog" ObjectFit="@ObjectFit.Contain" Elevation="25" Class="rounded-lg" />
-                </button> *@
-
                 }
             </div>
 
-            <!-- Controls Row -->
+            @* #4 — Controls with visual hierarchy: undo is prominent *@
             <div class="controls-row">
-                <button class="settings-btn no-zoom-element" @onclick="@OnExpandCollapseClick">
+                <button class="control-btn no-zoom-element" @onclick="@OnExpandCollapseClick">
                     <MudIcon Icon="@Icons.Material.Filled.Settings" Title="Settings" Size="Size.Large" />
                 </button>
-                <button class="undo-btn no-zoom-element" @onclick="UndoLastPoint">
+                <button class="control-btn-undo no-zoom-element" @onclick="UndoLastPoint">
                     <MudIcon Icon="@Icons.Material.Filled.Undo" Title="Undo" Size="Size.Large" />
                 </button>
-                <button class="settings-btn no-zoom-element" @onclick="OpenScoreEditor">
+                <button class="control-btn no-zoom-element" @onclick="OpenScoreEditor">
                     <MudIcon Icon="@Icons.Material.Filled.Edit" Title="Edit Score" Size="Size.Large" />
                 </button>
             </div>
         </div>
     </section>
-
 }
 
-<div style="margin: 10px;"></div>
-
-@if (@CurrentMatch != null && @CurrentMatch.Complete)
+@* #11 — Match complete as full-screen overlay instead of below the fold *@
+@if (CurrentMatch != null && CurrentMatch.Complete)
 {
-    if (!string.IsNullOrWhiteSpace(_winner) && !_winner.Equals("Congratulations "))
-    {
-        <MudAlert Style="margin-top: 10px;" Severity="Severity.Success">@_winner</MudAlert>
-    }
-    <MudButton Style="margin-top: 10px;" FullWidth=true Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.FiberNew" Color="Color.Secondary" Size="Size.Large" OnClick="@ReloadPage">Start New Match</MudButton>
-    @if (_competitionFixture != null)
-    {
-        <MudButton Style="margin-top: 10px;" FullWidth="true" Variant="Variant.Filled"
-                   StartIcon="@Icons.Material.Filled.EmojiEvents" Color="Color.Primary" Size="Size.Large"
-                   OnClick="@(() => Navigation.NavigateTo($"/competition/{_competitionFixture.CompetitionId}/view"))">
-            Back to @(_competitionFixture.Competition?.CompetitionName ?? "Competition")
-        </MudButton>
-    }
+    <div class="match-complete-overlay">
+        <div class="match-complete-trophy">🏆</div>
+        @if (!string.IsNullOrWhiteSpace(_winner) && !_winner.Equals("Congratulations "))
+        {
+            <div class="match-complete-winner">@_winner</div>
+        }
+        <div class="match-complete-score">
+            @string.Join("  ", _state.SetScores.Select(s => $"{s.UserGames}-{s.OpponentGames}"))
+        </div>
+        <MudButton Style="margin-top: 16px;" FullWidth="false" Variant="Variant.Filled"
+                   StartIcon="@Icons.Material.Filled.FiberNew" Color="Color.Secondary" Size="Size.Large"
+                   OnClick="@ReloadPage">Start New Match</MudButton>
+        @if (_competitionFixture != null)
+        {
+            <MudButton Style="margin-top: 8px;" FullWidth="false" Variant="Variant.Filled"
+                       StartIcon="@Icons.Material.Filled.EmojiEvents" Color="Color.Primary" Size="Size.Large"
+                       OnClick="@(() => Navigation.NavigateTo($"/competition/{_competitionFixture.CompetitionId}/view"))">
+                Back to @(_competitionFixture.Competition?.CompetitionName ?? "Competition")
+            </MudButton>
+        }
+    </div>
 }
+
+@implements IDisposable
 
 @code {
     private string _value = string.Empty;
@@ -279,6 +301,15 @@
     private string _winner = string.Empty;
 
     bool _expanded = false;
+
+    // #7 — Match elapsed timer
+    private System.Threading.Timer? _timerHandle;
+    private string _elapsedDisplay = "00:00";
+    private DateTime _matchStartUtc;
+
+    // #9 — Tap feedback animation flags
+    private bool _userTapAnim;
+    private bool _oppTapAnim;
 
     private void OnExpandCollapseClick()
     {
@@ -511,6 +542,9 @@
         CurrentMatch = _pendingMatch;
         _showCoinToss = false;
 
+        // #7 — Start the match timer
+        StartTimer();
+
         // Persist the new match immediately so we get a stable SavedMatchId for the URL.
         await SaveInitialMatchAsync();
 
@@ -681,6 +715,13 @@
                 _savedMatchId = savedMatch.SavedMatchId;
                 _selectedCourtId = savedMatch.CourtId;
 
+                // #7 — Resume timer from original start time
+                if (!_state.IsMatchEnded)
+                {
+                    _matchStartUtc = savedMatch.CreatedAt;
+                    _timerHandle = new System.Threading.Timer(TimerTick, null, 0, 1000);
+                }
+
                 // Load linked competition fixture if any
                 _competitionFixture = await DbContext.CompetitionFixtures
                     .Include(f => f.Competition)
@@ -846,26 +887,73 @@
         await PersistAndBroadcast();
     }
 
-    private void UserWinsPoint()
+    private async void UserWinsPoint()
     {
         if (_state.IsMatchEnded) return;
+
+        // #9 — Tap feedback
+        _userTapAnim = true;
+        StateHasChanged();
+        #pragma warning disable CS4014
+        Task.Delay(350).ContinueWith(_ => { _userTapAnim = false; InvokeAsync(StateHasChanged); });
+        #pragma warning restore CS4014
 
         _state.UserPoints++;
         ScoreService.CheckGame(_state);
         if (_state.IsMatchEnded && CurrentMatch != null)
+        {
             _winner = ScoreService.EndMatch(_state, CurrentMatch, Label_Switch1) ?? string.Empty;
-        SaveHistory();
+            StopTimer();
+        }
+        await SaveHistory();
     }
 
-    private void OpponentWinsPoint()
+    private async void OpponentWinsPoint()
     {
         if (_state.IsMatchEnded) return;
+
+        // #9 — Tap feedback
+        _oppTapAnim = true;
+        StateHasChanged();
+        #pragma warning disable CS4014
+        Task.Delay(350).ContinueWith(_ => { _oppTapAnim = false; InvokeAsync(StateHasChanged); });
+        #pragma warning restore CS4014
 
         _state.OppPoints++;
         ScoreService.CheckGame(_state);
         if (_state.IsMatchEnded && CurrentMatch != null)
+        {
             _winner = ScoreService.EndMatch(_state, CurrentMatch, Label_Switch1) ?? string.Empty;
-        SaveHistory();
+            StopTimer();
+        }
+        await SaveHistory();
+    }
+
+    // #7 — Timer helpers
+    private void StartTimer()
+    {
+        _matchStartUtc = DateTime.UtcNow;
+        _timerHandle = new System.Threading.Timer(TimerTick, null, 0, 1000);
+    }
+
+    private void TimerTick(object? _)
+    {
+        var elapsed = DateTime.UtcNow - _matchStartUtc;
+        _elapsedDisplay = elapsed.TotalHours >= 1
+            ? elapsed.ToString(@"h\:mm\:ss")
+            : elapsed.ToString(@"mm\:ss");
+        InvokeAsync(StateHasChanged);
+    }
+
+    private void StopTimer()
+    {
+        _timerHandle?.Dispose();
+        _timerHandle = null;
+    }
+
+    public void Dispose()
+    {
+        _timerHandle?.Dispose();
     }
 
     private async Task UndoLastPoint()

--- a/DropShot/Components/TennisScore.razor.css
+++ b/DropShot/Components/TennisScore.razor.css
@@ -1,10 +1,12 @@
-﻿
+
 :root {
 }
 
 .no-zoom-element {
-    touch-action: pan-x pan-y; /* Disables pinch and double-tap zoom on the element */
+    touch-action: pan-x pan-y;
 }
+
+/* ── Main Score Container ──────────────────────────────────── */
 
 .score-container {
     display: flex;
@@ -15,48 +17,83 @@
     border-radius: 20px;
     padding: 20px;
     font-family: sans-serif;
+    position: relative;
 }
 
+/* ── Background with overlay ───────────────────────────────── */
 
 .bg-tennis {
-/* Path to your non-repeating 1000×1000 image */
---bg-image: url('images/background.png');
-/* Overlay color and intensity (alpha) */
---overlay-color: 18, 18, 18; /* RGB triplet (no alpha) */
---overlay-alpha: 0.85; /* 0 = transparent, 1 = solid */
-/* Fallback background behind the image */
---bg-fallback: #121212;
-/* Background sizing/positioning */
---bg-size: cover; /* cover | contain | <length> */
---bg-position: center center;
-/* Layout */
---content-max-width: 72rem;
---content-padding: clamp(1.25rem, 3vw, 3rem);
---text-color: #ffffff;
+    --bg-image: url('images/background.png');
+    --overlay-color: 18, 18, 18;
+    --overlay-alpha: 0.85;
+    --bg-fallback: #121212;
+    --bg-size: cover;
+    --bg-position: center center;
+    --content-max-width: 72rem;
+    --content-padding: clamp(1.25rem, 3vw, 3rem);
+    --text-color: #ffffff;
     position: relative;
     min-height: var(--section-min-height);
-    /* Background image (no repeat) */
     background-color: var(--bg-fallback);
     background-image: var(--bg-image);
     background-repeat: no-repeat;
     background-size: var(--bg-size);
     background-position: var(--bg-position);
-    overflow: hidden; /* ensures ::before stays clipped to section */
+    overflow: hidden;
 }
 
-    /* ========== Pseudo-element overlay ========== */
     .bg-tennis::before {
         content: "";
         position: absolute;
-        inset: 0; /* top:0; right:0; bottom:0; left:0 */
-        z-index: 0; /* sits below the content */
+        inset: 0;
+        z-index: 0;
         background-color: rgba(var(--overlay-color), var(--overlay-alpha));
-        pointer-events: none; /* overlay doesn’t block clicks */
+        pointer-events: none;
     }
 
-  
+/* ── Match Header ──────────────────────────────────────────── */
 
+.match-header {
+    text-align: center;
+    padding: 4px 8px;
+}
 
+.match-header-competition {
+    font-size: 0.75rem;
+    color: #FFD700;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    font-weight: bold;
+}
+
+.match-header-court {
+    font-size: 0.85rem;
+    color: #aaa;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+}
+
+.match-header-players {
+    font-size: 1rem;
+    color: white;
+    font-weight: bold;
+}
+
+.match-header-vs {
+    color: #aaa;
+}
+
+/* ── Match Timer ───────────────────────────────────────────── */
+
+.match-timer {
+    font-size: 0.75rem;
+    color: #888;
+    letter-spacing: 1px;
+    font-variant-numeric: tabular-nums;
+    margin-top: 2px;
+}
+
+/* ── Player Buttons / Avatars ──────────────────────────────── */
 
 .player-btn {
     background: none;
@@ -71,53 +108,202 @@
         border: 3px solid white;
     }
 
-.score-display {
-    text-align: center;
-    font-size: 24px;
-    margin: 20px 0;
-}
-
-.score-row {
-    margin: 10px 0;
+.player-row {
+    display: flex;
+    align-items: center;
+    gap: 4px;
 }
 
 .initial-circle {
     width: 80px;
     height: 80px;
-    border: 3px solid white; /* Circle outline */
-    border-radius: 50%; /* Makes it a circle */
+    border: 3px solid white;
+    border-radius: 50%;
     display: flex;
     align-items: center;
     justify-content: center;
     font-size: 24px;
     font-weight: bold;
     color: white;
-    background-color: black; /* Optional background */
-    cursor: pointer; /* Show pointer on hover */
+    background-color: black;
+    cursor: pointer;
     transition: background-color 0.3s ease;
 }
 
     .initial-circle:hover {
-        background-color: #333; /* Hover effect */
+        background-color: #333;
     }
 
-.sets {
-    display: inline-block;
-    width: 50px;
+/* Avatar tap ripple feedback */
+.avatar-tap {
+    animation: avatarRipple 0.35s ease-out;
 }
 
-.score-container {
-    position: relative;
+@keyframes avatarRipple {
+    0%   { transform: scale(1);    box-shadow: 0 0 0 0 rgba(32,178,170,0.6); }
+    50%  { transform: scale(1.12); box-shadow: 0 0 0 14px rgba(32,178,170,0); }
+    100% { transform: scale(1);    box-shadow: 0 0 0 0 rgba(32,178,170,0); }
 }
+
+/* Doubles partner label */
+.doubles-partner-badge {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    background: rgba(32,178,170,0.25);
+    border: 1px solid rgba(32,178,170,0.5);
+    color: lightseagreen;
+    font-size: 14px;
+    font-weight: bold;
+    margin-left: -8px;
+    align-self: center;
+}
+
+/* ── Score Display ─────────────────────────────────────────── */
+
+.score-display {
+    text-align: center;
+    font-size: 24px;
+    margin: 20px 0;
+    width: 100%;
+}
+
+.score-row {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 6px 0;
+    gap: 2px;
+}
+
+/* Serve indicator (replaces emoji) */
+.serve-indicator {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 50px;
+    flex-shrink: 0;
+}
+
+.serve-dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: #4caf50;
+    box-shadow: 0 0 8px rgba(76,175,80,0.7);
+    animation: servePulse 2s ease-in-out infinite;
+}
+
+@keyframes servePulse {
+    0%, 100% { box-shadow: 0 0 8px rgba(76,175,80,0.7);  }
+    50%      { box-shadow: 0 0 16px rgba(76,175,80,0.95); }
+}
+
+.serve-indicator-empty {
+    display: inline-block;
+    width: 50px;
+    flex-shrink: 0;
+}
+
+/* Completed set scores */
+.set-score {
+    display: inline-block;
+    width: 36px;
+    text-align: center;
+    font-size: 20px;
+    color: #aaa;
+    font-weight: 500;
+    font-variant-numeric: tabular-nums;
+}
+
+/* Separator between completed sets and live game */
+.set-divider {
+    display: inline-block;
+    width: 2px;
+    height: 24px;
+    background: rgba(255,255,255,0.15);
+    margin: 0 6px;
+    vertical-align: middle;
+    border-radius: 1px;
+}
+
+/* Current game score - larger and prominent */
+.current-games {
+    display: inline-block;
+    width: 44px;
+    text-align: center;
+    font-size: 30px;
+    font-weight: 700;
+    color: white;
+    font-variant-numeric: tabular-nums;
+}
+
+/* Current points - most prominent */
+.current-points {
+    display: inline-block;
+    min-width: 50px;
+    text-align: center;
+    font-size: 34px;
+    font-weight: 800;
+    color: #4caf50;
+    font-variant-numeric: tabular-nums;
+}
+
+/* ── Controls Row ──────────────────────────────────────────── */
 
 .controls-row {
     display: flex;
     justify-content: space-between;
+    align-items: center;
     width: 100%;
     padding: 4px 20px;
     box-sizing: border-box;
+    gap: 8px;
 }
 
+.control-btn {
+    min-width: 44px;
+    min-height: 44px;
+    padding: 8px 12px;
+    font-size: 16px;
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+    touch-action: manipulation;
+    background: rgba(255,255,255,0.08);
+    color: #aaa;
+    transition: background 0.2s, color 0.2s;
+}
+
+    .control-btn:hover {
+        background: rgba(255,255,255,0.15);
+        color: white;
+    }
+
+/* Undo button stands out */
+.control-btn-undo {
+    min-width: 44px;
+    min-height: 44px;
+    padding: 8px 16px;
+    font-size: 16px;
+    border: 1px solid rgba(255,255,255,0.25);
+    border-radius: 8px;
+    cursor: pointer;
+    touch-action: manipulation;
+    background: rgba(255,255,255,0.12);
+    color: white;
+    transition: background 0.2s, border-color 0.2s;
+}
+
+    .control-btn-undo:hover {
+        background: rgba(255,255,255,0.22);
+        border-color: rgba(255,255,255,0.4);
+    }
+
+/* Legacy compat (kept for any external references) */
 .settings-btn {
     min-width: 44px;
     min-height: 44px;
@@ -140,7 +326,48 @@
     touch-action: manipulation;
 }
 
-/* ── Coin Toss Overlay ───────────────────────────────────────── */
+/* ── Match Complete Overlay ────────────────────────────────── */
+
+.match-complete-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.92);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    z-index: 9998;
+    gap: 16px;
+    padding: 24px;
+    text-align: center;
+}
+
+.match-complete-trophy {
+    font-size: 64px;
+    animation: trophyBounce 0.6s ease-out;
+}
+
+@keyframes trophyBounce {
+    0%   { transform: scale(0) rotate(-15deg); opacity: 0; }
+    60%  { transform: scale(1.15) rotate(5deg); opacity: 1; }
+    100% { transform: scale(1) rotate(0deg); opacity: 1; }
+}
+
+.match-complete-winner {
+    font-size: 1.5rem;
+    color: #FFD700;
+    font-weight: bold;
+    max-width: 80vw;
+    animation: fadeUp 0.4s ease-out 0.2s both;
+}
+
+.match-complete-score {
+    font-size: 1.1rem;
+    color: #ccc;
+    animation: fadeUp 0.4s ease-out 0.35s both;
+}
+
+/* ── Coin Toss Overlay ─────────────────────────────────────── */
 
 .coin-toss-overlay {
     position: fixed;
@@ -207,4 +434,51 @@
 @keyframes fadeUp {
     from { opacity: 0; transform: translateY(12px); }
     to   { opacity: 1; transform: translateY(0);    }
+}
+
+/* ── Landscape Layout ──────────────────────────────────────── */
+
+@media (orientation: landscape) and (max-height: 500px) {
+    .score-container {
+        flex-direction: row;
+        justify-content: space-around;
+        align-items: center;
+        padding: 8px 16px;
+        gap: 12px;
+    }
+
+    .match-header {
+        position: absolute;
+        top: 4px;
+        left: 50%;
+        transform: translateX(-50%);
+        padding: 0;
+    }
+
+    .match-header-players {
+        font-size: 0.85rem;
+    }
+
+    .player-row {
+        flex-direction: column;
+    }
+
+    .score-display {
+        margin: 0;
+        flex: 1;
+    }
+
+    .controls-row {
+        position: absolute;
+        bottom: 4px;
+        left: 50%;
+        transform: translateX(-50%);
+        width: auto;
+        padding: 0;
+        gap: 16px;
+    }
+
+    .match-timer {
+        display: none;
+    }
 }


### PR DESCRIPTION
## Summary
- **Score visual hierarchy**: current game/points are larger and bolder; completed sets are muted with dividers separating them from the live score
- **Bigger tap targets**: player avatars increased from 60px to 80px with ripple animation feedback on scoring
- **Styled serve indicator**: replaced 🎾 emoji with a pulsing green dot
- **Match elapsed timer**: displays time since match start, resumes correctly when loading a saved match
- **Settings drawer**: replaced collapsible panel with a slide-out drawer that doesn't push the score down
- **Control button hierarchy**: undo button is visually prominent; settings/edit are muted
- **Doubles partner badge**: replaced confusing arrow icon with an `&` badge between partner avatars
- **Match completion overlay**: full-screen overlay with trophy animation instead of content below the fold
- **Landscape layout**: media query for landscape orientation puts players on sides with score centered
- **Inline styles moved to scoped CSS**: match header styles extracted to named CSS classes

## Test plan
- [ ] Start a singles match and verify score display hierarchy (completed sets muted, current game/points prominent)
- [ ] Tap player avatars and confirm ripple animation fires
- [ ] Verify serve indicator shows as a pulsing green dot
- [ ] Check elapsed timer starts on new match and resumes on page reload
- [ ] Open settings and confirm it appears as a right-side drawer
- [ ] Verify undo button stands out from settings/edit buttons
- [ ] Start a doubles match and confirm `&` badge appears between partner avatars
- [ ] Complete a match and verify the full-screen overlay with trophy appears
- [ ] Rotate phone to landscape and confirm horizontal layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)