### PR TITLE
Hide QR scan-to-login on Home page for mobile

### DIFF
--- a/DropShot/Components/Pages/Home.razor
+++ b/DropShot/Components/Pages/Home.razor
@@ -204,14 +204,17 @@
     <MudCard Class="mt-4">
         <MudCardContent>
             <MudGrid>
-                <MudItem xs="12" sm="6">
+                <MudItem xs="12" md="6">
                     <MudText Typo="Typo.h5">Welcome to DropShot</MudText>
-                    <MudText Typo="Typo.body1" Class="mt-2">
+                    <MudText Typo="Typo.body1" Class="mt-2 d-none d-md-block">
                         Scan the QR code with your phone to log in, or
                         <MudLink Href="/Account/Login">use email and password</MudLink>.
                     </MudText>
+                    <MudText Typo="Typo.body1" Class="mt-2 d-md-none">
+                        <MudLink Href="/Account/Login">Log in with email and password</MudLink> to get started.
+                    </MudText>
                 </MudItem>
-                <MudItem xs="12" sm="6">
+                <MudItem xs="12" md="6" Class="d-none d-md-block">
                     <QrLoginPanel />
                 </MudItem>
             </MudGrid>


### PR DESCRIPTION
## Summary
- Hide the QR login panel on the Home page for mobile viewports using `d-none d-md-block`
- Show mobile-friendly welcome text with a simple login link instead of referencing QR scanning

## Test plan
- [ ] On mobile (<768px): QR panel hidden, welcome text says "Log in with email and password"
- [ ] On desktop (>=768px): QR panel visible, welcome text references scanning

🤖 Generated with [Claude Code](https://claude.com/claude-code)