### PR TITLE
Fix autocomplete retaining previous selection on step advance

### DIFF
--- a/DropShot/Components/MatchSetupWizard.razor
+++ b/DropShot/Components/MatchSetupWizard.razor
@@ -96,7 +96,7 @@
         }
         else if (_currentStep == stepIndex)
         {
-            <MudPaper Class="pa-4" Elevation="2">
+            <MudPaper @key="playerNumber" Class="pa-4" Elevation="2">
                 <MudText Typo="Typo.h6" Class="mb-3">@label</MudText>
 
                 <MudAutocomplete T="PlayerSelection" Label="Search players or type a name"


### PR DESCRIPTION
## Summary
- Add `@key` directive to player step container so Blazor creates a fresh `MudAutocomplete` for each player number instead of reusing the component with stale text from the previous step

## Test plan
- [ ] In doubles setup, select a player from the dropdown — confirm it auto-advances to the next step with an empty input field
- [ ] Verify you can immediately start typing/selecting without clearing first

🤖 Generated with [Claude Code](https://claude.com/claude-code)