### PR TITLE
Lock down overflow in scoreboard-fullscreen mode

### DIFF
--- a/DropShot/wwwroot/app.css
+++ b/DropShot/wwwroot/app.css
@@ -74,21 +74,32 @@ h1:focus {
 }
 
 /* Scoreboard fullscreen mode — hides sidebar and content padding */
+body.scoreboard-fullscreen {
+    overflow: hidden !important;
+    height: 100svh !important;
+}
+
 body.scoreboard-fullscreen .sidebar {
     display: none !important;
 }
 
 body.scoreboard-fullscreen .page {
     flex-direction: column;
+    height: 100% !important;
+    overflow: hidden !important;
 }
 
 body.scoreboard-fullscreen main {
     width: 100%;
+    height: 100% !important;
     padding-top: 0 !important;
+    overflow: hidden !important;
 }
 
 body.scoreboard-fullscreen .content {
     padding: 0 !important;
+    height: 100% !important;
+    overflow: hidden !important;
 }
 
 /* ── QR Login Panel ──────────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary
- Add `overflow: hidden` and `height: 100svh` to the entire element chain (`body` > `.page` > `main` > `.content`) when in scoreboard-fullscreen mode
- The previous fix hid the sidebar and stripped padding, but the body/page/main elements had no height constraint and could still push the document taller than the viewport

## Test plan
- [ ] Open scoring page on mobile — zero scroll in any direction
- [ ] Test in PWA standalone mode — controls fully visible, no overflow
- [ ] Other pages unaffected (class only applied on scoring page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)