### PR TITLE
Replace role banner button with sticky dropdown switcher

### DIFF
--- a/DropShot/Components/Shared/RoleBanner.razor
+++ b/DropShot/Components/Shared/RoleBanner.razor
@@ -1,4 +1,4 @@
-@* Pure SSR component — shows a banner when an admin user is browsing in a non-admin role *@
+@* Pure SSR component — shows a sticky banner with the active role and a dropdown to switch *@
 
 @using System.Security.Claims
 @using Microsoft.AspNetCore.Identity
@@ -9,24 +9,29 @@
 @inject IDbContextFactory<MyDbContext> DbFactory
 @inject NavigationManager NavigationManager
 
-@if (_showBanner)
+@if (_grantedRoles.Count > 0)
 {
-    <div class="role-banner" style="background: var(--mud-palette-info); color: white; padding: 8px 16px; display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 8px; font-size: 0.875rem;">
-        <span>You are browsing as a standard user</span>
-        <form action="Account/SwitchRole" method="post" data-enhance-nav="false" style="display: inline;">
-            <AntiforgeryToken />
-            <input type="hidden" name="role" value="@_highestAdminRole" />
-            <input type="hidden" name="returnUrl" value="@_currentUrl" />
-            <button type="submit" style="background: none; border: 1px solid white; color: white; padding: 2px 10px; border-radius: 4px; cursor: pointer; font-size: 0.8rem;">
-                Switch to @_highestAdminRole
-            </button>
-        </form>
+    <div class="role-banner">
+        <span>Browsing as: <strong>@_activeRole</strong></span>
+        @if (_grantedRoles.Count > 1)
+        {
+            <form action="Account/SwitchRole" method="post" data-enhance-nav="false" style="display: inline;">
+                <AntiforgeryToken />
+                <input type="hidden" name="returnUrl" value="@_currentUrl" />
+                <select name="role" class="role-banner-select" onchange="this.form.submit()">
+                    @foreach (var role in _grantedRoles)
+                    {
+                        <option value="@role" selected="@(role == _activeRole)">@role</option>
+                    }
+                </select>
+            </form>
+        }
     </div>
 }
 
 @code {
-    private bool _showBanner;
-    private string _highestAdminRole = "Admin";
+    private List<string> _grantedRoles = [];
+    private string _activeRole = "";
     private string _currentUrl = "/";
 
     protected override async Task OnInitializedAsync()
@@ -39,22 +44,16 @@
         var userId = httpContext.User.FindFirstValue(ClaimTypes.NameIdentifier);
         if (userId is null) return;
 
-        // Use a dedicated DbContext to avoid concurrency with other SSR components
         await using var db = DbFactory.CreateDbContext();
-        var grantedRoles = await db.UserRoles
+        _grantedRoles = await db.UserRoles
             .Where(ur => ur.UserId == userId)
             .Join(db.Roles, ur => ur.RoleId, r => r.Id, (ur, r) => r.Name!)
             .ToListAsync();
 
-        if (grantedRoles.Count <= 1) return;
+        if (_grantedRoles.Count == 0) return;
 
-        var hasAdminRole = grantedRoles.Any(r => r is "SuperAdmin" or "Admin");
-        if (!hasAdminRole) return;
-
-        var activeRole = httpContext.Request.Cookies["ActiveRole"] ?? grantedRoles[0];
-        var isInAdminRole = activeRole is "SuperAdmin" or "Admin";
-
-        _showBanner = !isInAdminRole;
-        _highestAdminRole = grantedRoles.Contains("SuperAdmin") ? "SuperAdmin" : "Admin";
+        _activeRole = httpContext.Request.Cookies["ActiveRole"] ?? _grantedRoles[0];
+        if (!_grantedRoles.Contains(_activeRole, StringComparer.OrdinalIgnoreCase))
+            _activeRole = _grantedRoles[0];
     }
 }

--- a/DropShot/Components/Shared/RoleBanner.razor.css
+++ b/DropShot/Components/Shared/RoleBanner.razor.css
@@ -1,0 +1,38 @@
+.role-banner {
+    background: var(--mud-palette-info);
+    color: white;
+    padding: 6px 16px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 8px;
+    font-size: 0.85rem;
+    position: sticky;
+    top: 0;
+    z-index: 10;
+}
+
+.role-banner-select {
+    background: rgba(255, 255, 255, 0.15);
+    color: white;
+    border: 1px solid rgba(255, 255, 255, 0.4);
+    border-radius: 4px;
+    padding: 2px 8px;
+    font-size: 0.8rem;
+    cursor: pointer;
+}
+
+    .role-banner-select:hover {
+        background: rgba(255, 255, 255, 0.25);
+    }
+
+    .role-banner-select:focus {
+        outline: none;
+        border-color: rgba(255, 255, 255, 0.6);
+    }
+
+    .role-banner-select option {
+        background: #1e1e2e;
+        color: #d7d7d7;
+    }


### PR DESCRIPTION
## Summary
- Replaced the single "Switch to Admin" button in the role banner with a dropdown select that shows all granted roles
- Banner now shows for all authenticated users displaying their active role
- Made the banner sticky so it stays pinned under the main header when scrolling

## Test plan
- [ ] Verify banner shows active role for single-role users (no dropdown)
- [ ] Verify dropdown appears and switches roles for multi-role users
- [ ] Verify banner stays sticky when scrolling

🤖 Generated with [Claude Code](https://claude.com/claude-code)