### PR TITLE
Improve scoring screen layout and readability

### DIFF
--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -117,10 +117,9 @@
             }
 
             <!-- Top Player Button -->
-            <div class="player-row">
-                <MudAvatarGroup Max="3" Spacing="2" MaxColor="Color.Primary">
-                    <MudAvatar @onclick="UserWinsPoint" disabled="@_state.IsMatchEnded"
-                               Class="@($"no-zoom-element {(_userTapAnim ? "avatar-tap" : "")}")"
+            <button class="team-btn no-zoom-element @(_userTapAnim ? "avatar-tap" : "")" @onclick="UserWinsPoint" disabled="@_state.IsMatchEnded">
+                <div class="team-avatars">
+                    <MudAvatar Class="no-zoom-element"
                                Style="border: solid 2px lightseagreen; width:80px; height: 80px;">
                         @if (GetPlayerAvatar(CurrentMatch.Player1) is string p1Src)
                         {
@@ -135,28 +134,27 @@
                             @CurrentMatch.Player1.GetInitials()
                         </div>
                     </MudAvatar>
-                </MudAvatarGroup>
-
-                @if (Label_Switch1)
-                {
-                    <span class="doubles-partner-badge">&</span>
-                    <MudAvatar @onclick="UserWinsPoint" Class="no-zoom-element" disabled="@_state.IsMatchEnded"
-                               Style="border: solid 2px lightseagreen; width:80px; height: 80px;">
-                        @if (GetPlayerAvatar(CurrentMatch.Player2) is string p2aSrc)
-                        {
-                            <MudImage Class="no-zoom-element" Src="@p2aSrc"></MudImage>
-                        }
-                        else
-                        {
-                            <MudIcon Icon="@Icons.Material.Filled.Person" Class="no-zoom-element" Style="font-size:40px; color:white;" />
-                        }
-                        <div class="no-zoom-element" style="position:absolute; top:50%; left:50%; transform:translate(-50%, -50%);
-                                                    color:white; font-size:22px; font-weight:bold;">
-                            @CurrentMatch.Player2.GetInitials()
-                        </div>
-                    </MudAvatar>
-                }
-            </div>
+                    @if (Label_Switch1)
+                    {
+                        <MudAvatar Class="no-zoom-element team-avatar-overlap"
+                                   Style="border: solid 2px lightseagreen; width:80px; height: 80px;">
+                            @if (GetPlayerAvatar(CurrentMatch.Player2) is string p2aSrc)
+                            {
+                                <MudImage Class="no-zoom-element" Src="@p2aSrc"></MudImage>
+                            }
+                            else
+                            {
+                                <MudIcon Icon="@Icons.Material.Filled.Person" Class="no-zoom-element" Style="font-size:40px; color:white;" />
+                            }
+                            <div class="no-zoom-element" style="position:absolute; top:50%; left:50%; transform:translate(-50%, -50%);
+                                                        color:white; font-size:22px; font-weight:bold;">
+                                @CurrentMatch.Player2.GetInitials()
+                            </div>
+                        </MudAvatar>
+                    }
+                </div>
+                <span class="team-name">@GetUserDisplayName()</span>
+            </button>
 
             @* #1 + #5 + #6 — Score display with visual hierarchy, set dividers, styled serve indicator *@
             <div class="score-display">
@@ -225,13 +223,12 @@
                 </div>
             </div>
 
-            @* #2 + #9 + #10 — Bottom Player with larger avatars, tap feedback, doubles badge *@
-            <div class="player-row">
-                @if (Label_Switch1)
-                {
-                    <MudAvatarGroup Max="3" Spacing="2" MaxColor="Color.Primary">
-                        <MudAvatar @onclick="OpponentWinsPoint" Class="@($"no-zoom-element {(_oppTapAnim ? "avatar-tap" : "")}")"
-                                   disabled="@_state.IsMatchEnded"
+            @* #2 + #9 + #10 — Bottom Player with larger avatars, tap feedback *@
+            <button class="team-btn no-zoom-element @(_oppTapAnim ? "avatar-tap" : "")" @onclick="OpponentWinsPoint" disabled="@_state.IsMatchEnded">
+                <div class="team-avatars">
+                    @if (Label_Switch1)
+                    {
+                        <MudAvatar Class="no-zoom-element"
                                    Style="border: solid 2px orangered; width:80px; height: 80px;">
                             @if (GetPlayerAvatar(CurrentMatch.Player3) is string p3Src)
                             {
@@ -246,29 +243,25 @@
                                 @CurrentMatch.Player3.GetInitials()
                             </div>
                         </MudAvatar>
-                    </MudAvatarGroup>
-                    <span class="doubles-partner-badge">&</span>
-                    <MudAvatar @onclick="OpponentWinsPoint" Class="no-zoom-element" disabled="@_state.IsMatchEnded"
-                               Style="border: solid 2px orangered; width:80px; height: 80px;">
-                        @if (GetPlayerAvatar(CurrentMatch.Player4) is string p4Src)
-                        {
-                            <MudImage Class="no-zoom-element" Src="@p4Src"></MudImage>
-                        }
-                        else
-                        {
-                            <MudIcon Icon="@Icons.Material.Filled.Person" Class="no-zoom-element" Style="font-size:40px; color:white;" />
-                        }
-                        <div class="no-zoom-element" style="position:absolute; top:50%; left:50%; transform:translate(-50%, -50%);
-                                    color:white; font-size:22px; font-weight:bold;">
-                            @CurrentMatch.Player4.GetInitials()
-                        </div>
-                    </MudAvatar>
-                }
-                else
-                {
-                    <MudAvatarGroup Max="3" Spacing="2" MaxColor="Color.Primary">
-                        <MudAvatar @onclick="OpponentWinsPoint" Class="@($"no-zoom-element {(_oppTapAnim ? "avatar-tap" : "")}")"
-                                   disabled="@_state.IsMatchEnded"
+                        <MudAvatar Class="no-zoom-element team-avatar-overlap"
+                                   Style="border: solid 2px orangered; width:80px; height: 80px;">
+                            @if (GetPlayerAvatar(CurrentMatch.Player4) is string p4Src)
+                            {
+                                <MudImage Class="no-zoom-element" Src="@p4Src"></MudImage>
+                            }
+                            else
+                            {
+                                <MudIcon Icon="@Icons.Material.Filled.Person" Class="no-zoom-element" Style="font-size:40px; color:white;" />
+                            }
+                            <div class="no-zoom-element" style="position:absolute; top:50%; left:50%; transform:translate(-50%, -50%);
+                                        color:white; font-size:22px; font-weight:bold;">
+                                @CurrentMatch.Player4.GetInitials()
+                            </div>
+                        </MudAvatar>
+                    }
+                    else
+                    {
+                        <MudAvatar Class="no-zoom-element"
                                    Style="border: solid 2px orangered; width:80px; height: 80px;">
                             @if (GetPlayerAvatar(CurrentMatch.Player2) is string p2bSrc)
                             {
@@ -279,13 +272,14 @@
                                 <MudIcon Icon="@Icons.Material.Filled.Person" Class="no-zoom-element" Style="font-size:40px; color:white;" />
                             }
                             <div class="no-zoom-element" style="position:absolute; top:50%; left:50%; transform:translate(-50%, -50%);
-                                color:white; font-size:22px; font-weight:bold;">
+                                    color:white; font-size:22px; font-weight:bold;">
                                 @CurrentMatch.Player2.GetInitials()
                             </div>
                         </MudAvatar>
-                    </MudAvatarGroup>
-                }
-            </div>
+                    }
+                </div>
+                <span class="team-name">@GetOpponentDisplayName()</span>
+            </button>
 
             @* #4 — Controls with visual hierarchy: undo is prominent *@
             <div class="controls-row">

--- a/DropShot/Components/TennisScore.razor.css
+++ b/DropShot/Components/TennisScore.razor.css
@@ -12,7 +12,8 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    justify-content: space-between;
+    justify-content: center;
+    gap: 12px;
     color: white;
     border-radius: 20px;
     padding: 20px;
@@ -64,10 +65,11 @@
 .match-header {
     text-align: center;
     padding: 4px 8px;
+    margin-bottom: auto;
 }
 
 .match-header-competition {
-    font-size: 0.75rem;
+    font-size: 0.95rem;
     color: #FFD700;
     letter-spacing: 1px;
     text-transform: uppercase;
@@ -75,14 +77,14 @@
 }
 
 .match-header-court {
-    font-size: 0.85rem;
+    font-size: 1.05rem;
     color: #aaa;
     letter-spacing: 1px;
     text-transform: uppercase;
 }
 
 .match-header-players {
-    font-size: 1rem;
+    font-size: 1.25rem;
     color: white;
     font-weight: bold;
 }
@@ -94,7 +96,7 @@
 /* ── Match Timer ───────────────────────────────────────────── */
 
 .match-timer {
-    font-size: 0.75rem;
+    font-size: 0.95rem;
     color: #888;
     letter-spacing: 1px;
     font-variant-numeric: tabular-nums;
@@ -120,6 +122,51 @@
     display: flex;
     align-items: center;
     gap: 4px;
+}
+
+/* Unified clickable team button */
+.team-btn {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 8px 16px;
+    border-radius: 12px;
+    transition: background 0.2s;
+    touch-action: manipulation;
+    color: white;
+}
+
+.team-btn:hover:not(:disabled) {
+    background: rgba(255,255,255,0.08);
+}
+
+.team-btn:disabled {
+    cursor: default;
+    opacity: 0.6;
+}
+
+.team-avatars {
+    display: flex;
+    align-items: center;
+}
+
+.team-avatar-overlap {
+    margin-left: -20px;
+}
+
+.team-name {
+    font-size: 0.85rem;
+    color: rgba(255,255,255,0.8);
+    font-weight: 500;
+    letter-spacing: 0.3px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 260px;
 }
 
 .initial-circle {
@@ -288,7 +335,7 @@
     align-items: center;
     width: 100%;
     padding: 4px 20px;
-    margin-top: 12px;
+    margin-top: auto;
     box-sizing: border-box;
     gap: 8px;
 }
@@ -489,6 +536,7 @@
         left: 50%;
         transform: translateX(-50%);
         padding: 0;
+        margin-bottom: 0;
     }
 
     .match-header-players {
@@ -497,6 +545,14 @@
 
     .player-row {
         flex-direction: column;
+    }
+
+    .team-btn {
+        padding: 4px 8px;
+    }
+
+    .team-name {
+        display: none;
     }
 
     .score-display {
@@ -512,6 +568,7 @@
         width: auto;
         padding: 0;
         gap: 16px;
+        margin-top: 0;
     }
 
     .match-timer {


### PR DESCRIPTION
## Summary
- Replace individual avatars + `&` badge with unified clickable team buttons — overlapping avatars with player names underneath, entire area is one tap target
- Center scoring elements vertically (header pinned top, controls pinned bottom, score group centered) instead of `space-between` spreading everything apart
- Increase match header font sizes for better readability (players 1rem->1.25rem, court 0.85rem->1.05rem, competition/timer 0.75rem->0.95rem)
- Update landscape media query for new team button layout

## Test plan
- [ ] Singles mode: single avatar with name below, whole button area clickable
- [ ] Doubles mode: two overlapping avatars with "Player1 & Player2" below, whole area clickable
- [ ] Score display and controls are grouped closer together vertically
- [ ] Match header text (players, court, timer) is larger and readable
- [ ] Landscape mode still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)