### PR TITLE
Move login section to bottom of home page

### DIFF
--- a/DropShot/Components/Pages/Home.razor
+++ b/DropShot/Components/Pages/Home.razor
@@ -44,26 +44,6 @@
     </MudAlert>
 }
 
-@if (!_isAuthenticated)
-{
-    <MudCard Class="mb-4">
-        <MudCardContent>
-            <MudGrid>
-                <MudItem xs="12" sm="6">
-                    <MudText Typo="Typo.h5">Welcome to DropShot</MudText>
-                    <MudText Typo="Typo.body1" Class="mt-2">
-                        Scan the QR code with your phone to log in, or
-                        <MudLink Href="/Account/Login">use email and password</MudLink>.
-                    </MudText>
-                </MudItem>
-                <MudItem xs="12" sm="6">
-                    <QrLoginPanel />
-                </MudItem>
-            </MudGrid>
-        </MudCardContent>
-    </MudCard>
-}
-
 @if (_pendingReviews.Count > 0)
 {
     <MudCard Class="mb-4" Elevation="2">
@@ -218,6 +198,26 @@
         <MudButton Variant="Variant.Text" Color="Color.Primary">Learn more</MudButton>
     </MudCardActions>
 </MudCard>
+
+@if (!_isAuthenticated)
+{
+    <MudCard Class="mt-4">
+        <MudCardContent>
+            <MudGrid>
+                <MudItem xs="12" sm="6">
+                    <MudText Typo="Typo.h5">Welcome to DropShot</MudText>
+                    <MudText Typo="Typo.body1" Class="mt-2">
+                        Scan the QR code with your phone to log in, or
+                        <MudLink Href="/Account/Login">use email and password</MudLink>.
+                    </MudText>
+                </MudItem>
+                <MudItem xs="12" sm="6">
+                    <QrLoginPanel />
+                </MudItem>
+            </MudGrid>
+        </MudCardContent>
+    </MudCard>
+}
 
 @code {
     private bool arrows = true;


### PR DESCRIPTION
## Summary
- Relocates the QR login/welcome section from the top of the home page to the last section before the footer
- Only visible to unauthenticated users (no change in behavior)

## Test plan
- [ ] Visit home page while logged out — login section should appear at the bottom
- [ ] Visit home page while logged in — no login section visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)