### PR TITLE
Only apply fullscreen mode during active match

### DIFF
--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -593,6 +593,7 @@
         _state.IsUserServing = _coinTossUserServes;
         CurrentMatch = _pendingMatch;
         _showCoinToss = false;
+        await SetScoringFullscreen(true);
 
         // #7 — Start the match timer
         StartTimer();
@@ -772,6 +773,7 @@
                 _state.GameScoring = CurrentMatch.GameScoring;
                 _savedMatchId = savedMatch.SavedMatchId;
                 _selectedCourtId = savedMatch.CourtId;
+                _restoreFullscreen = true;
 
                 // Already in progress — hide the tap hint
                 _tapHintDismissed = true;
@@ -848,8 +850,6 @@
     {
         if (firstRender)
         {
-            await JS.InvokeVoidAsync("eval", "document.body.classList.add('scoreboard-fullscreen')");
-
             if (_currentUserId == null)
             {
                 _deviceToken = await JS.InvokeAsync<string?>("localStorage.getItem", "dropshot-device-token");
@@ -875,7 +875,21 @@
                 await ButtonOnClick();
                 await InvokeAsync(StateHasChanged);
             }
+
+            if (_restoreFullscreen)
+            {
+                _restoreFullscreen = false;
+                await SetScoringFullscreen(true);
+            }
         }
+    }
+
+    private bool _restoreFullscreen;
+
+    private async Task SetScoringFullscreen(bool enabled)
+    {
+        var action = enabled ? "add" : "remove";
+        await JS.InvokeVoidAsync("eval", $"document.body.classList.{action}('scoreboard-fullscreen')");
     }
 
     private Stack<GameState> history = new(new[] { new GameState(0, 0, 0, 0, 0, 0, false, 0, false, 0, 0, new List<SetScore>(), DateTime.Now, false, "", "") });
@@ -1051,7 +1065,7 @@
     {
         _timerHandle?.Dispose();
         _countdownHandle?.Dispose();
-        try { await JS.InvokeVoidAsync("eval", "document.body.classList.remove('scoreboard-fullscreen')"); } catch { }
+        try { await SetScoringFullscreen(false); } catch { }
     }
 
     private async Task UndoLastPoint()


### PR DESCRIPTION
## Summary
- Move `scoreboard-fullscreen` class from first render to when the match actually starts (`StartAfterCoinToss`) or when restoring a saved match
- During match setup, the page now has normal layout with header/nav visible and scrolling enabled
- Extract `SetScoringFullscreen()` helper for toggling the class

## Fixes
- Header banner missing on scoring page (no way to navigate away)
- Match setup wizard "Start Match" button cut off at bottom with no scroll

## Test plan
- [ ] Match setup wizard scrolls normally, all buttons accessible
- [ ] Header/nav visible during setup
- [ ] Once match starts, scoring page goes fullscreen (no nav, no scroll)
- [ ] Restoring a saved match via URL also enters fullscreen
- [ ] Navigating away restores normal layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)