### PR TITLE
Add Mixed Team Tennis competition format

### DIFF
--- a/DropShot.Shared/Dtos/CompetitionDtos.cs
+++ b/DropShot.Shared/Dtos/CompetitionDtos.cs
@@ -49,7 +49,8 @@ public record CompetitionParticipantDto(
     DateTime RegisteredAt,
     int? TeamId,
     string? TeamName,
-    string? MobileNumber);
+    string? MobileNumber,
+    PlayerGrade? Grade = null);
 
 public record CompetitionFixtureDto(
     int CompetitionFixtureId,
@@ -71,12 +72,21 @@ public record CompetitionFixtureDto(
     int? Player4Id,
     string? Player4Name,
     string? ResultSummary,
-    int? WinnerPlayerId);
+    int? WinnerPlayerId,
+    int? HomeTeamId = null,
+    string? HomeTeamName = null,
+    int? AwayTeamId = null,
+    string? AwayTeamName = null,
+    int? WinnerTeamId = null,
+    int? CourtPairId = null,
+    string? CourtPairName = null);
 
 public record CompetitionTeamDto(
     int CompetitionTeamId,
     int CompetitionId,
-    string Name);
+    string Name,
+    int? CaptainPlayerId = null,
+    string? CaptainName = null);
 
 public record LeagueTableEntryDto(
     int PlayerId,
@@ -122,6 +132,57 @@ public record SaveFixtureRequest(
 public record SaveTeamRequest(string Name);
 
 public record AssignParticipantTeamRequest(int? TeamId);
+
+public record UpdateParticipantGradeRequest(PlayerGrade? Grade);
+
+public record UpdateTeamCaptainRequest(int? CaptainPlayerId);
+
+public record CourtPairDto(
+    int CourtPairId,
+    int CompetitionId,
+    int Court1Id,
+    string? Court1Name,
+    int Court2Id,
+    string? Court2Name,
+    string Name);
+
+public record SaveCourtPairRequest(
+    int Court1Id,
+    int Court2Id,
+    string Name);
+
+public record TeamMatchSetDto(
+    int TeamMatchSetId,
+    int CompetitionFixtureId,
+    int SetNumber,
+    TeamMatchPhase Phase,
+    TeamMatchSetType SetType,
+    int CourtNumber,
+    int? HomePlayer1Id,
+    string? HomePlayer1Name,
+    int? HomePlayer2Id,
+    string? HomePlayer2Name,
+    int? AwayPlayer1Id,
+    string? AwayPlayer1Name,
+    int? AwayPlayer2Id,
+    string? AwayPlayer2Name,
+    int HomeGames,
+    int AwayGames,
+    int? WinnerTeamId,
+    bool IsComplete,
+    int? SavedMatchId);
+
+public record TeamLeagueTableEntryDto(
+    int TeamId,
+    string TeamName,
+    string? CaptainName,
+    int Played,
+    int Won,
+    int Drawn,
+    int Lost,
+    int SetsWon,
+    int SetsAgainst,
+    int Points);
 
 // ── Event DTOs ──────────────────────────────────────────────────────────────
 

--- a/DropShot.Shared/Enums.cs
+++ b/DropShot.Shared/Enums.cs
@@ -5,7 +5,8 @@ public enum CompetitionFormat : byte
     Singles = 1,
     Doubles = 2,
     Team = 3,
-    MixedDoubles = 4
+    MixedDoubles = 4,
+    MixedTeam = 5
 }
 
 public enum PlayerSex : byte
@@ -45,6 +46,26 @@ public enum FriendStatus : byte
     Pending = 1,
     Accepted = 2,
     Blocked = 3
+}
+
+public enum PlayerGrade : byte
+{
+    A = 1,
+    B = 2
+}
+
+public enum TeamMatchPhase : byte
+{
+    GenderDoubles = 1,
+    MixedDoubles = 2
+}
+
+public enum TeamMatchSetType : byte
+{
+    MensDoubles = 1,
+    WomensDoubles = 2,
+    MixedDoublesA = 3,
+    MixedDoublesB = 4
 }
 
 public enum FixtureStatus : byte

--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -310,9 +310,14 @@
                         <MudTh>Player</MudTh>
                         <MudTh>Status</MudTh>
                         <MudTh>Registered</MudTh>
-                        @if (Model.CompetitionFormat == CompetitionFormat.Team)
+                        @if (Model.CompetitionFormat is CompetitionFormat.Team or CompetitionFormat.MixedTeam)
                         {
                             <MudTh>Team</MudTh>
+                        }
+                        @if (Model.CompetitionFormat == CompetitionFormat.MixedTeam)
+                        {
+                            <MudTh>Gender</MudTh>
+                            <MudTh>Grade</MudTh>
                         }
                         <MudTh></MudTh>
                     </HeaderContent>
@@ -329,7 +334,7 @@
                             </MudSelect>
                         </MudTd>
                         <MudTd>@context.RegisteredAt.ToString("dd MMM yyyy")</MudTd>
-                        @if (Model.CompetitionFormat == CompetitionFormat.Team)
+                        @if (Model.CompetitionFormat is CompetitionFormat.Team or CompetitionFormat.MixedTeam)
                         {
                             <MudTd>
                                 <MudSelect T="int?" Value="context.TeamId" Dense="true" Variant="Variant.Text"
@@ -339,6 +344,23 @@
                                     {
                                         <MudSelectItem T="int?" Value="@((int?)t.CompetitionTeamId)">@t.Name</MudSelectItem>
                                     }
+                                </MudSelect>
+                            </MudTd>
+                        }
+                        @if (Model.CompetitionFormat == CompetitionFormat.MixedTeam)
+                        {
+                            <MudTd>
+                                <MudText Typo="Typo.body2">@(context.Player?.Sex?.ToString() ?? "—")</MudText>
+                            </MudTd>
+                            <MudTd>
+                                @{
+                                    var currentGrade = context.Grade.HasValue ? (DropShot.Shared.PlayerGrade)(byte)context.Grade.Value : (DropShot.Shared.PlayerGrade?)null;
+                                }
+                                <MudSelect T="DropShot.Shared.PlayerGrade?" Value="currentGrade" Dense="true"
+                                           Variant="Variant.Text" Clearable="true"
+                                           ValueChanged="@((DropShot.Shared.PlayerGrade? g) => UpdateParticipantGrade(context, g))">
+                                    <MudSelectItem T="DropShot.Shared.PlayerGrade?" Value="@((DropShot.Shared.PlayerGrade?)DropShot.Shared.PlayerGrade.A)">A</MudSelectItem>
+                                    <MudSelectItem T="DropShot.Shared.PlayerGrade?" Value="@((DropShot.Shared.PlayerGrade?)DropShot.Shared.PlayerGrade.B)">B</MudSelectItem>
                                 </MudSelect>
                             </MudTd>
                         }
@@ -486,8 +508,8 @@
                 </MudPaper>
             }
 
-            @* ── Teams (only for Team competitions) ──────────── *@
-            @if (Model.CompetitionFormat == CompetitionFormat.Team)
+            @* ── Teams (Team and MixedTeam competitions) ──────── *@
+            @if (Model.CompetitionFormat is CompetitionFormat.Team or CompetitionFormat.MixedTeam)
             {
                 <MudPaper Class="pa-4 mb-4">
                     <MudStack Row="true" AlignItems="AlignItems.Center" Class="mb-3">
@@ -499,16 +521,77 @@
                     <MudTable Items="@_teams" Dense="true" Hover="true">
                         <HeaderContent>
                             <MudTh>Team Name</MudTh>
+                            @if (Model.CompetitionFormat == CompetitionFormat.MixedTeam)
+                            {
+                                <MudTh>Captain</MudTh>
+                            }
                             <MudTh>Members</MudTh>
+                            @if (Model.CompetitionFormat == CompetitionFormat.MixedTeam)
+                            {
+                                <MudTh>Composition</MudTh>
+                            }
                             <MudTh></MudTh>
                         </HeaderContent>
                         <RowTemplate>
                             <MudTd>@context.Name</MudTd>
+                            @if (Model.CompetitionFormat == CompetitionFormat.MixedTeam)
+                            {
+                                <MudTd>
+                                    <MudSelect T="int?" Value="context.CaptainPlayerId" Dense="true"
+                                               Variant="Variant.Text" Clearable="true"
+                                               ValueChanged="@((int? pid) => UpdateTeamCaptain(context, pid))">
+                                        @foreach (var p in _participants.Where(p => p.TeamId == context.CompetitionTeamId && p.Player != null))
+                                        {
+                                            <MudSelectItem T="int?" Value="@((int?)p.PlayerId)">@p.Player!.DisplayName</MudSelectItem>
+                                        }
+                                    </MudSelect>
+                                </MudTd>
+                            }
                             <MudTd>
-                                @string.Join(", ", _participants
-                                    .Where(p => p.TeamId == context.CompetitionTeamId)
-                                    .Select(p => p.Player?.DisplayName ?? ""))
+                                @{
+                                    var teamMembers = _participants.Where(p => p.TeamId == context.CompetitionTeamId).ToList();
+                                }
+                                @if (Model.CompetitionFormat == CompetitionFormat.MixedTeam)
+                                {
+                                    @foreach (var m in teamMembers)
+                                    {
+                                        <MudChip T="string" Size="Size.Small" Variant="Variant.Text"
+                                                 Color="@(m.Player?.Sex == DropShot.Models.PlayerSex.Male ? Color.Info : Color.Secondary)">
+                                            @(m.Player?.DisplayName ?? "") (@(m.Player?.Sex?.ToString().Substring(0,1) ?? "?")@(m.Grade.HasValue ? m.Grade.Value.ToString() : "?"))
+                                        </MudChip>
+                                    }
+                                }
+                                else
+                                {
+                                    @string.Join(", ", teamMembers.Select(p => p.Player?.DisplayName ?? ""))
+                                }
                             </MudTd>
+                            @if (Model.CompetitionFormat == CompetitionFormat.MixedTeam)
+                            {
+                                <MudTd>
+                                    @{
+                                        var validationErrors = ValidateTeamCompositionLocal(teamMembers);
+                                    }
+                                    @if (validationErrors.Count == 0)
+                                    {
+                                        <MudIcon Icon="@Icons.Material.Filled.CheckCircle" Color="Color.Success" Size="Size.Small" />
+                                    }
+                                    else
+                                    {
+                                        <MudTooltip>
+                                            <ChildContent>
+                                                <MudIcon Icon="@Icons.Material.Filled.Warning" Color="Color.Warning" Size="Size.Small" />
+                                            </ChildContent>
+                                            <TooltipContent>
+                                                @foreach (var err in validationErrors)
+                                                {
+                                                    <div>@err</div>
+                                                }
+                                            </TooltipContent>
+                                        </MudTooltip>
+                                    }
+                                </MudTd>
+                            }
                             <MudTd>
                                 <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="Size.Small"
                                                OnClick="@(() => OpenEditTeamDialog(context))" />
@@ -521,12 +604,80 @@
                 </MudPaper>
             }
 
