### PR TITLE
Fix all build warnings

### DIFF
--- a/DropShot.Maui/Components/Pages/Competitions.razor
+++ b/DropShot.Maui/Components/Pages/Competitions.razor
@@ -74,7 +74,7 @@ else
             @foreach (var ev in _events)
             {
                 <MudExpansionPanels Class="mb-2" Elevation="1">
-                    <MudExpansionPanel IsInitiallyExpanded="true">
+                    <MudExpansionPanel Expanded="true">
                         <TitleContent>
                             <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
                                 <MudIcon Icon="@Icons.Material.Filled.EmojiEvents" Color="Color.Primary" Size="Size.Small" />
@@ -116,7 +116,7 @@ else
             @if (ungrouped.Any())
             {
                 <MudExpansionPanels Class="mb-2" Elevation="1">
-                    <MudExpansionPanel IsInitiallyExpanded="true">
+                    <MudExpansionPanel Expanded="true">
                         <TitleContent>
                             <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
                                 <MudIcon Icon="@Icons.Material.Filled.Inbox" Color="Color.Default" Size="Size.Small" />

--- a/DropShot.Tests/Helpers/TestAuthStateProvider.cs
+++ b/DropShot.Tests/Helpers/TestAuthStateProvider.cs
@@ -11,7 +11,7 @@ public class TestAuthStateProvider : AuthenticationStateProvider
         bool authenticated = false,
         string userId = "test-user-id",
         string userName = "test@example.com",
-        string[] roles = null!)
+        string[]? roles = null)
     {
         if (!authenticated)
         {

--- a/DropShot/Components/Pages/Competitions.razor
+++ b/DropShot/Components/Pages/Competitions.razor
@@ -141,7 +141,7 @@
         @foreach (var ev in _events)
         {
             <MudExpansionPanels Class="mb-2" Elevation="1">
-                <MudExpansionPanel @bind-IsExpanded="ev.IsExpanded">
+                <MudExpansionPanel @bind-Expanded="ev.IsExpanded">
                     <TitleContent>
                         <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
                             <MudIcon Icon="@Icons.Material.Filled.EmojiEvents" Color="Color.Primary" />
@@ -156,12 +156,13 @@
                                 @ev.Competitions.Count competition(s)
                             </MudChip>
                             <MudSpacer />
-                            <MudButton Size="Size.Small" Variant="Variant.Text" Color="Color.Info"
-                                       StartIcon="@Icons.Material.Filled.Visibility"
-                                       OnClick="@(() => Nav.NavigateTo($"/event/{ev.Event.EventId}/view"))"
-                                       OnClick:stopPropagation="true">
-                                View Event
-                            </MudButton>
+                            <div @onclick:stopPropagation="true">
+                                <MudButton Size="Size.Small" Variant="Variant.Text" Color="Color.Info"
+                                           StartIcon="@Icons.Material.Filled.Visibility"
+                                           OnClick="@(() => Nav.NavigateTo($"/event/{ev.Event.EventId}/view"))">
+                                    View Event
+                                </MudButton>
+                            </div>
                         </MudStack>
                     </TitleContent>
                     <ChildContent>
@@ -198,7 +199,7 @@
         @if (_ungroupedCompetitions.Count > 0)
         {
             <MudExpansionPanels Class="mb-2" Elevation="1">
-                <MudExpansionPanel IsInitiallyExpanded="true">
+                <MudExpansionPanel Expanded="true">
                     <TitleContent>
                         <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
                             <MudIcon Icon="@Icons.Material.Filled.Inbox" Color="Color.Default" />

--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -403,7 +403,7 @@
                 _winner = ScoreService.EndMatch(_state, CurrentMatch, Label_Switch1) ?? string.Empty;
             StopTimer();
             StartMatchEndCountdown();
-            SaveHistory();
+            await SaveHistory();
         }
     }
 
@@ -444,8 +444,8 @@
     {
         _value = result.Player1;
         _value2 = result.Player2;
-        _value3 = result.Player3;
-        _value4 = result.Player4;
+        _value3 = result.Player3 ?? string.Empty;
+        _value4 = result.Player4 ?? string.Empty;
         Label_Switch1 = result.IsDoubles;
         _selectedCourtId = result.CourtId;
 
@@ -1073,7 +1073,7 @@
             _state.IsMatchEnded = false;
             _state.IsTieBreak = false;
             _state.DeuceCount = 0;
-            SaveHistory();
+            await SaveHistory();
         }
     }
 


### PR DESCRIPTION
## Summary
- Eliminates all 17 build warnings (8 unique) across DropShot, DropShot.Maui, and DropShot.Tests
- CS4014 (×2): `await SaveHistory()` in `TennisScore.razor`
- CS8601 (×2): coalesce nullable `Player3`/`Player4` to `string.Empty`
- CS8604 (×1): make `TestAuthStateProvider.roles` parameter nullable
- MUD0002 (×4 DropShot, ×2 Maui × frameworks): rename `IsExpanded`/`IsInitiallyExpanded` → `Expanded` per MudBlazor v8; wrap `MudButton` in a div for `@onclick:stopPropagation` (directive is invalid on components)

Build now reports **0 warnings, 0 errors**.

## Test plan
- [x] `dotnet build DropShot.sln` — 0 warnings, 0 errors
- [x] `dotnet test DropShot.Tests` — same pass/fail as main (2 pre-existing failures unrelated: missing `QrLoginService` / `FuzzySearchService` DI registrations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)