### PR TITLE
Reorder scoreboard toolbar on mobile

### DIFF
--- a/DropShot/Components/Pages/Scoreboard.razor
+++ b/DropShot/Components/Pages/Scoreboard.razor
@@ -23,20 +23,26 @@
     @if (!_isFullscreen)
     {
         <div class="scoreboard-toolbar">
-            <MudSelect T="int?" Value="_selectedCourtId" ValueChanged="OnCourtChanged" Label="Select Court"
-                       Variant="Variant.Outlined" Style="max-width: min(300px, 45vw);" Clearable="true">
-                @foreach (var court in _allCourts)
-                {
-                    <MudSelectItem T="int?" Value="@((int?)court.CourtId)">@court.Club.Name — @court.Name</MudSelectItem>
-                }
-            </MudSelect>
-            <MudSelect T="string" Value="_selectedLayout" ValueChanged="OnLayoutChanged" Label="Layout"
-                       Variant="Variant.Outlined" Style="max-width: min(180px, 30vw);">
-                <MudSelectItem T="string" Value=@("default")>Default</MudSelectItem>
-                <MudSelectItem T="string" Value=@("wimbledon")>Wimbledon</MudSelectItem>
-            </MudSelect>
-            <MudIconButton Icon="@Icons.Material.Filled.Fullscreen" aria-label="Enter fullscreen"
-                           OnClick="EnterFullscreenAsync" Size="Size.Large" />
+            <div class="toolbar-court">
+                <MudSelect T="int?" Value="_selectedCourtId" ValueChanged="OnCourtChanged" Label="Select Court"
+                           Variant="Variant.Outlined" Style="max-width: min(300px, 45vw);" Clearable="true">
+                    @foreach (var court in _allCourts)
+                    {
+                        <MudSelectItem T="int?" Value="@((int?)court.CourtId)">@court.Club.Name — @court.Name</MudSelectItem>
+                    }
+                </MudSelect>
+            </div>
+            <div class="toolbar-layout">
+                <MudSelect T="string" Value="_selectedLayout" ValueChanged="OnLayoutChanged" Label="Layout"
+                           Variant="Variant.Outlined" Style="max-width: min(180px, 30vw);">
+                    <MudSelectItem T="string" Value=@("default")>Default</MudSelectItem>
+                    <MudSelectItem T="string" Value=@("wimbledon")>Wimbledon</MudSelectItem>
+                </MudSelect>
+            </div>
+            <div class="toolbar-fullscreen">
+                <MudIconButton Icon="@Icons.Material.Filled.Fullscreen" aria-label="Enter fullscreen"
+                               OnClick="EnterFullscreenAsync" Size="Size.Large" />
+            </div>
         </div>
     }
     else

--- a/DropShot/Components/Pages/Scoreboard.razor.css
+++ b/DropShot/Components/Pages/Scoreboard.razor.css
@@ -14,6 +14,16 @@
     flex-shrink: 0;
 }
 
+@media (max-width: 600px) {
+    .toolbar-court {
+        flex: 1 1 100%;
+    }
+
+    .toolbar-fullscreen {
+        margin-left: auto;
+    }
+}
+
 .scoreboard-content {
     flex: 1;
     display: flex;


### PR DESCRIPTION
## Summary
- On narrow viewports, put the court selector on its own row above the layout selector
- Push the fullscreen toggle to the right on mobile
- Desktop layout is unchanged

## Test plan
- [ ] On mobile, court selector appears above layout selector
- [ ] On mobile, fullscreen button is right-aligned
- [ ] On desktop, toolbar still renders as a single row

🤖 Generated with [Claude Code](https://claude.com/claude-code)