### PR TITLE
Fix EF Core concurrency error in TennisScore

### DIFF
--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -17,7 +17,6 @@
 @rendermode InteractiveServer
 
 @using DropShot.Services
-@inject MyDbContext DbContext
 @inject NavigationManager Navigation
 @inject UserState State
 @inject IDialogService DialogService
@@ -705,6 +704,7 @@
 
     protected override async Task OnInitializedAsync()
     {
+        using var DbContext = DbFactory.CreateDbContext();
         var authState = await AuthStateProvider.GetAuthenticationStateAsync();
         _currentUserId = authState.User.FindFirstValue(ClaimTypes.NameIdentifier);
 


### PR DESCRIPTION
## Summary
- Replaced injected scoped `DbContext` with factory-created instance in `OnInitializedAsync` to fix `ConcurrencyDetector.EnterCriticalSection` error
- Blazor's SSR pre-render and interactive init can run concurrently against the same scoped DbContext — using `DbFactory.CreateDbContext()` gives each its own instance
- Removed unused `@inject MyDbContext DbContext` directive (rest of component already uses `DbFactory`)

## Test plan
- [ ] Load `/tennisscore` and `/match/{id}` routes without concurrency exceptions
- [ ] Verify match resumption, competition fixture loading, and court list still populate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)