+            @* ── Court Pairs (MixedTeam only) ──────────────────── *@
+            @if (Model.CompetitionFormat == CompetitionFormat.MixedTeam)
+            {
+                <MudPaper Class="pa-4 mb-4">
+                    <MudText Typo="Typo.h6" Class="mb-3">Court Pairs</MudText>
+                    <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mb-3">
+                        Each team match occupies one court pair — both courts are booked simultaneously.
+                    </MudText>
+
+                    <MudGrid Spacing="1" Class="mb-2">
+                        <MudItem xs="3">
+                            <MudSelect @bind-Value="_newCourtPairCourt1Id" Label="Court 1" Variant="Variant.Outlined"
+                                       Margin="Margin.Dense" Clearable="true">
+                                @foreach (var c in _courts)
+                                {
+                                    <MudSelectItem T="int?" Value="@((int?)c.CourtId)">@c.Name</MudSelectItem>
+                                }
+                            </MudSelect>
+                        </MudItem>
+                        <MudItem xs="3">
+                            <MudSelect @bind-Value="_newCourtPairCourt2Id" Label="Court 2" Variant="Variant.Outlined"
+                                       Margin="Margin.Dense" Clearable="true">
+                                @foreach (var c in _courts)
+                                {
+                                    <MudSelectItem T="int?" Value="@((int?)c.CourtId)">@c.Name</MudSelectItem>
+                                }
+                            </MudSelect>
+                        </MudItem>
+                        <MudItem xs="4">
+                            <MudTextField @bind-Value="_newCourtPairName" Label="Pair Name" Variant="Variant.Outlined"
+                                          Margin="Margin.Dense" Placeholder="e.g. Courts 1 & 2" />
+                        </MudItem>
+                        <MudItem xs="2" Class="d-flex align-center">
+                            <MudButton Variant="Variant.Filled" Color="Color.Primary" Size="Size.Small"
+                                       Disabled="@(!_newCourtPairCourt1Id.HasValue || !_newCourtPairCourt2Id.HasValue || string.IsNullOrWhiteSpace(_newCourtPairName))"
+                                       OnClick="AddCourtPair">Add</MudButton>
+                        </MudItem>
+                    </MudGrid>
+
+                    @if (_courtPairs.Count > 0)
+                    {
+                        <MudSimpleTable Dense="true">
+                            <thead>
+                                <tr><th>Name</th><th>Court 1</th><th>Court 2</th><th></th></tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var cp in _courtPairs)
+                                {
+                                    <tr>
+                                        <td>@cp.Name</td>
+                                        <td>@cp.Court1?.Name</td>
+                                        <td>@cp.Court2?.Name</td>
+                                        <td>
+                                            <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small"
+                                                           Color="Color.Error" OnClick="@(() => DeleteCourtPair(cp))" />
+                                        </td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </MudSimpleTable>
+                    }
+                    else
+                    {
+                        <MudText Typo="Typo.caption" Color="Color.Secondary">No court pairs configured yet.</MudText>
+                    }
+                </MudPaper>
+            }
+
             @* ── Fixtures ────────────────────────────────────── *@
             <MudPaper Class="pa-4">
                 <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="mb-3">
                     <MudText Typo="Typo.h6" Style="flex:1">Fixtures</MudText>
                     @if (_stages.Any(s => s.StageType == StageType.RoundRobin) &&
-                         _stages.Any(s => s.StageType is StageType.Knockout or StageType.QuarterFinal))
+                         _stages.Any(s => s.StageType is StageType.Knockout or StageType.QuarterFinal or StageType.SemiFinal))
                     {
                         <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Warning"
                                    StartIcon="@Icons.Material.Filled.Leaderboard"
@@ -559,7 +710,7 @@
                         <MudTd>@(context.FixtureLabel ?? "—")</MudTd>
                         <MudTd>@(context.ScheduledAt?.ToString("dd MMM yyyy HH:mm") ?? "—")</MudTd>
                         <MudTd>@FixturePlayers(context)</MudTd>
-                        <MudTd>@(context.Court?.Name ?? "—")</MudTd>
+                        <MudTd>@(context.CourtPair?.Name ?? context.Court?.Name ?? "—")</MudTd>
                         <MudTd>
                             @if (!string.IsNullOrEmpty(context.ResultSummary))
                             {
@@ -582,7 +733,14 @@
                             </MudChip>
                         </MudTd>
                         <MudTd>
-                            @if (context.Player1Id.HasValue && context.Player2Id.HasValue
+                            @if (context.HomeTeamId.HasValue && context.AwayTeamId.HasValue
+                                 && context.Status is not (FixtureStatus.Completed or FixtureStatus.Cancelled or FixtureStatus.Walkover))
+                            {
+                                <MudIconButton Icon="@Icons.Material.Filled.SportsScore" Size="Size.Small"
+                                               Color="Color.Success" aria-label="Team Match Scoring"
+                                               OnClick="@(() => Nav.NavigateTo($"/team-match/{context.CompetitionFixtureId}"))" />
+                            }
+                            else if (context.Player1Id.HasValue && context.Player2Id.HasValue
                                  && context.Status is not (FixtureStatus.Completed or FixtureStatus.Cancelled or FixtureStatus.Walkover or FixtureStatus.AwaitingVerification))
                             {
                                 <MudIconButton Icon="@Icons.Material.Filled.Scoreboard" Size="Size.Small"
@@ -967,6 +1125,12 @@
     private string _compEmailSubject = "";
     private string _compEmailBody = "";
 
+    // Court pairs (MixedTeam)
+    private List<CourtPair> _courtPairs = [];
+    private int? _newCourtPairCourt1Id;
+    private int? _newCourtPairCourt2Id;
+    private string _newCourtPairName = "";
+
     // Schedule options
     private bool _scheduleDeleteExisting;
 
@@ -1053,8 +1217,13 @@
                 .Include(c => c.Fixtures).ThenInclude(f => f.Player2)
                 .Include(c => c.Fixtures).ThenInclude(f => f.Player3)
                 .Include(c => c.Fixtures).ThenInclude(f => f.Player4)
-                .Include(c => c.Teams)
+                .Include(c => c.Fixtures).ThenInclude(f => f.HomeTeam)
+                .Include(c => c.Fixtures).ThenInclude(f => f.AwayTeam)
+                .Include(c => c.Fixtures).ThenInclude(f => f.CourtPair)
+                .Include(c => c.Teams).ThenInclude(t => t.Captain)
                 .Include(c => c.MatchWindows).ThenInclude(w => w.Court)
+                .Include(c => c.CourtPairs).ThenInclude(cp => cp.Court1)
+                .Include(c => c.CourtPairs).ThenInclude(cp => cp.Court2)
                 .AsNoTracking()
                 .FirstOrDefaultAsync(c => c.CompetitionID == Id);
 
@@ -1089,6 +1258,7 @@
             _matchWindows = comp.MatchWindows
                 .OrderBy(w => w.DayOfWeek).ThenBy(w => w.StartTime)
                 .ToList();
+            _courtPairs = comp.CourtPairs.OrderBy(cp => cp.Name).ToList();
 
             if (comp.HostClubId.HasValue)
             {
@@ -1250,6 +1420,7 @@
             CompetitionFormat.Doubles => "Doubles",
             CompetitionFormat.MixedDoubles => "Mixed Doubles",
             CompetitionFormat.Team => "Team",
+            CompetitionFormat.MixedTeam => "Mixed Team Tennis",
             _ => Model.CompetitionFormat.ToString()
         });
 
@@ -1438,6 +1609,18 @@
         if (row != null) { row.TeamId = teamId; await db.SaveChangesAsync(); cp.TeamId = teamId; }
     }
 
+    private async Task UpdateParticipantGrade(CompetitionParticipant cp, DropShot.Shared.PlayerGrade? grade)
+    {
+        await using var db = DbFactory.CreateDbContext();
+        var row = await db.CompetitionParticipants.FindAsync(cp.CompetitionId, cp.PlayerId);
+        if (row != null)
+        {
+            row.Grade = grade.HasValue ? (DropShot.Models.PlayerGrade)(byte)grade.Value : null;
+            await db.SaveChangesAsync();
+            cp.Grade = row.Grade;
+        }
+    }
+
     // ── Teams ────────────────────────────────────────────────────────────────
 
     private void OpenAddTeamDialog()
@@ -1487,6 +1670,83 @@
         if (t != null) { db.CompetitionTeams.Remove(t); await db.SaveChangesAsync(); }
         _teams.Remove(team);
         Snackbar.Add("Team removed.", Severity.Warning);
+    }
+
+    private async Task UpdateTeamCaptain(CompetitionTeam team, int? captainPlayerId)
+    {
+        await using var db = DbFactory.CreateDbContext();
+        var t = await db.CompetitionTeams.FindAsync(team.CompetitionTeamId);
+        if (t != null)
+        {
+            t.CaptainPlayerId = captainPlayerId;
+            await db.SaveChangesAsync();
+            team.CaptainPlayerId = captainPlayerId;
+        }
+    }
+
+    private static List<string> ValidateTeamCompositionLocal(List<CompetitionParticipant> members)
+    {
+        var errors = new List<string>();
+        if (members.Count != 4)
+        {
+            errors.Add($"Need 4 players (has {members.Count})");
+            return errors;
+        }
+
+        var maleA = members.Count(m => m.Player?.Sex == DropShot.Models.PlayerSex.Male && m.Grade == DropShot.Models.PlayerGrade.A);
+        var femaleA = members.Count(m => m.Player?.Sex == DropShot.Models.PlayerSex.Female && m.Grade == DropShot.Models.PlayerGrade.A);
+        var maleB = members.Count(m => m.Player?.Sex == DropShot.Models.PlayerSex.Male && m.Grade == DropShot.Models.PlayerGrade.B);
+        var femaleB = members.Count(m => m.Player?.Sex == DropShot.Models.PlayerSex.Female && m.Grade == DropShot.Models.PlayerGrade.B);
+
+        if (maleA != 1) errors.Add($"Need 1 Male A (has {maleA})");
+        if (femaleA != 1) errors.Add($"Need 1 Female A (has {femaleA})");
+        if (maleB != 1) errors.Add($"Need 1 Male B (has {maleB})");
+        if (femaleB != 1) errors.Add($"Need 1 Female B (has {femaleB})");
+
+        var unset = members.Count(m => m.Grade == null || m.Player?.Sex == null);
+        if (unset > 0) errors.Add($"{unset} player(s) missing grade/gender");
+
+        return errors;
+    }
+
+    // ── Court Pairs ─────────────────────────────────────────────────────────
+
+    private async Task AddCourtPair()
+    {
+        if (!_newCourtPairCourt1Id.HasValue || !_newCourtPairCourt2Id.HasValue
+            || string.IsNullOrWhiteSpace(_newCourtPairName)) return;
+        if (_newCourtPairCourt1Id == _newCourtPairCourt2Id)
+        {
+            Snackbar.Add("Court 1 and Court 2 must be different.", Severity.Warning);
+            return;
+        }
+
+        await using var db = DbFactory.CreateDbContext();
+        var pair = new CourtPair
+        {
+            CompetitionId = Id,
+            Court1Id = _newCourtPairCourt1Id.Value,
+            Court2Id = _newCourtPairCourt2Id.Value,
+            Name = _newCourtPairName.Trim()
+        };
+        db.CourtPairs.Add(pair);
+        await db.SaveChangesAsync();
+        pair.Court1 = _courts.FirstOrDefault(c => c.CourtId == pair.Court1Id);
+        pair.Court2 = _courts.FirstOrDefault(c => c.CourtId == pair.Court2Id);
+        _courtPairs.Add(pair);
+        _newCourtPairCourt1Id = null;
+        _newCourtPairCourt2Id = null;
+        _newCourtPairName = "";
+        Snackbar.Add("Court pair added.", Severity.Success);
+    }
+
+    private async Task DeleteCourtPair(CourtPair pair)
+    {
+        await using var db = DbFactory.CreateDbContext();
+        var p = await db.CourtPairs.FindAsync(pair.CourtPairId);
+        if (p != null) { db.CourtPairs.Remove(p); await db.SaveChangesAsync(); }
+        _courtPairs.Remove(pair);
+        Snackbar.Add("Court pair removed.", Severity.Warning);
     }
 
     // ── Fixtures ─────────────────────────────────────────────────────────────
@@ -2062,6 +2322,9 @@
             .Include(f => f.Player2)
             .Include(f => f.Player3)
             .Include(f => f.Player4)
+            .Include(f => f.HomeTeam)
+            .Include(f => f.AwayTeam)
+            .Include(f => f.CourtPair)
             .OrderBy(f => f.RoundNumber)
             .ThenBy(f => f.ScheduledAt)
             .ToListAsync();
@@ -2074,9 +2337,11 @@
         _showSeedConfirm = false;
         await using var db = DbFactory.CreateDbContext();
 
-        // Find the first-round knockout fixtures to update (QF fixtures in Knockout or QuarterFinal stages)
+        bool isMixedTeam = Model.CompetitionFormat == CompetitionFormat.MixedTeam;
+
+        // Find the first-round knockout fixtures
         var knockoutStageIds = _stages
-            .Where(s => s.StageType is StageType.Knockout or StageType.QuarterFinal)
+            .Where(s => s.StageType is StageType.Knockout or StageType.QuarterFinal or StageType.SemiFinal)
             .Select(s => s.CompetitionStageId)
             .ToHashSet();
 
@@ -2095,56 +2360,91 @@
             return;
         }
 
-        // Compute RR standings
         var rrStageIds = _stages
             .Where(s => s.StageType == StageType.RoundRobin)
             .Select(s => s.CompetitionStageId)
             .ToHashSet();
 
-        var activePlayers = _participants
-            .Where(p => p.Status == ParticipantStatus.Registered || p.Status == ParticipantStatus.Confirmed)
-            .Select(p => p.PlayerId)
-            .ToList();
-
-        List<int> seededPlayers;
-
-        var rrFixtures = await db.CompetitionFixtures
-            .Where(f => f.CompetitionId == Id
-                     && f.CompetitionStageId != null
-                     && rrStageIds.Contains(f.CompetitionStageId!.Value)
-                     && f.Status == FixtureStatus.Completed
-                     && f.WinnerPlayerId != null)
-            .ToListAsync();
-
-        if (rrFixtures.Count == 0)
+        if (isMixedTeam)
         {
-            // No results yet — fall back to registration order
-            seededPlayers = activePlayers.Take(firstRoundFixtures.Count * 2).ToList();
-        }
-        else
-        {
-            var pts = activePlayers.ToDictionary(pid => pid, _ => (Points: 0, Won: 0));
+            // Team seeding from team league table
+            var rrFixtures = await db.CompetitionFixtures
+                .Where(f => f.CompetitionId == Id
+                         && f.CompetitionStageId != null
+                         && rrStageIds.Contains(f.CompetitionStageId!.Value)
+                         && f.Status == FixtureStatus.Completed
+                         && f.HomeTeamId != null && f.AwayTeamId != null)
+                .Include(f => f.TeamMatchSets)
+                .ToListAsync();
+
+            var teamIds = _teams.Select(t => t.CompetitionTeamId).ToList();
+            var teamSetsWon = teamIds.ToDictionary(tid => tid, _ => 0);
+
             foreach (var f in rrFixtures)
             {
-                var pids = new[] { f.Player1Id, f.Player2Id, f.Player3Id, f.Player4Id }
-                    .Where(pid => pid.HasValue && pts.ContainsKey(pid.Value))
-                    .Select(pid => pid!.Value).Distinct();
-                foreach (var pid in pids)
-                {
-                    bool win = pid == f.WinnerPlayerId;
-                    var cur = pts[pid];
-                    pts[pid] = (cur.Points + (win ? 3 : 0), cur.Won + (win ? 1 : 0));
-                }
+                int homeId = f.HomeTeamId!.Value;
+                int awayId = f.AwayTeamId!.Value;
+                if (teamSetsWon.ContainsKey(homeId))
+                    teamSetsWon[homeId] += f.TeamMatchSets.Count(s => s.IsComplete && s.WinnerTeamId == homeId);
+                if (teamSetsWon.ContainsKey(awayId))
+                    teamSetsWon[awayId] += f.TeamMatchSets.Count(s => s.IsComplete && s.WinnerTeamId == awayId);
             }
-            seededPlayers = pts
-                .OrderByDescending(kv => kv.Value.Points)
-                .ThenByDescending(kv => kv.Value.Won)
+
+            var seededTeams = teamSetsWon
+                .OrderByDescending(kv => kv.Value)
                 .Take(firstRoundFixtures.Count * 2)
                 .Select(kv => kv.Key)
                 .ToList();
-        }
 
-        CompetitionProgressionService.AssignWinners(firstRoundFixtures, seededPlayers);
+            CompetitionProgressionService.AssignTeamWinners(firstRoundFixtures, seededTeams);
+        }
+        else
+        {
+            // Player seeding
+            var activePlayers = _participants
+                .Where(p => p.Status == ParticipantStatus.Registered || p.Status == ParticipantStatus.Confirmed)
+                .Select(p => p.PlayerId)
+                .ToList();
+
+            List<int> seededPlayers;
+
+            var rrFixtures = await db.CompetitionFixtures
+                .Where(f => f.CompetitionId == Id
+                         && f.CompetitionStageId != null
+                         && rrStageIds.Contains(f.CompetitionStageId!.Value)
+                         && f.Status == FixtureStatus.Completed
+                         && f.WinnerPlayerId != null)
+                .ToListAsync();
+
+            if (rrFixtures.Count == 0)
+            {
+                seededPlayers = activePlayers.Take(firstRoundFixtures.Count * 2).ToList();
+            }
+            else
+            {
+                var pts = activePlayers.ToDictionary(pid => pid, _ => (Points: 0, Won: 0));
+                foreach (var f in rrFixtures)
+                {
+                    var pids = new[] { f.Player1Id, f.Player2Id, f.Player3Id, f.Player4Id }
+                        .Where(pid => pid.HasValue && pts.ContainsKey(pid.Value))
+                        .Select(pid => pid!.Value).Distinct();
+                    foreach (var pid in pids)
+                    {
+                        bool win = pid == f.WinnerPlayerId;
+                        var cur = pts[pid];
+                        pts[pid] = (cur.Points + (win ? 3 : 0), cur.Won + (win ? 1 : 0));
+                    }
+                }
+                seededPlayers = pts
+                    .OrderByDescending(kv => kv.Value.Points)
+                    .ThenByDescending(kv => kv.Value.Won)
+                    .Take(firstRoundFixtures.Count * 2)
+                    .Select(kv => kv.Key)
+                    .ToList();
+            }
+
+            CompetitionProgressionService.AssignWinners(firstRoundFixtures, seededPlayers);
+        }
 
         await db.SaveChangesAsync();
 
@@ -2157,6 +2457,9 @@
             .Include(f => f.Player2)
             .Include(f => f.Player3)
             .Include(f => f.Player4)
+            .Include(f => f.HomeTeam)
+            .Include(f => f.AwayTeam)
+            .Include(f => f.CourtPair)
             .OrderBy(f => f.RoundNumber)
             .ThenBy(f => f.ScheduledAt)
             .ToListAsync();
