### PR TITLE
Add mock competition and tennis club ads to home carousel

### DIFF
--- a/DropShot/Components/Pages/Home.razor
+++ b/DropShot/Components/Pages/Home.razor
@@ -125,14 +125,34 @@
             <MudImage Class="mx-auto my-auto" Src="images/Logo.png" Style="height: 300px;"></MudImage>
         </div>
     </MudCarouselItem>
-    <MudCarouselItem Transition="transition" Color="@Color.Secondary">
-        <div class="d-flex" style="height:100%">
-            <MudImage Class="mx-auto my-auto" Src="images/Logo.png" Style="height: 300px;"></MudImage>
+    <MudCarouselItem Transition="transition">
+        <div class="d-flex align-center justify-center" style="height:100%; background: linear-gradient(135deg, #0f4c3a 0%, #1b8759 55%, #ffd54f 100%); color:#fff; padding: 24px; text-align:center;">
+            <div>
+                <MudText Typo="Typo.overline" Style="letter-spacing:3px; opacity:0.85;">DROPSHOT SUMMER SLAM</MudText>
+                <MudText Typo="Typo.h3" Style="font-weight:800; margin-top:8px;">Enter the Clay Court Classic</MudText>
+                <MudText Typo="Typo.h6" Style="font-weight:400; margin-top:8px; max-width:640px;">
+                    Singles &amp; doubles brackets · Prize pool £1,500 · Registration closes 14 June
+                </MudText>
+                <MudButton Variant="Variant.Filled" Color="Color.Warning" Size="Size.Large"
+                           StartIcon="@Icons.Material.Filled.EmojiEvents"
+                           Href="/competitions" Class="mt-4">
+                    Sign Up Now
+                </MudButton>
+            </div>
         </div>
     </MudCarouselItem>
     <MudCarouselItem Transition="transition">
-        <div class="d-flex" style="height:100%">
-            <MudImage Class="mx-auto my-auto" Src="images/Logo.png" Style="height: 300px;"></MudImage>
+        <div class="d-flex align-center justify-center" style="height:100%; background: linear-gradient(135deg, #1a237e 0%, #3949ab 50%, #c5cae9 100%); color:#fff; padding: 24px; text-align:center;">
+            <div>
+                <MudText Typo="Typo.overline" Style="letter-spacing:3px; opacity:0.85;">RIVERSIDE LAWN TENNIS CLUB</MudText>
+                <MudText Typo="Typo.h3" Style="font-weight:800; margin-top:8px;">Your Game. Your Club. Year Round.</MudText>
+                <MudText Typo="Typo.h6" Style="font-weight:400; margin-top:8px; max-width:640px;">
+                    12 floodlit courts · Coaching for all ages · Social mixers every Friday
+                </MudText>
+                <MudText Typo="Typo.body2" Class="mt-2" Style="opacity:0.9;">
+                    New member offer — first month free. Visit riverside-ltc.example
+                </MudText>
+            </div>
         </div>
     </MudCarouselItem>
 </MudCarousel>


### PR DESCRIPTION
## Summary
- Replaces two placeholder logo slides in the home page carousel with mock adverts
- Slide 2: DropShot Summer Slam competition signup ad linking to /competitions
- Slide 3: Mock "Riverside Lawn Tennis Club" advert
- Slide 1 remains the DropShot logo

## Test plan
- [ ] Visit home page and verify all three carousel slides render
- [ ] Confirm "Sign Up Now" button navigates to /competitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)