### PR TITLE
Add event grouping and smart stage auto-suggestion

### DIFF
--- a/DropShot.Maui/Components/Pages/CompetitionDialog.razor
+++ b/DropShot.Maui/Components/Pages/CompetitionDialog.razor
@@ -23,6 +23,9 @@
             <MudDatePicker @bind-Date="Model.EndDate" Label="End Date"
                            Variant="Variant.Outlined" Editable="true" DateFormat="dd/MM/yyyy" />
 
+            <MudNumericField @bind-Value="Model.MinAge" Label="Min Age (leave blank = open)"
+                             Variant="Variant.Outlined" Min="1" />
+
             <MudNumericField @bind-Value="Model.MaxAge" Label="Max Age (leave blank = open)"
                              Variant="Variant.Outlined" Min="1" />
 
@@ -49,6 +52,14 @@
                     <MudSelectItem Value="(int?)rs.RulesSetId">@rs.Name</MudSelectItem>
                 }
             </MudSelect>
+
+            <MudSelect @bind-Value="Model.EventId" Label="Event" Variant="Variant.Outlined"
+                       T="int?" Clearable="true">
+                @foreach (var ev in _events)
+                {
+                    <MudSelectItem Value="(int?)ev.EventId">@ev.Name</MudSelectItem>
+                }
+            </MudSelect>
         </MudStack>
     </DialogContent>
     <DialogActions>
@@ -65,6 +76,7 @@
 
     private List<ClubDto> _clubs = [];
     private List<RulesSetDto> _rulesSets = [];
+    private List<EventDto> _events = [];
 
     protected override async Task OnInitializedAsync()
     {
@@ -72,6 +84,7 @@
         {
             _clubs = await Api.GetClubsAsync() ?? [];
             _rulesSets = await Api.GetRulesSetsAsync() ?? [];
+            _events = await Api.GetEventsAsync() ?? [];
         }
         catch { /* non-critical – dropdowns will just be empty */ }
     }

--- a/DropShot.Maui/Components/Pages/CompetitionFormModel.cs
+++ b/DropShot.Maui/Components/Pages/CompetitionFormModel.cs
@@ -11,9 +11,11 @@ public class CompetitionFormModel
     public DateTime? StartDate { get; set; }
     public DateTime? EndDate { get; set; }
     public int? MaxAge { get; set; }
+    public int? MinAge { get; set; }
     public PlayerSex? EligibleSex { get; set; }
     public int? HostClubId { get; set; }
     public int? RulesSetId { get; set; }
+    public int? EventId { get; set; }
 
     public static CompetitionFormModel From(CompetitionDto dto) => new()
     {
@@ -23,8 +25,10 @@ public class CompetitionFormModel
         StartDate = dto.StartDate,
         EndDate = dto.EndDate,
         MaxAge = dto.MaxAge,
+        MinAge = dto.MinAge,
         EligibleSex = dto.EligibleSex,
         HostClubId = dto.HostClubId,
-        RulesSetId = dto.RulesSetId
+        RulesSetId = dto.RulesSetId,
+        EventId = dto.EventId
     };
 }

--- a/DropShot.Maui/Components/Pages/Competitions.razor
+++ b/DropShot.Maui/Components/Pages/Competitions.razor
@@ -29,41 +29,135 @@ else
         }
     </MudStack>
 
