### PR TITLE
Fix theme resetting on Blazor enhanced navigation

### DIFF
--- a/DropShot/Components/App.razor
+++ b/DropShot/Components/App.razor
@@ -11,7 +11,13 @@
     <link rel="stylesheet" href="app.css" />
     <link rel="stylesheet" href="DropShot.styles.css" />
     <link rel="stylesheet" href="css/theme-light.css" />
-    <script src="js/theme-switcher.js"></script>
+    <script>
+        // Apply saved theme immediately to prevent flash of wrong theme
+        (function() {
+            var t = localStorage.getItem('dropshot-theme');
+            if (t === 'light') document.documentElement.setAttribute('data-theme', 'light');
+        })();
+    </script>
     <link rel="icon" type="image/png" href="favicon.png" />
     <link rel="manifest" href="manifest.json" />
     <meta name="theme-color" content="#121212" />
@@ -31,6 +37,7 @@
     <script src="js/qrcode-helper.js"></script>
     <script src="js/paypal-interop.js"></script>
     <script src="_framework/blazor.web.js"></script>
+    <script src="js/theme-switcher.js"></script>
     <script>if ('serviceWorker' in navigator) navigator.serviceWorker.register('service-worker.js');</script>
 </body>
 

--- a/DropShot/wwwroot/js/theme-switcher.js
+++ b/DropShot/wwwroot/js/theme-switcher.js
@@ -1,5 +1,6 @@
 // DropShot – Theme Switcher
 // Persists user preference in localStorage and toggles data-theme attribute.
+// Re-applies after Blazor enhanced navigation to prevent reset.
 
 (function () {
     var STORAGE_KEY = 'dropshot-theme';
@@ -25,6 +26,17 @@
 
     // Apply saved theme immediately to prevent flash
     applyTheme(getPreferred());
+
+    // Re-apply after Blazor enhanced navigation (which patches the DOM and
+    // strips the data-theme attribute because the server doesn't set it).
+    document.addEventListener('blazor:enhanced-navigation-end', function () {
+        applyTheme(getPreferred());
+    });
+
+    // Fallback for older Blazor versions that use 'enhancedload'
+    document.addEventListener('enhancedload', function () {
+        applyTheme(getPreferred());
+    });
 
     // Expose toggle function globally for onclick
     window.toggleDropShotTheme = function () {


### PR DESCRIPTION
## Summary
- Fixes the light theme reverting to dark on every page navigation
- Blazor's enhanced navigation patches the DOM to match the server response, stripping the `data-theme` attribute each time
- Now listens for `blazor:enhanced-navigation-end` and `enhancedload` events to re-apply the saved theme after every navigation
- Moved `theme-switcher.js` after `blazor.web.js` so Blazor events are available; added a small inline script in `<head>` to prevent flash of wrong theme on initial load

## Test plan
- [ ] Switch to light theme, then navigate between pages — theme should persist
- [ ] Refresh the page — theme should persist
- [ ] Switch back to dark theme and navigate — should stay dark

https://claude.ai/code/session_01DSoDfVcRent1nzN1KcbKco