### PR TITLE
Fix PWA safe area insets cutting off controls

### DIFF
--- a/DropShot/Components/App.razor
+++ b/DropShot/Components/App.razor
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <base href="/" />
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet" />
     <link href="_content/MudBlazor/MudBlazor.min.css?v=@(MudBlazor.Metadata.Version)" rel="stylesheet" />

--- a/DropShot/Components/TennisScore.razor.css
+++ b/DropShot/Components/TennisScore.razor.css
@@ -16,6 +16,8 @@
     color: white;
     border-radius: 20px;
     padding: 20px;
+    padding-top: max(20px, env(safe-area-inset-top));
+    padding-bottom: max(20px, env(safe-area-inset-bottom));
     font-family: sans-serif;
     position: relative;
     z-index: 1;


### PR DESCRIPTION
## Summary
- Add `viewport-fit=cover` to extend app into device safe areas (notch, home indicator)
- Apply `env(safe-area-inset-top/bottom)` padding to score container so controls aren't hidden behind the home indicator bar

## Test plan
- [ ] Open as PWA on iPhone with notch/Dynamic Island — content clears top and bottom safe areas
- [ ] Controls row fully visible at bottom
- [ ] Regular browser usage unaffected (safe-area-inset values are 0 when no safe areas exist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)