### PR TITLE
Add profile image upload and avatar display

### DIFF
--- a/DropShot/Components/Account/Pages/Manage/Index.razor
+++ b/DropShot/Components/Account/Pages/Manage/Index.razor
@@ -1,4 +1,4 @@
-﻿@page "/Account/Manage"
+@page "/Account/Manage"
 
 @using System.ComponentModel.DataAnnotations
 @using Microsoft.AspNetCore.Identity
@@ -8,6 +8,7 @@
 @inject SignInManager<ApplicationUser> SignInManager
 @inject IdentityUserAccessor UserAccessor
 @inject IdentityRedirectManager RedirectManager
+@inject IWebHostEnvironment Environment
 
 <PageTitle>Profile</PageTitle>
 
@@ -16,6 +17,30 @@
 
 <div class="row">
     <div class="col-md-6">
+        <div class="text-center mb-4">
+            @if (!string.IsNullOrEmpty(user?.ProfileImagePath))
+            {
+                <img src="@user.ProfileImagePath" alt="Profile avatar" class="profile-avatar" />
+            }
+            else
+            {
+                <div class="profile-avatar-placeholder">
+                    <span>@(username?.Substring(0, 1).ToUpper() ?? "?")</span>
+                </div>
+            }
+            <div class="mt-2">
+                <label for="avatarUpload" class="btn btn-outline-primary btn-sm" style="cursor:pointer;">
+                    Change Avatar
+                </label>
+                <InputFile id="avatarUpload" OnChange="OnAvatarSelected" style="display:none;"
+                           accept=".jpg,.jpeg,.png,.gif,.webp" />
+            </div>
+            @if (!string.IsNullOrEmpty(avatarError))
+            {
+                <div class="text-danger mt-1">@avatarError</div>
+            }
+        </div>
+
         <EditForm Model="Input" FormName="profile" OnValidSubmit="OnValidSubmitAsync" method="post">
             <DataAnnotationsValidator />
             <ValidationSummary class="text-danger" role="alert" />
@@ -33,10 +58,41 @@
     </div>
 </div>
 