@@ -2168,6 +2471,14 @@
 
     private static string FixturePlayers(CompetitionFixture f)
     {
+        // Team match display
+        if (f.HomeTeamId.HasValue || f.AwayTeamId.HasValue)
+        {
+            var home = f.HomeTeam?.Name ?? "TBD";
+            var away = f.AwayTeam?.Name ?? "TBD";
+            return $"{home} vs {away}";
+        }
+
         var side1 = new[] { f.Player1?.DisplayName, f.Player3?.DisplayName }
             .Where(n => n != null).DefaultIfEmpty("TBD").Aggregate((a, b) => $"{a} & {b}");
         var side2 = new[] { f.Player2?.DisplayName, f.Player4?.DisplayName }

--- a/DropShot/Components/Pages/TeamMatchScoring.razor
+++ b/DropShot/Components/Pages/TeamMatchScoring.razor
@@ -1,0 +1,442 @@
+@page "/team-match/{FixtureId:int}"
+@rendermode InteractiveServer
+@using DropShot.Data
+@using DropShot.Models
+@using DropShot.Services
+@using Microsoft.EntityFrameworkCore
+@using System.Security.Claims
+
+@inject IDbContextFactory<MyDbContext> DbFactory
+@inject NavigationManager Nav
+@inject ISnackbar Snackbar
+@inject AuthenticationStateProvider AuthStateProvider
+
+<MudProviders />
+
+@if (_loading)
+{
+    <MudProgressLinear Indeterminate="true" />
+}
+else if (_fixture == null)
+{
+    <MudAlert Severity="Severity.Error">Fixture not found.</MudAlert>
+}
+else
+{
+    @* ── Match Header ──────────────────────────────────────── *@
+    <MudPaper Class="pa-3 mb-3" Elevation="2">
+        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+            <MudText Typo="Typo.h5" Style="flex:1">
+                @(_fixture.Competition?.CompetitionName ?? "Team Match")
+                @if (!string.IsNullOrEmpty(_fixture.FixtureLabel))
+                {
+                    <span> — @_fixture.FixtureLabel</span>
+                }
+            </MudText>
+        </MudStack>
+
+        @* ── Live Match Tally ──────────────────────────────── *@
+        <MudStack Row="true" Justify="Justify.Center" AlignItems="AlignItems.Center" Spacing="4" Class="mt-2">
+            <MudText Typo="Typo.h4" Color="Color.Primary" Style="font-weight:bold">
+                @(_fixture.HomeTeam?.Name ?? "Home")
+            </MudText>
+            <MudPaper Class="pa-2 px-4" Elevation="3" Style="background: #1a1a2e; border-radius: 8px;">
+                <MudText Typo="Typo.h3" Style="color: #FFD700; font-weight: bold; letter-spacing: 4px;">
+                    @_homeSetsWon — @_awaySetsWon
+                </MudText>
+            </MudPaper>
+            <MudText Typo="Typo.h4" Color="Color.Secondary" Style="font-weight:bold">
+                @(_fixture.AwayTeam?.Name ?? "Away")
+            </MudText>
+        </MudStack>
+
+        @if (_allComplete)
+        {
+            <MudAlert Severity="Severity.Success" Class="mt-2">
+                @if (_homeSetsWon > _awaySetsWon)
+                {
+                    <strong>@(_fixture.HomeTeam?.Name) wins @_homeSetsWon–@_awaySetsWon!</strong>
+                }
+                else if (_awaySetsWon > _homeSetsWon)
+                {
+                    <strong>@(_fixture.AwayTeam?.Name) wins @_awaySetsWon–@_homeSetsWon!</strong>
+                }
+                else
+                {
+                    <strong>Match drawn @_homeSetsWon–@_awaySetsWon</strong>
+                }
+            </MudAlert>
+        }
+    </MudPaper>
+
+    @* ── Phase Display ─────────────────────────────────────── *@
+    @foreach (var phase in new[] { TeamMatchPhase.GenderDoubles, TeamMatchPhase.MixedDoubles })
+    {
+        var phaseSets = _sets.Where(s => s.Phase == phase).ToList();
+        var phaseName = phase == TeamMatchPhase.GenderDoubles ? "Phase 1 — Gender Doubles" : "Phase 2 — Mixed Doubles";
+
+        <MudText Typo="Typo.h6" Class="mt-3 mb-2">@phaseName</MudText>
+
+        <MudGrid Spacing="3" Class="mb-3">
+            @* ── Court 1 ────────────────────────────────── *@
+            <MudItem xs="12" md="6">
+                <MudPaper Class="pa-3" Elevation="2" Style="border-left: 4px solid var(--mud-palette-primary);">
+                    <MudText Typo="Typo.subtitle1" Color="Color.Primary" Class="mb-2">
+                        Court 1
+                        @{ var court1Sets = phaseSets.Where(s => s.CourtNumber == 1).OrderBy(s => s.SetNumber).ToList(); }
+                        @if (court1Sets.Any())
+                        {
+                            <span> — @SetTypeLabel(court1Sets.First().SetType)</span>
+                        }
+                    </MudText>
+                    @foreach (var set in court1Sets)
+                    {
+                        <MudPaper Class="pa-2 mb-2" Outlined="true">
+                            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                                <MudText Typo="Typo.body2" Style="flex:1">
+                                    Set @set.SetNumber: @PlayerNames(set, true) vs @PlayerNames(set, false)
+                                </MudText>
+                                @if (set.IsComplete)
+                                {
+                                    <MudChip T="string" Size="Size.Small" Color="Color.Success" Variant="Variant.Filled">
+                                        @set.HomeGames–@set.AwayGames
+                                    </MudChip>
+                                    @if (set.WinnerTeamId == _fixture.HomeTeamId)
+                                    {
+                                        <MudIcon Icon="@Icons.Material.Filled.EmojiEvents" Size="Size.Small" Color="Color.Primary" />
+                                    }
+                                    else if (set.WinnerTeamId == _fixture.AwayTeamId)
+                                    {
+                                        <MudIcon Icon="@Icons.Material.Filled.EmojiEvents" Size="Size.Small" Color="Color.Secondary" />
+                                    }
+                                }
+                                else if (set.SavedMatchId.HasValue)
+                                {
+                                    <MudChip T="string" Size="Size.Small" Color="Color.Warning" Variant="Variant.Filled">In Progress</MudChip>
+                                    <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Warning"
+                                               OnClick="@(() => Nav.NavigateTo($"/match/{set.SavedMatchId}"))">
+                                        Resume
+                                    </MudButton>
+                                }
+                                else
+                                {
+                                    <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary"
+                                               Disabled="@(!CanStartSet(set))"
+                                               OnClick="@(() => StartSetScoring(set))">
+                                        Start
+                                    </MudButton>
+                                }
+                            </MudStack>
+                        </MudPaper>
+                    }
+                </MudPaper>
+            </MudItem>
+
+            @* ── Court 2 ────────────────────────────────── *@
+            <MudItem xs="12" md="6">
+                <MudPaper Class="pa-3" Elevation="2" Style="border-left: 4px solid var(--mud-palette-secondary);">
+                    <MudText Typo="Typo.subtitle1" Color="Color.Secondary" Class="mb-2">
+                        Court 2
+                        @{ var court2Sets = phaseSets.Where(s => s.CourtNumber == 2).OrderBy(s => s.SetNumber).ToList(); }
+                        @if (court2Sets.Any())
+                        {
+                            <span> — @SetTypeLabel(court2Sets.First().SetType)</span>
+                        }
+                    </MudText>
+                    @foreach (var set in court2Sets)
+                    {
+                        <MudPaper Class="pa-2 mb-2" Outlined="true">
+                            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                                <MudText Typo="Typo.body2" Style="flex:1">
+                                    Set @set.SetNumber: @PlayerNames(set, true) vs @PlayerNames(set, false)
+                                </MudText>
+                                @if (set.IsComplete)
+                                {
+                                    <MudChip T="string" Size="Size.Small" Color="Color.Success" Variant="Variant.Filled">
+                                        @set.HomeGames–@set.AwayGames
+                                    </MudChip>
+                                    @if (set.WinnerTeamId == _fixture.HomeTeamId)
+                                    {
+                                        <MudIcon Icon="@Icons.Material.Filled.EmojiEvents" Size="Size.Small" Color="Color.Primary" />
+                                    }
+                                    else if (set.WinnerTeamId == _fixture.AwayTeamId)
+                                    {
+                                        <MudIcon Icon="@Icons.Material.Filled.EmojiEvents" Size="Size.Small" Color="Color.Secondary" />
+                                    }
+                                }
+                                else if (set.SavedMatchId.HasValue)
+                                {
+                                    <MudChip T="string" Size="Size.Small" Color="Color.Warning" Variant="Variant.Filled">In Progress</MudChip>
+                                    <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Warning"
+                                               OnClick="@(() => Nav.NavigateTo($"/match/{set.SavedMatchId}"))">
+                                        Resume
+                                    </MudButton>
+                                }
+                                else
+                                {
+                                    <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary"
+                                               Disabled="@(!CanStartSet(set))"
+                                               OnClick="@(() => StartSetScoring(set))">
+                                        Start
+                                    </MudButton>
+                                }
+                            </MudStack>
+                        </MudPaper>
+                    }
+                </MudPaper>
+            </MudItem>
+        </MudGrid>
+    }
+
+    @* ── Refresh button ────────────────────────────────────── *@
+    <MudStack Row="true" Justify="Justify.Center" Class="mt-3 mb-4">
+        <MudButton Variant="Variant.Outlined" StartIcon="@Icons.Material.Filled.Refresh"
+                   OnClick="RefreshState">Refresh Scores</MudButton>
+        @if (_fixture.Competition != null)
+        {
+            <MudButton Variant="Variant.Outlined" StartIcon="@Icons.Material.Filled.ArrowBack"
+                       OnClick="@(() => Nav.NavigateTo($"/competition/{_fixture.CompetitionId}/view"))">
+                Back to Competition
+            </MudButton>
+        }
+    </MudStack>
+}
+
+@code {
+    [Parameter] public int FixtureId { get; set; }
+
+    private bool _loading = true;
+    private CompetitionFixture? _fixture;
+    private List<TeamMatchSet> _sets = [];
+    private int _homeSetsWon;
+    private int _awaySetsWon;
+    private bool _allComplete;
+    private string? _currentUserId;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var authState = await AuthStateProvider.GetAuthenticationStateAsync();
+        _currentUserId = authState.User.FindFirstValue(ClaimTypes.NameIdentifier);
+        await LoadFixture();
+        _loading = false;
+    }
+
+    private async Task LoadFixture()
+    {
+        await using var db = DbFactory.CreateDbContext();
+        _fixture = await db.CompetitionFixtures
+            .Include(f => f.Competition)
+            .Include(f => f.HomeTeam)
+            .Include(f => f.AwayTeam)
+            .Include(f => f.CourtPair).ThenInclude(cp => cp!.Court1)
+            .Include(f => f.CourtPair).ThenInclude(cp => cp!.Court2)
+            .Include(f => f.TeamMatchSets).ThenInclude(s => s.HomePlayer1)
+            .Include(f => f.TeamMatchSets).ThenInclude(s => s.HomePlayer2)
+            .Include(f => f.TeamMatchSets).ThenInclude(s => s.AwayPlayer1)
+            .Include(f => f.TeamMatchSets).ThenInclude(s => s.AwayPlayer2)
+            .Include(f => f.TeamMatchSets).ThenInclude(s => s.SavedMatch)
+            .FirstOrDefaultAsync(f => f.CompetitionFixtureId == FixtureId);
+
+        if (_fixture != null)
+        {
+            _sets = _fixture.TeamMatchSets.OrderBy(s => s.SetNumber).ToList();
+            await SyncCompletedSets();
+            RecalculateTally();
+        }
+    }
+
+    private async Task SyncCompletedSets()
+    {
+        // Check if any in-progress sets have completed (SavedMatch marked complete)
+        bool anyUpdated = false;
+        await using var db = DbFactory.CreateDbContext();
+
+        foreach (var set in _sets.Where(s => s.SavedMatchId.HasValue && !s.IsComplete))
+        {
+            var savedMatch = await db.SavedMatch.FindAsync(set.SavedMatchId);
+            if (savedMatch is { Complete: true } && !string.IsNullOrEmpty(savedMatch.MatchJson))
+            {
+                var match = Newtonsoft.Json.JsonConvert.DeserializeObject<Match>(savedMatch.MatchJson);
+                if (match?.Complete == true && match.HistoryList.Count > 0)
+                {
+                    var lastState = match.HistoryList[0]; // most recent is first in stack-to-list
+                    // The last entry in SetScores has the final set score
+                    if (lastState.SetScores?.Count > 0)
+                    {
+                        var finalSet = lastState.SetScores.Last();
+                        var dbSet = await db.TeamMatchSets.FindAsync(set.TeamMatchSetId);
+                        if (dbSet != null)
+                        {
+                            dbSet.HomeGames = finalSet.UserGames;
+                            dbSet.AwayGames = finalSet.OpponentGames;
+                            dbSet.IsComplete = true;
+                            dbSet.WinnerTeamId = finalSet.UserGames > finalSet.OpponentGames
+                                ? _fixture!.HomeTeamId
+                                : _fixture!.AwayTeamId;
+                            anyUpdated = true;
+
+                            // Update local state
+                            set.HomeGames = dbSet.HomeGames;
+                            set.AwayGames = dbSet.AwayGames;
+                            set.IsComplete = true;
+                            set.WinnerTeamId = dbSet.WinnerTeamId;
+                        }
+                    }
+                }
+            }
+        }
+
+        if (anyUpdated)
+        {
+            await db.SaveChangesAsync();
+            await CheckMatchComplete(db);
+        }
+    }
+
+    private async Task CheckMatchComplete(MyDbContext db)
+    {
+        if (_sets.All(s => s.IsComplete) && _fixture != null)
+        {
+            var fx = await db.CompetitionFixtures.FindAsync(_fixture.CompetitionFixtureId);
+            if (fx != null && fx.Status != FixtureStatus.Completed)
+            {
+                _homeSetsWon = _sets.Count(s => s.WinnerTeamId == _fixture.HomeTeamId);
+                _awaySetsWon = _sets.Count(s => s.WinnerTeamId == _fixture.AwayTeamId);
+
+                fx.Status = FixtureStatus.Completed;
+                fx.ResultSummary = $"{_homeSetsWon}–{_awaySetsWon}";
+                if (_homeSetsWon > _awaySetsWon)
+                    fx.WinnerTeamId = _fixture.HomeTeamId;
+                else if (_awaySetsWon > _homeSetsWon)
+                    fx.WinnerTeamId = _fixture.AwayTeamId;
+                // Draw: WinnerTeamId stays null
+
+                await db.SaveChangesAsync();
+                _allComplete = true;
+
+                // Auto-advance knockout bracket if all matches in this round are complete
+                await CompetitionProgressionService.TryAdvanceAsync(db, _fixture.CompetitionId, fx.CompetitionFixtureId);
+            }
+        }
+    }
+
+    private void RecalculateTally()
+    {
+        _homeSetsWon = _sets.Count(s => s.IsComplete && s.WinnerTeamId == _fixture?.HomeTeamId);
+        _awaySetsWon = _sets.Count(s => s.IsComplete && s.WinnerTeamId == _fixture?.AwayTeamId);
+        _allComplete = _sets.Count == 8 && _sets.All(s => s.IsComplete);
+    }
+
+    private async Task RefreshState()
+    {
+        _loading = true;
+        await LoadFixture();
+        _loading = false;
+        Snackbar.Add("Scores refreshed.", Severity.Info);
+    }
+
+    private bool CanStartSet(TeamMatchSet set)
+    {
+        if (set.IsComplete || set.SavedMatchId.HasValue) return false;
+        // Can start if no other set of the same type on the same court is in progress
+        var sameCourtSets = _sets.Where(s => s.CourtNumber == set.CourtNumber && s.Phase == set.Phase).OrderBy(s => s.SetNumber).ToList();
+        var idx = sameCourtSets.IndexOf(set);
+        // Must play sets sequentially on each court
+        if (idx > 0 && !sameCourtSets[idx - 1].IsComplete) return false;
+        return true;
+    }
+
+    private async Task StartSetScoring(TeamMatchSet set)
+    {
+        if (!CanStartSet(set)) return;
+
+        // Create a SavedMatch for this set and navigate to the scoring page
+        await using var db = DbFactory.CreateDbContext();
+
+        var homeP1 = set.HomePlayer1?.DisplayName ?? "Home 1";
+        var homeP2 = set.HomePlayer2?.DisplayName ?? "Home 2";
+        var awayP1 = set.AwayPlayer1?.DisplayName ?? "Away 1";
+        var awayP2 = set.AwayPlayer2?.DisplayName ?? "Away 2";
+
+        // Determine which court from the court pair
+        int? courtId = null;
+        if (_fixture?.CourtPair != null)
+        {
+            courtId = set.CourtNumber == 1
+                ? _fixture.CourtPair.Court1Id
+                : _fixture.CourtPair.Court2Id;
+        }
+
+        var match = new Match
+        {
+            Player1 = homeP1,
+            Player2 = homeP2,
+            Player3 = awayP1,
+            Player4 = awayP2,
+            CourtId = courtId,
+            GameScoring = true
+        };
+
+        var savedMatch = new SavedMatch
+        {
+            MatchJson = Newtonsoft.Json.JsonConvert.SerializeObject(match),
+            Complete = false,
+            Player1 = homeP1,
+            Player2 = homeP2,
+            Player3 = awayP1,
+            Player4 = awayP2,
+            CourtId = courtId,
+            CreatedAt = DateTime.UtcNow,
+            UserId = _currentUserId
+        };
+        db.SavedMatch.Add(savedMatch);
+        await db.SaveChangesAsync();
+
+        // Link to TeamMatchSet
+        var dbSet = await db.TeamMatchSets.FindAsync(set.TeamMatchSetId);
+        if (dbSet != null)
+        {
+            dbSet.SavedMatchId = savedMatch.SavedMatchId;
+            await db.SaveChangesAsync();
+        }
+
+        // Mark fixture as in progress
+        if (_fixture != null)
+        {
+            var fx = await db.CompetitionFixtures.FindAsync(_fixture.CompetitionFixtureId);
+            if (fx != null && fx.Status == FixtureStatus.Scheduled)
+            {
+                fx.Status = FixtureStatus.InProgress;
+                await db.SaveChangesAsync();
+            }
+        }
+
+        // Navigate to the existing scoring page (best-of-1, auto-start as doubles)
+        Nav.NavigateTo($"/match/{savedMatch.SavedMatchId}?bestOf=1");
+    }
+
+    private static string PlayerNames(TeamMatchSet set, bool home)
+    {
+        if (home)
+        {
+            var p1 = set.HomePlayer1?.DisplayName ?? "?";
+            var p2 = set.HomePlayer2?.DisplayName ?? "?";
+            return $"{p1} & {p2}";
+        }
+        else
+        {
+            var p1 = set.AwayPlayer1?.DisplayName ?? "?";
+            var p2 = set.AwayPlayer2?.DisplayName ?? "?";
+            return $"{p1} & {p2}";
+        }
+    }
+
+    private static string SetTypeLabel(TeamMatchSetType t) => t switch
+    {
+        TeamMatchSetType.MensDoubles => "Men's Doubles",
+        TeamMatchSetType.WomensDoubles => "Women's Doubles",
+        TeamMatchSetType.MixedDoublesA => "Mixed Doubles A",
+        TeamMatchSetType.MixedDoublesB => "Mixed Doubles B",
+        _ => t.ToString()
+    };
+}

