### PR TITLE
Fix TV overlay: move iframe z-index to inline style

### DIFF
--- a/DropShot/Components/Pages/Scoreboard.razor
+++ b/DropShot/Components/Pages/Scoreboard.razor
@@ -51,7 +51,7 @@
         @if (_streamEnabled && !string.IsNullOrWhiteSpace(_streamEmbedUrl))
         {
             <div class="stream-container">
-                <iframe src="@_streamEmbedUrl" style="width: 100%; height: 100%; border: none;"
+                <iframe src="@_streamEmbedUrl" style="position: relative; z-index: 1; width: 100%; height: 100%; border: none;"
                         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
                         allowfullscreen></iframe>
 

--- a/DropShot/Components/Pages/Scoreboard.razor.css
+++ b/DropShot/Components/Pages/Scoreboard.razor.css
@@ -33,11 +33,6 @@
     aspect-ratio: 16 / 9;
 }
 
-.stream-container iframe {
-    position: relative;
-    z-index: 1;
-}
-
 /* ── TV-style score overlay ──────────────────────────────────── */
 .tv-overlay {
     position: absolute;


### PR DESCRIPTION
## Summary
- Moved `position: relative; z-index: 1` from scoped CSS to inline style on the YouTube iframe
- Blazor CSS isolation may not reliably scope to the iframe element, so inline style ensures the score overlay always renders on top

## Test plan
- [ ] Open scoreboard with YouTube stream and active match — verify overlay is visible
- [ ] Check overlay renders on top in both windowed and fullscreen modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)