### PR TITLE
Refactor scoreboards and hide role banner in fullscreen

### DIFF
--- a/DropShot/wwwroot/app.css
+++ b/DropShot/wwwroot/app.css
@@ -100,7 +100,8 @@ body.scoring-active .content {
 }
 
 /* Legacy — keep for external scoreboard page if still used */
-body.scoreboard-fullscreen .sidebar {
+body.scoreboard-fullscreen .sidebar,
+body.scoreboard-fullscreen .role-banner {
     display: none !important;
 }
 


### PR DESCRIPTION
## Summary
- Extract scoreboard components (Default, Wimbledon, DotDigit) into a dedicated `Components/Scoreboards` folder
- Hide the role banner when the scoreboard is in fullscreen mode

## Test plan
- [ ] Verify scoreboard page loads with both Default and Wimbledon layouts
- [ ] Toggle fullscreen and confirm the role banner and sidebar are hidden
- [ ] Exit fullscreen and confirm the role banner reappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)