-    <MudTable Items="FilteredCompetitions" Dense="true" Hover="true" Striped="true" Elevation="2">
-        <HeaderContent>
-            <MudTh>Name</MudTh>
-            <MudTh>Format</MudTh>
-            <MudTh>Start</MudTh>
-            <MudTh>Club</MudTh>
-            @if (Auth.IsAdmin || (_competitions?.Any(c => Auth.CanEditCompetition(c.HostClubId)) == true))
+    <MudTabs @bind-ActivePanelIndex="_activeTab" Elevation="0" ApplyEffectsToContainer="true" Class="mb-4">
+        <MudTabPanel Text="All" Icon="@Icons.Material.Filled.List">
+            <MudTable Items="FilteredCompetitions" Dense="true" Hover="true" Striped="true" Elevation="2">
+                <HeaderContent>
+                    <MudTh>Name</MudTh>
+                    <MudTh>Format</MudTh>
+                    <MudTh>Start</MudTh>
+                    <MudTh>Club</MudTh>
+                    <MudTh>Event</MudTh>
+                    @if (Auth.IsAdmin || (_competitions?.Any(c => Auth.CanEditCompetition(c.HostClubId)) == true))
+                    {
+                        <MudTh></MudTh>
+                    }
+                </HeaderContent>
+                <RowTemplate>
+                    <MudTd>@context.CompetitionName</MudTd>
+                    <MudTd>@context.CompetitionFormat</MudTd>
+                    <MudTd>@(context.StartDate?.ToString("dd MMM yyyy") ?? "—")</MudTd>
+                    <MudTd>@(context.HostClubName ?? "—")</MudTd>
+                    <MudTd>
+                        @if (!string.IsNullOrEmpty(context.EventName))
+                        {
+                            <MudChip T="string" Size="Size.Small" Color="Color.Info" Variant="Variant.Text">
+                                @context.EventName
+                            </MudChip>
+                        }
+                    </MudTd>
+                    <MudTd>
+                        @if (Auth.IsAdmin || Auth.CanEditCompetition(context.HostClubId))
+                        {
+                            <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="Size.Small"
+                                           OnClick="@(() => OpenEditDialog(context))" />
+                            <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small"
+                                           Color="Color.Error"
+                                           OnClick="@(() => DeleteAsync(context))" />
+                        }
+                    </MudTd>
+                </RowTemplate>
+            </MudTable>
+        </MudTabPanel>
+
+        <MudTabPanel Text="By Event" Icon="@Icons.Material.Filled.FolderOpen">
+            @foreach (var ev in _events)
             {
-                <MudTh></MudTh>
+                <MudExpansionPanels Class="mb-2" Elevation="1">
+                    <MudExpansionPanel IsInitiallyExpanded="true">
+                        <TitleContent>
+                            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                                <MudIcon Icon="@Icons.Material.Filled.EmojiEvents" Color="Color.Primary" Size="Size.Small" />
+                                <MudText Typo="Typo.subtitle1" Style="font-weight:600">@ev.Name</MudText>
+                                <MudChip T="string" Size="Size.Small" Color="Color.Info">@ev.CompetitionCount</MudChip>
+                            </MudStack>
+                        </TitleContent>
+                        <ChildContent>
+                            @{
+                                var eventComps = FilteredCompetitions.Where(c => c.EventId == ev.EventId);
+                            }
+                            <MudSimpleTable Dense="true" Hover="true">
+                                <thead><tr><th>Name</th><th>Format</th><th></th></tr></thead>
+                                <tbody>
+                                    @foreach (var comp in eventComps)
+                                    {
+                                        <tr>
+                                            <td>@comp.CompetitionName</td>
+                                            <td>@comp.CompetitionFormat</td>
+                                            <td>
+                                                @if (Auth.IsAdmin || Auth.CanEditCompetition(comp.HostClubId))
+                                                {
+                                                    <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="Size.Small"
+                                                                   OnClick="@(() => OpenEditDialog(comp))" />
+                                                }
+                                            </td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </MudSimpleTable>
+                        </ChildContent>
+                    </MudExpansionPanel>
+                </MudExpansionPanels>
             }
-        </HeaderContent>
-        <RowTemplate>
-            <MudTd>@context.CompetitionName</MudTd>
-            <MudTd>@context.CompetitionFormat</MudTd>
-            <MudTd>@(context.StartDate?.ToString("dd MMM yyyy") ?? "—")</MudTd>
-            <MudTd>@(context.HostClubName ?? "—")</MudTd>
-            <MudTd>
-                @if (Auth.IsAdmin || Auth.CanEditCompetition(context.HostClubId))
-                {
-                    <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="Size.Small"
-                                   OnClick="@(() => OpenEditDialog(context))" />
-                    <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small"
-                                   Color="Color.Error"
-                                   OnClick="@(() => DeleteAsync(context))" />
-                }
-            </MudTd>
-        </RowTemplate>
-    </MudTable>
+
+            @{
+                var ungrouped = FilteredCompetitions.Where(c => c.EventId == null);
+            }
+            @if (ungrouped.Any())
+            {
+                <MudExpansionPanels Class="mb-2" Elevation="1">
+                    <MudExpansionPanel IsInitiallyExpanded="true">
+                        <TitleContent>
+                            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                                <MudIcon Icon="@Icons.Material.Filled.Inbox" Color="Color.Default" Size="Size.Small" />
+                                <MudText Typo="Typo.subtitle1" Style="font-weight:600">Ungrouped</MudText>
+                            </MudStack>
+                        </TitleContent>
+                        <ChildContent>
+                            <MudSimpleTable Dense="true" Hover="true">
+                                <thead><tr><th>Name</th><th>Format</th><th></th></tr></thead>
+                                <tbody>
+                                    @foreach (var comp in ungrouped)
+                                    {
+                                        <tr>
+                                            <td>@comp.CompetitionName</td>
+                                            <td>@comp.CompetitionFormat</td>
+                                            <td>
+                                                @if (Auth.IsAdmin || Auth.CanEditCompetition(comp.HostClubId))
+                                                {
+                                                    <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="Size.Small"
+                                                                   OnClick="@(() => OpenEditDialog(comp))" />
+                                                }
+                                            </td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </MudSimpleTable>
+                        </ChildContent>
+                    </MudExpansionPanel>
+                </MudExpansionPanels>
+            }
+        </MudTabPanel>
+    </MudTabs>
 }
 
 @code {
     private List<CompetitionDto>? _competitions;
+    private List<EventDto> _events = [];
     private bool _loading = true;
     private string? _error;
     private string _search = "";
+    private int _activeTab;
 
     private IEnumerable<CompetitionDto> FilteredCompetitions => _competitions is null
         ? []
@@ -75,6 +169,7 @@ else
         try
         {
             _competitions = await Api.GetCompetitionsAsync();
+            _events = await Api.GetEventsAsync();
         }
         catch (Exception ex)
         {
@@ -113,7 +208,8 @@ else
             var req = new SaveCompetitionRequest(
                 model.CompetitionName, model.CompetitionFormat,
                 model.MaxParticipants, model.StartDate, model.EndDate,
-                model.MaxAge, model.EligibleSex, model.HostClubId, model.RulesSetId);
+                model.MaxAge, model.MinAge, model.EligibleSex,
+                model.HostClubId, model.RulesSetId, model.EventId);
 
             var dto = await Api.SaveCompetitionAsync(id, req);
             if (dto is not null)

--- a/DropShot.Maui/Services/ApiService.cs
+++ b/DropShot.Maui/Services/ApiService.cs
@@ -37,6 +37,36 @@ public class ApiService(HttpClient http)
         r.EnsureSuccessStatusCode();
     }
 
+    // ── Events ────────────────────────────────────────────────────────────────
+
+    public async Task<List<EventDto>> GetEventsAsync() =>
+        await http.GetFromJsonAsync<List<EventDto>>("api/events") ?? [];
+
+    public Task<EventDetailDto?> GetEventAsync(int id) =>
+        http.GetFromJsonAsync<EventDetailDto>($"api/events/{id}");
+
+    public async Task<EventDto?> SaveEventAsync(int id, SaveEventRequest req)
+    {
+        HttpResponseMessage r = id == 0
+            ? await http.PostAsJsonAsync("api/events", req)
+            : await http.PutAsJsonAsync($"api/events/{id}", req);
+        r.EnsureSuccessStatusCode();
+        return await r.Content.ReadFromJsonAsync<EventDto>();
+    }
+
+    public async Task DeleteEventAsync(int id)
+    {
+        var r = await http.DeleteAsync($"api/events/{id}");
+        r.EnsureSuccessStatusCode();
+    }
+
+    public async Task<List<CompetitionDto>> BulkCreateEventCompetitionsAsync(int eventId, CreateEventCompetitionsRequest req)
+    {
+        var r = await http.PostAsJsonAsync($"api/events/{eventId}/competitions", req);
+        r.EnsureSuccessStatusCode();
+        return await r.Content.ReadFromJsonAsync<List<CompetitionDto>>() ?? [];
+    }
+
     // ── Competitions ─────────────────────────────────────────────────────────
 
     public async Task<List<CompetitionDto>> GetCompetitionsAsync() =>

--- a/DropShot.Shared/Dtos/CompetitionDtos.cs
+++ b/DropShot.Shared/Dtos/CompetitionDtos.cs
@@ -8,11 +8,14 @@ public record CompetitionDto(
     DateTime? StartDate,
     DateTime? EndDate,
     int? MaxAge,
+    int? MinAge,
     PlayerSex? EligibleSex,
     int? HostClubId,
     string? HostClubName,
     int? RulesSetId,
-    string? RulesSetName);
+    string? RulesSetName,
+    int? EventId,
+    string? EventName);
 
 public record CompetitionDetailDto(
     int CompetitionId,
@@ -22,11 +25,14 @@ public record CompetitionDetailDto(
     DateTime? StartDate,
     DateTime? EndDate,
     int? MaxAge,
+    int? MinAge,
     PlayerSex? EligibleSex,
     int? HostClubId,
     string? HostClubName,
     int? RulesSetId,
     string? RulesSetName,
+    int? EventId,
+    string? EventName,
     List<CompetitionStageDto> Stages,
     List<CompetitionParticipantDto> Participants);
 
@@ -87,9 +93,11 @@ public record SaveCompetitionRequest(
     DateTime? StartDate,
     DateTime? EndDate,
     int? MaxAge,
+    int? MinAge,
     PlayerSex? EligibleSex,
     int? HostClubId,
-    int? RulesSetId);
+    int? RulesSetId,
+    int? EventId);
 
 public record AddStageRequest(string Name, int StageOrder, StageType StageType);
 
@@ -114,3 +122,42 @@ public record SaveFixtureRequest(
 public record SaveTeamRequest(string Name);
 
 public record AssignParticipantTeamRequest(int? TeamId);
+
+// ── Event DTOs ──────────────────────────────────────────────────────────────
+
+public record EventDto(
+    int EventId,
+    string Name,
+    string? Description,
+    DateTime? StartDate,
+    DateTime? EndDate,
+    int? HostClubId,
+    string? HostClubName,
+    int CompetitionCount);
+
+public record EventDetailDto(
+    int EventId,
+    string Name,
+    string? Description,
+    DateTime? StartDate,
+    DateTime? EndDate,
+    int? HostClubId,
+    string? HostClubName,
+    List<CompetitionDto> Competitions);
+
+public record SaveEventRequest(
+    string Name,
+    string? Description,
+    DateTime? StartDate,
+    DateTime? EndDate,
+    int? HostClubId);
+
+public record CreateEventCompetitionsRequest(
+    List<EventCompetitionTemplate> Competitions);
+
+public record EventCompetitionTemplate(
+    string CompetitionName,
+    CompetitionFormat CompetitionFormat,
+    PlayerSex? EligibleSex,
+    int? MaxAge,
+    int? MinAge);

--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -74,6 +74,10 @@
                                          Min="2" Variant="Variant.Text" />
                     </MudItem>
                     <MudItem xs="12" sm="4">
+                        <MudNumericField @bind-Value="Model.MinAge" Label="Min Age (optional)"
+                                         Min="1" Max="120" Variant="Variant.Text" />
+                    </MudItem>
+                    <MudItem xs="12" sm="4">
                         <MudNumericField @bind-Value="Model.MaxAge" Label="Max Age (optional)"
                                          Min="1" Max="120" Variant="Variant.Text" />
                     </MudItem>
@@ -102,6 +106,15 @@
                             @foreach (var r in _rulesSets)
                             {
                                 <MudSelectItem T="int?" Value="@((int?)r.RulesSetId)">@r.Name</MudSelectItem>
+                            }
+                        </MudSelect>
+                    </MudItem>
+                    <MudItem xs="12" sm="6">
+                        <MudSelect @bind-Value="Model.EventId" Label="Event (optional)" Variant="Variant.Text"
+                                   Clearable="true">
+                            @foreach (var e in _events)
+                            {
+                                <MudSelectItem T="int?" Value="@((int?)e.EventId)">@e.Name</MudSelectItem>
                             }
                         </MudSelect>
                     </MudItem>
@@ -608,6 +621,22 @@
     </DialogActions>
 </MudDialog>
 
+@* ── Stage Follow-Up Dialog ────────────────────────────────── *@
+<MudDialog @bind-Visible="_showStageFollowUpDialog">
+    <TitleContent>Add Follow-On Stages</TitleContent>
+    <DialogContent>
+        <MudText Class="mb-3">@_stageFollowUpMessage</MudText>
+        @foreach (var opt in _stageFollowUpOptions)
+        {
+            <MudButton Variant="Variant.Outlined" Color="Color.Primary" Class="mr-2 mb-2"
+                       OnClick="@(() => ApplyStageFollowUp(opt.Stages))">@opt.Label</MudButton>
+        }
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@(() => _showStageFollowUpDialog = false)">No Thanks</MudButton>
+    </DialogActions>
+</MudDialog>
+
 @* ── Seed Knockout from Standings Dialog ───────────────────── *@
 <MudDialog @bind-Visible="_showSeedConfirm">
     <TitleContent>Seed Knockout from Standings</TitleContent>
@@ -776,6 +805,7 @@
 
 @code {
     [Parameter] public int Id { get; set; }
+    [SupplyParameterFromQuery] public int? EventId { get; set; }
 
     private MudForm? _form;
     private bool _isValid;
@@ -789,6 +819,7 @@
 
     private List<Club> _clubs = [];
     private List<RulesSet> _rulesSets = [];
+    private List<Event> _events = [];
     private List<CompetitionStage> _stages = [];
     private List<CompetitionParticipant> _participants = [];
     private List<Player> _allPlayers = [];
@@ -804,6 +835,11 @@
     // Stage dialog
     private bool _showStageDialog;
     private StageForm _stageForm = new();
+
+    // Stage follow-up dialog
+    private bool _showStageFollowUpDialog;
+    private string _stageFollowUpMessage = "";
+    private List<(string Label, List<(string Name, StageType Type)> Stages)> _stageFollowUpOptions = [];
 
     // Schedule confirm dialog
     private bool _showScheduleConfirm;
@@ -859,9 +895,11 @@
         public DateTime? StartDateDt { get; set; }
         public DateTime? EndDateDt { get; set; }
         public int? MaxAge { get; set; }
+        public int? MinAge { get; set; }
         public PlayerSex? EligibleSex { get; set; }
         public int? HostClubId { get; set; }
         public int? RulesSetId { get; set; }
+        public int? EventId { get; set; }
         public int BestOf { get; set; } = 3;
         public bool RequireVerification { get; set; } = false;
     }
@@ -899,6 +937,7 @@
 
         _clubs = await db.Clubs.OrderBy(c => c.Name).ToListAsync();
         _rulesSets = await db.RulesSets.OrderBy(r => r.Name).ToListAsync();
+        _events = await db.Events.OrderBy(e => e.Name).ToListAsync();
         _allPlayers = await db.Players.OrderBy(p => p.DisplayName).ToListAsync();
 
         if (IsEdit)
@@ -929,9 +968,11 @@
                 StartDateDt = comp.StartDate,
                 EndDateDt = comp.EndDate,
                 MaxAge = comp.MaxAge,
+                MinAge = comp.MinAge,
                 EligibleSex = comp.EligibleSex,
                 HostClubId = comp.HostClubId,
                 RulesSetId = comp.RulesSetId,
+                EventId = comp.EventId,
                 BestOf = comp.BestOf,
                 RequireVerification = comp.RequireVerification
             };
