### PR TITLE
Add site footer with placeholder pages and social media links

### DIFF
--- a/DropShot/Components/Layout/Footer.razor
+++ b/DropShot/Components/Layout/Footer.razor
@@ -1,0 +1,65 @@
+<footer class="site-footer">
+    <MudContainer MaxWidth="MaxWidth.Large">
+        <MudGrid Spacing="4">
+            <MudItem xs="6" sm="3">
+                <MudText Typo="Typo.subtitle2" Class="footer-heading mb-2">Product</MudText>
+                <div class="footer-links">
+                    <MudLink Href="/features" Color="Color.Inherit" Typo="Typo.body2">Features</MudLink>
+                    <MudLink Href="/whats-new" Color="Color.Inherit" Typo="Typo.body2">What's New</MudLink>
+                    <MudLink Href="/subscription" Color="Color.Inherit" Typo="Typo.body2">Subscription</MudLink>
+                </div>
+            </MudItem>
+
+            <MudItem xs="6" sm="3">
+                <MudText Typo="Typo.subtitle2" Class="footer-heading mb-2">Company</MudText>
+                <div class="footer-links">
+                    <MudLink Href="/about" Color="Color.Inherit" Typo="Typo.body2">About</MudLink>
+                    <MudLink Href="/careers" Color="Color.Inherit" Typo="Typo.body2">Careers</MudLink>
+                    <MudLink Href="/press" Color="Color.Inherit" Typo="Typo.body2">Press</MudLink>
+                </div>
+            </MudItem>
+
+            <MudItem xs="6" sm="3">
+                <MudText Typo="Typo.subtitle2" Class="footer-heading mb-2">Resources</MudText>
+                <div class="footer-links">
+                    <MudLink Href="/support" Color="Color.Inherit" Typo="Typo.body2">Support</MudLink>
+                    <MudLink Href="/student-discount" Color="Color.Inherit" Typo="Typo.body2">Student Discount</MudLink>
+                </div>
+            </MudItem>
+
+            <MudItem xs="6" sm="3">
+                <MudText Typo="Typo.subtitle2" Class="footer-heading mb-2">Legal</MudText>
+                <div class="footer-links">
+                    <MudLink Href="/privacy" Color="Color.Inherit" Typo="Typo.body2">Privacy</MudLink>
+                    <MudLink Href="/cookie-policy" Color="Color.Inherit" Typo="Typo.body2">Cookie Policy</MudLink>
+                    <MudLink Href="/terms" Color="Color.Inherit" Typo="Typo.body2">Terms</MudLink>
+                </div>
+            </MudItem>
+        </MudGrid>
+
+        <MudDivider Class="my-4" DividerType="DividerType.FullWidth" />
+
+        <div class="footer-bottom">
+            <div class="footer-social">
+                <MudIconButton Icon="@Icons.Custom.Brands.Facebook" Size="Size.Small" Color="Color.Inherit" Href="#" Target="_blank" Rel="noopener noreferrer" aria-label="Facebook" />
+                <MudIconButton Icon="@Icons.Custom.Brands.Twitter" Size="Size.Small" Color="Color.Inherit" Href="#" Target="_blank" Rel="noopener noreferrer" aria-label="X (Twitter)" />
+                <MudIconButton Icon="@InstagramIcon" Size="Size.Small" Color="Color.Inherit" Href="#" Target="_blank" Rel="noopener noreferrer" aria-label="Instagram" />
+                <MudIconButton Icon="@Icons.Custom.Brands.LinkedIn" Size="Size.Small" Color="Color.Inherit" Href="#" Target="_blank" Rel="noopener noreferrer" aria-label="LinkedIn" />
+                <MudIconButton Icon="@Icons.Custom.Brands.YouTube" Size="Size.Small" Color="Color.Inherit" Href="#" Target="_blank" Rel="noopener noreferrer" aria-label="YouTube" />
+                <MudIconButton Icon="@TikTokIcon" Size="Size.Small" Color="Color.Inherit" Href="#" Target="_blank" Rel="noopener noreferrer" aria-label="TikTok" />
+                <MudIconButton Icon="@PinterestIcon" Size="Size.Small" Color="Color.Inherit" Href="#" Target="_blank" Rel="noopener noreferrer" aria-label="Pinterest" />
+                <MudIconButton Icon="@SnapchatIcon" Size="Size.Small" Color="Color.Inherit" Href="#" Target="_blank" Rel="noopener noreferrer" aria-label="Snapchat" />
+            </div>
+            <MudText Typo="Typo.caption" Class="footer-copyright">
+                &copy; @DateTime.Now.Year DropShot. All rights reserved.
+            </MudText>
+        </div>
+    </MudContainer>
+</footer>
+
+@code {
+    private const string InstagramIcon = "<svg style=\"width:24px;height:24px\" viewBox=\"0 0 24 24\"><path fill=\"currentColor\" d=\"M7.8,2H16.2C19.4,2 22,4.6 22,7.8V16.2A5.8,5.8 0 0,1 16.2,22H7.8C4.6,22 2,19.4 2,16.2V7.8A5.8,5.8 0 0,1 7.8,2M7.6,4A3.6,3.6 0 0,0 4,7.6V16.4C4,18.39 5.61,20 7.6,20H16.4A3.6,3.6 0 0,0 20,16.4V7.6C20,5.61 18.39,4 16.4,4H7.6M17.25,5.5A1.25,1.25 0 0,1 18.5,6.75A1.25,1.25 0 0,1 17.25,8A1.25,1.25 0 0,1 16,6.75A1.25,1.25 0 0,1 17.25,5.5M12,7A5,5 0 0,1 17,12A5,5 0 0,1 12,17A5,5 0 0,1 7,12A5,5 0 0,1 12,7M12,9A3,3 0 0,0 9,12A3,3 0 0,0 12,15A3,3 0 0,0 15,12A3,3 0 0,0 12,9Z\" /></svg>";
+    private const string TikTokIcon = "<svg style=\"width:24px;height:24px\" viewBox=\"0 0 24 24\"><path fill=\"currentColor\" d=\"M16.6,5.82C15.9,5.04 15.5,4.02 15.5,2.91V2.5H12.38V15.91A2.88,2.88 0 0,1 9.5,18.79A2.88,2.88 0 0,1 6.62,15.91A2.88,2.88 0 0,1 9.5,13.03C9.84,13.03 10.16,13.08 10.47,13.17V10.03C10.15,9.99 9.83,9.96 9.5,9.96A5.96,5.96 0 0,0 3.54,15.91A5.96,5.96 0 0,0 9.5,21.87A5.96,5.96 0 0,0 15.46,15.91V9.12C17.07,10.24 19.04,10.91 21.15,10.91V7.79C19.39,7.79 17.81,7.03 16.6,5.82Z\" /></svg>";
+    private const string PinterestIcon = "<svg style=\"width:24px;height:24px\" viewBox=\"0 0 24 24\"><path fill=\"currentColor\" d=\"M9.04,21.54C10,21.83 10.97,22 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2A10,10 0 0,0 2,12C2,16.25 4.67,19.9 8.44,21.34C8.35,20.56 8.26,19.27 8.44,18.38L9.59,13.44C9.59,13.44 9.3,12.86 9.3,11.94C9.3,10.56 10.16,9.53 11.14,9.53C12,9.53 12.4,10.16 12.4,10.97C12.4,11.83 11.83,13.06 11.54,14.24C11.37,15.22 12.06,16.08 13.06,16.08C14.84,16.08 16.22,14.18 16.22,11.5C16.22,9.11 14.5,7.46 12.03,7.46C9.21,7.46 7.55,9.56 7.55,11.77C7.55,12.63 7.83,13.5 8.29,14.07C8.38,14.13 8.38,14.21 8.35,14.36L8.06,15.45C8.06,15.62 7.95,15.68 7.78,15.56C6.5,14.96 5.76,13.18 5.76,11.71C5.76,8.55 8.05,5.68 12.29,5.68C15.67,5.68 18.24,8.07 18.24,11.42C18.24,14.76 16.11,17.42 13.19,17.42C12.23,17.42 11.31,16.92 11,16.33L10.44,18.56C10.22,19.41 9.59,20.5 9.04,21.54Z\" /></svg>";
+    private const string SnapchatIcon = "<svg style=\"width:24px;height:24px\" viewBox=\"0 0 24 24\"><path fill=\"currentColor\" d=\"M12.07,2C14.74,2 16.36,3.37 16.95,5.07C17.15,5.65 17.24,6.28 17.24,6.97C17.24,7.88 17.13,8.7 17.03,9.34L17,9.5C17.5,9.79 18.14,9.93 18.58,9.93C19.12,9.93 19.47,9.77 19.64,9.58L19.73,9.47C20,9.92 20.03,10.45 19.76,10.87C19.34,11.5 18.37,11.89 16.85,12.07C16.78,12.22 16.65,12.58 16.5,12.97C16.08,14 15.39,15.62 13.41,16.67C12.97,16.91 12.5,17.08 12,17.18C11.5,17.08 11.03,16.91 10.59,16.67C8.61,15.62 7.92,14 7.5,12.97C7.35,12.58 7.22,12.22 7.15,12.07C5.63,11.89 4.66,11.5 4.24,10.87C3.97,10.45 4,9.92 4.27,9.47L4.36,9.58C4.53,9.77 4.88,9.93 5.42,9.93C5.86,9.93 6.5,9.79 7,9.5L6.97,9.34C6.87,8.7 6.76,7.88 6.76,6.97C6.76,6.28 6.85,5.65 7.05,5.07C7.64,3.37 9.26,2 11.93,2H12.07M12,4C10.26,4 9.15,4.82 8.79,5.81C8.63,6.27 8.56,6.75 8.56,7.25C8.56,8.07 8.66,8.82 8.75,9.41L8.81,9.73L8.44,9.94C8,10.16 7.44,10.36 6.82,10.47L6.72,10.5C7.08,10.65 7.58,10.78 8.27,10.87L8.82,10.94L9,11.46C9.07,11.63 9.18,11.93 9.34,12.31C9.72,13.24 10.34,14.64 12,15.5C13.66,14.64 14.28,13.24 14.66,12.31C14.82,11.93 14.93,11.63 15,11.46L15.18,10.94L15.73,10.87C16.42,10.78 16.92,10.65 17.28,10.5L17.18,10.47C16.56,10.36 16,10.16 15.56,9.94L15.19,9.73L15.25,9.41C15.34,8.82 15.44,8.07 15.44,7.25C15.44,6.75 15.37,6.27 15.21,5.81C14.85,4.82 13.74,4 12,4Z\" /></svg>";
+}

