### PR TITLE
Fix New Event dialog and add auto-name to competition form

### DIFF
--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -49,9 +49,16 @@
             <MudForm @ref="_form" @bind-IsValid="_isValid" @bind-Errors="_errors">
                 <MudGrid Spacing="2">
                     <MudItem xs="12" sm="8">
-                        <MudTextField T="string" Label="Competition Name" @bind-Value="Model.CompetitionName"
-                                      For="@(() => Model.CompetitionName)"
-                                      Required="true" RequiredError="Name is required" Immediate="true" />
+                        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                            <MudTextField T="string" Label="Competition Name" @bind-Value="Model.CompetitionName"
+                                          For="@(() => Model.CompetitionName)"
+                                          Required="true" RequiredError="Name is required" Immediate="true"
+                                          Style="flex:1" />
+                            <MudTooltip Text="Generate name from Format, Sex & Age settings below">
+                                <MudIconButton Icon="@Icons.Material.Filled.AutoAwesome" Color="Color.Primary"
+                                               OnClick="AutoGenerateName" />
+                            </MudTooltip>
+                        </MudStack>
                     </MudItem>
                     <MudItem xs="12" sm="4">
                         <MudSelect @bind-Value="Model.CompetitionFormat" Label="Format" Variant="Variant.Text">
@@ -1071,6 +1078,28 @@
         catch (DbUpdateException ex) { _serverError = "Database error: " + ex.InnerException?.Message ?? ex.Message; }
         catch (Exception ex) { _serverError = ex.Message; }
         finally { _isSaving = false; }
+    }
+
+    private void AutoGenerateName()
+    {
+        var parts = new List<string>();
+
+        if (Model.EligibleSex == PlayerSex.Male) parts.Add("Men's");
+        else if (Model.EligibleSex == PlayerSex.Female) parts.Add("Women's");
+
+        if (Model.MinAge.HasValue) parts.Add($"Over {Model.MinAge}");
+        else if (Model.MaxAge.HasValue) parts.Add($"U{Model.MaxAge}");
+
+        parts.Add(Model.CompetitionFormat switch
+        {
+            CompetitionFormat.Singles => "Singles",
+            CompetitionFormat.Doubles => "Doubles",
+            CompetitionFormat.MixedDoubles => "Mixed Doubles",
+            CompetitionFormat.Team => "Team",
+            _ => Model.CompetitionFormat.ToString()
+        });
+
+        Model.CompetitionName = string.Join(" ", parts);
     }
 
     private void ApplyModel(Competition comp, string name)

--- a/DropShot/Components/Pages/Competitions.razor
+++ b/DropShot/Components/Pages/Competitions.razor
@@ -16,6 +16,8 @@
 @inject IDialogService DialogService
 @inject ISnackbar Snackbar
 
+<MudProviders />
+
 @if (_pendingFixtures.Count > 0)
 {
     <MudCard Class="mb-4" Elevation="2">


### PR DESCRIPTION
## Summary
- **Fix**: Add missing `<MudProviders />` to Competitions.razor — the "New Event" button was silently failing because MudBlazor's dialog provider wasn't registered on that page
- **Feature**: Add auto-generate name button (sparkle icon) next to the Competition Name field on CompetitionPage. Builds a name from the current Format, Eligible Sex, and Min/Max Age settings (e.g. "Women's U18 Singles", "Men's Over 50 Doubles")

## Test plan
- [ ] Click "New Event" on Competitions page — dialog should now open
- [ ] Create a new competition, set Format=Singles, Sex=Female, MaxAge=18, click the sparkle button — name should auto-fill as "Women's U18 Singles"
- [ ] Verify auto-name works for various combos: Open Singles, Men's Over 50 Doubles, Mixed Doubles

🤖 Generated with [Claude Code](https://claude.com/claude-code)