--- a/DropShot/Components/Pages/ViewCompetition.razor
+++ b/DropShot/Components/Pages/ViewCompetition.razor
@@ -121,7 +121,38 @@ else
     }
 
     @* ── League Table (round-robin stages only) ──────────────── *@
-    @if (_leagueTable.Any())
+    @if (_competition.CompetitionFormat == CompetitionFormat.MixedTeam && _teamLeagueTable.Any())
+    {
+        <MudDivider Class="my-4" />
+        <MudText Typo="Typo.h5" Class="mb-3">League Table</MudText>
+        <MudTable Items="@_teamLeagueTable" Dense="true" Hover="true" Class="mb-4" Style="max-width:800px">
+            <HeaderContent>
+                <MudTh>Pos</MudTh>
+                <MudTh>Team</MudTh>
+                <MudTh>Captain</MudTh>
+                <MudTh>P</MudTh>
+                <MudTh>W</MudTh>
+                <MudTh>D</MudTh>
+                <MudTh>L</MudTh>
+                <MudTh>SW</MudTh>
+                <MudTh>SA</MudTh>
+                <MudTh>Pts</MudTh>
+            </HeaderContent>
+            <RowTemplate>
+                <MudTd>@(_teamLeagueTable.IndexOf(context) + 1)</MudTd>
+                <MudTd Style="font-weight:500">@context.TeamName</MudTd>
+                <MudTd>@(context.CaptainName ?? "—")</MudTd>
+                <MudTd>@context.Played</MudTd>
+                <MudTd>@context.Won</MudTd>
+                <MudTd>@context.Drawn</MudTd>
+                <MudTd>@context.Lost</MudTd>
+                <MudTd>@context.SetsWon</MudTd>
+                <MudTd>@context.SetsAgainst</MudTd>
+                <MudTd Style="font-weight:bold">@context.Points</MudTd>
+            </RowTemplate>
+        </MudTable>
+    }
+    else if (_leagueTable.Any())
     {
         <MudDivider Class="my-4" />
         <MudText Typo="Typo.h5" Class="mb-3">League Table</MudText>
@@ -149,7 +180,7 @@ else
     <MudDivider Class="my-4" />
     <MudText Typo="Typo.h5" Class="mb-3">Competitors</MudText>
 
-    @if (_competition.CompetitionFormat == CompetitionFormat.Team && _teams.Any())
+    @if ((_competition.CompetitionFormat is CompetitionFormat.Team or CompetitionFormat.MixedTeam) && _teams.Any())
     {
         @foreach (var team in _teams)
         {
@@ -231,6 +262,8 @@ else
 
     private record LeagueRow(int PlayerId, string PlayerName, int Played, int Won, int Lost, int Points);
     private List<LeagueRow> _leagueTable = [];
+    private record TeamLeagueRow(int TeamId, string TeamName, string? CaptainName, int Played, int Won, int Drawn, int Lost, int SetsWon, int SetsAgainst, int Points);
+    private List<TeamLeagueRow> _teamLeagueTable = [];
 
 #pragma warning disable CS8714 // Null keys are intentionally used for unstaged fixtures
     private Dictionary<string?, List<CompetitionFixture>> _fixturesByStage = [];
@@ -252,7 +285,10 @@ else
             .Include(c => c.Fixtures).ThenInclude(f => f.Player2)
             .Include(c => c.Fixtures).ThenInclude(f => f.Player3)
             .Include(c => c.Fixtures).ThenInclude(f => f.Player4)
-            .Include(c => c.Teams)
+            .Include(c => c.Fixtures).ThenInclude(f => f.HomeTeam)
+            .Include(c => c.Fixtures).ThenInclude(f => f.AwayTeam)
+            .Include(c => c.Teams).ThenInclude(t => t.Captain)
+            .Include(c => c.Fixtures).ThenInclude(f => f.TeamMatchSets)
             .AsNoTracking()
             .FirstOrDefaultAsync(c => c.CompetitionID == Id);
 
@@ -331,6 +367,56 @@ else
                     .ThenBy(r => r.Lost)
                     .ToList();
             }
+
+            // Team league table — MixedTeam format
+            if (_competition.CompetitionFormat == CompetitionFormat.MixedTeam && rrStageIds.Any() && _teams.Any())
+            {
+                var teamStats = _teams.ToDictionary(t => t.CompetitionTeamId,
+                    _ => (Played: 0, Won: 0, Drawn: 0, Lost: 0, SetsWon: 0, SetsAgainst: 0));
+
+                var teamH2h = new HashSet<(int winner, int loser)>();
+
+                foreach (var f in _fixtures.Where(f =>
+                    f.CompetitionStageId.HasValue &&
+                    rrStageIds.Contains(f.CompetitionStageId.Value) &&
+                    f.Status == FixtureStatus.Completed &&
+                    f.HomeTeamId.HasValue && f.AwayTeamId.HasValue))
+                {
+                    int homeId = f.HomeTeamId!.Value;
+                    int awayId = f.AwayTeamId!.Value;
+                    if (!teamStats.ContainsKey(homeId) || !teamStats.ContainsKey(awayId)) continue;
+
+                    int homeSets = f.TeamMatchSets.Count(s => s.IsComplete && s.WinnerTeamId == homeId);
+                    int awaySets = f.TeamMatchSets.Count(s => s.IsComplete && s.WinnerTeamId == awayId);
+
+                    var h = teamStats[homeId];
+                    var a = teamStats[awayId];
+
+                    h.Played++; a.Played++;
+                    h.SetsWon += homeSets; h.SetsAgainst += awaySets;
+                    a.SetsWon += awaySets; a.SetsAgainst += homeSets;
+
+                    if (homeSets > awaySets) { h.Won++; a.Lost++; teamH2h.Add((homeId, awayId)); }
+                    else if (awaySets > homeSets) { a.Won++; h.Lost++; teamH2h.Add((awayId, homeId)); }
+                    else { h.Drawn++; a.Drawn++; }
+
+                    teamStats[homeId] = h;
+                    teamStats[awayId] = a;
+                }
+
+                _teamLeagueTable = _teams
+                    .Where(t => teamStats.ContainsKey(t.CompetitionTeamId))
+                    .Select(t =>
+                    {
+                        var s = teamStats[t.CompetitionTeamId];
+                        return new TeamLeagueRow(t.CompetitionTeamId, t.Name, t.Captain?.DisplayName,
+                            s.Played, s.Won, s.Drawn, s.Lost, s.SetsWon, s.SetsAgainst, s.SetsWon);
+                    })
+                    .OrderByDescending(e => e.Points)
+                    .ThenByDescending(e => e.SetsWon - e.SetsAgainst)
+                    .ThenByDescending(e => teamH2h.Count(h => h.winner == e.TeamId))
+                    .ToList();
+            }
         }
 
         _loading = false;
@@ -338,6 +424,13 @@ else
 
     private static string FixturePlayers(CompetitionFixture f)
     {
+        if (f.HomeTeamId.HasValue || f.AwayTeamId.HasValue)
+        {
+            var home = f.HomeTeam?.Name ?? "TBD";
+            var away = f.AwayTeam?.Name ?? "TBD";
+            return $"{home} vs {away}";
+        }
+
         var side1 = new[] { f.Player1?.DisplayName, f.Player3?.DisplayName }
             .Where(n => n != null).DefaultIfEmpty("TBD").Aggregate((a, b) => $"{a} & {b}");
         var side2 = new[] { f.Player2?.DisplayName, f.Player4?.DisplayName }
@@ -347,6 +440,11 @@ else
 
     private string? WinnerName(CompetitionFixture f)
     {
+        if (f.WinnerTeamId.HasValue)
+        {
+            var team = f.HomeTeamId == f.WinnerTeamId ? f.HomeTeam : f.AwayTeam;
+            return team != null ? $"Winner: {team.Name}" : null;
+        }
         if (!f.WinnerPlayerId.HasValue) return null;
         var all = new[] { f.Player1, f.Player2, f.Player3, f.Player4 };
         return all.FirstOrDefault(p => p?.PlayerId == f.WinnerPlayerId)?.DisplayName is { } n

--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -273,7 +273,11 @@
             @string.Join("  ", _state.SetScores.Select(s => $"{s.UserGames}-{s.OpponentGames}"))
         </div>
         <div class="match-complete-countdown">
-            @if (_competitionFixture != null)
+            @if (_teamMatchFixtureId.HasValue)
+            {
+                <span>Returning to team match in @_countdownSeconds…</span>
+            }
+            else if (_competitionFixture != null)
             {
                 <span>Returning to @(_competitionFixture.Competition?.CompetitionName ?? "competition") in @_countdownSeconds…</span>
             }
@@ -620,9 +624,11 @@
     [Parameter] public int MatchId { get; set; }
     [SupplyParameterFromQuery] public int? FixtureId { get; set; }
     [SupplyParameterFromQuery] public bool? AutoStart { get; set; }
+    [SupplyParameterFromQuery] public int? BestOf { get; set; }
     private int _savedMatchId;
     private CompetitionFixture? _competitionFixture;
     private bool _autoStartPending;
+    private int? _teamMatchFixtureId; // set when this match is a TeamMatchSet
 
     private List<string> _states = [];
     private List<Court> _courts = [];
@@ -753,6 +759,12 @@
                     .Include(f => f.Player3)
                     .Include(f => f.Player4)
                     .FirstOrDefaultAsync(f => f.SavedMatchId == savedMatch.SavedMatchId);
+
+                // Check if this match is linked to a TeamMatchSet
+                var teamSet = await DbContext.TeamMatchSets
+                    .FirstOrDefaultAsync(s => s.SavedMatchId == savedMatch.SavedMatchId);
+                if (teamSet != null)
+                    _teamMatchFixtureId = teamSet.CompetitionFixtureId;
             }
         }
 
@@ -778,11 +790,15 @@
             }
         }
 
+        // Apply BestOf query parameter if provided (e.g. from team match sets)
+        if (BestOf.HasValue)
+            _state.BestOf = BestOf.Value;
+
         // Auto-start: skip wizard and go straight to match when all info is available
         if (AutoStart == true && _competitionFixture != null
             && !string.IsNullOrEmpty(_value) && !string.IsNullOrEmpty(_value2))
         {
-            _state.BestOf = _competitionFixture.Competition?.BestOf ?? 3;
+            _state.BestOf = BestOf ?? _competitionFixture.Competition?.BestOf ?? 3;
             _state.GameScoring = true;
             _state.UnlimitedDeuce = true;
             _state.GamesFirstTo = 6;
@@ -892,6 +908,41 @@
             await hubConnection.SendAsync("SendMessage",
                 JsonConvert.SerializeObject(history.Peek()),
                 CurrentMatch.CourtId?.ToString() ?? "");
+        }
+
+        // When match ends, record the result on the linked TeamMatchSet
+        if (_state.IsMatchEnded && _teamMatchFixtureId.HasValue)
+        {
+            using var dbc4 = DbFactory.CreateDbContext();
+            var teamSet = await dbc4.TeamMatchSets
+                .FirstOrDefaultAsync(s => s.SavedMatchId == _savedMatchId);
+            if (teamSet != null && !teamSet.IsComplete)
+            {
+                // For best-of-1, the final set score is the last entry in SetScores
+                if (_state.SetScores.Count > 0)
+                {
+                    var finalSet = _state.SetScores.Last();
+                    teamSet.HomeGames = finalSet.UserGames;
+                    teamSet.AwayGames = finalSet.OpponentGames;
+                }
+                else
+                {
+                    teamSet.HomeGames = _state.UserGames;
+                    teamSet.AwayGames = _state.OppGames;
+                }
+
+                teamSet.IsComplete = true;
+
+                // Load the parent fixture to determine team IDs
+                var parentFixture = await dbc4.CompetitionFixtures.FindAsync(_teamMatchFixtureId.Value);
+                if (parentFixture != null)
+                {
+                    bool userSideWon = _state.UserSets > _state.OppSets
+                        || (_state.UserSets == _state.OppSets && _state.UserGames > _state.OppGames);
+                    teamSet.WinnerTeamId = userSideWon ? parentFixture.HomeTeamId : parentFixture.AwayTeamId;
+                }
+                await dbc4.SaveChangesAsync();
+            }
         }
 
         // When match ends, record the result on the linked competition fixture
@@ -1014,7 +1065,9 @@
 
     private void NavigateAfterMatch()
     {
-        if (_competitionFixture != null)
+        if (_teamMatchFixtureId.HasValue)
+            Navigation.NavigateTo($"/team-match/{_teamMatchFixtureId.Value}");
+        else if (_competitionFixture != null)
             Navigation.NavigateTo($"/competition/{_competitionFixture.CompetitionId}/view");
         else
             Navigation.NavigateTo("/match");

--- a/DropShot/Controllers/CompetitionsController.cs
+++ b/DropShot/Controllers/CompetitionsController.cs
@@ -66,7 +66,8 @@ public class CompetitionsController(
                 p.PlayerId, p.Player?.DisplayName ?? "",
                 (DropShot.Shared.ParticipantStatus)p.Status,
                 p.RegisteredAt, p.TeamId, p.Team?.Name,
-                p.Player?.MobileNumber)).ToList());
+                p.Player?.MobileNumber,
+                (DropShot.Shared.PlayerGrade?)p.Grade)).ToList());
     }
 
     [HttpPost]
@@ -224,6 +225,22 @@ public class CompetitionsController(
         return Ok();
     }
 
