### PR TITLE
Make role banner static under main header

### DIFF
--- a/DropShot/Components/Shared/RoleBanner.razor.css
+++ b/DropShot/Components/Shared/RoleBanner.razor.css
@@ -8,9 +8,6 @@
     flex-wrap: wrap;
     gap: 8px;
     font-size: 0.85rem;
-    position: sticky;
-    top: 0;
-    z-index: 10;
 }
 
 .role-banner-select {


### PR DESCRIPTION
## Summary
- Remove sticky positioning from the "Browsing as" role banner so it scrolls with the page under the main header banner instead of sticking to the viewport top.

## Test plan
- [ ] Verify role banner appears directly below the main header and scrolls away with content