### PR TITLE
Fix AddClubIdToRulesSet migration: Competition table name

### DIFF
--- a/DropShot/Data/Migrations/20260407233335_AddClubIdToRulesSet.cs
+++ b/DropShot/Data/Migrations/20260407233335_AddClubIdToRulesSet.cs
@@ -26,7 +26,7 @@ namespace DropShot.Migrations
                 FROM RulesSets rs
                 CROSS APPLY (
                     SELECT TOP 1 c.HostClubId AS ClubId
-                    FROM Competitions c
+                    FROM Competition c
                     WHERE c.RulesSetId = rs.RulesSetId
                       AND c.HostClubId IS NOT NULL
                     GROUP BY c.HostClubId


### PR DESCRIPTION
## Summary
The backfill SQL in \`20260407233335_AddClubIdToRulesSet\` referenced the Competitions table as \`Competitions\` but the EF-mapped table name is \`Competition\` (singular). The deploy migration failed with:

\`\`\`
Microsoft.Data.SqlClient.SqlException: Invalid object name 'Competitions'.
\`\`\`

The failed UPDATE rolled back the whole migration transaction, so the deploy DB currently has no \`ClubId\` column and the migration is not recorded in \`__EFMigrationsHistory\`. Re-running after this fix will apply cleanly.

## Test plan
- [x] \`dotnet build\` succeeds.
- [ ] Deploy pipeline \`dotnet ef database update\` applies the migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)