### PR TITLE
Add alternative light theme with toggle switch

### DIFF
--- a/DropShot/Components/App.razor
+++ b/DropShot/Components/App.razor
@@ -10,6 +10,8 @@
     <link rel="stylesheet" href="bootstrap/bootstrap.min.css" />
     <link rel="stylesheet" href="app.css" />
     <link rel="stylesheet" href="DropShot.styles.css" />
+    <link rel="stylesheet" href="css/theme-light.css" />
+    <script src="js/theme-switcher.js"></script>
     <link rel="icon" type="image/png" href="favicon.png" />
     <link rel="manifest" href="manifest.json" />
     <meta name="theme-color" content="#121212" />

--- a/DropShot/Components/Layout/NavMenu.razor
+++ b/DropShot/Components/Layout/NavMenu.razor
@@ -84,6 +84,18 @@
             </NavLink>
         </div>
 
+        <div class="nav-item px-3">
+            <button class="theme-toggle-btn" onclick="toggleDropShotTheme()">
+                <svg class="nav-icon theme-toggle-icon theme-icon-light" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="currentColor">
+                    <path d="M12 7c-2.76 0-5 2.24-5 5s2.24 5 5 5 5-2.24 5-5-2.24-5-5-5zM2 13h2c.55 0 1-.45 1-1s-.45-1-1-1H2c-.55 0-1 .45-1 1s.45 1 1 1zm18 0h2c.55 0 1-.45 1-1s-.45-1-1-1h-2c-.55 0-1 .45-1 1s.45 1 1 1zM11 2v2c0 .55.45 1 1 1s1-.45 1-1V2c0-.55-.45-1-1-1s-1 .45-1 1zm0 18v2c0 .55.45 1 1 1s1-.45 1-1v-2c0-.55-.45-1-1-1s-1 .45-1 1zM5.99 4.58a.996.996 0 00-1.41 0 .996.996 0 000 1.41l1.06 1.06c.39.39 1.03.39 1.41 0s.39-1.03 0-1.41L5.99 4.58zm12.37 12.37a.996.996 0 00-1.41 0 .996.996 0 000 1.41l1.06 1.06c.39.39 1.03.39 1.41 0a.996.996 0 000-1.41l-1.06-1.06zm1.06-10.96a.996.996 0 000-1.41.996.996 0 00-1.41 0l-1.06 1.06c-.39.39-.39 1.03 0 1.41s1.03.39 1.41 0l1.06-1.06zM7.05 18.36a.996.996 0 000-1.41.996.996 0 00-1.41 0l-1.06 1.06c-.39.39-.39 1.03 0 1.41s1.03.39 1.41 0l1.06-1.06z"/>
+                </svg>
+                <svg class="nav-icon theme-toggle-icon theme-icon-dark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="currentColor">
+                    <path d="M12 3a9 9 0 109 9c0-.46-.04-.92-.1-1.36a5.389 5.389 0 01-4.4 2.26 5.403 5.403 0 01-3.14-9.8c-.44-.06-.9-.1-1.36-.1z"/>
+                </svg>
+                <span class="theme-toggle-label">Light Mode</span>
+            </button>
+        </div>
+
         <AuthorizeView Roles="Admin,SuperAdmin">
             <div class="nav-item px-3">
                 <NavLink class="nav-link" href="admin/users">

