### PR TITLE
Add PWA support to hide mobile address bar

### DIFF
--- a/DropShot/Components/App.razor
+++ b/DropShot/Components/App.razor
@@ -11,6 +11,12 @@
     <link rel="stylesheet" href="app.css" />
     <link rel="stylesheet" href="DropShot.styles.css" />
     <link rel="icon" type="image/png" href="favicon.png" />
+    <link rel="manifest" href="manifest.json" />
+    <meta name="theme-color" content="#121212" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="DropShot" />
+    <link rel="apple-touch-icon" href="Images/Logo.png" />
     <HeadOutlet />
 </head>
 
@@ -23,6 +29,7 @@
     <script src="js/qrcode-helper.js"></script>
     <script src="js/paypal-interop.js"></script>
     <script src="_framework/blazor.web.js"></script>
+    <script>if ('serviceWorker' in navigator) navigator.serviceWorker.register('service-worker.js');</script>
 </body>
 
 </html>

--- a/DropShot/Components/TennisScore.razor.css
+++ b/DropShot/Components/TennisScore.razor.css
@@ -37,7 +37,7 @@
     --content-padding: clamp(1.25rem, 3vw, 3rem);
     --text-color: #ffffff;
     position: relative;
-    height: 100dvh;
+    height: 100svh;
     background-color: var(--bg-fallback);
     background-image: var(--bg-image);
     background-repeat: no-repeat;

--- a/DropShot/wwwroot/manifest.json
+++ b/DropShot/wwwroot/manifest.json
@@ -1,0 +1,22 @@
+{
+  "name": "DropShot",
+  "short_name": "DropShot",
+  "description": "Tennis match scoring app",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#121212",
+  "theme_color": "#121212",
+  "icons": [
+    {
+      "src": "Images/Logo.png",
+      "sizes": "500x500",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "favicon.png",
+      "sizes": "32x32",
+      "type": "image/png"
+    }
+  ]
+}

--- a/DropShot/wwwroot/service-worker.js
+++ b/DropShot/wwwroot/service-worker.js
@@ -1,0 +1,3 @@
+// Minimal service worker required for PWA installability.
+// DropShot is a server-rendered Blazor app so we don't cache assets offline.
+self.addEventListener('fetch', () => {});


### PR DESCRIPTION
## Summary
- Add web app manifest (`display: standalone`) so the app runs full-screen when added to home screen — no browser address bar
- Add Apple mobile web app meta tags for iOS Safari support
- Add minimal service worker for Chrome PWA installability
- Switch scoring page from `100dvh` to `100svh` so content fits within the smaller viewport when browsing normally (address bar visible)

## How to use
- **iOS Safari**: Tap Share > "Add to Home Screen"
- **Android Chrome**: Tap menu > "Add to Home Screen" (or the install prompt)
- The app will then launch in standalone mode with no address bar

## Test plan
- [ ] Visit the scoring page in a mobile browser — no scroll even with address bar visible
- [ ] Add to home screen on iOS Safari — launches without browser chrome
- [ ] Add to home screen on Android Chrome — launches without browser chrome
- [ ] Landscape mode still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)