### PR TITLE
Widen TV overlay names and use / for doubles

### DIFF
--- a/DropShot/Components/Pages/Scoreboard.razor
+++ b/DropShot/Components/Pages/Scoreboard.razor
@@ -60,7 +60,7 @@
                     <div class="tv-overlay">
                         <div class="tv-row @(currentScore.IsUserServing ? "tv-serving" : "")">
                             <span class="tv-serve">@(currentScore.IsUserServing ? "\u25CF" : "")</span>
-                            <span class="tv-name">@(string.IsNullOrWhiteSpace(currentScore.UserName) ? _activeMatch.Player1 : currentScore.UserName)</span>
+                            <span class="tv-name">@(OverlayName(string.IsNullOrWhiteSpace(currentScore.UserName) ? _activeMatch.Player1 : currentScore.UserName))</span>
                             @foreach (var set in currentScore.SetScores ?? Enumerable.Empty<SetScore>())
                             {
                                 <span class="tv-set">@set.UserGames</span>
@@ -73,7 +73,7 @@
                         </div>
                         <div class="tv-row @(!currentScore.IsUserServing ? "tv-serving" : "")">
                             <span class="tv-serve">@(!currentScore.IsUserServing ? "\u25CF" : "")</span>
-                            <span class="tv-name">@(string.IsNullOrWhiteSpace(currentScore.OpponentName) ? _activeMatch.Player2 : currentScore.OpponentName)</span>
+                            <span class="tv-name">@(OverlayName(string.IsNullOrWhiteSpace(currentScore.OpponentName) ? _activeMatch.Player2 : currentScore.OpponentName))</span>
                             @foreach (var set in currentScore.SetScores ?? Enumerable.Empty<SetScore>())
                             {
                                 <span class="tv-set">@set.OpponentGames</span>
@@ -390,6 +390,9 @@
             await InvokeAsync(StateHasChanged);
         }
     }
+
+    private static string OverlayName(string? name) =>
+        string.IsNullOrWhiteSpace(name) ? "" : name.Replace(" & ", " / ");
 
     private static string PointDisplay(int myPts, int oppPts, int deuceCount, bool tieBreak, bool isUser)
     {

--- a/DropShot/Components/Pages/Scoreboard.razor.css
+++ b/DropShot/Components/Pages/Scoreboard.razor.css
@@ -76,7 +76,7 @@
 
 .tv-name {
     flex: 1;
-    width: clamp(80px, 14vw, 200px);
+    width: clamp(100px, 20vw, 300px);
     min-width: 0;
     font-weight: 600;
     color: #ffffff;


### PR DESCRIPTION
## Summary
- Widened name column in TV overlay (`clamp(100px, 20vw, 300px)`) so doubles names are easier to read
- Changed "&" to "/" between partner names in the overlay (e.g. "Smith / Jones")

## Test plan
- [ ] Check singles match overlay — names display normally
- [ ] Check doubles match overlay — names show with "/" separator and are not truncated

🤖 Generated with [Claude Code](https://claude.com/claude-code)