--- a/DropShot/wwwroot/css/theme-light.css
+++ b/DropShot/wwwroot/css/theme-light.css
@@ -1,0 +1,247 @@
+/* ══════════════════════════════════════════════════════════════════════
+   DropShot – Light Theme (Alternative Stylesheet)
+   Applied when <html data-theme="light"> is set.
+   ══════════════════════════════════════════════════════════════════════ */
+
+/* ── Base overrides ─────────────────────────────────────────────────── */
+[data-theme="light"] body {
+    background-color: #f5f5f5 !important;
+    color: #212121 !important;
+}
+
+/* ── Sidebar ────────────────────────────────────────────────────────── */
+[data-theme="light"] .sidebar {
+    background-image: none !important;
+    background-color: #ffffff !important;
+    border-right: 1px solid #e0e0e0;
+}
+
+/* ── Top navbar ─────────────────────────────────────────────────────── */
+[data-theme="light"] .top-row {
+    background-color: #1565c0 !important;
+}
+
+[data-theme="light"] .navbar-brand {
+    color: #ffffff !important;
+}
+
+/* ── Nav links ──────────────────────────────────────────────────────── */
+[data-theme="light"] .nav-item .nav-link,
+[data-theme="light"] .nav-item a.nav-link,
+[data-theme="light"] .nav-item button.nav-link,
+[data-theme="light"] .nav-group label .nav-link {
+    color: #424242 !important;
+}
+
+[data-theme="light"] .nav-item .nav-link:hover,
+[data-theme="light"] .nav-item a.nav-link:hover,
+[data-theme="light"] .nav-item button.nav-link:hover {
+    background-color: rgba(21, 101, 192, 0.08) !important;
+    color: #1565c0 !important;
+}
+
+[data-theme="light"] .nav-item a.active {
+    background-color: rgba(21, 101, 192, 0.15) !important;
+    color: #1565c0 !important;
+}
+
+[data-theme="light"] .nav-icon {
+    color: #616161 !important;
+}
+
+[data-theme="light"] .nav-item a.active .nav-icon,
+[data-theme="light"] .nav-item .nav-link:hover .nav-icon {
+    color: #1565c0 !important;
+}
+
+/* ── Mobile nav overlay ─────────────────────────────────────────────── */
+@media (max-width: 640.98px) {
+    [data-theme="light"] .nav-scrollable {
+        background-image: none !important;
+        background-color: #ffffff !important;
+        border-bottom: 1px solid #e0e0e0;
+    }
+}
+
+/* ── Nav toggler (mobile) ───────────────────────────────────────────── */
+[data-theme="light"] .navbar-toggler {
+    background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba%28255, 255, 255, 0.9%29' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e") no-repeat center/1.75rem rgba(255, 255, 255, 0.2) !important;
+    border-color: rgba(255, 255, 255, 0.3) !important;
+}
+
+/* ── Content area ───────────────────────────────────────────────────── */
+[data-theme="light"] .content {
+    background-color: #f5f5f5;
+}
+
+[data-theme="light"] a,
+[data-theme="light"] .btn-link {
+    color: #1565c0;
+}
+
+/* ── MudBlazor overrides for light mode ─────────────────────────────── */
+[data-theme="light"] .mud-theme-dark {
+    --mud-palette-black: #272c34;
+    --mud-palette-white: #ffffff;
+    --mud-palette-primary: #1565c0;
+    --mud-palette-primary-text: #ffffff;
+    --mud-palette-secondary: #00897b;
+    --mud-palette-secondary-text: #ffffff;
+    --mud-palette-tertiary: #7b1fa2;
+    --mud-palette-tertiary-text: #ffffff;
+    --mud-palette-info: #1976d2;
+    --mud-palette-info-text: #ffffff;
+    --mud-palette-success: #2e7d32;
+    --mud-palette-success-text: #ffffff;
+    --mud-palette-warning: #f57c00;
+    --mud-palette-warning-text: #ffffff;
+    --mud-palette-error: #d32f2f;
+    --mud-palette-error-text: #ffffff;
+    --mud-palette-dark: #424242;
+    --mud-palette-dark-text: #ffffff;
+    --mud-palette-text-primary: #212121;
+    --mud-palette-text-secondary: #616161;
+    --mud-palette-text-disabled: rgba(0,0,0,0.38);
+    --mud-palette-action-default: #616161;
+    --mud-palette-action-disabled: rgba(0,0,0,0.26);
+    --mud-palette-action-disabled-background: rgba(0,0,0,0.12);
+    --mud-palette-background: #f5f5f5;
+    --mud-palette-background-gray: #eeeeee;
+    --mud-palette-surface: #ffffff;
+    --mud-palette-drawer-background: #ffffff;
+    --mud-palette-drawer-text: #424242;
+    --mud-palette-drawer-icon: #616161;
+    --mud-palette-appbar-background: #1565c0;
+    --mud-palette-appbar-text: #ffffff;
+    --mud-palette-lines-default: #e0e0e0;
+    --mud-palette-lines-inputs: #bdbdbd;
+    --mud-palette-table-lines: #e0e0e0;
+    --mud-palette-table-striped: #fafafa;
+    --mud-palette-table-hover: #f5f5f5;
+    --mud-palette-divider: #e0e0e0;
+    --mud-palette-divider-light: rgba(0,0,0,0.08);
+    --mud-palette-overlay-dark: rgba(33,33,33,0.5);
+    --mud-palette-overlay-light: rgba(255,255,255,0.5);
+}
+
+/* ── MudBlazor component backgrounds ────────────────────────────────── */
+[data-theme="light"] .mud-paper,
+[data-theme="light"] .mud-card,
+[data-theme="light"] .mud-dialog {
+    background-color: #ffffff !important;
+    color: #212121 !important;
+}
+
+[data-theme="light"] .mud-table {
+    background-color: #ffffff !important;
+}
+
+[data-theme="light"] .mud-table .mud-table-head .mud-table-cell {
+    background-color: #fafafa !important;
+    color: #424242 !important;
+}
+
+[data-theme="light"] .mud-table .mud-table-body .mud-table-cell {
+    color: #212121 !important;
+}
+
+[data-theme="light"] .mud-input,
+[data-theme="light"] .mud-input-control {
+    color: #212121 !important;
+}
+
+[data-theme="light"] .mud-chip {
+    color: #212121 !important;
+}
+
+/* ── Nav avatar border ──────────────────────────────────────────────── */
+[data-theme="light"] .nav-avatar {
+    border-color: #1565c0 !important;
+}
+
+/* ── QR code panel ──────────────────────────────────────────────────── */
+[data-theme="light"] .qr-code-wrapper {
+    border-color: #e0e0e0 !important;
+}
+
+/* ── Role banner ────────────────────────────────────────────────────── */
+[data-theme="light"] .role-banner {
+    background-color: #e3f2fd !important;
+    color: #1565c0 !important;
+}
+
+/* ── Blazor error UI ────────────────────────────────────────────────── */
+[data-theme="light"] #blazor-error-ui {
+    background: #fff3cd;
+    color: #856404;
+}
+
+/* ── Scrollbar styling ──────────────────────────────────────────────── */
+[data-theme="light"] ::-webkit-scrollbar-track {
+    background: #f5f5f5;
+}
+
+[data-theme="light"] ::-webkit-scrollbar-thumb {
+    background: #bdbdbd;
+    border-radius: 4px;
+}
+
+[data-theme="light"] ::-webkit-scrollbar-thumb:hover {
+    background: #9e9e9e;
+}
+
+/* ── Theme toggle icon visibility ───────────────────────────────────── */
+/* Dark theme (default): show sun icon, hide moon */
+.theme-icon-dark {
+    display: none;
+}
+.theme-icon-light {
+    display: inline-block;
+}
+
+/* Light theme: show moon icon, hide sun */
+[data-theme="light"] .theme-icon-light {
+    display: none;
+}
+[data-theme="light"] .theme-icon-dark {
+    display: inline-block;
+}
+
+/* ── Theme toggle button ────────────────────────────────────────────── */
+.theme-toggle-btn {
+    background: none;
+    border: none;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    width: 100%;
+    padding: 0.5rem 10px;
+    border-radius: 4px;
+    font-size: 0.9rem;
+    color: #d7d7d7;
+    height: 3rem;
+    line-height: 3rem;
+}
+
+.theme-toggle-btn:hover {
+    background-color: rgba(255,255,255,0.1);
+    color: white;
+}
+
+[data-theme="light"] .theme-toggle-btn {
+    color: #424242 !important;
+}
+
+[data-theme="light"] .theme-toggle-btn:hover {
+    background-color: rgba(21, 101, 192, 0.08) !important;
+    color: #1565c0 !important;
+}
+
+[data-theme="light"] .theme-toggle-btn .nav-icon {
+    color: #616161 !important;
+}
+
+[data-theme="light"] .theme-toggle-btn:hover .nav-icon {
+    color: #1565c0 !important;
+}

