### PR TITLE
Center all scoring elements vertically as a group

### DIFF
--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -129,8 +129,7 @@
                         {
                             <MudIcon Icon="@Icons.Material.Filled.Person" Class="no-zoom-element" Style="font-size:40px; color:white;" />
                         }
-                        <div class="no-zoom-element" style="position:absolute; top:50%; left:50%; transform:translate(-50%, -50%);
-                                        color:white; font-size:22px; font-weight:bold;">
+                        <div class="no-zoom-element avatar-initials">
                             @CurrentMatch.Player1.GetInitials()
                         </div>
                     </MudAvatar>
@@ -237,8 +236,7 @@
                             {
                                 <MudIcon Icon="@Icons.Material.Filled.Person" Class="no-zoom-element" Style="font-size:40px; color:white;" />
                             }
-                            <div class="no-zoom-element" style="position:absolute; top:50%; left:50%; transform:translate(-50%, -50%);
-                                        color:white; font-size:22px; font-weight:bold;">
+                            <div class="no-zoom-element avatar-initials">
                                 @CurrentMatch.Player3.GetInitials()
                             </div>
                         </MudAvatar>
@@ -252,8 +250,7 @@
                             {
                                 <MudIcon Icon="@Icons.Material.Filled.Person" Class="no-zoom-element" Style="font-size:40px; color:white;" />
                             }
-                            <div class="no-zoom-element" style="position:absolute; top:50%; left:50%; transform:translate(-50%, -50%);
-                                        color:white; font-size:22px; font-weight:bold;">
+                            <div class="no-zoom-element avatar-initials">
                                 @CurrentMatch.Player4.GetInitials()
                             </div>
                         </MudAvatar>

--- a/DropShot/Components/TennisScore.razor.css
+++ b/DropShot/Components/TennisScore.razor.css
@@ -65,7 +65,6 @@
 .match-header {
     text-align: center;
     padding: 4px 8px;
-    margin-bottom: auto;
 }
 
 .match-header-competition {
@@ -155,6 +154,23 @@
 
 .team-avatar-overlap {
     margin-left: -20px;
+}
+
+.avatar-initials {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: white;
+    font-size: 22px;
+    font-weight: bold;
+    background: rgba(0, 0, 0, 0.45);
+    border-radius: 50%;
+    text-shadow: 0 1px 3px rgba(0, 0, 0, 0.6);
 }
 
 
@@ -324,7 +340,6 @@
     align-items: center;
     width: 100%;
     padding: 4px 20px;
-    margin-top: auto;
     box-sizing: border-box;
     gap: 8px;
 }


### PR DESCRIPTION
## Summary
- Remove `margin-bottom: auto` from `.match-header` and `margin-top: auto` from `.controls-row`
- All elements now center together via the container's `justify-content: center` with `gap: 12px` spacing
- Also includes avatar initials overlay styling from previous work

## Test plan
- [ ] Match header, player avatars, score, and controls are all centered vertically as a group
- [ ] Spacing between elements is consistent and not spread to edges
- [ ] Landscape mode still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)