### PR TITLE
Revert role banner to sticky positioning

### DIFF
--- a/DropShot/Components/Shared/RoleBanner.razor
+++ b/DropShot/Components/Shared/RoleBanner.razor
@@ -1,4 +1,4 @@
-@* Pure SSR component — shows a fixed banner with the active role and a dropdown to switch *@
+@* Pure SSR component — shows a sticky banner with the active role and a dropdown to switch *@
 
 @using System.Security.Claims
 @using Microsoft.AspNetCore.Identity
@@ -27,7 +27,6 @@
             </form>
         }
     </div>
-    <div class="role-banner-spacer" aria-hidden="true"></div>
 }
 
 @code {

--- a/DropShot/wwwroot/app.css
+++ b/DropShot/wwwroot/app.css
@@ -106,7 +106,7 @@ body.scoring-active .content {
     overflow: hidden !important;
 }
 
-/* ── Role banner (fixed at top of main column) ─────────────────────────── */
+/* ── Role banner (sticky at top of main column) ────────────────────────── */
 .role-banner {
     background: var(--mud-palette-info);
     color: white;
@@ -114,37 +114,19 @@ body.scoring-active .content {
     display: flex;
     align-items: center;
     justify-content: space-between;
+    flex-wrap: wrap;
     gap: 8px;
     font-size: 0.85rem;
-    height: 32px;
-    box-sizing: border-box;
-    position: fixed;
+    position: sticky;
     top: 0;
-    left: 0;
-    right: 0;
-    z-index: 1000;
-}
-
-/* Spacer reserves layout space equal to the fixed banner so page content
-   isn't hidden underneath it. */
-.role-banner-spacer {
-    height: 32px;
-    flex-shrink: 0;
+    z-index: 10;
 }
 
 /* On mobile the main header (.top-row) is position: fixed at top:0 with
-   height 3.5rem (z-index 100), so park the role banner just below it. */
+   height 3.5rem, so the sticky role banner needs to sit below it. */
 @media (max-width: 640.98px) {
     .role-banner {
         top: 3.5rem;
-    }
-}
-
-/* On desktop the sidebar (width 250px) occupies the left column, so the
-   fixed banner should start after it. */
-@media (min-width: 641px) {
-    .role-banner {
-        left: 250px;
     }
 }
 
@@ -172,16 +154,14 @@ body.scoring-active .content {
     color: #d7d7d7;
 }
 
-/* Hide the fixed role banner (and its flow spacer) when scoring takes over. */
-body.scoring-active .role-banner,
-body.scoring-active .role-banner-spacer {
+/* Hide the role banner when scoring takes over. */
+body.scoring-active .role-banner {
     display: none !important;
 }
 
 /* Legacy — keep for external scoreboard page if still used */
 body.scoreboard-fullscreen .sidebar,
-body.scoreboard-fullscreen .role-banner,
-body.scoreboard-fullscreen .role-banner-spacer {
+body.scoreboard-fullscreen .role-banner {
     display: none !important;
 }
 


### PR DESCRIPTION
## Summary
- Revert from \`position: fixed\` (z-index 1000, which was covering the mobile nav menu) back to \`position: sticky\`.
- Styles remain in global \`app.css\`, so Blazor scoped-CSS attribute filtering is no longer a concern.
- z-index lowered to 10 so the mobile nav-scrollable (z-index 99) correctly covers the banner when the menu is opened.

## Test plan
- [ ] Desktop: banner sticks at the top of the main column while scrolling, does not cover the sidebar
- [ ] Mobile: banner sticks just below the fixed header while scrolling
- [ ] Mobile: opening the nav menu covers the banner correctly (no overlap)
- [ ] Scoring page: banner is hidden