@@ -971,7 +1012,7 @@
         {
             // Only Admins can create new competitions
             _canEdit = await AuthzService.IsAdminAsync(authState.User);
-            Model = new CompetitionFormModel();
+            Model = new CompetitionFormModel { EventId = EventId };
             _stages = [];
             _participants = [];
             _fixtures = [];
@@ -1040,9 +1081,11 @@
         comp.StartDate = Model.StartDateDt;
         comp.EndDate = Model.EndDateDt;
         comp.MaxAge = Model.MaxAge;
+        comp.MinAge = Model.MinAge;
         comp.EligibleSex = Model.EligibleSex;
         comp.HostClubId = Model.HostClubId;
         comp.RulesSetId = Model.RulesSetId;
+        comp.EventId = Model.EventId;
         comp.BestOf = Model.BestOf;
         comp.RequireVerification = Model.RequireVerification;
     }
@@ -1071,6 +1114,83 @@
         _stages.Add(stage);
         _showStageDialog = false;
         Snackbar.Add("Stage added.", Severity.Success);
+
+        OfferFollowOnStages(stage.StageType, stage.StageOrder);
+    }
+
+    private void OfferFollowOnStages(StageType added, int lastOrder)
+    {
+        var existingTypes = _stages.Select(s => s.StageType).ToHashSet();
+        _stageFollowUpOptions = [];
+
+        if (added == StageType.QuarterFinal)
+        {
+            bool hasSf = existingTypes.Contains(StageType.SemiFinal);
+            bool hasFinal = existingTypes.Contains(StageType.Final);
+            if (!hasSf && !hasFinal)
+            {
+                _stageFollowUpMessage = "Would you like to add the remaining knockout stages?";
+                _stageFollowUpOptions.Add(("Semi-Final + Final", [("Semi-Final", StageType.SemiFinal), ("Final", StageType.Final)]));
+            }
+            else if (!hasSf)
+            {
+                _stageFollowUpMessage = "Would you like to add a Semi-Final stage?";
+                _stageFollowUpOptions.Add(("Semi-Final", [("Semi-Final", StageType.SemiFinal)]));
+            }
+            else if (!hasFinal)
+            {
+                _stageFollowUpMessage = "Would you like to add a Final stage?";
+                _stageFollowUpOptions.Add(("Final", [("Final", StageType.Final)]));
+            }
+        }
+        else if (added == StageType.SemiFinal)
+        {
+            if (!existingTypes.Contains(StageType.Final))
+            {
+                _stageFollowUpMessage = "Would you like to add a Final stage?";
+                _stageFollowUpOptions.Add(("Final", [("Final", StageType.Final)]));
+            }
+        }
+        else if (added == StageType.RoundRobin)
+        {
+            bool hasQf = existingTypes.Contains(StageType.QuarterFinal);
+            bool hasSf = existingTypes.Contains(StageType.SemiFinal);
+            bool hasFinal = existingTypes.Contains(StageType.Final);
+            bool hasKo = existingTypes.Contains(StageType.Knockout);
+
+            if (!hasKo && !hasQf && !hasSf && !hasFinal)
+            {
+                _stageFollowUpMessage = "Would you like to add knockout stages?";
+                _stageFollowUpOptions.Add(("QF + SF + Final", [("Quarter-Final", StageType.QuarterFinal), ("Semi-Final", StageType.SemiFinal), ("Final", StageType.Final)]));
+                _stageFollowUpOptions.Add(("SF + Final", [("Semi-Final", StageType.SemiFinal), ("Final", StageType.Final)]));
+                _stageFollowUpOptions.Add(("Final Only", [("Final", StageType.Final)]));
+            }
+        }
+
+        if (_stageFollowUpOptions.Count > 0)
+            _showStageFollowUpDialog = true;
+    }
+
+    private async Task ApplyStageFollowUp(List<(string Name, StageType Type)> stages)
+    {
+        await using var db = DbFactory.CreateDbContext();
+        int order = _stages.Max(s => s.StageOrder);
+        foreach (var (name, type) in stages)
+        {
+            order++;
+            var stage = new CompetitionStage
+            {
+                CompetitionId = Id,
+                Name = name,
+                StageOrder = order,
+                StageType = type
+            };
+            db.CompetitionStages.Add(stage);
+            await db.SaveChangesAsync();
+            _stages.Add(stage);
+        }
+        _showStageFollowUpDialog = false;
+        Snackbar.Add($"{stages.Count} stage(s) added.", Severity.Success);
     }
 
     private async Task DeleteStage(CompetitionStage stage)

--- a/DropShot/Components/Pages/Competitions.razor
+++ b/DropShot/Components/Pages/Competitions.razor
@@ -6,6 +6,7 @@
 @using DropShot.Data
 @using DropShot.Models
 @using DropShot.Services
+@using DropShot.Shared.Dtos
 @using Microsoft.EntityFrameworkCore
 
 @inject NavigationManager Nav
@@ -94,48 +95,180 @@
               Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search"
               Immediate="true" Class="mb-4" />
 