+<style>
+    .profile-avatar {
+        width: 120px;
+        height: 120px;
+        border-radius: 50%;
+        object-fit: cover;
+        border: 3px solid lightseagreen;
+    }
+
+    .profile-avatar-placeholder {
+        width: 120px;
+        height: 120px;
+        border-radius: 50%;
+        background: linear-gradient(135deg, #056267, #052767);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border: 3px solid lightseagreen;
+    }
+
+        .profile-avatar-placeholder span {
+            color: white;
+            font-size: 48px;
+            font-weight: bold;
+        }
+</style>
+
 @code {
     private ApplicationUser user = default!;
     private string? username;
     private string? phoneNumber;
+    private string? avatarError;
+
+    private const long MaxFileSize = 2 * 1024 * 1024; // 2 MB
+    private static readonly HashSet<string> AllowedExtensions = [".jpg", ".jpeg", ".png", ".gif", ".webp"];
 
     [CascadingParameter]
     private HttpContext HttpContext { get; set; } = default!;
@@ -53,6 +109,44 @@
         phoneNumber = await UserManager.GetPhoneNumberAsync(user);
 
         Input.PhoneNumber ??= phoneNumber;
+    }
+
+    private async Task OnAvatarSelected(InputFileChangeEventArgs e)
+    {
+        avatarError = null;
+        var file = e.File;
+
+        var ext = Path.GetExtension(file.Name).ToLowerInvariant();
+        if (!AllowedExtensions.Contains(ext))
+        {
+            avatarError = "Please upload a JPG, PNG, GIF, or WebP image.";
+            return;
+        }
+
+        if (file.Size > MaxFileSize)
+        {
+            avatarError = "Image must be less than 2 MB.";
+            return;
+        }
+
+        var fileName = $"{user.Id}{ext}";
+        var uploadsDir = Path.Combine(Environment.WebRootPath, "uploads", "avatars");
+        Directory.CreateDirectory(uploadsDir);
+
+        // Remove any existing avatar with a different extension
+        foreach (var existing in Directory.GetFiles(uploadsDir, $"{user.Id}.*"))
+        {
+            File.Delete(existing);
+        }
+
+        var filePath = Path.Combine(uploadsDir, fileName);
+        await using var stream = new FileStream(filePath, FileMode.Create);
+        await file.OpenReadStream(MaxFileSize).CopyToAsync(stream);
+
+        user.ProfileImagePath = $"/uploads/avatars/{fileName}";
+        await UserManager.UpdateAsync(user);
+
+        RedirectManager.RedirectToCurrentPageWithStatus("Profile picture updated.", HttpContext);
     }
 
     private async Task OnValidSubmitAsync()

--- a/DropShot/Components/Layout/NavMenu.razor
+++ b/DropShot/Components/Layout/NavMenu.razor
@@ -1,6 +1,10 @@
 ﻿@implements IDisposable
 
+@using Microsoft.AspNetCore.Identity
+@using DropShot.Data
+
 @inject NavigationManager NavigationManager
+@inject UserManager<ApplicationUser> UserManager
 
 <div class="top-row navbar navbar-dark">
     <div class="container-fluid">
@@ -102,7 +106,15 @@
                 </div>
                 <div class="nav-item px-3">
                     <a class="nav-link" href="Account/Manage" data-enhance-nav="false">
-                        <MudIcon Icon="@Icons.Material.Filled.Person" Class="nav-icon" /> @context.User.Identity?.Name
+                        @if (!string.IsNullOrEmpty(_avatarPath))
+                        {
+                            <img src="@_avatarPath" alt="Avatar" class="nav-avatar" />
+                        }
+                        else
+                        {
+                            <MudIcon Icon="@Icons.Material.Filled.Person" Class="nav-icon" />
+                        }
+                        @context.User.Identity?.Name
                     </a>
                 </div>
                 <div class="nav-item px-3">
@@ -136,11 +148,21 @@
 
 @code {
     private string? currentUrl;
+    private string? _avatarPath;
 
-    protected override void OnInitialized()
+    [CascadingParameter]
+    private HttpContext? HttpContext { get; set; }
+
+    protected override async Task OnInitializedAsync()
     {
         currentUrl = NavigationManager.ToBaseRelativePath(NavigationManager.Uri);
         NavigationManager.LocationChanged += OnLocationChanged;
+
+        if (HttpContext?.User.Identity?.IsAuthenticated == true)
+        {
+            var user = await UserManager.GetUserAsync(HttpContext.User);
+            _avatarPath = user?.ProfileImagePath;
+        }
     }
 
     private void OnLocationChanged(object? sender, LocationChangedEventArgs e)

--- a/DropShot/Components/Layout/NavMenu.razor.css
+++ b/DropShot/Components/Layout/NavMenu.razor.css
@@ -149,6 +149,14 @@
     }
 }
 