+    [HttpPut("{id:int}/participants/{playerId:int}/grade")]
+    public async Task<IActionResult> UpdateParticipantGrade(
+        int id, int playerId, [FromBody] UpdateParticipantGradeRequest req)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var comp = await db.Competition.FindAsync(id);
+        if (comp is null) return NotFound();
+        if (!await authzService.CanEditCompetitionAsync(User, comp.HostClubId)) return Forbid();
+
+        var cp = await db.CompetitionParticipants.FindAsync(id, playerId);
+        if (cp is null) return NotFound();
+        cp.Grade = req.Grade.HasValue ? (DropShot.Models.PlayerGrade)req.Grade.Value : null;
+        await db.SaveChangesAsync();
+        return Ok();
+    }
+
     // ── Teams ─────────────────────────────────────────────────────────────────
 
     [HttpGet("{id:int}/teams")]
@@ -232,9 +249,12 @@ public class CompetitionsController(
         await using var db = dbFactory.CreateDbContext();
         var teams = await db.CompetitionTeams
             .Where(t => t.CompetitionId == id)
+            .Include(t => t.Captain)
             .OrderBy(t => t.Name)
             .ToListAsync();
-        return teams.Select(t => new CompetitionTeamDto(t.CompetitionTeamId, t.CompetitionId, t.Name)).ToList();
+        return teams.Select(t => new CompetitionTeamDto(
+            t.CompetitionTeamId, t.CompetitionId, t.Name,
+            t.CaptainPlayerId, t.Captain?.DisplayName)).ToList();
     }
 
     [HttpPost("{id:int}/teams")]
@@ -288,6 +308,112 @@ public class CompetitionsController(
         return NoContent();
     }
 
+    [HttpPut("{id:int}/teams/{teamId:int}/captain")]
+    public async Task<IActionResult> UpdateTeamCaptain(
+        int id, int teamId, [FromBody] UpdateTeamCaptainRequest req)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var comp = await db.Competition.FindAsync(id);
+        if (comp is null) return NotFound();
+        if (!await authzService.CanEditCompetitionAsync(User, comp.HostClubId)) return Forbid();
+
+        var team = await db.CompetitionTeams.FindAsync(teamId);
+        if (team is null || team.CompetitionId != id) return NotFound();
+
+        if (req.CaptainPlayerId.HasValue)
+        {
+            var isMember = await db.CompetitionParticipants
+                .AnyAsync(cp => cp.CompetitionId == id && cp.PlayerId == req.CaptainPlayerId.Value && cp.TeamId == teamId);
+            if (!isMember)
+                return BadRequest(new { message = "Captain must be a member of the team." });
+        }
+
+        team.CaptainPlayerId = req.CaptainPlayerId;
+        await db.SaveChangesAsync();
+        return Ok();
+    }
+
+    [HttpPost("{id:int}/teams/{teamId:int}/validate")]
+    public async Task<IActionResult> ValidateTeamComposition(int id, int teamId)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var members = await db.CompetitionParticipants
+            .Where(cp => cp.CompetitionId == id && cp.TeamId == teamId)
+            .Include(cp => cp.Player)
+            .ToListAsync();
+
+        var errors = ValidateMixedTeamComposition(members);
+        if (errors.Count > 0)
+            return BadRequest(new { errors });
+        return Ok(new { message = "Team composition is valid." });
+    }
+
+    // ── Court Pairs ──────────────────────────────────────────────────────────
+
+    [HttpGet("{id:int}/courtpairs")]
+    public async Task<ActionResult<List<CourtPairDto>>> GetCourtPairs(int id)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var pairs = await db.CourtPairs
+            .Where(cp => cp.CompetitionId == id)
+            .Include(cp => cp.Court1)
+            .Include(cp => cp.Court2)
+            .OrderBy(cp => cp.Name)
+            .ToListAsync();
+        return pairs.Select(cp => new CourtPairDto(
+            cp.CourtPairId, cp.CompetitionId,
+            cp.Court1Id, cp.Court1.Name,
+            cp.Court2Id, cp.Court2.Name,
+            cp.Name)).ToList();
+    }
+
+    [HttpPost("{id:int}/courtpairs")]
+    public async Task<IActionResult> AddCourtPair(int id, [FromBody] SaveCourtPairRequest req)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var comp = await db.Competition.FindAsync(id);
+        if (comp is null) return NotFound();
+        if (!await authzService.CanEditCompetitionAsync(User, comp.HostClubId)) return Forbid();
+
+        if (req.Court1Id == req.Court2Id)
+            return BadRequest(new { message = "Court 1 and Court 2 must be different." });
+
+        var court1 = await db.Courts.FindAsync(req.Court1Id);
+        var court2 = await db.Courts.FindAsync(req.Court2Id);
+        if (court1 is null || court2 is null)
+            return BadRequest(new { message = "One or more court IDs are invalid." });
+
+        var pair = new CourtPair
+        {
+            CompetitionId = id,
+            Court1Id = req.Court1Id,
+            Court2Id = req.Court2Id,
+            Name = req.Name.Trim()
+        };
+        db.CourtPairs.Add(pair);
+        await db.SaveChangesAsync();
+        return Ok(new CourtPairDto(
+            pair.CourtPairId, pair.CompetitionId,
+            pair.Court1Id, court1.Name,
+            pair.Court2Id, court2.Name,
+            pair.Name));
+    }
+
+    [HttpDelete("{id:int}/courtpairs/{pairId:int}")]
+    public async Task<IActionResult> DeleteCourtPair(int id, int pairId)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var comp = await db.Competition.FindAsync(id);
+        if (comp is null) return NotFound();
+        if (!await authzService.CanEditCompetitionAsync(User, comp.HostClubId)) return Forbid();
+
+        var pair = await db.CourtPairs.FindAsync(pairId);
+        if (pair is null || pair.CompetitionId != id) return NotFound();
+        db.CourtPairs.Remove(pair);
+        await db.SaveChangesAsync();
+        return NoContent();
+    }
+
     // ── Fixtures ──────────────────────────────────────────────────────────────
 
     [HttpGet("{id:int}/fixtures")]
