### PR TITLE
Apply fullscreen mode to scoring page

### DIFF
--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -331,7 +331,7 @@
     </div>
 }
 
-@implements IDisposable
+@implements IAsyncDisposable
 
 @code {
     private string _value = string.Empty;
@@ -848,6 +848,8 @@
     {
         if (firstRender)
         {
+            await JS.InvokeVoidAsync("eval", "document.body.classList.add('scoreboard-fullscreen')");
+
             if (_currentUserId == null)
             {
                 _deviceToken = await JS.InvokeAsync<string?>("localStorage.getItem", "dropshot-device-token");
@@ -1045,10 +1047,11 @@
             Navigation.NavigateTo("/match");
     }
 
-    public void Dispose()
+    public async ValueTask DisposeAsync()
     {
         _timerHandle?.Dispose();
         _countdownHandle?.Dispose();
+        try { await JS.InvokeVoidAsync("eval", "document.body.classList.remove('scoreboard-fullscreen')"); } catch { }
     }
 
     private async Task UndoLastPoint()


### PR DESCRIPTION
## Summary
- Apply existing `scoreboard-fullscreen` CSS class on TennisScore first render — hides sidebar nav and strips content padding
- Remove class on dispose so other pages aren't affected
- Switch from `IDisposable` to `IAsyncDisposable` to support async JS cleanup

The scoring page was being rendered inside MainLayout's sidebar + padded content wrapper, adding extra height that pushed the controls row off screen on mobile.

## Test plan
- [ ] Open scoring page on mobile — no sidebar visible, controls fully visible at bottom
- [ ] Navigate away from scoring page — sidebar/nav returns on other pages
- [ ] PWA standalone mode — full screen with no browser chrome or layout padding

🤖 Generated with [Claude Code](https://claude.com/claude-code)