### PR TITLE
Fix role banner returnUrl missing leading slash

### DIFF
--- a/DropShot/Components/Shared/RoleBanner.razor
+++ b/DropShot/Components/Shared/RoleBanner.razor
@@ -39,7 +39,7 @@
         var httpContext = HttpContextAccessor.HttpContext;
         if (httpContext?.User.Identity?.IsAuthenticated != true) return;
 
-        _currentUrl = NavigationManager.ToBaseRelativePath(NavigationManager.Uri);
+        _currentUrl = "/" + NavigationManager.ToBaseRelativePath(NavigationManager.Uri);
 
         var userId = httpContext.User.FindFirstValue(ClaimTypes.NameIdentifier);
         if (userId is null) return;


### PR DESCRIPTION
## Summary
- `NavigationManager.ToBaseRelativePath()` strips the leading `/`, so the return URL after role switch was `tennisscore` instead of `/tennisscore`
- The SwitchRole endpoint redirect resolved this relative to `/Account/`, resulting in `/Account/tennisscore` — a blank page
- Prefixed with `/` so the redirect goes back to the correct page

## Test plan
- [ ] Navigate to /tennisscore, switch role via banner dropdown, confirm page reloads correctly
- [ ] Test on other pages to verify redirect works everywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)