### PR TITLE
Show faded profile image behind initials on scoring avatars

### DIFF
--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -121,13 +121,21 @@
                 <div class="team-avatars">
                     <MudAvatar Class="no-zoom-element avatar-initials-circle"
                                Style="border: solid 2px lightseagreen; width:80px; height: 80px;">
-                        @CurrentMatch.Player1.GetInitials()
+                        @if (GetPlayerAvatar(CurrentMatch.Player1) is string p1Src)
+                        {
+                            <MudImage Class="no-zoom-element avatar-photo" Src="@p1Src" />
+                        }
+                        <span class="avatar-initials-text">@CurrentMatch.Player1.GetInitials()</span>
                     </MudAvatar>
                     @if (Label_Switch1)
                     {
                         <MudAvatar Class="no-zoom-element avatar-initials-circle team-avatar-overlap"
                                    Style="border: solid 2px lightseagreen; width:80px; height: 80px;">
-                            @CurrentMatch.Player2.GetInitials()
+                            @if (GetPlayerAvatar(CurrentMatch.Player2) is string p2Src)
+                            {
+                                <MudImage Class="no-zoom-element avatar-photo" Src="@p2Src" />
+                            }
+                            <span class="avatar-initials-text">@CurrentMatch.Player2.GetInitials()</span>
                         </MudAvatar>
                     }
                 </div>
@@ -207,18 +215,30 @@
                     {
                         <MudAvatar Class="no-zoom-element avatar-initials-circle"
                                    Style="border: solid 2px orangered; width:80px; height: 80px;">
-                            @CurrentMatch.Player3.GetInitials()
+                            @if (GetPlayerAvatar(CurrentMatch.Player3) is string p3Src)
+                            {
+                                <MudImage Class="no-zoom-element avatar-photo" Src="@p3Src" />
+                            }
+                            <span class="avatar-initials-text">@CurrentMatch.Player3.GetInitials()</span>
                         </MudAvatar>
                         <MudAvatar Class="no-zoom-element avatar-initials-circle team-avatar-overlap"
                                    Style="border: solid 2px orangered; width:80px; height: 80px;">
-                            @CurrentMatch.Player4.GetInitials()
+                            @if (GetPlayerAvatar(CurrentMatch.Player4) is string p4Src)
+                            {
+                                <MudImage Class="no-zoom-element avatar-photo" Src="@p4Src" />
+                            }
+                            <span class="avatar-initials-text">@CurrentMatch.Player4.GetInitials()</span>
                         </MudAvatar>
                     }
                     else
                     {
                         <MudAvatar Class="no-zoom-element avatar-initials-circle"
                                    Style="border: solid 2px orangered; width:80px; height: 80px;">
-                            @CurrentMatch.Player2.GetInitials()
+                            @if (GetPlayerAvatar(CurrentMatch.Player2) is string p2bSrc)
+                            {
+                                <MudImage Class="no-zoom-element avatar-photo" Src="@p2bSrc" />
+                            }
+                            <span class="avatar-initials-text">@CurrentMatch.Player2.GetInitials()</span>
                         </MudAvatar>
                     }
                 </div>

--- a/DropShot/Components/TennisScore.razor.css
+++ b/DropShot/Components/TennisScore.razor.css
@@ -161,6 +161,24 @@
     font-weight: bold;
     color: white;
     background: rgba(255, 255, 255, 0.1);
+    position: relative;
+    overflow: hidden;
+}
+
+::deep .avatar-photo {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    opacity: 0.35;
+    border-radius: 50%;
+}
+
+.avatar-initials-text {
+    position: relative;
+    z-index: 1;
+    text-shadow: 0 1px 4px rgba(0, 0, 0, 0.7);
 }
 
 


### PR DESCRIPTION
## Summary
- When a player has a profile image, show it at 35% opacity behind bold initials with text shadow
- When no image is set, show clean initials on the circle (no person icon)

## Test plan
- [ ] Player with profile image: faded photo visible behind clear initials
- [ ] Player without profile image: clean initials on dark circle
- [ ] Works for both singles and doubles layouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)