### PR TITLE
Keep banner and menu visible during match scoring

### DIFF
--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -889,7 +889,7 @@
     private async Task SetScoringFullscreen(bool enabled)
     {
         var action = enabled ? "add" : "remove";
-        await JS.InvokeVoidAsync("eval", $"document.body.classList.{action}('scoreboard-fullscreen')");
+        await JS.InvokeVoidAsync("eval", $"document.body.classList.{action}('scoring-active')");
     }
 
     private Stack<GameState> history = new(new[] { new GameState(0, 0, 0, 0, 0, 0, false, 0, false, 0, 0, new List<SetScore>(), DateTime.Now, false, "", "") });

--- a/DropShot/Components/TennisScore.razor.css
+++ b/DropShot/Components/TennisScore.razor.css
@@ -16,7 +16,6 @@
     color: white;
     border-radius: 20px;
     padding: 20px;
-    padding-top: max(20px, env(safe-area-inset-top));
     padding-bottom: max(20px, env(safe-area-inset-bottom));
     font-family: sans-serif;
     position: relative;
@@ -38,8 +37,8 @@
     --content-max-width: 72rem;
     --content-padding: clamp(1.25rem, 3vw, 3rem);
     --text-color: #ffffff;
-    position: fixed;
-    inset: 0;
+    position: relative;
+    flex: 1;
     background-color: var(--bg-fallback);
     background-image: var(--bg-image);
     background-repeat: no-repeat;

--- a/DropShot/wwwroot/app.css
+++ b/DropShot/wwwroot/app.css
@@ -73,33 +73,39 @@ h1:focus {
     text-align: center;
 }
 
-/* Scoreboard fullscreen mode — hides sidebar and content padding */
-body.scoreboard-fullscreen {
+/* Scoring-active mode — fills remaining viewport below banner, no scroll */
+body.scoring-active {
     overflow: hidden !important;
     height: 100svh !important;
 }
 
+body.scoring-active .page {
+    height: 100% !important;
+    overflow: hidden !important;
+}
+
+body.scoring-active main {
+    display: flex !important;
+    flex-direction: column !important;
+    overflow: hidden !important;
+    height: 100% !important;
+}
+
+body.scoring-active .content {
+    padding: 0 !important;
+    flex: 1 !important;
+    display: flex !important;
+    flex-direction: column !important;
+    overflow: hidden !important;
+}
+
+/* Legacy — keep for external scoreboard page if still used */
 body.scoreboard-fullscreen .sidebar {
     display: none !important;
 }
 
-body.scoreboard-fullscreen .page {
-    flex-direction: column;
-    height: 100% !important;
-    overflow: hidden !important;
-}
-
-body.scoreboard-fullscreen main {
-    width: 100%;
-    height: 100% !important;
-    padding-top: 0 !important;
-    overflow: hidden !important;
-}
-
 body.scoreboard-fullscreen .content {
     padding: 0 !important;
-    height: 100% !important;
-    overflow: hidden !important;
 }
 
 /* ── QR Login Panel ──────────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary
- Replace `scoreboard-fullscreen` (hid sidebar/banner) with `scoring-active` class
- Uses flexbox chain (`body > .page > main > .content > .bg-tennis`) so the scoring section fills remaining viewport below the banner
- `.bg-tennis` switched from `position: fixed; inset: 0` to `flex: 1` — it naturally fills available space
- Banner and hamburger menu remain accessible during match

## Test plan
- [ ] Match setup — banner visible, page scrolls, Start Match button accessible
- [ ] Active match — banner visible, menu works, scoring fits below it with no scroll
- [ ] Controls row fully visible at bottom
- [ ] Navigate away from match — normal layout restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)