### PR TITLE
Replace tap-anywhere skip with explicit Skip button

### DIFF
--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -306,7 +306,7 @@
 @* #11 — Match complete as full-screen overlay instead of below the fold *@
 @if (CurrentMatch != null && CurrentMatch.Complete)
 {
-    <div class="match-complete-overlay" @onclick="NavigateAfterMatch">
+    <div class="match-complete-overlay">
         <div class="match-complete-trophy">🏆</div>
         @if (!string.IsNullOrWhiteSpace(_winner) && !_winner.Equals("Congratulations "))
         {
@@ -325,7 +325,9 @@
                 <span>New match in @_countdownSeconds…</span>
             }
         </div>
-        <div class="match-complete-tap-hint">Tap anywhere to skip</div>
+        <MudButton Style="margin-top: 12px;" Variant="Variant.Filled" Color="Color.Primary" Size="Size.Medium"
+                   StartIcon="@Icons.Material.Filled.SkipNext"
+                   OnClick="@NavigateAfterMatch">Skip</MudButton>
     </div>
 }
 

--- a/DropShot/Components/TennisScore.razor.css
+++ b/DropShot/Components/TennisScore.razor.css
@@ -366,7 +366,6 @@
     gap: 16px;
     padding: 24px;
     text-align: center;
-    cursor: pointer;
 }
 
 .match-complete-trophy {
@@ -399,12 +398,6 @@
     color: rgba(255, 255, 255, 0.7);
     margin-top: 16px;
     animation: fadeUp 0.4s ease-out 0.5s both;
-}
-
-.match-complete-tap-hint {
-    font-size: 0.8rem;
-    color: rgba(255, 255, 255, 0.35);
-    animation: fadeUp 0.4s ease-out 0.65s both;
 }
 
 /* ── Coin Toss Overlay ─────────────────────────────────────── */


### PR DESCRIPTION
## Summary
- Removes `@onclick` from the match-complete overlay to prevent accidental double-tap navigation
- Adds an explicit "Skip" `MudButton` so users must intentionally click to skip the countdown
- Removes `cursor: pointer` and `.match-complete-tap-hint` styles (no longer needed)

## Test plan
- [ ] Complete a match — verify double-tapping the last point does NOT skip the countdown
- [ ] Click the Skip button — verify it navigates immediately
- [ ] Let countdown reach 0 — verify auto-redirect still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)