### PR TITLE
Increase home carousel auto-cycle time to 10 seconds

### DIFF
--- a/DropShot/Components/Pages/Home.razor
+++ b/DropShot/Components/Pages/Home.razor
@@ -119,7 +119,7 @@
     </MudCard>
 }
 
-<MudCarousel Class="mud-width-full" Style="height:400px; touch-action:pan-y;" ShowArrows="@arrows" ShowBullets="@bullets" EnableSwipeGesture="@enableSwipeGesture" AutoCycle="@autocycle" TData="object">
+<MudCarousel Class="mud-width-full" Style="height:400px; touch-action:pan-y;" ShowArrows="@arrows" ShowBullets="@bullets" EnableSwipeGesture="@enableSwipeGesture" AutoCycle="@autocycle" AutoCycleTime="@autocycleTime" TData="object">
     <MudCarouselItem Transition="transition" Color="@Color.Primary">
         <div class="d-flex" style="height:100%">
             <MudImage Class="mx-auto my-auto" Src="images/Logo.png" Style="height: 300px;"></MudImage>
@@ -223,6 +223,7 @@
     private bool bullets = true;
     private bool enableSwipeGesture = true;
     private bool autocycle = true;
+    private TimeSpan autocycleTime = TimeSpan.FromSeconds(10);
     private Transition transition = Transition.Slide;
 
     [SupplyParameterFromQuery]


### PR DESCRIPTION
## Summary
- Sets `AutoCycleTime` on the home page `MudCarousel` to 10s (up from the MudBlazor default of 5s), giving visitors more time to read each slide.

## Test plan
- [ ] Load the home page and confirm each carousel slide stays visible for ~10 seconds before advancing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)