@@ -302,6 +428,9 @@ public class CompetitionsController(
             .Include(f => f.Player2)
             .Include(f => f.Player3)
             .Include(f => f.Player4)
+            .Include(f => f.HomeTeam)
+            .Include(f => f.AwayTeam)
+            .Include(f => f.CourtPair)
             .OrderBy(f => f.RoundNumber).ThenBy(f => f.ScheduledAt)
             .ToListAsync();
         return fixtures.Select(ToFixtureDto).ToList();
@@ -404,8 +533,10 @@ public class CompetitionsController(
         await using var db = dbFactory.CreateDbContext();
         var comp = await db.Competition
             .Include(c => c.Stages.OrderBy(s => s.StageOrder))
-            .Include(c => c.Participants)
+            .Include(c => c.Participants).ThenInclude(p => p.Player)
+            .Include(c => c.Teams)
             .Include(c => c.MatchWindows).ThenInclude(w => w.Court)
+            .Include(c => c.CourtPairs)
             .FirstOrDefaultAsync(c => c.CompetitionID == id);
         if (comp is null) return NotFound();
         if (!await authzService.CanEditCompetitionAsync(User, comp.HostClubId)) return Forbid();
@@ -456,44 +587,200 @@ public class CompetitionsController(
             };
         }
 
-        foreach (var stage in comp.Stages)
+        bool isMixedTeam = comp.CompetitionFormat == DropShot.Models.CompetitionFormat.MixedTeam;
+
+        if (isMixedTeam)
         {
-            switch (stage.StageType)
+            var teamList = comp.Teams.ToList();
+            var courtPairs = comp.CourtPairs.ToList();
+            int courtPairIdx = 0;
+
+            CompetitionFixture NewTeamFixture(int compId, int stageId)
             {
-                case DropShot.Models.StageType.RoundRobin:
+                var slot = SchedulingSlotPicker.PickSlot(matchWindows, startDate, endDate, rng);
+                var f = new CompetitionFixture
                 {
-                    var players = activePlayers.ToList();
-                    for (int i = 0; i < players.Count; i++)
-                    {
-                        for (int j = i + 1; j < players.Count; j++)
-                        {
-                            var fixture = NewFixture(id, stage.CompetitionStageId);
-                            fixture.Player1Id = players[i];
-                            fixture.Player2Id = players[j];
-                            db.CompetitionFixtures.Add(fixture);
-                        }
-                    }
-                    break;
+                    CompetitionId = compId,
+                    CompetitionStageId = stageId,
+                    ScheduledAt = slot,
+                    Status = DropShot.Models.FixtureStatus.Scheduled
+                };
+                if (courtPairs.Count > 0)
+                {
+                    f.CourtPairId = courtPairs[courtPairIdx % courtPairs.Count].CourtPairId;
+                    courtPairIdx++;
                 }
+                return f;
+            }
 
-                case DropShot.Models.StageType.Knockout:
+            // Build participant lookup by team for auto-assigning set players
+            var participantsByTeam = comp.Participants
+                .Where(p => p.TeamId.HasValue && p.Grade.HasValue && p.Player?.Sex != null)
+                .GroupBy(p => p.TeamId!.Value)
+                .ToDictionary(g => g.Key, g => g.ToList());
+
+            foreach (var stage in comp.Stages)
+            {
+                switch (stage.StageType)
                 {
-                    // Smart knockout: generates exactly the right rounds based on player count.
-                    // No Byes, no power-of-2 bracket inflation.
-                    //
-                    //  n >= 8  →  Quarter-Finals (top 8, 4 matches) + 2 SF placeholders + Final
-                    //  n >= 4  →  Semi-Finals (top 4, 2 matches) + Final placeholder
-                    //  n >= 2  →  Final only (2 players)
-                    //
-                    // Players are seeded from the RR league table when results exist,
-                    // otherwise from registration order.
-
-                    int n = activePlayers.Count;
-                    if (n < 2) break;
-
-                    if (n >= 8)
+                    case DropShot.Models.StageType.RoundRobin:
                     {
-                        // ── Quarter-Finals (players assigned automatically when RR completes) ──
+                        // Round-robin: each team plays every other team once
+                        // Use circle method for scheduling rounds (handles odd teams with a bye)
+                        var teams = teamList.Select(t => t.CompetitionTeamId).ToList();
+                        int n = teams.Count;
+                        bool hasBye = n % 2 != 0;
+                        if (hasBye) teams.Add(-1); // sentinel for bye
+                        int totalTeams = teams.Count;
+                        int rounds = totalTeams - 1;
+
+                        for (int round = 0; round < rounds; round++)
+                        {
+                            for (int match = 0; match < totalTeams / 2; match++)
+                            {
+                                int home = teams[match];
+                                int away = teams[totalTeams - 1 - match];
+
+                                if (home == -1 || away == -1) continue; // bye round
+
+                                var fixture = NewTeamFixture(id, stage.CompetitionStageId);
+                                fixture.HomeTeamId = home;
+                                fixture.AwayTeamId = away;
+                                fixture.RoundNumber = round + 1;
+                                fixture.FixtureLabel = $"Round {round + 1}";
+                                db.CompetitionFixtures.Add(fixture);
+
+                                // Create 8 TeamMatchSet rows
+                                CreateTeamMatchSets(fixture, home, away, participantsByTeam);
+                            }
+
+                            // Rotate: fix position 0, rotate the rest
+                            var last = teams[totalTeams - 1];
+                            for (int k = totalTeams - 1; k > 1; k--)
+                                teams[k] = teams[k - 1];
+                            teams[1] = last;
+                        }
+                        break;
+                    }
+
+                    case DropShot.Models.StageType.Knockout:
+                    {
+                        // Top 4 → SF + Final
+                        int n = teamList.Count;
+                        if (n < 2) break;
+
+                        for (int m = 0; m < 2; m++)
+                        {
+                            var sf = NewTeamFixture(id, stage.CompetitionStageId);
+                            sf.FixtureLabel = $"Semi-Final {m + 1}";
+                            sf.RoundNumber = 1;
+                            db.CompetitionFixtures.Add(sf);
+                        }
+
+                        var final1 = NewTeamFixture(id, stage.CompetitionStageId);
+                        final1.FixtureLabel = "Final";
+                        final1.RoundNumber = 2;
+                        db.CompetitionFixtures.Add(final1);
+                        break;
+                    }
+
+                    case DropShot.Models.StageType.SemiFinal:
+                    {
+                        for (int m = 0; m < 2; m++)
+                        {
+                            var sf = NewTeamFixture(id, stage.CompetitionStageId);
+                            sf.FixtureLabel = $"Semi-Final {m + 1}";
+                            sf.RoundNumber = 1;
+                            db.CompetitionFixtures.Add(sf);
+                        }
+                        break;
+                    }
+
+                    case DropShot.Models.StageType.Final:
+                    {
+                        var final2 = NewTeamFixture(id, stage.CompetitionStageId);
+                        final2.FixtureLabel = "Final";
+                        final2.RoundNumber = 1;
+                        db.CompetitionFixtures.Add(final2);
+                        break;
+                    }
+                }
+            }
+        }
+        else
+        {
+            // Standard player-based scheduling (Singles, Doubles, etc.)
+            foreach (var stage in comp.Stages)
+            {
+                switch (stage.StageType)
+                {
+                    case DropShot.Models.StageType.RoundRobin:
+                    {
+                        var players = activePlayers.ToList();
+                        for (int i = 0; i < players.Count; i++)
+                        {
+                            for (int j = i + 1; j < players.Count; j++)
+                            {
+                                var fixture = NewFixture(id, stage.CompetitionStageId);
+                                fixture.Player1Id = players[i];
+                                fixture.Player2Id = players[j];
+                                db.CompetitionFixtures.Add(fixture);
+                            }
+                        }
+                        break;
+                    }
+
+                    case DropShot.Models.StageType.Knockout:
+                    {
+                        int n = activePlayers.Count;
+                        if (n < 2) break;
+
+                        if (n >= 8)
+                        {
+                            for (int m = 0; m < 4; m++)
+                            {
+                                var qf = NewFixture(id, stage.CompetitionStageId);
+                                qf.FixtureLabel = $"Quarter-Final {m + 1}";
+                                qf.RoundNumber = 1;
+                                db.CompetitionFixtures.Add(qf);
+                            }
+                            for (int m = 0; m < 2; m++)
+                            {
+                                var sf = NewFixture(id, stage.CompetitionStageId);
+                                sf.FixtureLabel = $"Semi-Final {m + 1}";
+                                sf.RoundNumber = 2;
+                                db.CompetitionFixtures.Add(sf);
+                            }
+                        }
+                        else
+                        {
+                            for (int m = 0; m < 2; m++)
+                            {
+                                var sf = NewFixture(id, stage.CompetitionStageId);
+                                sf.FixtureLabel = $"Semi-Final {m + 1}";
+                                sf.RoundNumber = 1;
+                                db.CompetitionFixtures.Add(sf);
+                            }
+                        }
+
+                        var final1 = NewFixture(id, stage.CompetitionStageId);
+                        final1.FixtureLabel = "Final";
+                        final1.RoundNumber = n >= 8 ? 3 : 2;
+                        db.CompetitionFixtures.Add(final1);
+                        break;
+                    }
+
+                    case DropShot.Models.StageType.Final:
+                    {
+                        var final2 = NewFixture(id, stage.CompetitionStageId);
+                        final2.FixtureLabel = "Final";
+                        final2.RoundNumber = 1;
+                        db.CompetitionFixtures.Add(final2);
+                        break;
+                    }
+
+                    case DropShot.Models.StageType.QuarterFinal:
+                    {
                         for (int m = 0; m < 4; m++)
                         {
                             var qf = NewFixture(id, stage.CompetitionStageId);
@@ -501,19 +788,11 @@ public class CompetitionsController(
                             qf.RoundNumber = 1;
                             db.CompetitionFixtures.Add(qf);
                         }
-
-                        // ── Semi-Finals (players assigned automatically when QF completes) ───
-                        for (int m = 0; m < 2; m++)
-                        {
-                            var sf = NewFixture(id, stage.CompetitionStageId);
-                            sf.FixtureLabel = $"Semi-Final {m + 1}";
-                            sf.RoundNumber = 2;
-                            db.CompetitionFixtures.Add(sf);
-                        }
+                        break;
                     }
-                    else
+
+                    case DropShot.Models.StageType.SemiFinal:
                     {
-                        // ── Semi-Finals (players assigned automatically when RR completes) ────
                         for (int m = 0; m < 2; m++)
                         {
                             var sf = NewFixture(id, stage.CompetitionStageId);
@@ -521,47 +800,8 @@ public class CompetitionsController(
                             sf.RoundNumber = 1;
                             db.CompetitionFixtures.Add(sf);
                         }
+                        break;
                     }
-
-                    // ── Final (always a placeholder) ─────────────────────────────
-                    var final1 = NewFixture(id, stage.CompetitionStageId);
-                    final1.FixtureLabel = "Final";
-                    final1.RoundNumber = n >= 8 ? 3 : 2;
-                    db.CompetitionFixtures.Add(final1);
-                    break;
-                }
-
-                case DropShot.Models.StageType.Final:
-                {
-                    var final2 = NewFixture(id, stage.CompetitionStageId);
-                    final2.FixtureLabel = "Final";
-                    final2.RoundNumber = 1;
-                    db.CompetitionFixtures.Add(final2);
-                    break;
-                }
-
-                case DropShot.Models.StageType.QuarterFinal:
-                {
-                    for (int m = 0; m < 4; m++)
-                    {
-                        var qf = NewFixture(id, stage.CompetitionStageId);
-                        qf.FixtureLabel = $"Quarter-Final {m + 1}";
-                        qf.RoundNumber = 1;
-                        db.CompetitionFixtures.Add(qf);
-                    }
-                    break;
-                }
-
-                case DropShot.Models.StageType.SemiFinal:
-                {
-                    for (int m = 0; m < 2; m++)
-                    {
-                        var sf = NewFixture(id, stage.CompetitionStageId);
-                        sf.FixtureLabel = $"Semi-Final {m + 1}";
-                        sf.RoundNumber = 1;
-                        db.CompetitionFixtures.Add(sf);
-                    }
-                    break;
                 }
             }
         }
@@ -653,6 +893,168 @@ public class CompetitionsController(
         return entries;
     }
 
+    // ── Team League Table ──────────────────────────────────────────────────────
+
+    [HttpGet("{id:int}/teamleaguetable")]
+    public async Task<ActionResult<List<TeamLeagueTableEntryDto>>> GetTeamLeagueTable(int id)
+    {
+        await using var db = dbFactory.CreateDbContext();
+
+        var comp = await db.Competition.FindAsync(id);
+        if (comp is null) return NotFound();
+
+        var rrStageIds = await db.CompetitionStages
+            .Where(s => s.CompetitionId == id && s.StageType == DropShot.Models.StageType.RoundRobin)
+            .Select(s => s.CompetitionStageId)
+            .ToListAsync();
+
+        var teams = await db.CompetitionTeams
+            .Where(t => t.CompetitionId == id)
+            .Include(t => t.Captain)
+            .ToListAsync();
+
+        if (rrStageIds.Count == 0 || teams.Count == 0)
+            return Ok(new List<TeamLeagueTableEntryDto>());
+
+        // Load completed RR fixtures with their TeamMatchSets
+        var fixtures = await db.CompetitionFixtures
+            .Where(f => f.CompetitionId == id
+                        && f.CompetitionStageId != null
+                        && rrStageIds.Contains(f.CompetitionStageId!.Value)
+                        && f.Status == DropShot.Models.FixtureStatus.Completed
+                        && f.HomeTeamId != null && f.AwayTeamId != null)
+            .Include(f => f.TeamMatchSets)
+            .ToListAsync();
+
+        var teamIds = teams.Select(t => t.CompetitionTeamId).ToHashSet();
+        var stats = teamIds.ToDictionary(tid => tid, _ => (Played: 0, Won: 0, Drawn: 0, Lost: 0, SetsWon: 0, SetsAgainst: 0));
+
+        foreach (var f in fixtures)
+        {
+            int homeId = f.HomeTeamId!.Value;
+            int awayId = f.AwayTeamId!.Value;
+            if (!stats.ContainsKey(homeId) || !stats.ContainsKey(awayId)) continue;
+
+            // Count sets won by each team in this fixture
+            int homeSets = f.TeamMatchSets.Count(s => s.IsComplete && s.WinnerTeamId == homeId);
+            int awaySets = f.TeamMatchSets.Count(s => s.IsComplete && s.WinnerTeamId == awayId);
+
+            var h = stats[homeId];
+            var a = stats[awayId];
+
+            h.Played++;
+            a.Played++;
+            h.SetsWon += homeSets;
+            h.SetsAgainst += awaySets;
+            a.SetsWon += awaySets;
+            a.SetsAgainst += homeSets;
+
+            if (homeSets > awaySets) { h.Won++; a.Lost++; }
+            else if (awaySets > homeSets) { a.Won++; h.Lost++; }
+            else { h.Drawn++; a.Drawn++; }
+
+            stats[homeId] = h;
+            stats[awayId] = a;
+        }
+
+        // Head-to-head tiebreaker: (winner team, loser team)
+        var h2h = new HashSet<(int winner, int loser)>();
+        foreach (var f in fixtures)
+        {
+            int homeId = f.HomeTeamId!.Value;
+            int awayId = f.AwayTeamId!.Value;
+            int homeSets = f.TeamMatchSets.Count(s => s.IsComplete && s.WinnerTeamId == homeId);
+            int awaySets = f.TeamMatchSets.Count(s => s.IsComplete && s.WinnerTeamId == awayId);
+            if (homeSets > awaySets) h2h.Add((homeId, awayId));
+            else if (awaySets > homeSets) h2h.Add((awayId, homeId));
+        }
+
+        // Points = total sets won
+        var entries = teams
+            .Where(t => stats.ContainsKey(t.CompetitionTeamId))
+            .Select(t =>
+            {
+                var s = stats[t.CompetitionTeamId];
+                return new TeamLeagueTableEntryDto(
+                    t.CompetitionTeamId, t.Name, t.Captain?.DisplayName,
+                    s.Played, s.Won, s.Drawn, s.Lost,
+                    s.SetsWon, s.SetsAgainst, s.SetsWon);
+            })
+            .OrderByDescending(e => e.Points)
+            .ThenByDescending(e => e.SetsWon - e.SetsAgainst)
+            .ThenByDescending(e => h2h.Count(h => h.winner == e.TeamId))
+            .ToList();
+
+        return entries;
+    }
+
+    // ── Team Knockout Seeding ────────────────────────────────────────────────
+
+    [HttpPost("{id:int}/fixtures/seed-team-knockout")]
+    public async Task<IActionResult> SeedTeamKnockout(int id)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var comp = await db.Competition.FindAsync(id);
+        if (comp is null) return NotFound();
+        if (!await authzService.CanEditCompetitionAsync(User, comp.HostClubId)) return Forbid();
+
+        // Get team league table standings
+        var tableResult = await GetTeamLeagueTable(id);
+        if (tableResult.Result is not OkObjectResult okResult) return tableResult.Result!;
+        var table = (tableResult.Value ?? (okResult.Value as List<TeamLeagueTableEntryDto>))!;
+
+        if (table.Count < 4)
+            return BadRequest(new { message = "Need at least 4 teams for knockout seeding." });
+
+        // Get top 4 team IDs
+        var top4 = table.Take(4).Select(e => e.TeamId).ToList();
+
+        // Find knockout/SF stage fixtures
+        var allStages = await db.CompetitionStages
+            .Where(s => s.CompetitionId == id)
+            .OrderBy(s => s.StageOrder)
+            .ToListAsync();
+
+        var koStage = allStages.FirstOrDefault(s =>
+            s.StageType is DropShot.Models.StageType.Knockout or DropShot.Models.StageType.SemiFinal);
+
+        if (koStage is null)
+            return BadRequest(new { message = "No knockout or semi-final stage found." });
+
+        var sfFixtures = await db.CompetitionFixtures
+            .Where(f => f.CompetitionId == id
+                     && f.CompetitionStageId == koStage.CompetitionStageId
+                     && (koStage.StageType != DropShot.Models.StageType.Knockout || f.RoundNumber == 1)
+                     && f.Status == DropShot.Models.FixtureStatus.Scheduled)
+            .OrderBy(f => f.FixtureLabel)
+            .ToListAsync();
+
+        if (sfFixtures.Count < 2)
+            return BadRequest(new { message = "Not enough unassigned semi-final fixtures." });
+
+        // Seed: 1st vs 4th, 2nd vs 3rd
+        sfFixtures[0].HomeTeamId = top4[0];
+        sfFixtures[0].AwayTeamId = top4[3];
+        sfFixtures[1].HomeTeamId = top4[1];
+        sfFixtures[1].AwayTeamId = top4[2];
+
+        // Load participants for creating TeamMatchSets
+        var participantsByTeam = await db.CompetitionParticipants
+            .Where(p => p.CompetitionId == id && p.TeamId.HasValue && p.Grade.HasValue)
+            .Include(p => p.Player)
+            .GroupBy(p => p.TeamId!.Value)
+            .ToDictionaryAsync(g => g.Key, g => g.ToList());
+
+        foreach (var sf in sfFixtures)
+        {
+            if (sf.HomeTeamId.HasValue && sf.AwayTeamId.HasValue)
+                CreateTeamMatchSets(sf, sf.HomeTeamId.Value, sf.AwayTeamId.Value, participantsByTeam);
+        }
+
+        await db.SaveChangesAsync();
+        return Ok(new { message = "Top 4 teams seeded into semi-finals." });
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     private static void Apply(Competition c, SaveCompetitionRequest r)
@@ -704,5 +1106,120 @@ public class CompetitionsController(
         f.Player2Id, f.Player2?.DisplayName,
         f.Player3Id, f.Player3?.DisplayName,
         f.Player4Id, f.Player4?.DisplayName,
-        f.ResultSummary, f.WinnerPlayerId);
+        f.ResultSummary, f.WinnerPlayerId,
+        f.HomeTeamId, f.HomeTeam?.Name,
+        f.AwayTeamId, f.AwayTeam?.Name,
+        f.WinnerTeamId, f.CourtPairId, f.CourtPair?.Name);
+
+    private static void CreateTeamMatchSets(
+        CompetitionFixture fixture, int homeTeamId, int awayTeamId,
+        Dictionary<int, List<CompetitionParticipant>> participantsByTeam)
+    {
+        participantsByTeam.TryGetValue(homeTeamId, out var homeMembers);
+        participantsByTeam.TryGetValue(awayTeamId, out var awayMembers);
+
+        var homeMaleA = homeMembers?.FirstOrDefault(p => p.Player?.Sex == DropShot.Models.PlayerSex.Male && p.Grade == DropShot.Models.PlayerGrade.A);
+        var homeFemaleA = homeMembers?.FirstOrDefault(p => p.Player?.Sex == DropShot.Models.PlayerSex.Female && p.Grade == DropShot.Models.PlayerGrade.A);
+        var homeMaleB = homeMembers?.FirstOrDefault(p => p.Player?.Sex == DropShot.Models.PlayerSex.Male && p.Grade == DropShot.Models.PlayerGrade.B);
+        var homeFemaleB = homeMembers?.FirstOrDefault(p => p.Player?.Sex == DropShot.Models.PlayerSex.Female && p.Grade == DropShot.Models.PlayerGrade.B);
+
+        var awayMaleA = awayMembers?.FirstOrDefault(p => p.Player?.Sex == DropShot.Models.PlayerSex.Male && p.Grade == DropShot.Models.PlayerGrade.A);
+        var awayFemaleA = awayMembers?.FirstOrDefault(p => p.Player?.Sex == DropShot.Models.PlayerSex.Female && p.Grade == DropShot.Models.PlayerGrade.A);
+        var awayMaleB = awayMembers?.FirstOrDefault(p => p.Player?.Sex == DropShot.Models.PlayerSex.Male && p.Grade == DropShot.Models.PlayerGrade.B);
+        var awayFemaleB = awayMembers?.FirstOrDefault(p => p.Player?.Sex == DropShot.Models.PlayerSex.Female && p.Grade == DropShot.Models.PlayerGrade.B);
+
+        // Phase 1: Gender Doubles (Court 1 = Men's, Court 2 = Women's)
+        // Set 1: Men's Doubles 1
+        fixture.TeamMatchSets.Add(new TeamMatchSet
+        {
+            SetNumber = 1, Phase = DropShot.Models.TeamMatchPhase.GenderDoubles,
+            SetType = DropShot.Models.TeamMatchSetType.MensDoubles, CourtNumber = 1,
+            HomePlayer1Id = homeMaleA?.PlayerId, HomePlayer2Id = homeMaleB?.PlayerId,
+            AwayPlayer1Id = awayMaleA?.PlayerId, AwayPlayer2Id = awayMaleB?.PlayerId
+        });
+        // Set 2: Men's Doubles 2
+        fixture.TeamMatchSets.Add(new TeamMatchSet
+        {
+            SetNumber = 2, Phase = DropShot.Models.TeamMatchPhase.GenderDoubles,
+            SetType = DropShot.Models.TeamMatchSetType.MensDoubles, CourtNumber = 1,
+            HomePlayer1Id = homeMaleA?.PlayerId, HomePlayer2Id = homeMaleB?.PlayerId,
+            AwayPlayer1Id = awayMaleA?.PlayerId, AwayPlayer2Id = awayMaleB?.PlayerId
+        });
+        // Set 3: Women's Doubles 1
+        fixture.TeamMatchSets.Add(new TeamMatchSet
+        {
+            SetNumber = 3, Phase = DropShot.Models.TeamMatchPhase.GenderDoubles,
+            SetType = DropShot.Models.TeamMatchSetType.WomensDoubles, CourtNumber = 2,
+            HomePlayer1Id = homeFemaleA?.PlayerId, HomePlayer2Id = homeFemaleB?.PlayerId,
+            AwayPlayer1Id = awayFemaleA?.PlayerId, AwayPlayer2Id = awayFemaleB?.PlayerId
+        });
+        // Set 4: Women's Doubles 2
+        fixture.TeamMatchSets.Add(new TeamMatchSet
+        {
+            SetNumber = 4, Phase = DropShot.Models.TeamMatchPhase.GenderDoubles,
+            SetType = DropShot.Models.TeamMatchSetType.WomensDoubles, CourtNumber = 2,
+            HomePlayer1Id = homeFemaleA?.PlayerId, HomePlayer2Id = homeFemaleB?.PlayerId,
+            AwayPlayer1Id = awayFemaleA?.PlayerId, AwayPlayer2Id = awayFemaleB?.PlayerId
+        });
+
+        // Phase 2: Mixed Doubles (Court 1 = A grade, Court 2 = B grade)
+        // Set 5: Mixed Doubles A 1
+        fixture.TeamMatchSets.Add(new TeamMatchSet
+        {
+            SetNumber = 5, Phase = DropShot.Models.TeamMatchPhase.MixedDoubles,
+            SetType = DropShot.Models.TeamMatchSetType.MixedDoublesA, CourtNumber = 1,
+            HomePlayer1Id = homeMaleA?.PlayerId, HomePlayer2Id = homeFemaleA?.PlayerId,
+            AwayPlayer1Id = awayMaleA?.PlayerId, AwayPlayer2Id = awayFemaleA?.PlayerId
+        });
+        // Set 6: Mixed Doubles A 2
+        fixture.TeamMatchSets.Add(new TeamMatchSet
+        {
+            SetNumber = 6, Phase = DropShot.Models.TeamMatchPhase.MixedDoubles,
+            SetType = DropShot.Models.TeamMatchSetType.MixedDoublesA, CourtNumber = 1,
+            HomePlayer1Id = homeMaleA?.PlayerId, HomePlayer2Id = homeFemaleA?.PlayerId,
+            AwayPlayer1Id = awayMaleA?.PlayerId, AwayPlayer2Id = awayFemaleA?.PlayerId
+        });
+        // Set 7: Mixed Doubles B 1
+        fixture.TeamMatchSets.Add(new TeamMatchSet
+        {
+            SetNumber = 7, Phase = DropShot.Models.TeamMatchPhase.MixedDoubles,
+            SetType = DropShot.Models.TeamMatchSetType.MixedDoublesB, CourtNumber = 2,
+            HomePlayer1Id = homeMaleB?.PlayerId, HomePlayer2Id = homeFemaleB?.PlayerId,
+            AwayPlayer1Id = awayMaleB?.PlayerId, AwayPlayer2Id = awayFemaleB?.PlayerId
+        });
+        // Set 8: Mixed Doubles B 2
+        fixture.TeamMatchSets.Add(new TeamMatchSet
+        {
+            SetNumber = 8, Phase = DropShot.Models.TeamMatchPhase.MixedDoubles,
+            SetType = DropShot.Models.TeamMatchSetType.MixedDoublesB, CourtNumber = 2,
+            HomePlayer1Id = homeMaleB?.PlayerId, HomePlayer2Id = homeFemaleB?.PlayerId,
+            AwayPlayer1Id = awayMaleB?.PlayerId, AwayPlayer2Id = awayFemaleB?.PlayerId
+        });
+    }
+
+    private static List<string> ValidateMixedTeamComposition(List<CompetitionParticipant> members)
+    {
+        var errors = new List<string>();
+        if (members.Count != 4)
+        {
+            errors.Add($"Team must have exactly 4 players (has {members.Count}).");
+            return errors;
+        }
+
+        var maleA = members.Count(m => m.Player?.Sex == DropShot.Models.PlayerSex.Male && m.Grade == DropShot.Models.PlayerGrade.A);
+        var femaleA = members.Count(m => m.Player?.Sex == DropShot.Models.PlayerSex.Female && m.Grade == DropShot.Models.PlayerGrade.A);
+        var maleB = members.Count(m => m.Player?.Sex == DropShot.Models.PlayerSex.Male && m.Grade == DropShot.Models.PlayerGrade.B);
+        var femaleB = members.Count(m => m.Player?.Sex == DropShot.Models.PlayerSex.Female && m.Grade == DropShot.Models.PlayerGrade.B);
+
+        if (maleA != 1) errors.Add($"Team needs exactly 1 Male A player (has {maleA}).");
+        if (femaleA != 1) errors.Add($"Team needs exactly 1 Female A player (has {femaleA}).");
+        if (maleB != 1) errors.Add($"Team needs exactly 1 Male B player (has {maleB}).");
+        if (femaleB != 1) errors.Add($"Team needs exactly 1 Female B player (has {femaleB}).");
+
+        var ungradedOrUngendered = members.Where(m => m.Grade == null || m.Player?.Sex == null).ToList();
+        if (ungradedOrUngendered.Count > 0)
+            errors.Add($"{ungradedOrUngendered.Count} player(s) missing grade or gender assignment.");
+
+        return errors;
+    }
 }

--- a/DropShot/Data/Migrations/20260406140000_AddMixedTeamTennis.cs
+++ b/DropShot/Data/Migrations/20260406140000_AddMixedTeamTennis.cs
@@ -1,0 +1,351 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropShot.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMixedTeamTennis : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // ── New columns on existing tables ──────────────────────────────────
+
+            migrationBuilder.AddColumn<byte>(
+                name: "Grade",
+                table: "CompetitionParticipants",
+                type: "tinyint",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "CaptainPlayerId",
+                table: "CompetitionTeams",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "HomeTeamId",
+                table: "CompetitionFixtures",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "AwayTeamId",
+                table: "CompetitionFixtures",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "WinnerTeamId",
+                table: "CompetitionFixtures",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "CourtPairId",
+                table: "CompetitionFixtures",
+                type: "int",
+                nullable: true);
+
+            // ── CourtPairs table ────────────────────────────────────────────────
+
+            migrationBuilder.CreateTable(
+                name: "CourtPairs",
+                columns: table => new
+                {
+                    CourtPairId = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    CompetitionId = table.Column<int>(type: "int", nullable: false),
+                    Court1Id = table.Column<int>(type: "int", nullable: false),
+                    Court2Id = table.Column<int>(type: "int", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CourtPairs", x => x.CourtPairId);
+                    table.ForeignKey(
+                        name: "FK_CourtPairs_Competition_CompetitionId",
+                        column: x => x.CompetitionId,
+                        principalTable: "Competition",
+                        principalColumn: "CompetitionID",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_CourtPairs_Courts_Court1Id",
+                        column: x => x.Court1Id,
+                        principalTable: "Courts",
+                        principalColumn: "CourtId",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_CourtPairs_Courts_Court2Id",
+                        column: x => x.Court2Id,
+                        principalTable: "Courts",
+                        principalColumn: "CourtId",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            // ── TeamMatchSets table ─────────────────────────────────────────────
+
+            migrationBuilder.CreateTable(
+                name: "TeamMatchSets",
+                columns: table => new
+                {
+                    TeamMatchSetId = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    CompetitionFixtureId = table.Column<int>(type: "int", nullable: false),
+                    SetNumber = table.Column<int>(type: "int", nullable: false),
+                    Phase = table.Column<byte>(type: "tinyint", nullable: false),
+                    SetType = table.Column<byte>(type: "tinyint", nullable: false),
+                    CourtNumber = table.Column<int>(type: "int", nullable: false),
+                    HomePlayer1Id = table.Column<int>(type: "int", nullable: true),
+                    HomePlayer2Id = table.Column<int>(type: "int", nullable: true),
+                    AwayPlayer1Id = table.Column<int>(type: "int", nullable: true),
+                    AwayPlayer2Id = table.Column<int>(type: "int", nullable: true),
+                    HomeGames = table.Column<int>(type: "int", nullable: false),
+                    AwayGames = table.Column<int>(type: "int", nullable: false),
+                    WinnerTeamId = table.Column<int>(type: "int", nullable: true),
+                    IsComplete = table.Column<bool>(type: "bit", nullable: false),
+                    SavedMatchId = table.Column<int>(type: "int", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TeamMatchSets", x => x.TeamMatchSetId);
+                    table.ForeignKey(
+                        name: "FK_TeamMatchSets_CompetitionFixtures_CompetitionFixtureId",
+                        column: x => x.CompetitionFixtureId,
+                        principalTable: "CompetitionFixtures",
+                        principalColumn: "CompetitionFixtureId",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_TeamMatchSets_Players_HomePlayer1Id",
+                        column: x => x.HomePlayer1Id,
+                        principalTable: "Players",
+                        principalColumn: "PlayerId",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_TeamMatchSets_Players_HomePlayer2Id",
+                        column: x => x.HomePlayer2Id,
+                        principalTable: "Players",
+                        principalColumn: "PlayerId",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_TeamMatchSets_Players_AwayPlayer1Id",
+                        column: x => x.AwayPlayer1Id,
+                        principalTable: "Players",
+                        principalColumn: "PlayerId",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_TeamMatchSets_Players_AwayPlayer2Id",
+                        column: x => x.AwayPlayer2Id,
+                        principalTable: "Players",
+                        principalColumn: "PlayerId",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_TeamMatchSets_CompetitionTeams_WinnerTeamId",
+                        column: x => x.WinnerTeamId,
+                        principalTable: "CompetitionTeams",
+                        principalColumn: "CompetitionTeamId",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_TeamMatchSets_SavedMatch_SavedMatchId",
+                        column: x => x.SavedMatchId,
+                        principalTable: "SavedMatch",
+                        principalColumn: "SavedMatchId",
+                        onDelete: ReferentialAction.SetNull);
+                });
+
+            // ── Indexes ─────────────────────────────────────────────────────────
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CompetitionTeams_CaptainPlayerId",
+                table: "CompetitionTeams",
+                column: "CaptainPlayerId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CompetitionFixtures_HomeTeamId",
+                table: "CompetitionFixtures",
+                column: "HomeTeamId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CompetitionFixtures_AwayTeamId",
+                table: "CompetitionFixtures",
+                column: "AwayTeamId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CompetitionFixtures_WinnerTeamId",
+                table: "CompetitionFixtures",
+                column: "WinnerTeamId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CompetitionFixtures_CourtPairId",
+                table: "CompetitionFixtures",
+                column: "CourtPairId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CourtPairs_CompetitionId",
+                table: "CourtPairs",
+                column: "CompetitionId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CourtPairs_Court1Id",
+                table: "CourtPairs",
+                column: "Court1Id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CourtPairs_Court2Id",
+                table: "CourtPairs",
+                column: "Court2Id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TeamMatchSets_CompetitionFixtureId",
+                table: "TeamMatchSets",
+                column: "CompetitionFixtureId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TeamMatchSets_HomePlayer1Id",
+                table: "TeamMatchSets",
+                column: "HomePlayer1Id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TeamMatchSets_HomePlayer2Id",
+                table: "TeamMatchSets",
+                column: "HomePlayer2Id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TeamMatchSets_AwayPlayer1Id",
+                table: "TeamMatchSets",
+                column: "AwayPlayer1Id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TeamMatchSets_AwayPlayer2Id",
+                table: "TeamMatchSets",
+                column: "AwayPlayer2Id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TeamMatchSets_WinnerTeamId",
+                table: "TeamMatchSets",
+                column: "WinnerTeamId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TeamMatchSets_SavedMatchId",
+                table: "TeamMatchSets",
+                column: "SavedMatchId");
+
+            // ── Foreign keys on existing tables ─────────────────────────────────
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CompetitionTeams_Players_CaptainPlayerId",
+                table: "CompetitionTeams",
+                column: "CaptainPlayerId",
+                principalTable: "Players",
+                principalColumn: "PlayerId",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CompetitionFixtures_CompetitionTeams_HomeTeamId",
+                table: "CompetitionFixtures",
+                column: "HomeTeamId",
+                principalTable: "CompetitionTeams",
+                principalColumn: "CompetitionTeamId",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CompetitionFixtures_CompetitionTeams_AwayTeamId",
+                table: "CompetitionFixtures",
+                column: "AwayTeamId",
+                principalTable: "CompetitionTeams",
+                principalColumn: "CompetitionTeamId",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CompetitionFixtures_CompetitionTeams_WinnerTeamId",
+                table: "CompetitionFixtures",
+                column: "WinnerTeamId",
+                principalTable: "CompetitionTeams",
+                principalColumn: "CompetitionTeamId",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CompetitionFixtures_CourtPairs_CourtPairId",
+                table: "CompetitionFixtures",
+                column: "CourtPairId",
+                principalTable: "CourtPairs",
+                principalColumn: "CourtPairId",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_CompetitionFixtures_CourtPairs_CourtPairId",
+                table: "CompetitionFixtures");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_CompetitionFixtures_CompetitionTeams_WinnerTeamId",
+                table: "CompetitionFixtures");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_CompetitionFixtures_CompetitionTeams_AwayTeamId",
+                table: "CompetitionFixtures");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_CompetitionFixtures_CompetitionTeams_HomeTeamId",
+                table: "CompetitionFixtures");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_CompetitionTeams_Players_CaptainPlayerId",
+                table: "CompetitionTeams");
+
+            migrationBuilder.DropTable(
+                name: "TeamMatchSets");
+
+            migrationBuilder.DropTable(
+                name: "CourtPairs");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CompetitionFixtures_CourtPairId",
+                table: "CompetitionFixtures");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CompetitionFixtures_WinnerTeamId",
+                table: "CompetitionFixtures");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CompetitionFixtures_AwayTeamId",
+                table: "CompetitionFixtures");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CompetitionFixtures_HomeTeamId",
+                table: "CompetitionFixtures");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CompetitionTeams_CaptainPlayerId",
+                table: "CompetitionTeams");
+
+            migrationBuilder.DropColumn(
+                name: "CourtPairId",
+                table: "CompetitionFixtures");
+
+            migrationBuilder.DropColumn(
+                name: "WinnerTeamId",
+                table: "CompetitionFixtures");
+
+            migrationBuilder.DropColumn(
+                name: "AwayTeamId",
+                table: "CompetitionFixtures");
+
+            migrationBuilder.DropColumn(
+                name: "HomeTeamId",
+                table: "CompetitionFixtures");
+
+            migrationBuilder.DropColumn(
+                name: "CaptainPlayerId",
+                table: "CompetitionTeams");
+
+            migrationBuilder.DropColumn(
+                name: "Grade",
+                table: "CompetitionParticipants");
+        }
+    }
+}