-<MudDataGrid Items="@_competitions" Filterable="false" SortMode="@SortMode.None" Groupable="false"
-             QuickFilter="@FilterCompetitions">
-    <Columns>
-        <PropertyColumn Property="x => x.CompetitionName" />
-        <PropertyColumn Property="x => x.CompetitionFormat" />
-        <TemplateColumn CellClass="d-flex justify-end gap-2">
-            <CellTemplate>
-                <MudButton Size="@Size.Small"
-                           Variant="@Variant.Outlined"
-                           Color="@Color.Info"
-                           OnClick="@(() => Nav.NavigateTo($"/competition/{context.Item.CompetitionID}/view"))">
-                    View
-                </MudButton>
-                @if (CanEdit(context.Item))
-                {
-                    <MudButton Size="@Size.Small"
-                               Variant="@Variant.Filled"
-                               Color="@Color.Primary"
-                               OnClick="@(() => Nav.NavigateTo($"/competition/{context.Item.CompetitionID}"))">
-                        Edit
-                    </MudButton>
-                }
-            </CellTemplate>
-        </TemplateColumn>
-    </Columns>
-</MudDataGrid>
+<MudTabs @bind-ActivePanelIndex="_activeTab" Elevation="0" ApplyEffectsToContainer="true" Class="mb-4">
+    <MudTabPanel Text="All Competitions" Icon="@Icons.Material.Filled.List">
+        <MudDataGrid Items="@_competitions" Filterable="false" SortMode="@SortMode.None" Groupable="false"
+                     QuickFilter="@FilterCompetitions">
+            <Columns>
+                <PropertyColumn Property="x => x.CompetitionName" />
+                <PropertyColumn Property="x => x.CompetitionFormat" />
+                <TemplateColumn Title="Event">
+                    <CellTemplate>
+                        @if (context.Item.Event != null)
+                        {
+                            <MudChip T="string" Size="Size.Small" Color="Color.Info" Variant="Variant.Text">
+                                @context.Item.Event.Name
+                            </MudChip>
+                        }
+                    </CellTemplate>
+                </TemplateColumn>
+                <TemplateColumn CellClass="d-flex justify-end gap-2">
+                    <CellTemplate>
+                        <MudButton Size="@Size.Small"
+                                   Variant="@Variant.Outlined"
+                                   Color="@Color.Info"
+                                   OnClick="@(() => Nav.NavigateTo($"/competition/{context.Item.CompetitionID}/view"))">
+                            View
+                        </MudButton>
+                        @if (CanEdit(context.Item))
+                        {
+                            <MudButton Size="@Size.Small"
+                                       Variant="@Variant.Filled"
+                                       Color="@Color.Primary"
+                                       OnClick="@(() => Nav.NavigateTo($"/competition/{context.Item.CompetitionID}"))">
+                                Edit
+                            </MudButton>
+                        }
+                    </CellTemplate>
+                </TemplateColumn>
+            </Columns>
+        </MudDataGrid>
+    </MudTabPanel>
+
+    <MudTabPanel Text="By Event" Icon="@Icons.Material.Filled.FolderOpen">
+        @foreach (var ev in _events)
+        {
+            <MudExpansionPanels Class="mb-2" Elevation="1">
+                <MudExpansionPanel @bind-IsExpanded="ev.IsExpanded">
+                    <TitleContent>
+                        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                            <MudIcon Icon="@Icons.Material.Filled.EmojiEvents" Color="Color.Primary" />
+                            <MudText Typo="Typo.subtitle1" Style="font-weight:600">@ev.Event.Name</MudText>
+                            @if (ev.Event.StartDate.HasValue || ev.Event.EndDate.HasValue)
+                            {
+                                <MudText Typo="Typo.caption" Color="Color.Secondary">
+                                    @(ev.Event.StartDate?.ToString("dd MMM") ?? "?") – @(ev.Event.EndDate?.ToString("dd MMM yyyy") ?? "?")
+                                </MudText>
+                            }
+                            <MudChip T="string" Size="Size.Small" Color="Color.Info">
+                                @ev.Competitions.Count competition(s)
+                            </MudChip>
+                            <MudSpacer />
+                            <MudButton Size="Size.Small" Variant="Variant.Text" Color="Color.Info"
+                                       StartIcon="@Icons.Material.Filled.Visibility"
+                                       OnClick="@(() => Nav.NavigateTo($"/event/{ev.Event.EventId}/view"))"
+                                       OnClick:stopPropagation="true">
+                                View Event
+                            </MudButton>
+                        </MudStack>
+                    </TitleContent>
+                    <ChildContent>
+                        <MudSimpleTable Dense="true" Hover="true">
+                            <thead><tr><th>Competition</th><th>Format</th><th></th></tr></thead>
+                            <tbody>
+                                @foreach (var comp in ev.Competitions.Where(c => FilterCompetitions(c)))
+                                {
+                                    <tr>
+                                        <td>@comp.CompetitionName</td>
+                                        <td>@comp.CompetitionFormat</td>
+                                        <td class="d-flex justify-end gap-2">
+                                            <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Info"
+                                                       OnClick="@(() => Nav.NavigateTo($"/competition/{comp.CompetitionID}/view"))">
+                                                View
+                                            </MudButton>
+                                            @if (CanEdit(comp))
+                                            {
+                                                <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary"
+                                                           OnClick="@(() => Nav.NavigateTo($"/competition/{comp.CompetitionID}"))">
+                                                    Edit
+                                                </MudButton>
+                                            }
+                                        </td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </MudSimpleTable>
+                    </ChildContent>
+                </MudExpansionPanel>
+            </MudExpansionPanels>
+        }
+
+        @if (_ungroupedCompetitions.Count > 0)
+        {
+            <MudExpansionPanels Class="mb-2" Elevation="1">
+                <MudExpansionPanel IsInitiallyExpanded="true">
+                    <TitleContent>
+                        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                            <MudIcon Icon="@Icons.Material.Filled.Inbox" Color="Color.Default" />
+                            <MudText Typo="Typo.subtitle1" Style="font-weight:600">Ungrouped</MudText>
+                            <MudChip T="string" Size="Size.Small" Color="Color.Default">
+                                @_ungroupedCompetitions.Count
+                            </MudChip>
+                        </MudStack>
+                    </TitleContent>
+                    <ChildContent>
+                        <MudSimpleTable Dense="true" Hover="true">
+                            <thead><tr><th>Competition</th><th>Format</th><th></th></tr></thead>
+                            <tbody>
+                                @foreach (var comp in _ungroupedCompetitions.Where(c => FilterCompetitions(c)))
+                                {
+                                    <tr>
+                                        <td>@comp.CompetitionName</td>
+                                        <td>@comp.CompetitionFormat</td>
+                                        <td class="d-flex justify-end gap-2">
+                                            <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Info"
+                                                       OnClick="@(() => Nav.NavigateTo($"/competition/{comp.CompetitionID}/view"))">
+                                                View
+                                            </MudButton>
+                                            @if (CanEdit(comp))
+                                            {
+                                                <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary"
+                                                           OnClick="@(() => Nav.NavigateTo($"/competition/{comp.CompetitionID}"))">
+                                                    Edit
+                                                </MudButton>
+                                            }
+                                        </td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </MudSimpleTable>
+                    </ChildContent>
+                </MudExpansionPanel>
+            </MudExpansionPanels>
+        }
+    </MudTabPanel>
+</MudTabs>
 
 @if (_isAdmin)
 {
-    <MudButton Size="@Size.Small" Variant="@Variant.Filled" Color="@Color.Primary" Class="mt-3"
-               OnClick="@(() => Nav.NavigateTo($"/competition/0"))">
-        Add New
-    </MudButton>
+    <MudStack Row="true" Spacing="2" Class="mt-3">
+        <MudButton Size="@Size.Small" Variant="@Variant.Filled" Color="@Color.Primary"
+                   OnClick="@(() => Nav.NavigateTo($"/competition/0"))">
+            Add Competition
+        </MudButton>
+        <MudButton Size="@Size.Small" Variant="@Variant.Outlined" Color="@Color.Secondary"
+                   StartIcon="@Icons.Material.Filled.CreateNewFolder"
+                   OnClick="OpenCreateEventDialogAsync">
+            New Event
+        </MudButton>
+    </MudStack>
 }
 
 @code {
     private List<Competition> _competitions = [];
+    private List<EventGroup> _events = [];
+    private List<Competition> _ungroupedCompetitions = [];
     private string _searchText = "";
     private bool _isAdmin;
+    private int _activeTab;
     private List<CompetitionFixture> _pendingFixtures = [];
     private HashSet<int> _editableClubIds = [];
     private HashSet<int> _competitionAdminIds = [];
+
+    private record EventGroup(Event Event, List<Competition> Competitions)
+    {
+        public bool IsExpanded { get; set; } = true;
+    }
 
     private bool FilterCompetitions(Competition c) =>
         string.IsNullOrWhiteSpace(_searchText) ||
@@ -151,14 +284,33 @@
 
         await using var dbc = DbFactory.CreateDbContext();
         _competitions = await dbc.Competition
+            .Include(c => c.Event)
             .Select(c => new Competition
             {
                 CompetitionID = c.CompetitionID,
                 CompetitionName = c.CompetitionName,
                 CompetitionFormat = c.CompetitionFormat,
-                HostClubId = c.HostClubId
+                HostClubId = c.HostClubId,
+                EventId = c.EventId,
+                Event = c.Event
             })
             .ToListAsync();
+
+        // Build event groups
+        var events = await dbc.Events
+            .Include(e => e.HostClub)
+            .OrderBy(e => e.Name)
+            .ToListAsync();
+
+        var compsByEvent = _competitions
+            .Where(c => c.EventId.HasValue)
+            .GroupBy(c => c.EventId!.Value)
+            .ToDictionary(g => g.Key, g => g.ToList());
+
+        _events = events.Select(e => new EventGroup(
+            e, compsByEvent.GetValueOrDefault(e.EventId, []))).ToList();
+
+        _ungroupedCompetitions = _competitions.Where(c => !c.EventId.HasValue).ToList();
 
         // Load pending verifications for admins / club admins / competition admins
         if (_isAdmin || _editableClubIds.Count > 0 || _competitionAdminIds.Count > 0)
@@ -237,5 +389,63 @@
             _pendingFixtures.Remove(fixture);
             Snackbar.Add("Result verified.", Severity.Success);
         }
+    }
+
+    private async Task OpenCreateEventDialogAsync()
+    {
+        await using var db = DbFactory.CreateDbContext();
+        var clubs = await db.Clubs.OrderBy(c => c.Name).ToListAsync();
+
+        var parameters = new DialogParameters<CreateEventDialog> { { x => x.Clubs, clubs } };
+        var dialog = await DialogService.ShowAsync<CreateEventDialog>("Create Event", parameters,
+            new DialogOptions { MaxWidth = MaxWidth.Medium, FullWidth = true });
+        var result = await dialog.Result;
+        if (result is null || result.Canceled) return;
+
+        var data = (CreateEventDialog.CreateEventResult)result.Data!;
+
+        // Create the event
+        var ev = new Event
+        {
+            Name = data.Name,
+            Description = data.Description,
+            StartDate = data.StartDate,
+            EndDate = data.EndDate,
+            HostClubId = data.HostClubId
+        };
+        db.Events.Add(ev);
+        await db.SaveChangesAsync();
+
+        // Bulk-create competitions
+        var createdComps = new List<Competition>();
+        foreach (var c in data.Competitions)
+        {
+            var comp = new Competition
+            {
+                CompetitionName = c.Name,
+                CompetitionFormat = c.Format,
+                EligibleSex = c.EligibleSex,
+                MaxAge = c.MaxAge,
+                MinAge = c.MinAge,
+                EventId = ev.EventId,
+                HostClubId = ev.HostClubId,
+                StartDate = ev.StartDate,
+                EndDate = ev.EndDate
+            };
+            db.Competition.Add(comp);
+            createdComps.Add(comp);
+        }
+        await db.SaveChangesAsync();
+
+        // Update local state
+        foreach (var comp in createdComps)
+        {
+            comp.Event = ev;
+            _competitions.Add(comp);
+        }
+        _events.Add(new EventGroup(ev, createdComps));
+
+        Snackbar.Add($"Event '{ev.Name}' created with {createdComps.Count} competition(s).", Severity.Success);
+        _activeTab = 1; // Switch to "By Event" tab
     }
 }

