### PR TITLE
Hide QR scan-to-login on mobile devices

### DIFF
--- a/DropShot/Components/Account/Pages/Login.razor
+++ b/DropShot/Components/Account/Pages/Login.razor
@@ -65,7 +65,7 @@
             </section>
         </div>
     }
-    <div class="col-md-4">
+    <div class="col-md-4 d-none d-md-block">
         <section>
             <h3>Scan QR code to log in</h3>
             <hr />


### PR DESCRIPTION
## Summary
- Hide the QR code login panel on mobile devices using Bootstrap `d-none d-md-block` classes
- QR scan-to-login is only useful on desktop/kiosk views where a separate mobile device scans the screen

## Test plan
- [ ] Verify QR login panel is hidden on mobile viewport (<768px)
- [ ] Verify QR login panel is visible on tablet/desktop viewport (>=768px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)