### PR TITLE
Fix mobile scroll blocked by carousel swipe area

### DIFF
--- a/DropShot/Components/Pages/Home.razor
+++ b/DropShot/Components/Pages/Home.razor
@@ -139,7 +139,7 @@
     </MudCard>
 }
 
-<MudCarousel Class="mud-width-full" Style="height:400px; touch-action:pan-y;" ShowArrows="@arrows" ShowBullets="@bullets" EnableSwipeGesture="@enableSwipeGesture" AutoCycle="@autocycle" TData="object">
+<MudCarousel Class="mud-width-full" Style="height:400px;" ShowArrows="@arrows" ShowBullets="@bullets" EnableSwipeGesture="@enableSwipeGesture" AutoCycle="@autocycle" TData="object">
     <MudCarouselItem Transition="transition" Color="@Color.Primary">
         <div class="d-flex" style="height:100%">
             <MudImage Class="mx-auto my-auto" Src="images/Logo.png" Style="height: 300px;"></MudImage>

--- a/DropShot/Components/Pages/Home.razor
+++ b/DropShot/Components/Pages/Home.razor
@@ -139,7 +139,7 @@
     </MudCard>
 }
 
-<MudCarousel Class="mud-width-full" Style="height:400px;" ShowArrows="@arrows" ShowBullets="@bullets" EnableSwipeGesture="@enableSwipeGesture" AutoCycle="@autocycle" TData="object">
+<MudCarousel Class="mud-width-full" Style="height:400px; touch-action:pan-y;" ShowArrows="@arrows" ShowBullets="@bullets" EnableSwipeGesture="@enableSwipeGesture" AutoCycle="@autocycle" TData="object">
     <MudCarouselItem Transition="transition" Color="@Color.Primary">
         <div class="d-flex" style="height:100%">
             <MudImage Class="mx-auto my-auto" Src="images/Logo.png" Style="height: 300px;"></MudImage>

--- a/DropShot/wwwroot/app.css
+++ b/DropShot/wwwroot/app.css
@@ -3,6 +3,11 @@ html, body {
     touch-action: manipulation;
 }
 
+/* MudBlazor's .mud-swipearea sets touch-action:none which blocks page scrolling on mobile */
+.mud-carousel .mud-swipearea {
+    touch-action: pan-y;
+}
+
 a, .btn-link {
     color: #006bb7;
 }


### PR DESCRIPTION
## Summary
- MudBlazor's `.mud-swipearea` sets `touch-action: none` which tells the browser not to handle any touch gestures natively
- This blocks vertical page scrolling when touching anywhere on the carousel on mobile
- Override with `touch-action: pan-y` so the browser handles vertical scrolling natively while the carousel retains horizontal swipe detection

## Test plan
- [ ] On mobile, touch and drag vertically on the carousel — page should now scroll
- [ ] Horizontal swipe on the carousel should still change slides

🤖 Generated with [Claude Code](https://claude.com/claude-code)