--- a/DropShot/Components/Pages/CreateEventDialog.razor
+++ b/DropShot/Components/Pages/CreateEventDialog.razor
@@ -1,0 +1,219 @@
+@using DropShot.Models
+
+<MudDialog>
+    <TitleContent>Create Event</TitleContent>
+    <DialogContent>
+        <MudForm @ref="_form" @bind-IsValid="_isValid">
+            <MudGrid Spacing="2">
+                <MudItem xs="12">
+                    <MudTextField @bind-Value="Name" Label="Event Name" Variant="Variant.Outlined"
+                                  Required="true" RequiredError="Name is required"
+                                  Placeholder="e.g. Club Championships 2026" Immediate="true" />
+                </MudItem>
+                <MudItem xs="12">
+                    <MudTextField @bind-Value="Description" Label="Description (optional)" Variant="Variant.Outlined"
+                                  Lines="2" />
+                </MudItem>
+                <MudItem xs="12" sm="6">
+                    <MudDatePicker @bind-Date="StartDate" Label="Start Date" DateFormat="dd/MM/yyyy" />
+                </MudItem>
+                <MudItem xs="12" sm="6">
+                    <MudDatePicker @bind-Date="EndDate" Label="End Date" DateFormat="dd/MM/yyyy" />
+                </MudItem>
+                <MudItem xs="12">
+                    <MudSelect @bind-Value="HostClubId" Label="Host Club (optional)" Variant="Variant.Outlined"
+                               Clearable="true">
+                        @foreach (var c in Clubs)
+                        {
+                            <MudSelectItem T="int?" Value="@((int?)c.ClubId)">@c.Name</MudSelectItem>
+                        }
+                    </MudSelect>
+                </MudItem>
+            </MudGrid>
+
+            <MudDivider Class="my-4" />
+
+            <MudText Typo="Typo.h6" Class="mb-2">Competitions</MudText>
+
+            @* ── Preset Buttons ──────────────────── *@
+            <MudStack Row="true" Spacing="1" Class="mb-3" Wrap="Wrap.Wrap">
+                <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Primary"
+                           OnClick="AddStandard5">Standard 5</MudButton>
+            </MudStack>
+
+            @* ── Builder Row ─────────────────────── *@
+            <MudGrid Spacing="1" Class="mb-2">
+                <MudItem xs="12" sm="3">
+                    <MudSelect @bind-Value="_buildFormat" Label="Format" Variant="Variant.Outlined" Margin="Margin.Dense">
+                        <MudSelectItem Value="CompetitionFormat.Singles">Singles</MudSelectItem>
+                        <MudSelectItem Value="CompetitionFormat.Doubles">Doubles</MudSelectItem>
+                        <MudSelectItem Value="CompetitionFormat.MixedDoubles">Mixed Doubles</MudSelectItem>
+                        <MudSelectItem Value="CompetitionFormat.Team">Team</MudSelectItem>
+                    </MudSelect>
+                </MudItem>
+                <MudItem xs="12" sm="3">
+                    <MudSelect @bind-Value="_buildSex" Label="Sex" Variant="Variant.Outlined" Margin="Margin.Dense"
+                               Clearable="true">
+                        <MudSelectItem T="PlayerSex?" Value="@((PlayerSex?)PlayerSex.Male)">Men's</MudSelectItem>
+                        <MudSelectItem T="PlayerSex?" Value="@((PlayerSex?)PlayerSex.Female)">Women's</MudSelectItem>
+                    </MudSelect>
+                </MudItem>
+                <MudItem xs="12" sm="3">
+                    <MudSelect @bind-Value="_buildAgeBracket" Label="Age Bracket" Variant="Variant.Outlined"
+                               Margin="Margin.Dense">
+                        @foreach (var ab in _ageBrackets)
+                        {
+                            <MudSelectItem Value="@ab">@ab.Label</MudSelectItem>
+                        }
+                    </MudSelect>
+                </MudItem>
+                <MudItem xs="12" sm="3" Class="d-flex align-center">
+                    <MudButton Variant="Variant.Filled" Color="Color.Primary" Size="Size.Small"
+                               OnClick="AddFromBuilder">Add</MudButton>
+                </MudItem>
+            </MudGrid>
+
+            <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mb-2">
+                Preview: @BuildAutoName()
+            </MudText>
+
+            @* ── Competition List ─────────────────── *@
+            @if (Competitions.Count > 0)
+            {
+                <MudSimpleTable Dense="true">
+                    <thead>
+                        <tr><th>Name</th><th>Format</th><th>Sex</th><th>Age</th><th></th></tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var comp in Competitions)
+                        {
+                            <tr>
+                                <td>@comp.Name</td>
+                                <td>@comp.Format</td>
+                                <td>@(comp.EligibleSex?.ToString() ?? "Open")</td>
+                                <td>@FormatAge(comp.MinAge, comp.MaxAge)</td>
+                                <td>
+                                    <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small"
+                                                   Color="Color.Error" OnClick="@(() => Competitions.Remove(comp))" />
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </MudSimpleTable>
+            }
+            else
+            {
+                <MudText Typo="Typo.caption" Color="Color.Secondary">
+                    No competitions added yet. Use the builder above or the "Standard 5" preset.
+                </MudText>
+            }
+        </MudForm>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel">Cancel</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="@(!_isValid)"
+                   OnClick="Submit">Create Event</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = null!;
+    [Parameter] public List<Club> Clubs { get; set; } = [];
+
+    private MudForm? _form;
+    private bool _isValid;
+
+    public string Name { get; set; } = "";
+    public string? Description { get; set; }
+    public DateTime? StartDate { get; set; }
+    public DateTime? EndDate { get; set; }
+    public int? HostClubId { get; set; }
+
+    public List<CompetitionEntry> Competitions { get; set; } = [];
+
+    // Builder state
+    private CompetitionFormat _buildFormat = CompetitionFormat.Singles;
+    private PlayerSex? _buildSex;
+    private AgeBracket _buildAgeBracket = _ageBrackets[0];
+
+    public record CompetitionEntry(string Name, CompetitionFormat Format, PlayerSex? EligibleSex, int? MinAge, int? MaxAge);
+
+    public record AgeBracket(string Label, int? MinAge, int? MaxAge);
+
+    private static readonly AgeBracket[] _ageBrackets =
+    [
+        new("Open", null, null),
+        new("U8", null, 8),
+        new("U10", null, 10),
+        new("U12", null, 12),
+        new("U14", null, 14),
+        new("U16", null, 16),
+        new("U18", null, 18),
+        new("Over 35", 35, null),
+        new("Over 40", 40, null),
+        new("Over 50", 50, null),
+        new("Over 60", 60, null),
+    ];
+
+    private string BuildAutoName()
+    {
+        var parts = new List<string>();
+
+        if (_buildSex == PlayerSex.Male) parts.Add("Men's");
+        else if (_buildSex == PlayerSex.Female) parts.Add("Women's");
+
+        if (_buildAgeBracket.Label != "Open")
+            parts.Add(_buildAgeBracket.Label);
+
+        parts.Add(_buildFormat switch
+        {
+            CompetitionFormat.Singles => "Singles",
+            CompetitionFormat.Doubles => "Doubles",
+            CompetitionFormat.MixedDoubles => "Mixed Doubles",
+            CompetitionFormat.Team => "Team",
+            _ => _buildFormat.ToString()
+        });
+
+        return string.Join(" ", parts);
+    }
+
+    private void AddFromBuilder()
+    {
+        var name = BuildAutoName();
+        if (Competitions.Any(c => c.Name == name)) return;
+        Competitions.Add(new CompetitionEntry(name, _buildFormat, _buildSex, _buildAgeBracket.MinAge, _buildAgeBracket.MaxAge));
+    }
+
+    private void AddStandard5()
+    {
+        var standard = new (string Name, CompetitionFormat Format, PlayerSex? Sex)[]
+        {
+            ("Men's Singles", CompetitionFormat.Singles, PlayerSex.Male),
+            ("Women's Singles", CompetitionFormat.Singles, PlayerSex.Female),
+            ("Men's Doubles", CompetitionFormat.Doubles, PlayerSex.Male),
+            ("Women's Doubles", CompetitionFormat.Doubles, PlayerSex.Female),
+            ("Mixed Doubles", CompetitionFormat.MixedDoubles, null),
+        };
+        foreach (var (name, format, sex) in standard)
+        {
+            if (!Competitions.Any(c => c.Name == name))
+                Competitions.Add(new CompetitionEntry(name, format, sex, null, null));
+        }
+    }
+
+    private static string FormatAge(int? minAge, int? maxAge)
+    {
+        if (minAge.HasValue) return $"Over {minAge}";
+        if (maxAge.HasValue) return $"U{maxAge}";
+        return "Open";
+    }
+
+    private void Cancel() => MudDialog.Cancel();
+
+    private void Submit() => MudDialog.Close(DialogResult.Ok(new CreateEventResult(
+        Name.Trim(), Description?.Trim(), StartDate, EndDate, HostClubId, Competitions)));
+
+    public record CreateEventResult(
+        string Name, string? Description, DateTime? StartDate, DateTime? EndDate,
+        int? HostClubId, List<CompetitionEntry> Competitions);
+}

