### PR TITLE
Fix TV score overlay visibility on YouTube stream and increase size

### DIFF
--- a/DropShot/Components/Pages/Scoreboard.razor.css
+++ b/DropShot/Components/Pages/Scoreboard.razor.css
@@ -88,6 +88,11 @@
     aspect-ratio: 16 / 9;
 }
 
+.stream-container iframe {
+    position: relative;
+    z-index: 1;
+}
+
 /* ── TV-style score overlay ──────────────────────────────────── */
 .tv-overlay {
     position: absolute;
@@ -95,10 +100,10 @@
     right: clamp(12px, 3%, 32px);
     background: rgba(10, 14, 21, 0.88);
     backdrop-filter: blur(6px);
-    border-radius: 4px;
+    border-radius: 6px;
     overflow: hidden;
     font-family: 'Helvetica Neue', Arial, sans-serif;
-    font-size: clamp(0.7rem, 1.4vw, 1rem);
+    font-size: clamp(0.95rem, 2vw, 1.5rem);
     line-height: 1;
     z-index: 10;
     box-shadow: 0 2px 12px rgba(0, 0, 0, 0.5);
@@ -108,7 +113,7 @@
 .tv-row {
     display: flex;
     align-items: center;
-    padding: clamp(4px, 0.6vh, 8px) clamp(6px, 1vw, 12px);
+    padding: clamp(6px, 0.8vh, 12px) clamp(8px, 1.4vw, 18px);
     border-bottom: 1px solid rgba(255, 255, 255, 0.08);
     gap: 0;
 }
@@ -122,29 +127,29 @@
 }
 
 .tv-serve {
-    width: clamp(12px, 1.6vw, 20px);
+    width: clamp(16px, 2.2vw, 28px);
     text-align: center;
     color: #c9a84c;
-    font-size: clamp(0.45rem, 0.9vw, 0.7rem);
+    font-size: clamp(0.6rem, 1.2vw, 1rem);
     flex-shrink: 0;
 }
 
 .tv-name {
     flex: 1;
-    width: clamp(60px, 10vw, 140px);
+    width: clamp(80px, 14vw, 200px);
     min-width: 0;
     font-weight: 600;
     color: #ffffff;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    padding-right: clamp(6px, 1vw, 12px);
+    padding-right: clamp(8px, 1.4vw, 16px);
     text-transform: uppercase;
     letter-spacing: 0.04em;
 }
 
 .tv-set {
-    width: clamp(16px, 2.2vw, 28px);
+    width: clamp(22px, 3vw, 40px);
     text-align: center;
     color: #999999;
     font-weight: 500;
@@ -152,23 +157,23 @@
 }
 
 .tv-game {
-    width: clamp(16px, 2.2vw, 28px);
+    width: clamp(22px, 3vw, 40px);
     text-align: center;
     color: #ffffff;
     font-weight: 700;
     flex-shrink: 0;
     border-left: 1px solid rgba(255, 255, 255, 0.15);
-    padding-left: clamp(4px, 0.6vw, 8px);
-    margin-left: clamp(2px, 0.4vw, 6px);
+    padding-left: clamp(6px, 0.8vw, 12px);
+    margin-left: clamp(3px, 0.5vw, 8px);
 }
 
 .tv-pts {
-    width: clamp(20px, 2.8vw, 36px);
+    width: clamp(28px, 3.8vw, 50px);
     text-align: center;
     color: #FFD700;
     font-weight: 700;
     flex-shrink: 0;
     border-left: 1px solid rgba(255, 255, 255, 0.15);
-    padding-left: clamp(4px, 0.6vw, 8px);
-    margin-left: clamp(2px, 0.4vw, 6px);
+    padding-left: clamp(6px, 0.8vw, 12px);
+    margin-left: clamp(3px, 0.5vw, 8px);
 }


### PR DESCRIPTION
## Summary
- Fixed overlay disappearing by adding explicit `z-index: 1` to the YouTube iframe so the score overlay (`z-index: 10`) always renders on top
- Scaled up all overlay elements ~40% (font size, padding, column widths) for better readability on stream

## Test plan
- [ ] Open scoreboard with a YouTube stream enabled and verify the score overlay is visible
- [ ] Check overlay is readable at various screen sizes (fullscreen, windowed)
- [ ] Verify overlay still positions correctly in bottom-right corner

🤖 Generated with [Claude Code](https://claude.com/claude-code)