### PR TITLE
Restore image carousel on home page

### DIFF
--- a/DropShot/Components/Pages/Home.razor
+++ b/DropShot/Components/Pages/Home.razor
@@ -119,6 +119,23 @@
     </MudCard>
 }
 
+<MudCarousel Class="mud-width-full" Style="height:400px; touch-action:pan-y;" ShowArrows="@arrows" ShowBullets="@bullets" EnableSwipeGesture="@enableSwipeGesture" AutoCycle="@autocycle" TData="object">
+    <MudCarouselItem Transition="transition" Color="@Color.Primary">
+        <div class="d-flex" style="height:100%">
+            <MudImage Class="mx-auto my-auto" Src="images/Logo.png" Style="height: 300px;"></MudImage>
+        </div>
+    </MudCarouselItem>
+    <MudCarouselItem Transition="transition" Color="@Color.Secondary">
+        <div class="d-flex" style="height:100%">
+            <MudImage Class="mx-auto my-auto" Src="images/Logo.png" Style="height: 300px;"></MudImage>
+        </div>
+    </MudCarouselItem>
+    <MudCarouselItem Transition="transition">
+        <div class="d-flex" style="height:100%">
+            <MudImage Class="mx-auto my-auto" Src="images/Logo.png" Style="height: 300px;"></MudImage>
+        </div>
+    </MudCarouselItem>
+</MudCarousel>
 
 @if (_upcomingFixtures.Any())
 {
@@ -195,6 +212,12 @@
 }
 
 @code {
+    private bool arrows = true;
+    private bool bullets = true;
+    private bool enableSwipeGesture = true;
+    private bool autocycle = true;
+    private Transition transition = Transition.Slide;
+
     [SupplyParameterFromQuery]
     private bool LinkedPlayer { get; set; }
 


### PR DESCRIPTION
## Summary
- Restores the image carousel that was incorrectly removed in #207
- Only the placeholder welcome card (lorem ipsum, Share, Learn more) should have been removed

## Test plan
- [ ] Verify carousel displays on home page with 3 logo slides
- [ ] Confirm auto-cycle and swipe gestures work

🤖 Generated with [Claude Code](https://claude.com/claude-code)