--- a/DropShot/Components/Pages/ViewEvent.razor
+++ b/DropShot/Components/Pages/ViewEvent.razor
@@ -1,0 +1,136 @@
+@page "/event/{Id:int}/view"
+@rendermode InteractiveServer
+@attribute [Authorize]
+
+@using Microsoft.AspNetCore.Authorization
+@using DropShot.Data
+@using DropShot.Models
+@using Microsoft.EntityFrameworkCore
+
+@inject IDbContextFactory<MyDbContext> DbFactory
+@inject NavigationManager Nav
+
+@if (_loading)
+{
+    <MudProgressLinear Indeterminate="true" />
+}
+else if (_event == null)
+{
+    <MudAlert Severity="Severity.Error">Event not found.</MudAlert>
+}
+else
+{
+    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="mb-4">
+        <MudText Typo="Typo.h4" Style="flex:1">@_event.Name</MudText>
+        <MudButton Variant="Variant.Outlined" Color="Color.Default"
+                   StartIcon="@Icons.Material.Filled.ArrowBack"
+                   OnClick="@(() => Nav.NavigateTo("/competitions"))">
+            Back to Competitions
+        </MudButton>
+    </MudStack>
+
+    <MudPaper Class="pa-4 mb-4">
+        <MudGrid Spacing="2">
+            @if (!string.IsNullOrEmpty(_event.Description))
+            {
+                <MudItem xs="12">
+                    <MudText Typo="Typo.body1">@_event.Description</MudText>
+                </MudItem>
+            }
+            @if (_event.StartDate.HasValue || _event.EndDate.HasValue)
+            {
+                <MudItem xs="12" sm="6">
+                    <MudText Typo="Typo.caption" Color="Color.Secondary">Dates</MudText>
+                    <MudText Typo="Typo.body2">
+                        @(_event.StartDate?.ToString("dd MMM yyyy") ?? "?") – @(_event.EndDate?.ToString("dd MMM yyyy") ?? "?")
+                    </MudText>
+                </MudItem>
+            }
+            @if (_event.HostClub != null)
+            {
+                <MudItem xs="12" sm="6">
+                    <MudText Typo="Typo.caption" Color="Color.Secondary">Host Club</MudText>
+                    <MudText Typo="Typo.body2">@_event.HostClub.Name</MudText>
+                </MudItem>
+            }
+        </MudGrid>
+    </MudPaper>
+
+    <MudText Typo="Typo.h6" Class="mb-3">Competitions (@_competitions.Count)</MudText>
+
+    <MudSimpleTable Dense="true" Hover="true" Elevation="1">
+        <thead>
+            <tr>
+                <th>Competition</th>
+                <th>Format</th>
+                <th>Eligibility</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var comp in _competitions)
+            {
+                <tr>
+                    <td>@comp.CompetitionName</td>
+                    <td>@comp.CompetitionFormat</td>
+                    <td>
+                        @{
+                            var parts = new List<string>();
+                            if (comp.EligibleSex.HasValue) parts.Add(comp.EligibleSex.Value.ToString());
+                            if (comp.MinAge.HasValue) parts.Add($"Over {comp.MinAge}");
+                            if (comp.MaxAge.HasValue) parts.Add($"U{comp.MaxAge}");
+                        }
+                        @(parts.Count > 0 ? string.Join(", ", parts) : "Open")
+                    </td>
+                    <td class="d-flex justify-end gap-2">
+                        <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Info"
+                                   OnClick="@(() => Nav.NavigateTo($"/competition/{comp.CompetitionID}/view"))">
+                            View
+                        </MudButton>
+                        <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary"
+                                   OnClick="@(() => Nav.NavigateTo($"/competition/{comp.CompetitionID}"))">
+                            Edit
+                        </MudButton>
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </MudSimpleTable>
+
+    @if (_competitions.Count == 0)
+    {
+        <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mt-2">No competitions in this event yet.</MudText>
+    }
+
+    <MudButton Variant="Variant.Outlined" Color="Color.Primary" Class="mt-3"
+               StartIcon="@Icons.Material.Filled.Add"
+               OnClick="@(() => Nav.NavigateTo($"/competition/0?eventId={Id}"))">
+        Add Competition
+    </MudButton>
+}
+
+@code {
+    [Parameter] public int Id { get; set; }
+
+    private bool _loading = true;
+    private Event? _event;
+    private List<Competition> _competitions = [];
+
+    protected override async Task OnParametersSetAsync()
+    {
+        _loading = true;
+        await using var db = DbFactory.CreateDbContext();
+        _event = await db.Events
+            .Include(e => e.HostClub)
+            .FirstOrDefaultAsync(e => e.EventId == Id);
+
+        if (_event != null)
+        {
+            _competitions = await db.Competition
+                .Where(c => c.EventId == Id)
+                .OrderBy(c => c.CompetitionName)
+                .ToListAsync();
+        }
+        _loading = false;
+    }
+}

