### PR TITLE
Add consistent padding between page content and footer

### DIFF
--- a/DropShot/Components/Layout/MainLayout.razor.css
+++ b/DropShot/Components/Layout/MainLayout.razor.css
@@ -12,6 +12,7 @@ main {
 
     main ::deep .content {
         flex: 1;
+        padding-bottom: 3rem;
     }
 
 .sidebar {


### PR DESCRIPTION
Add padding-bottom to the .content area in MainLayout so all pages
have spacing before the footer, not just pages with explicit mb-* classes.

https://claude.ai/code/session_019yzRwx3fbi9omVkWL6EURj