### PR TITLE
Use site logo as browser favicon

### DIFF
--- a/DropShot/Components/App.razor
+++ b/DropShot/Components/App.razor
@@ -18,7 +18,7 @@
             if (t === 'light') document.documentElement.setAttribute('data-theme', 'light');
         })();
     </script>
-    <link rel="icon" type="image/png" href="favicon.png" />
+    <link rel="icon" type="image/png" href="Images/Logo.png" />
     <link rel="manifest" href="manifest.json" />
     <meta name="theme-color" content="#121212" />
     <meta name="apple-mobile-web-app-capable" content="yes" />


### PR DESCRIPTION
## Summary
- Changed the browser favicon from the generic `favicon.png` to the DropShot logo (`Images/Logo.png`)

## Test plan
- [ ] Verify the DropShot logo appears in the browser tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)