--- a/DropShot/Controllers/CompetitionsController.cs
+++ b/DropShot/Controllers/CompetitionsController.cs
@@ -16,12 +16,20 @@ public class CompetitionsController(
     ClubAuthorizationService authzService) : ControllerBase
 {
     [HttpGet]
-    public async Task<ActionResult<List<CompetitionDto>>> GetAll([FromQuery] int skip = 0, [FromQuery] int take = 50)
+    public async Task<ActionResult<List<CompetitionDto>>> GetAll(
+        [FromQuery] int skip = 0, [FromQuery] int take = 50, [FromQuery] int? eventId = null)
     {
         await using var db = dbFactory.CreateDbContext();
-        var comps = await db.Competition
+        var query = db.Competition
             .Include(c => c.HostClub)
             .Include(c => c.Rules)
+            .Include(c => c.Event)
+            .AsQueryable();
+
+        if (eventId.HasValue)
+            query = query.Where(c => c.EventId == eventId.Value);
+
+        var comps = await query
             .OrderBy(c => c.CompetitionName)
             .Skip(skip)
             .Take(Math.Min(take, 200))
@@ -36,6 +44,7 @@ public class CompetitionsController(
         var c = await db.Competition
             .Include(x => x.HostClub)
             .Include(x => x.Rules)
+            .Include(x => x.Event)
             .Include(x => x.Stages.OrderBy(s => s.StageOrder))
             .Include(x => x.Participants).ThenInclude(p => p.Player)
             .Include(x => x.Participants).ThenInclude(p => p.Team)
@@ -46,9 +55,10 @@ public class CompetitionsController(
         return new CompetitionDetailDto(
             c.CompetitionID, c.CompetitionName,
             (DropShot.Shared.CompetitionFormat)c.CompetitionFormat,
-            c.MaxParticipants, c.StartDate, c.EndDate, c.MaxAge,
+            c.MaxParticipants, c.StartDate, c.EndDate, c.MaxAge, c.MinAge,
             (DropShot.Shared.PlayerSex?)c.EligibleSex,
             c.HostClubId, c.HostClub?.Name, c.RulesSetId, c.Rules?.Name,
+            c.EventId, c.Event?.Name,
             c.Stages.Select(s => new CompetitionStageDto(
                 s.CompetitionStageId, s.Name, s.StageOrder,
                 (DropShot.Shared.StageType)s.StageType)).ToList(),
@@ -653,9 +663,11 @@ public class CompetitionsController(
         c.StartDate = r.StartDate;
         c.EndDate = r.EndDate;
         c.MaxAge = r.MaxAge;
+        c.MinAge = r.MinAge;
         c.EligibleSex = (DropShot.Models.PlayerSex?)r.EligibleSex;
         c.HostClubId = r.HostClubId;
         c.RulesSetId = r.RulesSetId;
+        c.EventId = r.EventId;
     }
 
     private static void ApplyFixture(CompetitionFixture f, SaveFixtureRequest r)
@@ -677,9 +689,10 @@ public class CompetitionsController(
     private static CompetitionDto ToDto(Competition c) => new(
         c.CompetitionID, c.CompetitionName,
         (DropShot.Shared.CompetitionFormat)c.CompetitionFormat,
-        c.MaxParticipants, c.StartDate, c.EndDate, c.MaxAge,
+        c.MaxParticipants, c.StartDate, c.EndDate, c.MaxAge, c.MinAge,
         (DropShot.Shared.PlayerSex?)c.EligibleSex,
-        c.HostClubId, c.HostClub?.Name, c.RulesSetId, c.Rules?.Name);
+        c.HostClubId, c.HostClub?.Name, c.RulesSetId, c.Rules?.Name,
+        c.EventId, c.Event?.Name);
 
     private static CompetitionFixtureDto ToFixtureDto(CompetitionFixture f) => new(
         f.CompetitionFixtureId, f.CompetitionId,

--- a/DropShot/Controllers/EventsController.cs
+++ b/DropShot/Controllers/EventsController.cs
@@ -1,0 +1,154 @@
+using DropShot.Data;
+using DropShot.Models;
+using DropShot.Services;
+using DropShot.Shared.Dtos;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace DropShot.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize(AuthenticationSchemes = "Bearer")]
+public class EventsController(
+    IDbContextFactory<MyDbContext> dbFactory,
+    ClubAuthorizationService authzService) : ControllerBase
+{
+    [HttpGet]
+    public async Task<ActionResult<List<EventDto>>> GetAll([FromQuery] int skip = 0, [FromQuery] int take = 50)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var events = await db.Events
+            .Include(e => e.HostClub)
+            .Include(e => e.Competitions)
+            .OrderBy(e => e.Name)
+            .Skip(skip)
+            .Take(Math.Min(take, 200))
+            .Select(e => new EventDto(
+                e.EventId, e.Name, e.Description,
+                e.StartDate, e.EndDate,
+                e.HostClubId, e.HostClub != null ? e.HostClub.Name : null,
+                e.Competitions.Count))
+            .ToListAsync();
+        return events;
+    }
+
+    [HttpGet("{id:int}")]
+    public async Task<ActionResult<EventDetailDto>> Get(int id)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var e = await db.Events
+            .Include(ev => ev.HostClub)
+            .Include(ev => ev.Competitions).ThenInclude(c => c.HostClub)
+            .Include(ev => ev.Competitions).ThenInclude(c => c.Rules)
+            .FirstOrDefaultAsync(ev => ev.EventId == id);
+
+        if (e is null) return NotFound();
+
+        return new EventDetailDto(
+            e.EventId, e.Name, e.Description,
+            e.StartDate, e.EndDate,
+            e.HostClubId, e.HostClub?.Name,
+            e.Competitions.Select(c => new CompetitionDto(
+                c.CompetitionID, c.CompetitionName,
+                (DropShot.Shared.CompetitionFormat)c.CompetitionFormat,
+                c.MaxParticipants, c.StartDate, c.EndDate, c.MaxAge, c.MinAge,
+                (DropShot.Shared.PlayerSex?)c.EligibleSex,
+                c.HostClubId, c.HostClub?.Name, c.RulesSetId, c.Rules?.Name,
+                c.EventId, e.Name)).ToList());
+    }
+
+    [HttpPost]
+    [Authorize(Roles = "Admin")]
+    public async Task<ActionResult<EventDto>> Create([FromBody] SaveEventRequest req)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var ev = new Event
+        {
+            Name = req.Name.Trim(),
+            Description = req.Description?.Trim(),
+            StartDate = req.StartDate,
+            EndDate = req.EndDate,
+            HostClubId = req.HostClubId
+        };
+        db.Events.Add(ev);
+        await db.SaveChangesAsync();
+        return CreatedAtAction(nameof(Get), new { id = ev.EventId },
+            new EventDto(ev.EventId, ev.Name, ev.Description, ev.StartDate, ev.EndDate,
+                ev.HostClubId, null, 0));
+    }
+
+    [HttpPut("{id:int}")]
+    public async Task<ActionResult<EventDto>> Update(int id, [FromBody] SaveEventRequest req)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var ev = await db.Events.Include(e => e.HostClub).FirstOrDefaultAsync(e => e.EventId == id);
+        if (ev is null) return NotFound();
+
+        if (!await authzService.CanEditCompetitionAsync(User, ev.HostClubId))
+            return Forbid();
+
+        ev.Name = req.Name.Trim();
+        ev.Description = req.Description?.Trim();
+        ev.StartDate = req.StartDate;
+        ev.EndDate = req.EndDate;
+        ev.HostClubId = req.HostClubId;
+        await db.SaveChangesAsync();
+
+        return new EventDto(ev.EventId, ev.Name, ev.Description, ev.StartDate, ev.EndDate,
+            ev.HostClubId, ev.HostClub?.Name, await db.Competition.CountAsync(c => c.EventId == id));
+    }
+
+    [HttpDelete("{id:int}")]
+    [Authorize(Roles = "Admin")]
+    public async Task<IActionResult> Delete(int id)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var ev = await db.Events.FindAsync(id);
+        if (ev is null) return NotFound();
+        db.Events.Remove(ev);
+        await db.SaveChangesAsync();
+        return NoContent();
+    }
+
+    [HttpPost("{id:int}/competitions")]
+    public async Task<ActionResult<List<CompetitionDto>>> BulkCreateCompetitions(
+        int id, [FromBody] CreateEventCompetitionsRequest req)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var ev = await db.Events.FindAsync(id);
+        if (ev is null) return NotFound();
+
+        if (!await authzService.CanEditCompetitionAsync(User, ev.HostClubId))
+            return Forbid();
+
+        var created = new List<Competition>();
+        foreach (var t in req.Competitions)
+        {
+            var comp = new Competition
+            {
+                CompetitionName = t.CompetitionName.Trim(),
+                CompetitionFormat = (DropShot.Models.CompetitionFormat)t.CompetitionFormat,
+                EligibleSex = (DropShot.Models.PlayerSex?)t.EligibleSex,
+                MaxAge = t.MaxAge,
+                MinAge = t.MinAge,
+                EventId = id,
+                HostClubId = ev.HostClubId,
+                StartDate = ev.StartDate,
+                EndDate = ev.EndDate
+            };
+            db.Competition.Add(comp);
+            created.Add(comp);
+        }
+        await db.SaveChangesAsync();
+
+        return created.Select(c => new CompetitionDto(
+            c.CompetitionID, c.CompetitionName,
+            (DropShot.Shared.CompetitionFormat)c.CompetitionFormat,
+            c.MaxParticipants, c.StartDate, c.EndDate, c.MaxAge, c.MinAge,
+            (DropShot.Shared.PlayerSex?)c.EligibleSex,
+            c.HostClubId, null, c.RulesSetId, null,
+            c.EventId, ev.Name)).ToList();
+    }
+}

