### PR TITLE
Fix RulesSets_Clubs FK cascade path error in migration

### DIFF
--- a/DropShot/Data/Migrations/20260407233335_AddClubIdToRulesSet.Designer.cs
+++ b/DropShot/Data/Migrations/20260407233335_AddClubIdToRulesSet.Designer.cs
@@ -1578,7 +1578,7 @@ namespace DropShot.Migrations
                     b.HasOne("DropShot.Models.Club", "Club")
                         .WithMany("RulesSets")
                         .HasForeignKey("ClubId")
-                        .OnDelete(DeleteBehavior.Cascade)
+                        .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
                     b.Navigation("Club");

--- a/DropShot/Data/Migrations/20260407233335_AddClubIdToRulesSet.cs
+++ b/DropShot/Data/Migrations/20260407233335_AddClubIdToRulesSet.cs
@@ -67,7 +67,7 @@ namespace DropShot.Migrations
                 column: "ClubId",
                 principalTable: "Clubs",
                 principalColumn: "ClubId",
-                onDelete: ReferentialAction.Cascade);
+                onDelete: ReferentialAction.Restrict);
         }
 
         /// <inheritdoc />

--- a/DropShot/Data/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/DropShot/Data/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -1575,7 +1575,7 @@ namespace DropShot.Migrations
                     b.HasOne("DropShot.Models.Club", "Club")
                         .WithMany("RulesSets")
                         .HasForeignKey("ClubId")
-                        .OnDelete(DeleteBehavior.Cascade)
+                        .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
                     b.Navigation("Club");

--- a/DropShot/Data/MyDbContext.cs
+++ b/DropShot/Data/MyDbContext.cs
@@ -110,7 +110,7 @@ namespace DropShot.Data
                 entity.HasOne(r => r.Club)
                       .WithMany(c => c.RulesSets)
                       .HasForeignKey(r => r.ClubId)
-                      .OnDelete(DeleteBehavior.Cascade);
+                      .OnDelete(DeleteBehavior.Restrict);
             });
 
             builder.Entity<RulesSetItem>(entity =>


### PR DESCRIPTION
## Summary
- The `AddClubIdToRulesSet` migration failed on deploy with `Introducing FOREIGN KEY constraint 'FK_RulesSets_Clubs_ClubId' on table 'RulesSets' may cause cycles or multiple cascade paths.`
- Club already reaches Competition via `SetNull` on `HostClubId` and (via the new RulesSet link) `RulesSetId`. SQL Server counts SET NULL as a cascade path and rejects the FK.
- Switched `RulesSet → Club` delete behavior from `Cascade` to `Restrict` in the migration, its Designer snapshot, the model snapshot, and `MyDbContext`.

## Test plan
- [x] `dotnet build DropShot` clean (0 warnings, 0 errors)
- [ ] Deploy pipeline applies migration successfully