### PR TITLE
Fix scoring screen: remove names, fix advantage alignment, bigger timer

### DIFF
--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -153,7 +153,6 @@
                         </MudAvatar>
                     }
                 </div>
-                <span class="team-name">@GetUserDisplayName()</span>
             </button>
 
             @* #1 + #5 + #6 — Score display with visual hierarchy, set dividers, styled serve indicator *@
@@ -278,7 +277,6 @@
                         </MudAvatar>
                     }
                 </div>
-                <span class="team-name">@GetOpponentDisplayName()</span>
             </button>
 
             @* #4 — Controls with visual hierarchy: undo is prominent *@

--- a/DropShot/Components/TennisScore.razor.css
+++ b/DropShot/Components/TennisScore.razor.css
@@ -96,7 +96,7 @@
 /* ── Match Timer ───────────────────────────────────────────── */
 
 .match-timer {
-    font-size: 0.95rem;
+    font-size: 1.1rem;
     color: #888;
     letter-spacing: 1px;
     font-variant-numeric: tabular-nums;
@@ -129,11 +129,10 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 6px;
     background: none;
     border: none;
     cursor: pointer;
-    padding: 8px 16px;
+    padding: 8px 12px;
     border-radius: 12px;
     transition: background 0.2s;
     touch-action: manipulation;
@@ -158,16 +157,6 @@
     margin-left: -20px;
 }
 
-.team-name {
-    font-size: 0.85rem;
-    color: rgba(255,255,255,0.8);
-    font-weight: 500;
-    letter-spacing: 0.3px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    max-width: 260px;
-}
 
 .initial-circle {
     width: 80px;
@@ -299,7 +288,7 @@
 /* Current points - most prominent */
 .current-points {
     display: inline-block;
-    min-width: 50px;
+    width: 70px;
     text-align: center;
     font-size: 34px;
     font-weight: 800;
@@ -549,10 +538,6 @@
 
     .team-btn {
         padding: 4px 8px;
-    }
-
-    .team-name {
-        display: none;
     }
 
     .score-display {


### PR DESCRIPTION
## Summary
- Remove player name labels from team buttons to reduce vertical spread
- Fix score row misalignment at advantage by using fixed `width: 70px` on `.current-points` instead of `min-width: 50px` — prevents `A(1)` text from shifting the row
- Increase match timer font size from `0.95rem` to `1.1rem`

## Test plan
- [ ] Score display rows stay aligned when advantage is shown (A(1), A(2), etc.)
- [ ] Player buttons show only avatars with initials overlaid, no text labels
- [ ] Match timer is larger and easier to read
- [ ] Layout is more compact vertically

🤖 Generated with [Claude Code](https://claude.com/claude-code)