### PR TITLE
Fix mobile scroll blocked by carousel

### DIFF
--- a/DropShot/Components/Pages/Home.razor
+++ b/DropShot/Components/Pages/Home.razor
@@ -139,7 +139,7 @@
     </MudCard>
 }
 
-<MudCarousel Class="mud-width-full" Style="height:400px;" ShowArrows="@arrows" ShowBullets="@bullets" EnableSwipeGesture="@enableSwipeGesture" AutoCycle="@autocycle" TData="object">
+<MudCarousel Class="mud-width-full" Style="height:400px; touch-action:pan-y;" ShowArrows="@arrows" ShowBullets="@bullets" EnableSwipeGesture="@enableSwipeGesture" AutoCycle="@autocycle" TData="object">
     <MudCarouselItem Transition="transition" Color="@Color.Primary">
         <div class="d-flex" style="height:100%">
             <MudImage Class="mx-auto my-auto" Src="images/Logo.png" Style="height: 300px;"></MudImage>


### PR DESCRIPTION
## Summary
- Added `touch-action: pan-y` to the MudCarousel on the Home page
- Fixes issue where vertical page scrolling was blocked when touching the carousel on mobile devices
- The browser now handles vertical scrolling natively while the carousel retains horizontal swipe gesture support

## Test plan
- [ ] On mobile (or device emulation), touch and drag vertically on the carousel area — page should scroll
- [ ] Horizontal swipe on the carousel should still change slides

🤖 Generated with [Claude Code](https://claude.com/claude-code)