### PR TITLE
Fix tap-to-score hint not visible

### DIFF
--- a/DropShot/Components/TennisScore.razor.css
+++ b/DropShot/Components/TennisScore.razor.css
@@ -18,6 +18,7 @@
     padding: 20px;
     font-family: sans-serif;
     position: relative;
+    z-index: 1;
 }
 
 /* ── Background with overlay ───────────────────────────────── */
@@ -259,13 +260,14 @@
 /* ── Tap-to-score hint ─────────────────────────────────────── */
 
 .tap-hint {
-    font-size: 0.7rem;
-    color: rgba(255,255,255,0.4);
+    font-size: 0.75rem;
+    color: rgba(255,255,255,0.6);
     letter-spacing: 0.5px;
     text-transform: uppercase;
-    margin-top: 2px;
+    margin-top: 4px;
+    margin-bottom: 4px;
     text-align: center;
-    animation: hintFade 4s ease-out forwards;
+    animation: hintFade 6s ease-out forwards;
     pointer-events: none;
 }
 


### PR DESCRIPTION
## Summary
- Add `z-index: 1` to `.score-container` so content stacks above the `::before` overlay that was hiding the hint
- Bump hint font size (0.75rem), opacity (0.6), and fade duration (6s) for better visibility

## Test plan
- [ ] Start a new match and confirm "Tap a player to score a point" hint is visible
- [ ] Confirm it fades out after ~6 seconds
- [ ] Tap a player before fade completes and confirm hint disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)