### PR TITLE
Make role banner sticky below mobile header

### DIFF
--- a/DropShot/Components/Shared/RoleBanner.razor.css
+++ b/DropShot/Components/Shared/RoleBanner.razor.css
@@ -8,6 +8,17 @@
     flex-wrap: wrap;
     gap: 8px;
     font-size: 0.85rem;
+    position: sticky;
+    top: 0;
+    z-index: 10;
+}
+
+/* On mobile the main header (.top-row) is position: fixed at the top
+   with height 3.5rem, so the sticky role banner needs to sit below it. */
+@media (max-width: 640.98px) {
+    .role-banner {
+        top: 3.5rem;
+    }
 }
 
 .role-banner-select {

--- a/DropShot/Components/Shared/RoleBanner.razor.css
+++ b/DropShot/Components/Shared/RoleBanner.razor.css
@@ -8,9 +8,6 @@
     flex-wrap: wrap;
     gap: 8px;
     font-size: 0.85rem;
-    position: sticky;
-    top: 0;
-    z-index: 10;
 }
 
 .role-banner-select {


### PR DESCRIPTION
## Summary
- Restore sticky positioning on the "Browsing as" role banner.
- Offset the sticky top to 3.5rem on mobile so the banner sits below the fixed main header (which was previously hiding it).

## Test plan
- [ ] On desktop, verify the banner sticks to the top of the main content area while scrolling
- [ ] On mobile, verify the banner sticks directly below the fixed header (not hidden behind it)