--- a/DropShot/Components/Layout/Footer.razor.css
+++ b/DropShot/Components/Layout/Footer.razor.css
@@ -1,0 +1,69 @@
+footer.site-footer {
+    background: linear-gradient(120deg, rgb(3, 68, 72) 0%, rgb(3, 27, 72) 70%);
+    color: rgba(255, 255, 255, 0.7);
+    padding: 3rem 0 1.5rem;
+    margin-top: auto;
+}
+
+.footer-heading {
+    color: rgba(255, 255, 255, 0.9);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-size: 0.75rem;
+}
+
+.footer-links {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+    .footer-links ::deep a {
+        color: rgba(255, 255, 255, 0.6);
+        text-decoration: none;
+        transition: color 0.2s ease;
+    }
+
+        .footer-links ::deep a:hover {
+            color: rgba(255, 255, 255, 1);
+            text-decoration: none;
+        }
+
+.footer-bottom {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+.footer-social {
+    display: flex;
+    gap: 0.25rem;
+}
+
+    .footer-social ::deep .mud-icon-button {
+        color: rgba(255, 255, 255, 0.6);
+        transition: color 0.2s ease;
+    }
+
+        .footer-social ::deep .mud-icon-button:hover {
+            color: rgba(255, 255, 255, 1);
+        }
+
+.footer-copyright {
+    color: rgba(255, 255, 255, 0.4);
+}
+
+@media (max-width: 640.98px) {
+    footer.site-footer {
+        padding: 2rem 0 1rem;
+    }
+
+    .footer-bottom {
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
+    }
+}

--- a/DropShot/Components/Layout/MainLayout.razor
+++ b/DropShot/Components/Layout/MainLayout.razor
@@ -16,6 +16,7 @@
         <article class="content px-4">
             @Body
         </article>
+        <Footer />
     </main>
 </div>
 

--- a/DropShot/Components/Layout/MainLayout.razor.css
+++ b/DropShot/Components/Layout/MainLayout.razor.css
@@ -6,7 +6,13 @@
 
 main {
     flex: 1;
+    display: flex;
+    flex-direction: column;
 }
+
+    main ::deep .content {
+        flex: 1;
+    }
 
 .sidebar {
     background-image: linear-gradient(120deg, rgb(5, 98, 103) 0%, rgb(5, 39, 103) 70%);

--- a/DropShot/Components/Pages/About.razor
+++ b/DropShot/Components/Pages/About.razor
@@ -1,0 +1,10 @@
+@page "/about"
+
+<PageTitle>About - DropShot</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Medium" Class="mt-8 mb-8">
+    <MudText Typo="Typo.h4" Align="Align.Center" GutterBottom="true">About</MudText>
+    <MudText Typo="Typo.subtitle1" Align="Align.Center" Color="Color.Secondary">
+        Coming Soon
+    </MudText>
+</MudContainer>

--- a/DropShot/Components/Pages/Careers.razor
+++ b/DropShot/Components/Pages/Careers.razor
@@ -1,0 +1,10 @@
+@page "/careers"
+
+<PageTitle>Careers - DropShot</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Medium" Class="mt-8 mb-8">
+    <MudText Typo="Typo.h4" Align="Align.Center" GutterBottom="true">Careers</MudText>
+    <MudText Typo="Typo.subtitle1" Align="Align.Center" Color="Color.Secondary">
+        Coming Soon
+    </MudText>
+</MudContainer>

--- a/DropShot/Components/Pages/CookiePolicy.razor
+++ b/DropShot/Components/Pages/CookiePolicy.razor
@@ -1,0 +1,10 @@
+@page "/cookie-policy"
+
+<PageTitle>Cookie Policy - DropShot</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Medium" Class="mt-8 mb-8">
+    <MudText Typo="Typo.h4" Align="Align.Center" GutterBottom="true">Cookie Policy</MudText>
+    <MudText Typo="Typo.subtitle1" Align="Align.Center" Color="Color.Secondary">
+        Coming Soon
+    </MudText>
+</MudContainer>

--- a/DropShot/Components/Pages/Features.razor
+++ b/DropShot/Components/Pages/Features.razor
@@ -1,0 +1,10 @@
+@page "/features"
+
+<PageTitle>Features - DropShot</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Medium" Class="mt-8 mb-8">
+    <MudText Typo="Typo.h4" Align="Align.Center" GutterBottom="true">Features</MudText>
+    <MudText Typo="Typo.subtitle1" Align="Align.Center" Color="Color.Secondary">
+        Coming Soon
+    </MudText>
+</MudContainer>

--- a/DropShot/Components/Pages/Press.razor
+++ b/DropShot/Components/Pages/Press.razor
@@ -1,0 +1,10 @@
+@page "/press"
+
+<PageTitle>Press - DropShot</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Medium" Class="mt-8 mb-8">
+    <MudText Typo="Typo.h4" Align="Align.Center" GutterBottom="true">Press</MudText>
+    <MudText Typo="Typo.subtitle1" Align="Align.Center" Color="Color.Secondary">
+        Coming Soon
+    </MudText>
+</MudContainer>

--- a/DropShot/Components/Pages/Privacy.razor
+++ b/DropShot/Components/Pages/Privacy.razor
@@ -1,0 +1,10 @@
+@page "/privacy"
+
+<PageTitle>Privacy - DropShot</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Medium" Class="mt-8 mb-8">
+    <MudText Typo="Typo.h4" Align="Align.Center" GutterBottom="true">Privacy</MudText>
+    <MudText Typo="Typo.subtitle1" Align="Align.Center" Color="Color.Secondary">
+        Coming Soon
+    </MudText>
+</MudContainer>

--- a/DropShot/Components/Pages/StudentDiscount.razor
+++ b/DropShot/Components/Pages/StudentDiscount.razor
@@ -1,0 +1,10 @@
+@page "/student-discount"
+
+<PageTitle>Student Discount - DropShot</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Medium" Class="mt-8 mb-8">
+    <MudText Typo="Typo.h4" Align="Align.Center" GutterBottom="true">Student Discount</MudText>
+    <MudText Typo="Typo.subtitle1" Align="Align.Center" Color="Color.Secondary">
+        Coming Soon
+    </MudText>
+</MudContainer>

--- a/DropShot/Components/Pages/Subscription.razor
+++ b/DropShot/Components/Pages/Subscription.razor
@@ -1,0 +1,10 @@
+@page "/subscription"
+
+<PageTitle>Subscription - DropShot</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Medium" Class="mt-8 mb-8">
+    <MudText Typo="Typo.h4" Align="Align.Center" GutterBottom="true">Subscription</MudText>
+    <MudText Typo="Typo.subtitle1" Align="Align.Center" Color="Color.Secondary">
+        Coming Soon
+    </MudText>
+</MudContainer>

--- a/DropShot/Components/Pages/Support.razor
+++ b/DropShot/Components/Pages/Support.razor
@@ -1,0 +1,10 @@
+@page "/support"
+
+<PageTitle>Support - DropShot</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Medium" Class="mt-8 mb-8">
+    <MudText Typo="Typo.h4" Align="Align.Center" GutterBottom="true">Support</MudText>
+    <MudText Typo="Typo.subtitle1" Align="Align.Center" Color="Color.Secondary">
+        Coming Soon
+    </MudText>
+</MudContainer>

--- a/DropShot/Components/Pages/Terms.razor
+++ b/DropShot/Components/Pages/Terms.razor
@@ -1,0 +1,10 @@
+@page "/terms"
+
+<PageTitle>Terms - DropShot</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Medium" Class="mt-8 mb-8">
+    <MudText Typo="Typo.h4" Align="Align.Center" GutterBottom="true">Terms</MudText>
+    <MudText Typo="Typo.subtitle1" Align="Align.Center" Color="Color.Secondary">
+        Coming Soon
+    </MudText>
+</MudContainer>

--- a/DropShot/Components/Pages/WhatsNew.razor
+++ b/DropShot/Components/Pages/WhatsNew.razor
@@ -1,0 +1,10 @@
+@page "/whats-new"
+
+<PageTitle>What's New - DropShot</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Medium" Class="mt-8 mb-8">
+    <MudText Typo="Typo.h4" Align="Align.Center" GutterBottom="true">What's New</MudText>
+    <MudText Typo="Typo.subtitle1" Align="Align.Center" Color="Color.Secondary">
+        Coming Soon
+    </MudText>
+</MudContainer>

--- a/DropShot/wwwroot/css/theme-light.css
+++ b/DropShot/wwwroot/css/theme-light.css
@@ -207,6 +207,37 @@
     display: inline-block;
 }
 
+/* ── Footer ─────────────────────────────────────────────────────────── */
+[data-theme="light"] .site-footer {
+    background: #ffffff !important;
+    border-top: 1px solid #e0e0e0;
+    color: #616161 !important;
+}
+
+[data-theme="light"] .footer-heading {
+    color: #424242 !important;
+}
+
+[data-theme="light"] .footer-links a {
+    color: #757575 !important;
+}
+
+[data-theme="light"] .footer-links a:hover {
+    color: #1565c0 !important;
+}
+
+[data-theme="light"] .footer-social .mud-icon-button {
+    color: #757575 !important;
+}
+
+[data-theme="light"] .footer-social .mud-icon-button:hover {
+    color: #1565c0 !important;
+}
+
+[data-theme="light"] .footer-copyright {
+    color: #9e9e9e !important;
+}
+
 /* ── Theme toggle button ────────────────────────────────────────────── */
 .theme-toggle-btn {
     background: none;


### PR DESCRIPTION
## Summary
- Adds a responsive footer component with 4 link columns (Product, Company, Resources, Legal) and 8 social media icon buttons (Facebook, X/Twitter, Instagram, LinkedIn, YouTube, TikTok, Pinterest, Snapchat)
- Creates 11 placeholder pages (Features, What's New, About, Subscription, Student Discount, Support, Careers, Press, Privacy, Cookie Policy, Terms) each with a Coming Soon message
- Supports both dark and light themes with appropriate styling

## Test plan
- [ ] Verify footer appears at the bottom of all pages
- [ ] Click each footer link to confirm placeholder pages render correctly
- [ ] Toggle light/dark theme to verify footer adapts
- [ ] Check responsive layout on mobile and desktop viewports
- [ ] Verify social media icons display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)