--- a/DropShot/Data/Migrations/20260406073727_AddEvents.Designer.cs
+++ b/DropShot/Data/Migrations/20260406073727_AddEvents.Designer.cs
@@ -4,6 +4,7 @@ using DropShot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DropShot.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260406073727_AddEvents")]
+    partial class AddEvents
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DropShot/Data/Migrations/20260406073727_AddEvents.cs
+++ b/DropShot/Data/Migrations/20260406073727_AddEvents.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropShot.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddEvents : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "EventId",
+                table: "Competition",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "MinAge",
+                table: "Competition",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "Events",
+                columns: table => new
+                {
+                    EventId = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Name = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(1000)", maxLength: 1000, nullable: true),
+                    StartDate = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    EndDate = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    HostClubId = table.Column<int>(type: "int", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Events", x => x.EventId);
+                    table.ForeignKey(
+                        name: "FK_Events_Clubs_HostClubId",
+                        column: x => x.HostClubId,
+                        principalTable: "Clubs",
+                        principalColumn: "ClubId",
+                        onDelete: ReferentialAction.SetNull);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Competition_EventId",
+                table: "Competition",
+                column: "EventId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Events_HostClubId",
+                table: "Events",
+                column: "HostClubId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Competition_Events_EventId",
+                table: "Competition",
+                column: "EventId",
+                principalTable: "Events",
+                principalColumn: "EventId",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Competition_Events_EventId",
+                table: "Competition");
+
+            migrationBuilder.DropTable(
+                name: "Events");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Competition_EventId",
+                table: "Competition");
+
+            migrationBuilder.DropColumn(
+                name: "EventId",
+                table: "Competition");
+
+            migrationBuilder.DropColumn(
+                name: "MinAge",
+                table: "Competition");
+        }
+    }
+}

--- a/DropShot/Data/MyDbContext.cs
+++ b/DropShot/Data/MyDbContext.cs
@@ -35,6 +35,7 @@ namespace DropShot.Data
         public DbSet<ScoreboardDisplaySetting> ScoreboardDisplaySettings { get; set; }
         public DbSet<UserPlayer> UserPlayers { get; set; }
         public DbSet<RoleSwitchLog> RoleSwitchLogs { get; set; }
+        public DbSet<Event> Events { get; set; }
 
         protected override void OnModelCreating(ModelBuilder builder)
         {
@@ -81,6 +82,23 @@ namespace DropShot.Data
                 entity.HasOne(c => c.HostClub)
                       .WithMany(cl => cl.Competitions)
                       .HasForeignKey(c => c.HostClubId)
+                      .OnDelete(DeleteBehavior.SetNull);
+
+                entity.HasOne(c => c.Event)
+                      .WithMany(e => e.Competitions)
+                      .HasForeignKey(c => c.EventId)
+                      .OnDelete(DeleteBehavior.SetNull);
+            });
+
+            // ── Event ───────────────────────────────────────────────────────────────
+            builder.Entity<Event>(entity =>
+            {
+                entity.Property(e => e.Name).HasMaxLength(200).IsRequired();
+                entity.Property(e => e.Description).HasMaxLength(1000);
+
+                entity.HasOne(e => e.HostClub)
+                      .WithMany(c => c.Events)
+                      .HasForeignKey(e => e.HostClubId)
                       .OnDelete(DeleteBehavior.SetNull);
             });
 

--- a/DropShot/Models/Club.cs
+++ b/DropShot/Models/Club.cs
@@ -28,6 +28,7 @@ public class Club
     public ICollection<ClubSchedulingTemplate> SchedulingTemplates { get; set; } = [];
     public ICollection<CompetitionTemplate> CompetitionTemplates { get; set; } = [];
     public ICollection<ClubEmailTemplate> EmailTemplates { get; set; } = [];
+    public ICollection<Event> Events { get; set; } = [];
 }
 
 public class Court

--- a/DropShot/Models/Competition.cs
+++ b/DropShot/Models/Competition.cs
@@ -18,14 +18,17 @@
         public DateTime? StartDate { get; set; }
         public DateTime? EndDate { get; set; }
         public int? MaxAge { get; set; }
+        public int? MinAge { get; set; }
         public PlayerSex? EligibleSex { get; set; }
         public int? RulesSetId { get; set; }
         public int? HostClubId { get; set; }
+        public int? EventId { get; set; }
         public int BestOf { get; set; } = 3;
         public bool RequireVerification { get; set; } = false;
 
         public RulesSet? Rules { get; set; }
         public Club? HostClub { get; set; }
+        public Event? Event { get; set; }
         public ICollection<CompetitionParticipant> Participants { get; set; } = [];
         public ICollection<CompetitionFixture> Fixtures { get; set; } = [];
         public ICollection<CompetitionStage> Stages { get; set; } = [];

--- a/DropShot/Models/Event.cs
+++ b/DropShot/Models/Event.cs
@@ -1,0 +1,14 @@
+namespace DropShot.Models;
+
+public class Event
+{
+    public int EventId { get; set; }
+    public string Name { get; set; } = "";
+    public string? Description { get; set; }
+    public DateTime? StartDate { get; set; }
+    public DateTime? EndDate { get; set; }
+    public int? HostClubId { get; set; }
+
+    public Club? HostClub { get; set; }
+    public ICollection<Competition> Competitions { get; set; } = [];
+}


### PR DESCRIPTION
## Summary
- **Event grouping**: Competitions can now be grouped into events (e.g. "Club Championships 2026"). New Event model, API, and UI with a CreateEventDialog that auto-generates competition names from format/sex/age criteria, plus a "Standard 5" preset button
- **Smart stage suggestions**: After adding a QF/SF/RoundRobin stage, the system offers to auto-create follow-on stages (SF+Final, etc.), reducing manual setup clicks
- **MinAge field**: Competitions now support minimum age restrictions (e.g. "Over 50") alongside the existing MaxAge
- **Competitions page tabs**: Toggle between "All Competitions" flat list and "By Event" grouped view with expansion panels
- **Full MAUI support**: Event dropdown, MinAge, and event grouping added to all mobile competition screens

## Test plan
- [ ] Add a QuarterFinal stage to a competition — verify SF+Final are offered
- [ ] Add a RoundRobin stage — verify knockout stage options are offered
- [ ] Create an event with "Standard 5" preset — verify 5 competitions are bulk-created
- [ ] Use the competition builder to add a custom entry (e.g. Over 50 Women's Doubles) — verify name auto-generates
- [ ] Toggle "By Event" tab on Competitions page — verify grouping with expansion panels
- [ ] Edit a competition — verify Event dropdown and MinAge field work
- [ ] Run `dotnet build` — 0 errors
- [ ] Run unit tests — all competition tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)