### PR TITLE
Move scoreboard fullscreen toggle to top-right on mobile

### DIFF
--- a/DropShot/Components/Pages/Scoreboard.razor.css
+++ b/DropShot/Components/Pages/Scoreboard.razor.css
@@ -15,12 +15,14 @@
 }
 
 @media (max-width: 600px) {
-    .toolbar-court {
-        flex: 1 1 100%;
-    }
-
     .toolbar-fullscreen {
         margin-left: auto;
+        order: 2;
+    }
+
+    .toolbar-layout {
+        flex: 1 1 100%;
+        order: 3;
     }
 }
 


### PR DESCRIPTION
## Summary
- Keep the fullscreen button on the same row as the court selector on mobile, pushed to the right
- Layout selector wraps to its own row below
- Desktop layout unchanged

## Test plan
- [ ] On mobile, fullscreen button is top-right next to court selector
- [ ] On mobile, layout selector sits below on its own row
- [ ] Desktop toolbar still renders as a single row

🤖 Generated with [Claude Code](https://claude.com/claude-code)