### PR TITLE
Fix scoring page viewport overflow with position:fixed

### DIFF
--- a/DropShot/Components/TennisScore.razor.css
+++ b/DropShot/Components/TennisScore.razor.css
@@ -38,14 +38,13 @@
     --content-max-width: 72rem;
     --content-padding: clamp(1.25rem, 3vw, 3rem);
     --text-color: #ffffff;
-    position: relative;
-    height: 100svh;
+    position: fixed;
+    inset: 0;
     background-color: var(--bg-fallback);
     background-image: var(--bg-image);
     background-repeat: no-repeat;
     background-size: var(--bg-size);
     background-position: var(--bg-position);
-    background-attachment: fixed;
     overflow: hidden;
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Summary
- Replace `height: 100svh` with `position: fixed; inset: 0` on the scoring background
- This takes the section completely out of document flow, so it fills the exact visible viewport regardless of parent layout wrappers, MudProviders siblings, or browser chrome

## Why
The previous approach (`height: 100svh`) was still affected by the parent element chain (MainLayout's `.page > main > .content`) and sibling elements rendered by `<MudProviders />`. `position: fixed` bypasses all of that.

## Test plan
- [ ] Scoring page fills exact viewport on mobile — no scroll
- [ ] Controls row fully visible at bottom
- [ ] Works in both regular browser and PWA standalone mode
- [ ] Landscape mode unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)