### PR TITLE
Make role banner actually stick on desktop

### DIFF
--- a/DropShot/Components/Shared/RoleBanner.razor
+++ b/DropShot/Components/Shared/RoleBanner.razor
@@ -27,6 +27,7 @@
             </form>
         }
     </div>
+    <div class="role-banner-spacer" aria-hidden="true"></div>
 }
 
 @code {

--- a/DropShot/Components/Shared/RoleBanner.razor.css
+++ b/DropShot/Components/Shared/RoleBanner.razor.css
@@ -5,16 +5,37 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    flex-wrap: wrap;
     gap: 8px;
     font-size: 0.85rem;
+    height: 32px;
+    box-sizing: border-box;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 99;
 }
 
-/* On mobile the main header (.top-row) is position: fixed at the top
-   with height 3.5rem, so the sticky role banner needs to sit below it. */
+/* Spacer reserves layout space equal to the fixed banner so page content
+   isn't hidden underneath it. */
+.role-banner-spacer {
+    height: 32px;
+    flex-shrink: 0;
+}
+
+/* On mobile the main header (.top-row) is position: fixed at top:0 with
+   height 3.5rem (z-index 100), so park the role banner just below it. */
 @media (max-width: 640.98px) {
     .role-banner {
         top: 3.5rem;
+    }
+}
+
+/* On desktop the sidebar (width 250px) occupies the left column, so the
+   fixed banner should start after it. */
+@media (min-width: 641px) {
+    .role-banner {
+        left: 250px;
     }
 }
 

--- a/DropShot/wwwroot/app.css
+++ b/DropShot/wwwroot/app.css
@@ -106,9 +106,16 @@ body.scoring-active .content {
     overflow: hidden !important;
 }
 
+/* Hide the fixed role banner (and its flow spacer) when scoring takes over. */
+body.scoring-active .role-banner,
+body.scoring-active .role-banner-spacer {
+    display: none !important;
+}
+
 /* Legacy — keep for external scoreboard page if still used */
 body.scoreboard-fullscreen .sidebar,
-body.scoreboard-fullscreen .role-banner {
+body.scoreboard-fullscreen .role-banner,
+body.scoreboard-fullscreen .role-banner-spacer {
     display: none !important;
 }
 


### PR DESCRIPTION
## Summary
- Replace \`position: sticky\` with \`position: fixed\` on the role banner — sticky was failing on desktop due to the flex ancestor layout.
- Render a same-height in-flow spacer sibling so page content still lays out correctly below the fixed banner.
- Hide the banner + spacer in \`scoring-active\` and \`scoreboard-fullscreen\` modes.

## Test plan
- [ ] Desktop: banner stays pinned to the top of the main column while scrolling
- [ ] Mobile: banner sits just below the fixed header and stays there while scrolling
- [ ] Scoring page: banner is hidden