--- a/DropShot/Data/MyDbContext.cs
+++ b/DropShot/Data/MyDbContext.cs
@@ -36,6 +36,8 @@ namespace DropShot.Data
         public DbSet<UserPlayer> UserPlayers { get; set; }
         public DbSet<RoleSwitchLog> RoleSwitchLogs { get; set; }
         public DbSet<Event> Events { get; set; }
+        public DbSet<CourtPair> CourtPairs { get; set; }
+        public DbSet<TeamMatchSet> TeamMatchSets { get; set; }
 
         protected override void OnModelCreating(ModelBuilder builder)
         {
@@ -183,6 +185,11 @@ namespace DropShot.Data
                       .WithMany(c => c.Teams)
                       .HasForeignKey(t => t.CompetitionId)
                       .OnDelete(DeleteBehavior.Cascade);
+
+                entity.HasOne(t => t.Captain)
+                      .WithMany()
+                      .HasForeignKey(t => t.CaptainPlayerId)
+                      .OnDelete(DeleteBehavior.Restrict);
             });
 
             // ── CompetitionParticipant ───────────────────────────────────────────
@@ -190,6 +197,7 @@ namespace DropShot.Data
             {
                 entity.HasKey(cp => new { cp.CompetitionId, cp.PlayerId });
                 entity.Property(cp => cp.Status).HasConversion<byte>();
+                entity.Property(cp => cp.Grade).HasConversion<byte?>();
 
                 entity.HasOne(cp => cp.Competition)
                       .WithMany(c => c.Participants)
@@ -251,6 +259,27 @@ namespace DropShot.Data
                 entity.HasOne(f => f.SavedMatch)
                       .WithMany()
                       .HasForeignKey(f => f.SavedMatchId)
+                      .OnDelete(DeleteBehavior.SetNull);
+
+                // Team match FKs (MixedTeam format)
+                entity.HasOne(f => f.HomeTeam)
+                      .WithMany()
+                      .HasForeignKey(f => f.HomeTeamId)
+                      .OnDelete(DeleteBehavior.Restrict);
+
+                entity.HasOne(f => f.AwayTeam)
+                      .WithMany()
+                      .HasForeignKey(f => f.AwayTeamId)
+                      .OnDelete(DeleteBehavior.Restrict);
+
+                entity.HasOne(f => f.WinnerTeam)
+                      .WithMany()
+                      .HasForeignKey(f => f.WinnerTeamId)
+                      .OnDelete(DeleteBehavior.Restrict);
+
+                entity.HasOne(f => f.CourtPair)
+                      .WithMany()
+                      .HasForeignKey(f => f.CourtPairId)
                       .OnDelete(DeleteBehavior.SetNull);
             });
 
@@ -429,6 +458,54 @@ namespace DropShot.Data
                       .WithMany()
                       .HasForeignKey(up => up.PlayerId)
                       .OnDelete(DeleteBehavior.Cascade);