+.nav-avatar {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    object-fit: cover;
+    border: 1px solid lightseagreen;
+}
+
 @media (min-width: 641px) {
     .navbar-toggler {
         display: none;

--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -124,7 +124,14 @@
                     <MudAvatar @onclick="UserWinsPoint" disabled="@_state.IsMatchEnded"
                                Class="@($"no-zoom-element {(_userTapAnim ? "avatar-tap" : "")}")"
                                Style="border: solid 2px lightseagreen; width:80px; height: 80px;">
-                        <MudImage Class="no-zoom-element" Src="images/me.png"></MudImage>
+                        @if (GetPlayerAvatar(CurrentMatch.Player1) is string p1Src)
+                        {
+                            <MudImage Class="no-zoom-element" Src="@p1Src"></MudImage>
+                        }
+                        else
+                        {
+                            <MudIcon Icon="@Icons.Material.Filled.Person" Class="no-zoom-element" Style="font-size:40px; color:white;" />
+                        }
                         <div class="no-zoom-element" style="position:absolute; top:50%; left:50%; transform:translate(-50%, -50%);
                                         color:white; font-size:22px; font-weight:bold;">
                             @CurrentMatch.Player1.GetInitials()
@@ -137,7 +144,14 @@
                     <span class="doubles-partner-badge">&</span>
                     <MudAvatar @onclick="UserWinsPoint" Class="no-zoom-element" disabled="@_state.IsMatchEnded"
                                Style="border: solid 2px lightseagreen; width:80px; height: 80px;">
-                        <MudImage Class="no-zoom-element" Src="images/me.png"></MudImage>
+                        @if (GetPlayerAvatar(CurrentMatch.Player2) is string p2aSrc)
+                        {
+                            <MudImage Class="no-zoom-element" Src="@p2aSrc"></MudImage>
+                        }
+                        else
+                        {
+                            <MudIcon Icon="@Icons.Material.Filled.Person" Class="no-zoom-element" Style="font-size:40px; color:white;" />
+                        }
                         <div class="no-zoom-element" style="position:absolute; top:50%; left:50%; transform:translate(-50%, -50%);
                                                     color:white; font-size:22px; font-weight:bold;">
                             @CurrentMatch.Player2.GetInitials()
@@ -221,7 +235,14 @@
                         <MudAvatar @onclick="OpponentWinsPoint" Class="@($"no-zoom-element {(_oppTapAnim ? "avatar-tap" : "")}")"
                                    disabled="@_state.IsMatchEnded"
                                    Style="border: solid 2px orangered; width:80px; height: 80px;">
-                            <MudImage Class="no-zoom-element" Src="images/me.png"></MudImage>
+                            @if (GetPlayerAvatar(CurrentMatch.Player3) is string p3Src)
+                            {
+                                <MudImage Class="no-zoom-element" Src="@p3Src"></MudImage>
+                            }
+                            else
+                            {
+                                <MudIcon Icon="@Icons.Material.Filled.Person" Class="no-zoom-element" Style="font-size:40px; color:white;" />
+                            }
                             <div class="no-zoom-element" style="position:absolute; top:50%; left:50%; transform:translate(-50%, -50%);
                                         color:white; font-size:22px; font-weight:bold;">
                                 @CurrentMatch.Player3.GetInitials()
@@ -231,7 +252,14 @@
                     <span class="doubles-partner-badge">&</span>
                     <MudAvatar @onclick="OpponentWinsPoint" Class="no-zoom-element" disabled="@_state.IsMatchEnded"
                                Style="border: solid 2px orangered; width:80px; height: 80px;">
-                        <MudImage Class="no-zoom-element" Src="images/me.png"></MudImage>
+                        @if (GetPlayerAvatar(CurrentMatch.Player4) is string p4Src)
+                        {
+                            <MudImage Class="no-zoom-element" Src="@p4Src"></MudImage>
+                        }
+                        else
+                        {
+                            <MudIcon Icon="@Icons.Material.Filled.Person" Class="no-zoom-element" Style="font-size:40px; color:white;" />
+                        }
                         <div class="no-zoom-element" style="position:absolute; top:50%; left:50%; transform:translate(-50%, -50%);
                                     color:white; font-size:22px; font-weight:bold;">
                             @CurrentMatch.Player4.GetInitials()
@@ -244,7 +272,14 @@
                         <MudAvatar @onclick="OpponentWinsPoint" Class="@($"no-zoom-element {(_oppTapAnim ? "avatar-tap" : "")}")"
                                    disabled="@_state.IsMatchEnded"
                                    Style="border: solid 2px orangered; width:80px; height: 80px;">
-                            <MudImage Class="no-zoom-element" Src="images/me.png"></MudImage>
+                            @if (GetPlayerAvatar(CurrentMatch.Player2) is string p2bSrc)
+                            {
+                                <MudImage Class="no-zoom-element" Src="@p2bSrc"></MudImage>
+                            }
+                            else
+                            {
+                                <MudIcon Icon="@Icons.Material.Filled.Person" Class="no-zoom-element" Style="font-size:40px; color:white;" />
+                            }
                             <div class="no-zoom-element" style="position:absolute; top:50%; left:50%; transform:translate(-50%, -50%);
                                 color:white; font-size:22px; font-weight:bold;">
                                 @CurrentMatch.Player2.GetInitials()
@@ -544,6 +579,13 @@
         return Label_Switch1 ? $"{_value3} & {_value4}" : _value2;
     }
 
+    private string? GetPlayerAvatar(string? playerName)
+    {
+        if (!string.IsNullOrEmpty(playerName) && _avatarByName.TryGetValue(playerName, out var path))
+            return path;
+        return null;
+    }
+
     private async Task StartAfterCoinToss()
     {
         _state.IsUserServing = _coinTossUserServes;
@@ -643,6 +685,7 @@
     private string? _deviceToken;
     private int? _myPlayerId;
     private Dictionary<string, int> _playerIdByName = [];
+    private Dictionary<string, string> _avatarByName = [];
     private HashSet<int> _friendPlayerIds = [];
     private TennisMatchState _state = new();
     private List<Score> scores = new();
@@ -678,11 +721,15 @@
         }
 
         var allPlayers = await DbContext.Players
+            .Include(p => p.User)
             .OrderBy(p => p.DisplayName)
-            .Select(p => new { p.PlayerId, p.DisplayName })
+            .Select(p => new { p.PlayerId, p.DisplayName, AvatarPath = p.User != null ? p.User.ProfileImagePath : null })
             .ToListAsync();
 
         _playerIdByName = allPlayers.ToDictionary(p => p.DisplayName, p => p.PlayerId);
+        _avatarByName = allPlayers
+            .Where(p => !string.IsNullOrEmpty(p.AvatarPath))
+            .ToDictionary(p => p.DisplayName, p => p.AvatarPath!);
 
         if (_currentUserId != null)
         {

--- a/DropShot/Data/ApplicationUser.cs
+++ b/DropShot/Data/ApplicationUser.cs
@@ -11,5 +11,6 @@ namespace DropShot.Data
         public DateTime? SubscriptionEndDate { get; set; }
         public string? PaypalSubscriptionId { get; set; }
         public string? PaypalPayerId { get; set; }
+        public string? ProfileImagePath { get; set; }
     }
 }