--- a/DropShot/wwwroot/js/theme-switcher.js
+++ b/DropShot/wwwroot/js/theme-switcher.js
@@ -1,0 +1,36 @@
+// DropShot – Theme Switcher
+// Persists user preference in localStorage and toggles data-theme attribute.
+
+(function () {
+    var STORAGE_KEY = 'dropshot-theme';
+
+    function getPreferred() {
+        return localStorage.getItem(STORAGE_KEY) || 'dark';
+    }
+
+    function applyTheme(theme) {
+        if (theme === 'light') {
+            document.documentElement.setAttribute('data-theme', 'light');
+        } else {
+            document.documentElement.removeAttribute('data-theme');
+        }
+        updateToggleLabels(theme);
+    }
+
+    function updateToggleLabels(theme) {
+        document.querySelectorAll('.theme-toggle-label').forEach(function (el) {
+            el.textContent = theme === 'light' ? 'Dark Mode' : 'Light Mode';
+        });
+    }
+
+    // Apply saved theme immediately to prevent flash
+    applyTheme(getPreferred());
+
+    // Expose toggle function globally for onclick
+    window.toggleDropShotTheme = function () {
+        var current = getPreferred();
+        var next = current === 'dark' ? 'light' : 'dark';
+        localStorage.setItem(STORAGE_KEY, next);
+        applyTheme(next);
+    };
+})();


### PR DESCRIPTION
## Summary
- Adds a light color scheme alternative to the default dark theme
- Adds a sun/moon toggle button in the sidebar navigation for switching themes
- User preference is persisted in localStorage across sessions

## Changes
- `wwwroot/css/theme-light.css` — Light palette overrides scoped under `[data-theme="light"]`, covering sidebar, navbar, MudBlazor components, tables, cards, etc.
- `wwwroot/js/theme-switcher.js` — Toggles `data-theme` attribute on `<html>` and persists to localStorage
- `NavMenu.razor` — Theme toggle button with sun/moon SVG icons
- `App.razor` — Includes new stylesheet and script

## Test plan
- [ ] Verify default dark theme is unchanged
- [ ] Click toggle to switch to light theme and confirm sidebar, navbar, content area, and MudBlazor components all render with light colors
- [ ] Click toggle again to switch back to dark theme
- [ ] Refresh the page and confirm the chosen theme persists
- [ ] Test on mobile viewport — toggle should work in the collapsible nav menu

https://claude.ai/code/session_01DSoDfVcRent1nzN1KcbKco