### PR TITLE
Allow club admins to create competitions and events

### DIFF
--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -1118,8 +1118,9 @@
         }
         else
         {
-            // Only Admins can create new competitions
-            _canEdit = await AuthzService.IsAdminAsync(authState.User);
+            // Admins and ClubAdmins can create new competitions
+            _canEdit = await AuthzService.IsAdminAsync(authState.User)
+                || (await AuthzService.GetAdminClubIdsAsync(authState.User)).Count > 0;
             Model = new CompetitionFormModel { EventId = EventId };
             _stages = [];
             _participants = [];

--- a/DropShot/Components/Pages/Competitions.razor
+++ b/DropShot/Components/Pages/Competitions.razor
@@ -324,7 +324,7 @@
     </MudTabPanel>
 </MudTabs>
 
-@if (_isAdmin)
+@if (_isAdmin || _editableClubIds.Count > 0)
 {
     <MudStack Row="true" Spacing="2" Class="mt-3">
         <MudButton Size="@Size.Small" Variant="@Variant.Filled" Color="@Color.Primary"

--- a/DropShot/Controllers/CompetitionsController.cs
+++ b/DropShot/Controllers/CompetitionsController.cs
@@ -70,9 +70,11 @@ public class CompetitionsController(
     }
 
     [HttpPost]
-    [Authorize(Roles = "Admin")]
     public async Task<ActionResult<CompetitionDto>> Create([FromBody] SaveCompetitionRequest req)
     {
+        if (!await authzService.CanEditCompetitionAsync(User, req.HostClubId))
+            return Forbid();
+
         await using var db = dbFactory.CreateDbContext();
         var comp = new Competition();
         Apply(comp, req);

--- a/DropShot/Controllers/EventsController.cs
+++ b/DropShot/Controllers/EventsController.cs
@@ -60,9 +60,11 @@ public class EventsController(
     }
 
     [HttpPost]
-    [Authorize(Roles = "Admin")]
     public async Task<ActionResult<EventDto>> Create([FromBody] SaveEventRequest req)
     {
+        if (!await authzService.CanEditCompetitionAsync(User, req.HostClubId))
+            return Forbid();
+
         await using var db = dbFactory.CreateDbContext();
         var ev = new Event
         {


### PR DESCRIPTION
## Summary
- Club admins can now see and use the "Add Competition" and "New Event" buttons on the Competitions page
- Updated API endpoints to use `CanEditCompetitionAsync` authorization instead of hard-coded `Admin` role check
- Club admins can create competitions/events scoped to clubs they administer; site admins retain full access

## Test plan
- [ ] Log in as a ClubAdmin and verify "Add Competition" and "New Event" buttons appear
- [ ] Create a competition as ClubAdmin for an administered club — should succeed
- [ ] Create an event as ClubAdmin for an administered club — should succeed
- [ ] Verify a ClubAdmin cannot create a competition for a club they don't administer
- [ ] Verify site Admin can still create competitions/events for any club

🤖 Generated with [Claude Code](https://claude.com/claude-code)