+            });
+
+            // ── CourtPair ────────────────────────────────────────────────────────
+            builder.Entity<CourtPair>(entity =>
+            {
+                entity.Property(cp => cp.Name).HasMaxLength(100).IsRequired();
+
+                entity.HasOne(cp => cp.Competition)
+                      .WithMany(c => c.CourtPairs)
+                      .HasForeignKey(cp => cp.CompetitionId)
+                      .OnDelete(DeleteBehavior.Cascade);
+
+                entity.HasOne(cp => cp.Court1)
+                      .WithMany()
+                      .HasForeignKey(cp => cp.Court1Id)
+                      .OnDelete(DeleteBehavior.Restrict);
+
+                entity.HasOne(cp => cp.Court2)
+                      .WithMany()
+                      .HasForeignKey(cp => cp.Court2Id)
+                      .OnDelete(DeleteBehavior.Restrict);
+            });
+
+            // ── TeamMatchSet ────────────────────────────────────────────────────
+            builder.Entity<TeamMatchSet>(entity =>
+            {
+                entity.Property(s => s.Phase).HasConversion<byte>();
+                entity.Property(s => s.SetType).HasConversion<byte>();
+
+                entity.HasOne(s => s.CompetitionFixture)
+                      .WithMany(f => f.TeamMatchSets)
+                      .HasForeignKey(s => s.CompetitionFixtureId)
+                      .OnDelete(DeleteBehavior.Cascade);
+
+                entity.HasOne(s => s.HomePlayer1).WithMany().HasForeignKey(s => s.HomePlayer1Id).OnDelete(DeleteBehavior.Restrict);
+                entity.HasOne(s => s.HomePlayer2).WithMany().HasForeignKey(s => s.HomePlayer2Id).OnDelete(DeleteBehavior.Restrict);
+                entity.HasOne(s => s.AwayPlayer1).WithMany().HasForeignKey(s => s.AwayPlayer1Id).OnDelete(DeleteBehavior.Restrict);
+                entity.HasOne(s => s.AwayPlayer2).WithMany().HasForeignKey(s => s.AwayPlayer2Id).OnDelete(DeleteBehavior.Restrict);
+
+                entity.HasOne(s => s.WinnerTeam)
+                      .WithMany()
+                      .HasForeignKey(s => s.WinnerTeamId)
+                      .OnDelete(DeleteBehavior.Restrict);
+
+                entity.HasOne(s => s.SavedMatch)
+                      .WithMany()
+                      .HasForeignKey(s => s.SavedMatchId)
+                      .OnDelete(DeleteBehavior.SetNull);
             });
 
             // ── RoleSwitchLog ───────────────────────────────────────────────────

--- a/DropShot/Models/Competition.cs
+++ b/DropShot/Models/Competition.cs
@@ -5,7 +5,8 @@
         Singles = 1,
         Doubles = 2,
         Team = 3,
-        MixedDoubles = 4
+        MixedDoubles = 4,
+        MixedTeam = 5
     }
 
     public class Competition
@@ -35,5 +36,6 @@
         public ICollection<CompetitionTeam> Teams { get; set; } = [];
         public ICollection<CompetitionMatchWindow> MatchWindows { get; set; } = [];
         public ICollection<CompetitionAdmin> Admins { get; set; } = [];
+        public ICollection<CourtPair> CourtPairs { get; set; } = [];
     }
 }

--- a/DropShot/Models/CompetitionFixture.cs
+++ b/DropShot/Models/CompetitionFixture.cs
@@ -32,6 +32,12 @@ public class CompetitionFixture
     public int? WinnerPlayerId { get; set; }
     public Guid? VerificationToken { get; set; }
 
+    // Team match fields (MixedTeam format)
+    public int? HomeTeamId { get; set; }
+    public int? AwayTeamId { get; set; }
+    public int? WinnerTeamId { get; set; }
+    public int? CourtPairId { get; set; }
+
     // Audit trail for admin-modified results
     public string? OriginalResultSummary { get; set; }
     public int? OriginalWinnerPlayerId { get; set; }
@@ -45,4 +51,9 @@ public class CompetitionFixture
     public Player? Player3 { get; set; }
     public Player? Player4 { get; set; }
     public SavedMatch? SavedMatch { get; set; }
+    public CompetitionTeam? HomeTeam { get; set; }
+    public CompetitionTeam? AwayTeam { get; set; }
+    public CompetitionTeam? WinnerTeam { get; set; }
+    public CourtPair? CourtPair { get; set; }
+    public ICollection<TeamMatchSet> TeamMatchSets { get; set; } = [];
 }

--- a/DropShot/Models/CompetitionParticipant.cs
+++ b/DropShot/Models/CompetitionParticipant.cs
@@ -8,6 +8,12 @@ public enum ParticipantStatus : byte
     Disqualified = 4
 }
 
+public enum PlayerGrade : byte
+{
+    A = 1,
+    B = 2
+}
+
 public class CompetitionParticipant
 {
     public int CompetitionId { get; set; }
@@ -15,6 +21,7 @@ public class CompetitionParticipant
     public DateTime RegisteredAt { get; set; } = DateTime.UtcNow;
     public ParticipantStatus Status { get; set; } = ParticipantStatus.Registered;
     public int? TeamId { get; set; }
+    public PlayerGrade? Grade { get; set; }
 
     public Competition Competition { get; set; } = null!;
     public Player Player { get; set; } = null!;

--- a/DropShot/Models/CompetitionTeam.cs
+++ b/DropShot/Models/CompetitionTeam.cs
@@ -5,7 +5,9 @@ public class CompetitionTeam
     public int CompetitionTeamId { get; set; }
     public int CompetitionId { get; set; }
     public string Name { get; set; } = "";
+    public int? CaptainPlayerId { get; set; }
 
     public Competition Competition { get; set; } = null!;
+    public Player? Captain { get; set; }
     public ICollection<CompetitionParticipant> Participants { get; set; } = [];
 }

--- a/DropShot/Models/CourtPair.cs
+++ b/DropShot/Models/CourtPair.cs
@@ -1,0 +1,14 @@
+namespace DropShot.Models;
+
+public class CourtPair
+{
+    public int CourtPairId { get; set; }
+    public int CompetitionId { get; set; }
+    public int Court1Id { get; set; }
+    public int Court2Id { get; set; }
+    public string Name { get; set; } = "";
+
+    public Competition Competition { get; set; } = null!;
+    public Court Court1 { get; set; } = null!;
+    public Court Court2 { get; set; } = null!;
+}

--- a/DropShot/Models/TeamMatchSet.cs
+++ b/DropShot/Models/TeamMatchSet.cs
@@ -1,0 +1,49 @@
+namespace DropShot.Models;
+
+public enum TeamMatchPhase : byte
+{
+    GenderDoubles = 1,
+    MixedDoubles = 2
+}
+
+public enum TeamMatchSetType : byte
+{
+    MensDoubles = 1,
+    WomensDoubles = 2,
+    MixedDoublesA = 3,
+    MixedDoublesB = 4
+}
+
+public class TeamMatchSet
+{
+    public int TeamMatchSetId { get; set; }
+    public int CompetitionFixtureId { get; set; }
+    public int SetNumber { get; set; }
+    public TeamMatchPhase Phase { get; set; }
+    public TeamMatchSetType SetType { get; set; }
+    public int CourtNumber { get; set; } // 1 or 2
+
+    // Players for this specific set (doubles pair per side)
+    public int? HomePlayer1Id { get; set; }
+    public int? HomePlayer2Id { get; set; }
+    public int? AwayPlayer1Id { get; set; }
+    public int? AwayPlayer2Id { get; set; }
+
+    // Set score (games won)
+    public int HomeGames { get; set; }
+    public int AwayGames { get; set; }
+    public int? WinnerTeamId { get; set; }
+    public bool IsComplete { get; set; }
+
+    // Link to live scoring system
+    public int? SavedMatchId { get; set; }
+
+    // Navigation
+    public CompetitionFixture CompetitionFixture { get; set; } = null!;
+    public Player? HomePlayer1 { get; set; }
+    public Player? HomePlayer2 { get; set; }
+    public Player? AwayPlayer1 { get; set; }
+    public Player? AwayPlayer2 { get; set; }
+    public CompetitionTeam? WinnerTeam { get; set; }
+    public SavedMatch? SavedMatch { get; set; }
+}

--- a/DropShot/Services/CompetitionProgressionService.cs
+++ b/DropShot/Services/CompetitionProgressionService.cs
@@ -155,52 +155,109 @@ public static class CompetitionProgressionService
 
         if (!allDone) return;
 
-        var winners = sourceFixtures
-            .OrderBy(f => f.FixtureLabel)
-            .Where(f => f.WinnerPlayerId.HasValue)
-            .Select(f => f.WinnerPlayerId!.Value)
-            .ToList();
+        // Check if these are team fixtures or player fixtures
+        bool isTeamFixtures = sourceFixtures.Any(f => f.WinnerTeamId.HasValue);
 
-        if (!winners.Any()) return;
-
-        // Find the unassigned target fixtures in the next round
-        List<CompetitionFixture> targetFixtures;
-
-        if (stage.StageType == StageType.Knockout)
+        if (isTeamFixtures)
         {
-            int nextRound = completedFixture.RoundNumber!.Value + 1;
-            targetFixtures = await db.CompetitionFixtures
-                .Where(f => f.CompetitionId == competitionId
-                         && f.CompetitionStageId == completedFixture.CompetitionStageId
-                         && f.RoundNumber == nextRound
-                         && f.Player1Id == null && f.Player2Id == null
-                         && f.Status == FixtureStatus.Scheduled)
+            var winnerTeamIds = sourceFixtures
                 .OrderBy(f => f.FixtureLabel)
-                .ToListAsync();
+                .Where(f => f.WinnerTeamId.HasValue)
+                .Select(f => f.WinnerTeamId!.Value)
+                .ToList();
+
+            if (!winnerTeamIds.Any()) return;
+
+            List<CompetitionFixture> targetFixtures;
+            if (stage.StageType == StageType.Knockout)
+            {
+                int nextRound = completedFixture.RoundNumber!.Value + 1;
+                targetFixtures = await db.CompetitionFixtures
+                    .Where(f => f.CompetitionId == competitionId
+                             && f.CompetitionStageId == completedFixture.CompetitionStageId
+                             && f.RoundNumber == nextRound
+                             && f.HomeTeamId == null && f.AwayTeamId == null
+                             && f.Status == FixtureStatus.Scheduled)
+                    .OrderBy(f => f.FixtureLabel)
+                    .ToListAsync();
+            }
+            else
+            {
+                var nextStage = allStages
+                    .Where(s => s.StageOrder > stage.StageOrder)
+                    .OrderBy(s => s.StageOrder)
+                    .FirstOrDefault();
+                if (nextStage is null) return;
+
+                targetFixtures = await db.CompetitionFixtures
+                    .Where(f => f.CompetitionId == competitionId
+                             && f.CompetitionStageId == nextStage.CompetitionStageId
+                             && f.HomeTeamId == null && f.AwayTeamId == null
+                             && f.Status == FixtureStatus.Scheduled)
+                    .OrderBy(f => f.FixtureLabel)
+                    .ToListAsync();
+            }
+
+            if (!targetFixtures.Any()) return;
+            AssignTeamWinners(targetFixtures, winnerTeamIds);
+            await db.SaveChangesAsync();
         }
         else
         {
-            // Move to the next stage in StageOrder
-            var nextStage = allStages
-                .Where(s => s.StageOrder > stage.StageOrder)
-                .OrderBy(s => s.StageOrder)
-                .FirstOrDefault();
-
-            if (nextStage is null) return; // This is the final stage — nothing to advance to
-
-            targetFixtures = await db.CompetitionFixtures
-                .Where(f => f.CompetitionId == competitionId
-                         && f.CompetitionStageId == nextStage.CompetitionStageId
-                         && f.Player1Id == null && f.Player2Id == null
-                         && f.Status == FixtureStatus.Scheduled)
+            var winners = sourceFixtures
                 .OrderBy(f => f.FixtureLabel)
-                .ToListAsync();
+                .Where(f => f.WinnerPlayerId.HasValue)
+                .Select(f => f.WinnerPlayerId!.Value)
+                .ToList();
+
+            if (!winners.Any()) return;
+
+            List<CompetitionFixture> targetFixtures;
+            if (stage.StageType == StageType.Knockout)
+            {
+                int nextRound = completedFixture.RoundNumber!.Value + 1;
+                targetFixtures = await db.CompetitionFixtures
+                    .Where(f => f.CompetitionId == competitionId
+                             && f.CompetitionStageId == completedFixture.CompetitionStageId
+                             && f.RoundNumber == nextRound
+                             && f.Player1Id == null && f.Player2Id == null
+                             && f.Status == FixtureStatus.Scheduled)
+                    .OrderBy(f => f.FixtureLabel)
+                    .ToListAsync();
+            }
+            else
+            {
+                var nextStage = allStages
+                    .Where(s => s.StageOrder > stage.StageOrder)
+                    .OrderBy(s => s.StageOrder)
+                    .FirstOrDefault();
+                if (nextStage is null) return;
+
+                targetFixtures = await db.CompetitionFixtures
+                    .Where(f => f.CompetitionId == competitionId
+                             && f.CompetitionStageId == nextStage.CompetitionStageId
+                             && f.Player1Id == null && f.Player2Id == null
+                             && f.Status == FixtureStatus.Scheduled)
+                    .OrderBy(f => f.FixtureLabel)
+                    .ToListAsync();
+            }
+
+            if (!targetFixtures.Any()) return;
+            AssignWinners(targetFixtures, winners);
+            await db.SaveChangesAsync();
         }
+    }
 
-        if (!targetFixtures.Any()) return;
-
-        AssignWinners(targetFixtures, winners);
-        await db.SaveChangesAsync();
+    // ── Helper: bracket-pair team winners into target fixtures ─────────────
+    internal static void AssignTeamWinners(List<CompetitionFixture> targets, List<int> winnerTeamIds)
+    {
+        // Pair winners sequentially: [0]→HomeTeam, [1]→AwayTeam of first target, etc.
+        int idx = 0;
+        foreach (var target in targets)
+        {
+            if (idx < winnerTeamIds.Count) target.HomeTeamId = winnerTeamIds[idx++];
+            if (idx < winnerTeamIds.Count) target.AwayTeamId = winnerTeamIds[idx++];
+        }
     }
 
     // ── Helper: bracket-pair winners into target fixtures ────────────────────


### PR DESCRIPTION
Implements a new "Mixed Team Tennis" competition type with teams of 4 (1 Male A, 1 Female A, 1 Male B, 1 Female B) playing 8 sets across 2 courts simultaneously in 2 phases.

## Data Model
- CompetitionFormat.MixedTeam (5), PlayerGrade (A/B), TeamMatchPhase, TeamMatchSetType enums
- CourtPair table: pairs two courts for simultaneous play
- TeamMatchSet table: 8 rows per fixture with players, score, SavedMatch link
- CompetitionFixture: HomeTeamId, AwayTeamId, WinnerTeamId, CourtPairId
- CompetitionTeam: CaptainPlayerId
- CompetitionParticipant: Grade (A/B)

## Registration & Team Configuration
- Admin assigns A/B grade and confirms gender per participant
- Team composition validation (exactly 1 of each role)
- Captain assignment per team
- Court pair CRUD for configuring fixed court pairs

## Scheduling
- Round-robin via circle method (handles 6-8 teams, bye for odd counts)
- 8 TeamMatchSets auto-created per fixture with correct player assignments: Phase 1: Men's doubles (Court 1) + Women's doubles (Court 2) Phase 2: Mixed doubles A (Court 1) + Mixed doubles B (Court 2)
- Court pairs assigned round-robin; knockout generates SF + Final

## Live Scoring
- /team-match/{id} page: two-court side-by-side view with live tally
- Each set launches existing scoring (/match/{id}?bestOf=1)
- Results auto-recorded to TeamMatchSet on set completion
- Fixture auto-completed when all 8 sets done
- Score validation uses existing RequireVerification config

## League Table & Knockout
- Team league table: Team, Captain, P, W, D, L, SW, SA, Points (points = total sets won, tiebreak by set diff then head-to-head)
- Top 4 teams seed into semi-finals (1st vs 4th, 2nd vs 3rd)
- CompetitionProgressionService handles team bracket advancement

https://claude.ai/code/session_01XNhutxMJLtCYXhPp7UbUcz