### PR TITLE
Fix role switcher dropdown not working on mobile

### DIFF
--- a/DropShot/Components/Shared/RoleSwitcher.razor
+++ b/DropShot/Components/Shared/RoleSwitcher.razor
@@ -13,7 +13,7 @@
     <form action="Account/SwitchRole" method="post" data-enhance-nav="false">
         <AntiforgeryToken />
         <input type="hidden" name="returnUrl" value="/" />
-        <div class="role-switcher-row">
+        <div class="role-switcher-row" onclick="event.stopPropagation()">
             <MudIcon Icon="@Icons.Material.Filled.SwapHoriz" Class="nav-icon" />
             <select name="role" class="role-switcher-select" onchange="this.form.submit()">
                 @foreach (var role in _grantedRoles)


### PR DESCRIPTION
## Summary
- The `nav-scrollable` div's `onclick` handler (which closes the mobile hamburger menu) was capturing clicks on the role `<select>`, collapsing the nav before the native picker could open
- Added `event.stopPropagation()` to the role switcher row to prevent click bubbling

## Test plan
- [ ] On mobile, open the nav menu and tap the role dropdown — it should open the native picker
- [ ] Selecting a role should submit the form and switch roles
- [ ] Other nav items should still close the menu when tapped

🤖 Generated with [Claude Code](https://claude.com/claude-code)