### PR TITLE
Hide role banner for single-role users

### DIFF
--- a/DropShot/Components/Shared/RoleBanner.razor
+++ b/DropShot/Components/Shared/RoleBanner.razor
@@ -9,7 +9,7 @@
 @inject IDbContextFactory<MyDbContext> DbFactory
 @inject NavigationManager NavigationManager
 
-@if (_grantedRoles.Count > 0)
+@if (_grantedRoles.Count > 1)
 {
     <div class="role-banner">
         <span>Browsing as: <strong>@_activeRole</strong></span>


### PR DESCRIPTION
## Summary
- Hide the "Browsing as" banner when a user has only one role, since the role switcher is unnecessary in that case

## Test plan
- [ ] Log in as a user with a single role — banner should not appear
- [ ] Log in as a user with multiple roles — banner with role switcher should still appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)