### PR TITLE
Fix EF Core concurrency error on Manage Profile page

### DIFF
--- a/DropShot/Components/Layout/NavMenu.razor
+++ b/DropShot/Components/Layout/NavMenu.razor
@@ -1,10 +1,12 @@
 ﻿@implements IDisposable
 
+@using System.Security.Claims
 @using Microsoft.AspNetCore.Identity
+@using Microsoft.EntityFrameworkCore
 @using DropShot.Data
 
 @inject NavigationManager NavigationManager
-@inject UserManager<ApplicationUser> UserManager
+@inject IDbContextFactory<MyDbContext> DbFactory
 
 <div class="top-row navbar navbar-dark">
     <div class="container-fluid">
@@ -160,8 +162,15 @@
 
         if (HttpContext?.User.Identity?.IsAuthenticated == true)
         {
-            var user = await UserManager.GetUserAsync(HttpContext.User);
-            _avatarPath = user?.ProfileImagePath;
+            var userId = HttpContext.User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (userId is not null)
+            {
+                await using var db = await DbFactory.CreateDbContextAsync();
+                _avatarPath = await db.Users
+                    .Where(u => u.Id == userId)
+                    .Select(u => u.ProfileImagePath)
+                    .FirstOrDefaultAsync();
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- NavMenu and the Manage/Index page both called `UserManager.GetUserAsync()` in `OnInitializedAsync`, which ran concurrently during Blazor SSR sharing the same scoped `DbContext` — triggering the EF Core concurrency detector
- Changed NavMenu to use `IDbContextFactory<MyDbContext>` for its own short-lived context, querying only `ProfileImagePath` instead of loading the full user entity

## Test plan
- [ ] Navigate to Account/Manage while logged in — page loads without `ConcurrencyDetector.EnterCriticalSection` error
- [ ] Avatar still displays correctly in the nav menu
- [ ] Profile update (phone number, avatar upload) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)