### PR TITLE
Hide top toolbar in scoreboard fullscreen

### DIFF
--- a/DropShot/wwwroot/app.css
+++ b/DropShot/wwwroot/app.css
@@ -106,12 +106,18 @@ body.scoring-active .content {
 
 /* Legacy — keep for external scoreboard page if still used */
 body.scoreboard-fullscreen .sidebar,
-body.scoreboard-fullscreen .role-banner {
+body.scoreboard-fullscreen .role-banner,
+body.scoreboard-fullscreen .top-row,
+body.scoreboard-fullscreen .navbar-toggler {
     display: none !important;
 }
 
 body.scoreboard-fullscreen .content {
     padding: 0 !important;
+}
+
+body.scoreboard-fullscreen main {
+    padding-top: 0 !important;
 }
 
 /* ── QR Login Panel ──────────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary
- Exit-fullscreen button on the scoreboard collided with the layout top-row on desktop and sat under the NavMenu hamburger toggler on mobile
- Extend the existing `body.scoreboard-fullscreen` rules to hide `.top-row` and `.navbar-toggler`, and zero out `main` top padding

## Test plan
- [ ] Enter fullscreen on /score desktop — exit button visible, no top toolbar behind it
- [ ] Enter fullscreen on /score mobile — exit button visible, hamburger hidden
- [ ] Exit fullscreen — toolbar and hamburger return

🤖 Generated with [Claude Code](https://claude.com/claude-code)