--- a/DropShot/Data/Migrations/20260405210846_AddUserProfileImage.Designer.cs
+++ b/DropShot/Data/Migrations/20260405210846_AddUserProfileImage.Designer.cs
@@ -4,6 +4,7 @@ using DropShot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DropShot.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260405210846_AddUserProfileImage")]
+    partial class AddUserProfileImage
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DropShot/Data/Migrations/20260405210846_AddUserProfileImage.cs
+++ b/DropShot/Data/Migrations/20260405210846_AddUserProfileImage.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropShot.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserProfileImage : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ProfileImagePath",
+                table: "AspNetUsers",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ProfileImagePath",
+                table: "AspNetUsers");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Users can upload a profile image (JPG/PNG/GIF/WebP, max 2MB) from the Account/Manage page
- Avatar is displayed in the nav sidebar next to the username
- Match screen player avatars show uploaded profile images for linked players, with a person icon fallback

## Test plan
- [ ] Log in, navigate to `/Account/Manage`, upload an image — verify it appears as circular avatar
- [ ] Verify avatar appears in the nav sidebar next to username
- [ ] Start a match with a player who has an uploaded avatar — verify it shows on the match screen
- [ ] Start a match with a player without an avatar — verify person icon fallback
- [ ] Test uploading an oversized file (>2MB) — verify error message
- [ ] Test uploading an invalid file type — verify error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)