### PR TITLE
Full-page background, centered scoring, tap hint

### DIFF
--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -112,7 +112,12 @@
                 <div class="match-timer">@_elapsedDisplay</div>
             </div>
 
-            @* #2 — Larger tap targets (80px avatars) + #9 tap feedback + #10 doubles badge *@
+            @* Tap-to-score hint — fades out after a few seconds *@
+            @if (!_tapHintDismissed)
+            {
+                <div class="tap-hint">Tap a player to score a point</div>
+            }
+
             <!-- Top Player Button -->
             <div class="player-row">
                 <MudAvatarGroup Max="3" Spacing="2" MaxColor="Color.Primary">
@@ -310,6 +315,9 @@
     // #9 — Tap feedback animation flags
     private bool _userTapAnim;
     private bool _oppTapAnim;
+
+    // Tap-to-score hint — shown until first point scored
+    private bool _tapHintDismissed;
 
     private void OnExpandCollapseClick()
     {
@@ -715,6 +723,9 @@
                 _savedMatchId = savedMatch.SavedMatchId;
                 _selectedCourtId = savedMatch.CourtId;
 
+                // Already in progress — hide the tap hint
+                _tapHintDismissed = true;
+
                 // #7 — Resume timer from original start time
                 if (!_state.IsMatchEnded)
                 {
@@ -890,6 +901,7 @@
     private async void UserWinsPoint()
     {
         if (_state.IsMatchEnded) return;
+        _tapHintDismissed = true;
 
         // #9 — Tap feedback
         _userTapAnim = true;
@@ -911,6 +923,7 @@
     private async void OpponentWinsPoint()
     {
         if (_state.IsMatchEnded) return;
+        _tapHintDismissed = true;
 
         // #9 — Tap feedback
         _oppTapAnim = true;

--- a/DropShot/Components/TennisScore.razor.css
+++ b/DropShot/Components/TennisScore.razor.css
@@ -33,13 +33,17 @@
     --content-padding: clamp(1.25rem, 3vw, 3rem);
     --text-color: #ffffff;
     position: relative;
-    min-height: var(--section-min-height);
+    min-height: 100dvh;
     background-color: var(--bg-fallback);
     background-image: var(--bg-image);
     background-repeat: no-repeat;
     background-size: var(--bg-size);
     background-position: var(--bg-position);
+    background-attachment: fixed;
     overflow: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
     .bg-tennis::before {
@@ -252,6 +256,25 @@
     font-variant-numeric: tabular-nums;
 }
 
+/* ── Tap-to-score hint ─────────────────────────────────────── */
+
+.tap-hint {
+    font-size: 0.7rem;
+    color: rgba(255,255,255,0.4);
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+    margin-top: 2px;
+    text-align: center;
+    animation: hintFade 4s ease-out forwards;
+    pointer-events: none;
+}
+
+@keyframes hintFade {
+    0%   { opacity: 1; }
+    70%  { opacity: 1; }
+    100% { opacity: 0; }
+}
+
 /* ── Controls Row ──────────────────────────────────────────── */
 
 .controls-row {
@@ -260,6 +283,7 @@
     align-items: center;
     width: 100%;
     padding: 4px 20px;
+    margin-top: 24px;
     box-sizing: border-box;
     gap: 8px;
 }


### PR DESCRIPTION
## Summary
- **Full-page background**: `.bg-tennis` now uses `min-height: 100dvh` with flexbox centering so the background fills the viewport and the score container is vertically centered
- **Increased spacing**: Added `margin-top: 24px` to the controls row for more breathing room between the bottom player avatar and the undo/settings buttons
- **Tap-to-score hint**: A subtle "Tap a player to score a point" label appears above the top player avatar when a match starts, then fades out after ~4 seconds or as soon as the first point is scored. Hidden when loading an existing match.

## Test plan
- [ ] Start a new match and verify the background covers the full page with scoring centered vertically
- [ ] Confirm the "Tap a player to score a point" hint appears and fades away
- [ ] Tap a player avatar before the fade completes and confirm the hint disappears immediately
- [ ] Reload an existing in-progress match and confirm the hint does not appear
- [ ] Check spacing between bottom player avatar and control buttons is comfortable

🤖 Generated with [Claude Code](https://claude.com/claude-code)