### PR TITLE
Darken main stylesheet and remove blue

### DIFF
--- a/DropShot/wwwroot/app.css
+++ b/DropShot/wwwroot/app.css
@@ -1,6 +1,8 @@
 html, body {
     font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
     touch-action: manipulation;
+    background-color: #121212;
+    color: #e0e0e0;
 }
 
 /* MudBlazor's .mud-swipearea sets touch-action:none which blocks page scrolling on mobile */
@@ -9,17 +11,17 @@ html, body {
 }
 
 a, .btn-link {
-    color: #006bb7;
+    color: #c0c0c0;
 }
 
 .btn-primary {
     color: #fff;
-    background-color: #1b6ec2;
-    border-color: #1861ac;
+    background-color: #2a2a2a;
+    border-color: #1a1a1a;
 }
 
 .btn:focus, .btn:active:focus, .btn-link.nav-link:focus, .form-control:focus, .form-check-input:focus {
-  box-shadow: 0 0 0 0.1rem white, 0 0 0 0.25rem #258cfb;
+  box-shadow: 0 0 0 0.1rem #1a1a1a, 0 0 0 0.25rem #555;
 }
 
 .content {


### PR DESCRIPTION
## Summary
- Darken `DropShot/wwwroot/app.css` with `#121212` background and light text
- Replace blue link, button, and focus-ring colors with neutral grays

🤖 Generated with [Claude Code](https://claude.com/claude-code)