### PR TITLE
Fix migration: add Designer.cs and update model snapshot

### DIFF
--- a/DropShot/Data/Migrations/20260406140000_AddMixedTeamTennis.Designer.cs
+++ b/DropShot/Data/Migrations/20260406140000_AddMixedTeamTennis.Designer.cs
@@ -4,6 +4,7 @@ using DropShot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DropShot.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260406140000_AddMixedTeamTennis")]
+    partial class AddMixedTeamTennis
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder


### PR DESCRIPTION
## Summary
- The deploy failed because the EF Core migration was missing its `.Designer.cs` file
- The `ApplicationDbContextModelSnapshot.cs` also wasn't updated with the new entities and columns from the Mixed Team Tennis feature

## What was missing
- `20260406140000_AddMixedTeamTennis.Designer.cs` — the model snapshot required by EF Core to apply the migration
- Snapshot updates for: `CourtPair`, `TeamMatchSet` entities, `CompetitionFixture` team FK columns, `CompetitionParticipant.Grade`, `CompetitionTeam.CaptainPlayerId`

## Test plan
- [ ] Verify deploy pipeline passes (build + EF migration + publish)
- [ ] Verify database schema matches the model after migration applies

https://claude.ai/code/session_01XNhutxMJLtCYXhPp7UbUcz