### PR TITLE
Remove placeholder content from home page

### DIFF
--- a/DropShot/Components/Pages/Home.razor
+++ b/DropShot/Components/Pages/Home.razor
@@ -46,7 +46,7 @@
 
 @if (!_isAuthenticated)
 {
-    <MudCard Class="mb-4">
+    <MudCard Class="mb-8">
         <MudCardContent>
             <MudGrid>
                 <MudItem xs="12" sm="6">
@@ -139,23 +139,6 @@
     </MudCard>
 }
 
-<MudCarousel Class="mud-width-full" Style="height:400px;" ShowArrows="@arrows" ShowBullets="@bullets" EnableSwipeGesture="@enableSwipeGesture" AutoCycle="@autocycle" TData="object">
-    <MudCarouselItem Transition="transition" Color="@Color.Primary">
-        <div class="d-flex" style="height:100%">
-            <MudImage Class="mx-auto my-auto" Src="images/Logo.png" Style="height: 300px;"></MudImage>
-        </div>
-    </MudCarouselItem>
-    <MudCarouselItem Transition="transition" Color="@Color.Secondary">
-        <div class="d-flex" style="height:100%">
-            <MudImage Class="mx-auto my-auto" Src="images/Logo.png" Style="height: 300px;"></MudImage>
-        </div>
-    </MudCarouselItem>
-    <MudCarouselItem Transition="transition">
-        <div class="d-flex" style="height:100%">
-            <MudImage Class="mx-auto my-auto" Src="images/Logo.png" Style="height: 300px;"></MudImage>
-        </div>
-    </MudCarouselItem>
-</MudCarousel>
 
 @if (_upcomingFixtures.Any())
 {
@@ -207,25 +190,8 @@
     </MudCard>
 }
 
-<MudCard Class="mt-4">
-    <MudCardMedia Image="images/background.png" Height="200" />
-    <MudCardContent>
-        <MudText Typo="Typo.h5">Welcome</MudText>
-        <MudText Typo="Typo.body2">Ipsum loreum</MudText>
-    </MudCardContent>
-    <MudCardActions>
-        <MudButton Variant="Variant.Text" Color="Color.Primary">Share</MudButton>
-        <MudButton Variant="Variant.Text" Color="Color.Primary">Learn more</MudButton>
-    </MudCardActions>
-</MudCard>
 
 @code {
-    private bool arrows = true;
-    private bool bullets = true;
-    private bool enableSwipeGesture = true;
-    private bool autocycle = true;
-    private Transition transition = Transition.Slide;
-
     [SupplyParameterFromQuery]
     private bool LinkedPlayer { get; set; }
 


### PR DESCRIPTION
## Summary
- Removed the image carousel section (3 logo slides)
- Removed the placeholder welcome card with lorem ipsum text, Share and Learn more buttons
- Cleaned up unused carousel variables from the code block
- Increased bottom padding on the Welcome to DropShot card (`mb-4` → `mb-8`) for footer separation

## Test plan
- [ ] Verify home page loads without errors
- [ ] Confirm the Welcome to DropShot block with QR login still displays for unauthenticated users
- [ ] Check adequate spacing between the welcome block and footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)