### PR TITLE
Replace competition name with live auto-generating label

### DIFF
--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -22,7 +22,22 @@
 <MudProviders />
 
 <MudStack Row="true" AlignItems="AlignItems.Center" Class="mb-4" Spacing="2">
-    <MudText Typo="Typo.h5" Style="flex:1">@(IsEdit ? "Edit Competition" : "New Competition")</MudText>
+    @if (_nameOverride)
+    {
+        <MudTextField T="string" @bind-Value="Model.CompetitionName" Variant="Variant.Text"
+                      Typo="Typo.h5" Style="flex:1" Immediate="true" Placeholder="Competition Name"
+                      Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.Check"
+                      OnAdornmentClick="@(() => _nameOverride = false)" />
+    }
+    else
+    {
+        <MudText Typo="Typo.h5" Style="flex:1" Color="@(string.IsNullOrWhiteSpace(Model.CompetitionName) ? Color.Secondary : Color.Default)">
+            @(string.IsNullOrWhiteSpace(Model.CompetitionName) ? "New Competition" : Model.CompetitionName)
+        </MudText>
+        <MudTooltip Text="Edit name manually">
+            <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="Size.Small" OnClick="@(() => _nameOverride = true)" />
+        </MudTooltip>
+    }
     @if (IsEdit)
     {
         <MudButton Variant="Variant.Outlined" Color="Color.Info" StartIcon="@Icons.Material.Filled.Visibility"
@@ -48,25 +63,30 @@
 
             <MudForm @ref="_form" @bind-IsValid="_isValid" @bind-Errors="_errors">
                 <MudGrid Spacing="2">
-                    <MudItem xs="12" sm="8">
-                        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
-                            <MudTextField T="string" Label="Competition Name" @bind-Value="Model.CompetitionName"
-                                          For="@(() => Model.CompetitionName)"
-                                          Required="true" RequiredError="Name is required" Immediate="true"
-                                          Style="flex:1" />
-                            <MudTooltip Text="Generate name from Format, Sex & Age settings below">
-                                <MudIconButton Icon="@Icons.Material.Filled.AutoAwesome" Color="Color.Primary"
-                                               OnClick="AutoGenerateName" />
-                            </MudTooltip>
-                        </MudStack>
-                    </MudItem>
                     <MudItem xs="12" sm="4">
-                        <MudSelect @bind-Value="Model.CompetitionFormat" Label="Format" Variant="Variant.Text">
+                        <MudSelect T="CompetitionFormat" Label="Format" Variant="Variant.Text"
+                                   Value="Model.CompetitionFormat"
+                                   ValueChanged="@(v => { Model.CompetitionFormat = v; AutoGenerateName(); })">
                             @foreach (CompetitionFormat f in Enum.GetValues<CompetitionFormat>())
                             {
                                 <MudSelectItem Value="@f">@f</MudSelectItem>
                             }
                         </MudSelect>
+                    </MudItem>
+                    <MudItem xs="12" sm="4">
+                        <MudSelect T="PlayerSex?" Label="Eligible Sex" Variant="Variant.Text"
+                                   Clearable="true"
+                                   Value="Model.EligibleSex"
+                                   ValueChanged="@(v => { Model.EligibleSex = v; AutoGenerateName(); })">
+                            @foreach (PlayerSex s in Enum.GetValues<PlayerSex>())
+                            {
+                                <MudSelectItem T="PlayerSex?" Value="@((PlayerSex?)s)">@s</MudSelectItem>
+                            }
+                        </MudSelect>
+                    </MudItem>
+                    <MudItem xs="12" sm="4">
+                        <MudNumericField @bind-Value="Model.MaxParticipants" Label="Max Participants (optional)"
+                                         Min="2" Variant="Variant.Text" />
                     </MudItem>
 
                     <MudItem xs="12" sm="6">
@@ -77,25 +97,16 @@
                     </MudItem>
 
                     <MudItem xs="12" sm="4">
-                        <MudNumericField @bind-Value="Model.MaxParticipants" Label="Max Participants (optional)"
-                                         Min="2" Variant="Variant.Text" />
+                        <MudNumericField T="int?" Label="Min Age (optional)"
+                                         Min="1" Max="120" Variant="Variant.Text"
+                                         Value="Model.MinAge"
+                                         ValueChanged="@(v => { Model.MinAge = v; AutoGenerateName(); })" />
                     </MudItem>
                     <MudItem xs="12" sm="4">
-                        <MudNumericField @bind-Value="Model.MinAge" Label="Min Age (optional)"
-                                         Min="1" Max="120" Variant="Variant.Text" />
-                    </MudItem>
-                    <MudItem xs="12" sm="4">
-                        <MudNumericField @bind-Value="Model.MaxAge" Label="Max Age (optional)"
-                                         Min="1" Max="120" Variant="Variant.Text" />
-                    </MudItem>
-                    <MudItem xs="12" sm="4">
-                        <MudSelect @bind-Value="Model.EligibleSex" Label="Eligible Sex" Variant="Variant.Text"
-                                   Clearable="true">
-                            @foreach (PlayerSex s in Enum.GetValues<PlayerSex>())
-                            {
-                                <MudSelectItem T="PlayerSex?" Value="@((PlayerSex?)s)">@s</MudSelectItem>
-                            }
-                        </MudSelect>
+                        <MudNumericField T="int?" Label="Max Age (optional)"
+                                         Min="1" Max="120" Variant="Variant.Text"
+                                         Value="Model.MaxAge"
+                                         ValueChanged="@(v => { Model.MaxAge = v; AutoGenerateName(); })" />
                     </MudItem>
 
                     <MudItem xs="12" sm="6">
@@ -821,6 +832,7 @@
     private string[] _errors = [];
     private string? _serverError;
     private bool IsEdit => Id != 0;
+    private bool _nameOverride;
 
     private CompetitionFormModel Model { get; set; } = new();
 
@@ -966,6 +978,7 @@
             if (comp is null) { _serverError = $"Competition {Id} not found."; return; }
 
             _canEdit = await AuthzService.CanEditCompetitionAsync(authState.User, comp.HostClubId, Id);
+            _nameOverride = true; // Existing competition — preserve its name
 
             Model = new CompetitionFormModel
             {
@@ -1082,13 +1095,15 @@
 
     private void AutoGenerateName()
     {
+        if (_nameOverride) return;
+
         var parts = new List<string>();
 
         if (Model.EligibleSex == PlayerSex.Male) parts.Add("Men's");
         else if (Model.EligibleSex == PlayerSex.Female) parts.Add("Women's");
 
-        if (Model.MinAge.HasValue) parts.Add($"Over {Model.MinAge}");
-        else if (Model.MaxAge.HasValue) parts.Add($"U{Model.MaxAge}");
+        if (Model.MinAge is > 0) parts.Add($"Over {Model.MinAge}");
+        if (Model.MaxAge is > 0) parts.Add($"U{Model.MaxAge}");
 
         parts.Add(Model.CompetitionFormat switch
         {


### PR DESCRIPTION
## Summary
- Competition name is now a **heading label** at the top of the page that auto-updates as you select Format, Eligible Sex, Min Age, and Max Age
- Selecting "Women's" + "U18" + "Singles" instantly shows **"Women's U18 Singles"** as the heading
- Pencil icon switches to manual text field for custom names; check icon returns to label mode
- Existing competitions start in manual mode to preserve their current name
- Ages of 0 or null no longer produce "Over 0" or "U0" in the title

## Test plan
- [ ] Create new competition — heading should show "Singles" initially, then update as criteria change
- [ ] Select Format=Doubles, Sex=Male — heading should read "Men's Doubles"
- [ ] Set MinAge=50 — heading should read "Men's Over 50 Doubles"  
- [ ] Set MinAge=0 — heading should read "Men's Doubles" (no "Over 0")
- [ ] Click pencil icon — heading becomes editable text field
- [ ] Type custom name, click check — returns to label with custom name preserved
- [ ] Edit existing competition — name stays as-is, doesn't auto-overwrite

🤖 Generated with [Claude Code](https://claude.com/claude-code)