### PR TITLE
Add numeric keypad on mobile and fix light mode score inputs

### DIFF
--- a/DropShot/Components/EditScoreDialog.razor
+++ b/DropShot/Components/EditScoreDialog.razor
@@ -11,16 +11,16 @@
 
         <MudText Typo="Typo.subtitle2" Class="mb-2">@UserName</MudText>
         <MudStack Row="true" Spacing="2" Class="mb-3">
-            <MudNumericField @bind-Value="UserSets" Label="Sets" Min="0" Max="3" Variant="Variant.Outlined" Style="max-width:100px;" />
-            <MudNumericField @bind-Value="UserGames" Label="Games" Min="0" Max="13" Variant="Variant.Outlined" Style="max-width:100px;" />
-            <MudNumericField @bind-Value="UserPoints" Label="Points" Min="0" Max="20" Variant="Variant.Outlined" Style="max-width:100px;" />
+            <MudNumericField @bind-Value="UserSets" Label="Sets" Min="0" Max="3" Variant="Variant.Outlined" InputMode="InputMode.numeric" Style="max-width:100px;" />
+            <MudNumericField @bind-Value="UserGames" Label="Games" Min="0" Max="13" Variant="Variant.Outlined" InputMode="InputMode.numeric" Style="max-width:100px;" />
+            <MudNumericField @bind-Value="UserPoints" Label="Points" Min="0" Max="20" Variant="Variant.Outlined" InputMode="InputMode.numeric" Style="max-width:100px;" />
         </MudStack>
 
         <MudText Typo="Typo.subtitle2" Class="mb-2">@OpponentName</MudText>
         <MudStack Row="true" Spacing="2" Class="mb-3">
-            <MudNumericField @bind-Value="OppSets" Label="Sets" Min="0" Max="3" Variant="Variant.Outlined" Style="max-width:100px;" />
-            <MudNumericField @bind-Value="OppGames" Label="Games" Min="0" Max="13" Variant="Variant.Outlined" Style="max-width:100px;" />
-            <MudNumericField @bind-Value="OppPoints" Label="Points" Min="0" Max="20" Variant="Variant.Outlined" Style="max-width:100px;" />
+            <MudNumericField @bind-Value="OppSets" Label="Sets" Min="0" Max="3" Variant="Variant.Outlined" InputMode="InputMode.numeric" Style="max-width:100px;" />
+            <MudNumericField @bind-Value="OppGames" Label="Games" Min="0" Max="13" Variant="Variant.Outlined" InputMode="InputMode.numeric" Style="max-width:100px;" />
+            <MudNumericField @bind-Value="OppPoints" Label="Points" Min="0" Max="20" Variant="Variant.Outlined" InputMode="InputMode.numeric" Style="max-width:100px;" />
         </MudStack>
 
         <MudSwitch @bind-Value="IsUserServing" Label="@($"{UserName} is serving")" Color="Color.Primary" />

--- a/DropShot/Components/ReviewResultDialog.razor
+++ b/DropShot/Components/ReviewResultDialog.razor
@@ -64,12 +64,14 @@
                                 <td>
                                     <MudNumericField T="int?" @bind-Value="_score1[idx]"
                                                     Min="0" Max="13" Variant="Variant.Outlined"
+                                                    InputMode="InputMode.numeric"
                                                     Style="width:65px" HideSpinButtons="true" />
                                 </td>
                                 <td style="text-align:center; padding:0 4px; font-weight:bold">-</td>
                                 <td>
                                     <MudNumericField T="int?" @bind-Value="_score2[idx]"
                                                     Min="0" Max="13" Variant="Variant.Outlined"
+                                                    InputMode="InputMode.numeric"
                                                     Style="width:65px" HideSpinButtons="true" />
                                 </td>
                             </tr>

--- a/DropShot/Components/SubmitScoreDialog.razor
+++ b/DropShot/Components/SubmitScoreDialog.razor
@@ -48,6 +48,7 @@
                                                 Value="_score1[idx]"
                                                 ValueChanged="@(v => Score1Changed(idx, v))"
                                                 Min="0" Max="10" Variant="Variant.Outlined"
+                                                InputMode="InputMode.numeric"
                                                 Style="width:65px" HideSpinButtons="true" />
                             </td>
                             <td style="text-align:center; padding:0 4px; font-weight:bold">–</td>
@@ -56,6 +57,7 @@
                                                 Value="_score2[idx]"
                                                 ValueChanged="@(v => Score2Changed(idx, v))"
                                                 Min="0" Max="10" Variant="Variant.Outlined"
+                                                InputMode="InputMode.numeric"
                                                 Style="width:65px" HideSpinButtons="true" />
                             </td>
                         </tr>

--- a/DropShot/wwwroot/css/theme-light.css
+++ b/DropShot/wwwroot/css/theme-light.css
@@ -150,6 +150,26 @@
     color: #212121 !important;
 }
 
+[data-theme="light"] .mud-input-outlined .mud-input-outlined-border {
+    border-color: #bdbdbd !important;
+}
+
+[data-theme="light"] .mud-input-outlined:hover .mud-input-outlined-border {
+    border-color: #424242 !important;
+}
+
+[data-theme="light"] .mud-input-outlined.mud-focused .mud-input-outlined-border {
+    border-color: #1565c0 !important;
+}
+
+[data-theme="light"] .mud-input-label {
+    color: #616161 !important;
+}
+
+[data-theme="light"] .mud-input-label-outlined.mud-input-label-inputcontrol {
+    background-color: #ffffff;
+}
+
 [data-theme="light"] .mud-chip {
     color: #212121 !important;
 }


### PR DESCRIPTION
## Summary
- Adds `InputMode.numeric` to all score `MudNumericField` inputs across SubmitScoreDialog, EditScoreDialog, and ReviewResultDialog so mobile devices show a numeric keypad
- Fixes outlined input borders being invisible in light mode by adding explicit border, hover, focus, and label color overrides in `theme-light.css`

## Test plan
- [ ] Open Submit Score dialog on mobile — verify numeric keypad appears when tapping score fields
- [ ] Open Edit Score dialog on mobile — verify numeric keypad for sets/games/points fields
- [ ] Switch to light mode and open Submit Score dialog — verify input boxes have visible borders
- [ ] Verify outlined inputs show hover and focus states in light mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)