### PR TITLE
Add Mixed Team Tennis competition format

### DIFF
--- a/DropShot.Shared/Dtos/CompetitionDtos.cs
+++ b/DropShot.Shared/Dtos/CompetitionDtos.cs
@@ -49,7 +49,9 @@ public record CompetitionParticipantDto(
     DateTime RegisteredAt,
     int? TeamId,
     string? TeamName,
-    string? MobileNumber);
+    string? MobileNumber,
+    PlayerGrade? Grade = null,
+    PlayerSex? Sex = null);
 
 public record CompetitionFixtureDto(
     int CompetitionFixtureId,
@@ -71,12 +73,21 @@ public record CompetitionFixtureDto(
     int? Player4Id,
     string? Player4Name,
     string? ResultSummary,
-    int? WinnerPlayerId);
+    int? WinnerPlayerId,
+    int? HomeTeamId = null,
+    string? HomeTeamName = null,
+    int? AwayTeamId = null,
+    string? AwayTeamName = null,
+    int? WinnerTeamId = null,
+    int? CourtPairId = null,
+    string? CourtPairName = null);
 
 public record CompetitionTeamDto(
     int CompetitionTeamId,
     int CompetitionId,
-    string Name);
+    string Name,
+    int? CaptainPlayerId = null,
+    string? CaptainName = null);
 
 public record LeagueTableEntryDto(
     int PlayerId,
@@ -161,3 +172,55 @@ public record EventCompetitionTemplate(
     PlayerSex? EligibleSex,
     int? MaxAge,
     int? MinAge);
+
+// ── Mixed Team Tennis DTOs ──────────────────────────────────────────────────
+
+public record CourtPairDto(
+    int CourtPairId,
+    int CompetitionId,
+    int Court1Id,
+    string Court1Name,
+    int Court2Id,
+    string Court2Name,
+    string Name);
+
+public record TeamMatchSetDto(
+    int TeamMatchSetId,
+    int CompetitionFixtureId,
+    int SetNumber,
+    TeamMatchPhase Phase,
+    TeamMatchSetType SetType,
+    int CourtNumber,
+    int? HomePlayer1Id,
+    string? HomePlayer1Name,
+    int? HomePlayer2Id,
+    string? HomePlayer2Name,
+    int? AwayPlayer1Id,
+    string? AwayPlayer1Name,
+    int? AwayPlayer2Id,
+    string? AwayPlayer2Name,
+    int? HomeGames,
+    int? AwayGames,
+    int? WinnerTeamId,
+    bool IsComplete,
+    int? SavedMatchId);
+
+public record TeamLeagueTableEntryDto(
+    int TeamId,
+    string TeamName,
+    string? CaptainName,
+    int Played,
+    int Won,
+    int Drawn,
+    int Lost,
+    int SetsWon,
+    int SetsAgainst,
+    int Points);
+
+public record SaveCourtPairRequest(int Court1Id, int Court2Id, string Name);
+
+public record SetParticipantGradeRequest(PlayerGrade Grade);
+
+public record SetTeamCaptainRequest(int CaptainPlayerId);
+
+public record TeamValidationResultDto(bool IsValid, List<string> Errors);

--- a/DropShot.Shared/Enums.cs
+++ b/DropShot.Shared/Enums.cs
@@ -5,7 +5,28 @@ public enum CompetitionFormat : byte
     Singles = 1,
     Doubles = 2,
     Team = 3,
-    MixedDoubles = 4
+    MixedDoubles = 4,
+    MixedTeam = 5
+}
+
+public enum PlayerGrade : byte
+{
+    A = 1,
+    B = 2
+}
+
+public enum TeamMatchPhase : byte
+{
+    GenderDoubles = 1,
+    MixedDoubles = 2
+}
+
+public enum TeamMatchSetType : byte
+{
+    MensDoubles = 1,
+    WomensDoubles = 2,
+    MixedDoublesA = 3,
+    MixedDoublesB = 4
 }
 
 public enum PlayerSex : byte

--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -315,9 +315,14 @@
                         <MudTh>Player</MudTh>
                         <MudTh>Status</MudTh>
                         <MudTh>Registered</MudTh>
-                        @if (Model.CompetitionFormat == CompetitionFormat.Team)
+                        @if (Model.CompetitionFormat is CompetitionFormat.Team or CompetitionFormat.MixedTeam)
                         {
                             <MudTh>Team</MudTh>
+                        }
+                        @if (Model.CompetitionFormat == CompetitionFormat.MixedTeam)
+                        {
+                            <MudTh>Sex</MudTh>
+                            <MudTh>Grade</MudTh>
                         }
                         <MudTh></MudTh>
                     </HeaderContent>
@@ -334,7 +339,7 @@
                             </MudSelect>
                         </MudTd>
                         <MudTd>@context.RegisteredAt.ToString("dd MMM yyyy")</MudTd>
-                        @if (Model.CompetitionFormat == CompetitionFormat.Team)
+                        @if (Model.CompetitionFormat is CompetitionFormat.Team or CompetitionFormat.MixedTeam)
                         {
                             <MudTd>
                                 <MudSelect T="int?" Value="context.TeamId" Dense="true" Variant="Variant.Text"
@@ -343,6 +348,20 @@
                                     @foreach (var t in _teams)
                                     {
                                         <MudSelectItem T="int?" Value="@((int?)t.CompetitionTeamId)">@t.Name</MudSelectItem>
+                                    }
+                                </MudSelect>
+                            </MudTd>
+                        }
+                        @if (Model.CompetitionFormat == CompetitionFormat.MixedTeam)
+                        {
+                            <MudTd>@(context.Player?.Sex?.ToString() ?? "—")</MudTd>
+                            <MudTd>
+                                <MudSelect T="PlayerGrade?" Value="context.Grade" Dense="true" Variant="Variant.Text"
+                                           Clearable="true"
+                                           ValueChanged="@((PlayerGrade? g) => AssignGrade(context, g))">
+                                    @foreach (PlayerGrade g in Enum.GetValues<PlayerGrade>())
+                                    {
+                                        <MudSelectItem T="PlayerGrade?" Value="@((PlayerGrade?)g)">@g</MudSelectItem>
                                     }
                                 </MudSelect>
                             </MudTd>
@@ -491,8 +510,8 @@
                 </MudPaper>
             }
 
-            @* ── Teams (only for Team competitions) ──────────── *@
-            @if (Model.CompetitionFormat == CompetitionFormat.Team)
+            @* ── Teams (for Team and MixedTeam competitions) ──────────── *@
+            @if (Model.CompetitionFormat is CompetitionFormat.Team or CompetitionFormat.MixedTeam)
             {
                 <MudPaper Class="pa-4 mb-4">
                     <MudStack Row="true" AlignItems="AlignItems.Center" Class="mb-3">
@@ -504,17 +523,51 @@
                     <MudTable Items="@_teams" Dense="true" Hover="true">
                         <HeaderContent>
                             <MudTh>Team Name</MudTh>
+                            @if (Model.CompetitionFormat == CompetitionFormat.MixedTeam)
+                            {
+                                <MudTh>Captain</MudTh>
+                            }
                             <MudTh>Members</MudTh>
                             <MudTh></MudTh>
                         </HeaderContent>
                         <RowTemplate>
                             <MudTd>@context.Name</MudTd>
+                            @if (Model.CompetitionFormat == CompetitionFormat.MixedTeam)
+                            {
+                                <MudTd>
+                                    <MudSelect T="int?" Value="context.CaptainPlayerId" Dense="true" Variant="Variant.Text"
+                                               Clearable="true"
+                                               ValueChanged="@((int? pid) => AssignCaptain(context, pid))">
+                                        @foreach (var p in _participants.Where(p => p.TeamId == context.CompetitionTeamId))
+                                        {
+                                            <MudSelectItem T="int?" Value="@((int?)p.PlayerId)">@(p.Player?.DisplayName ?? "")</MudSelectItem>
+                                        }
+                                    </MudSelect>
+                                </MudTd>
+                            }
                             <MudTd>
-                                @string.Join(", ", _participants
-                                    .Where(p => p.TeamId == context.CompetitionTeamId)
-                                    .Select(p => p.Player?.DisplayName ?? ""))
+                                @if (Model.CompetitionFormat == CompetitionFormat.MixedTeam)
+                                {
+                                    @foreach (var p in _participants.Where(p => p.TeamId == context.CompetitionTeamId))
+                                    {
+                                        var label = $"{p.Player?.DisplayName} ({p.Player?.Sex?.ToString()?[0]}{p.Grade})";
+                                        <MudChip T="string" Size="Size.Small" Variant="Variant.Text">@label</MudChip>
+                                    }
+                                }
+                                else
+                                {
+                                    @string.Join(", ", _participants
+                                        .Where(p => p.TeamId == context.CompetitionTeamId)
+                                        .Select(p => p.Player?.DisplayName ?? ""))
+                                }
                             </MudTd>
                             <MudTd>
+                                @if (Model.CompetitionFormat == CompetitionFormat.MixedTeam)
+                                {
+                                    <MudIconButton Icon="@Icons.Material.Filled.CheckCircle" Size="Size.Small"
+                                                   Color="Color.Info" aria-label="Validate"
+                                                   OnClick="@(() => ValidateTeam(context))" />
+                                }
                                 <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="Size.Small"
                                                OnClick="@(() => OpenEditTeamDialog(context))" />
                                 <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small"
@@ -587,7 +640,14 @@
                             </MudChip>
                         </MudTd>
                         <MudTd>
-                            @if (context.Player1Id.HasValue && context.Player2Id.HasValue
+                            @if (context.HomeTeamId.HasValue && context.AwayTeamId.HasValue
+                                 && context.Status is not (FixtureStatus.Completed or FixtureStatus.Cancelled or FixtureStatus.Walkover or FixtureStatus.AwaitingVerification))
+                            {
+                                <MudIconButton Icon="@Icons.Material.Filled.SportsTennis" Size="Size.Small"
+                                               Color="Color.Success" aria-label="Play Team Match"
+                                               Href="@($"/team-match/{context.CompetitionFixtureId}")" />
+                            }
+                            else if (context.Player1Id.HasValue && context.Player2Id.HasValue
                                  && context.Status is not (FixtureStatus.Completed or FixtureStatus.Cancelled or FixtureStatus.Walkover or FixtureStatus.AwaitingVerification))
                             {
                                 <MudIconButton Icon="@Icons.Material.Filled.Scoreboard" Size="Size.Small"
@@ -1058,7 +1118,10 @@
                 .Include(c => c.Fixtures).ThenInclude(f => f.Player2)
                 .Include(c => c.Fixtures).ThenInclude(f => f.Player3)
                 .Include(c => c.Fixtures).ThenInclude(f => f.Player4)
-                .Include(c => c.Teams)
+                .Include(c => c.Fixtures).ThenInclude(f => f.HomeTeam)
+                .Include(c => c.Fixtures).ThenInclude(f => f.AwayTeam)
+                .Include(c => c.Fixtures).ThenInclude(f => f.CourtPair)
+                .Include(c => c.Teams).ThenInclude(t => t.Captain)
                 .Include(c => c.MatchWindows).ThenInclude(w => w.Court)
                 .AsNoTracking()
                 .FirstOrDefaultAsync(c => c.CompetitionID == Id);
@@ -1275,6 +1338,7 @@
             CompetitionFormat.Doubles => "Doubles",
             CompetitionFormat.MixedDoubles => "Mixed Doubles",
             CompetitionFormat.Team => "Team",
+            CompetitionFormat.MixedTeam => "Mixed Team Tennis",
             _ => Model.CompetitionFormat.ToString()
         });
 
@@ -1461,6 +1525,58 @@
         await using var db = DbFactory.CreateDbContext();
         var row = await db.CompetitionParticipants.FindAsync(cp.CompetitionId, cp.PlayerId);
         if (row != null) { row.TeamId = teamId; await db.SaveChangesAsync(); cp.TeamId = teamId; }
+    }
+
+    private async Task AssignGrade(CompetitionParticipant cp, PlayerGrade? grade)
+    {
+        await using var db = DbFactory.CreateDbContext();
+        var row = await db.CompetitionParticipants.FindAsync(cp.CompetitionId, cp.PlayerId);
+        if (row != null)
+        {
+            row.Grade = grade.HasValue ? (DropShot.Models.PlayerGrade)grade.Value : null;
+            await db.SaveChangesAsync();
+            cp.Grade = grade;
+        }
+    }
+
+    private async Task AssignCaptain(CompetitionTeam team, int? captainPlayerId)
+    {
+        await using var db = DbFactory.CreateDbContext();
+        var row = await db.CompetitionTeams.FindAsync(team.CompetitionTeamId);
+        if (row != null) { row.CaptainPlayerId = captainPlayerId; await db.SaveChangesAsync(); team.CaptainPlayerId = captainPlayerId; }
+    }
+
+    private async Task ValidateTeam(CompetitionTeam team)
+    {
+        await using var db = DbFactory.CreateDbContext();
+        var members = _participants
+            .Where(p => p.TeamId == team.CompetitionTeamId
+                && (p.Status == ParticipantStatus.Registered || p.Status == ParticipantStatus.Confirmed))
+            .ToList();
+
+        var errors = new List<string>();
+        if (members.Count != 4) errors.Add($"Need exactly 4 members (has {members.Count})");
+        foreach (var m in members)
+        {
+            if (m.Player?.Sex == null) errors.Add($"{m.Player?.DisplayName}: no sex");
+            if (m.Grade == null) errors.Add($"{m.Player?.DisplayName}: no grade");
+        }
+        if (errors.Count == 0 && members.Count == 4)
+        {
+            int mA = members.Count(m => m.Player?.Sex == PlayerSex.Male && m.Grade == PlayerGrade.A);
+            int fA = members.Count(m => m.Player?.Sex == PlayerSex.Female && m.Grade == PlayerGrade.A);
+            int mB = members.Count(m => m.Player?.Sex == PlayerSex.Male && m.Grade == PlayerGrade.B);
+            int fB = members.Count(m => m.Player?.Sex == PlayerSex.Female && m.Grade == PlayerGrade.B);
+            if (mA != 1) errors.Add($"Need 1 Male A (has {mA})");
+            if (fA != 1) errors.Add($"Need 1 Female A (has {fA})");
+            if (mB != 1) errors.Add($"Need 1 Male B (has {mB})");
+            if (fB != 1) errors.Add($"Need 1 Female B (has {fB})");
+        }
+
+        if (errors.Count == 0)
+            Snackbar.Add($"{team.Name}: Valid", Severity.Success);
+        else
+            Snackbar.Add($"{team.Name}: {string.Join("; ", errors)}", Severity.Warning);
     }
 
     // ── Teams ────────────────────────────────────────────────────────────────
@@ -2087,6 +2203,9 @@
             .Include(f => f.Player2)
             .Include(f => f.Player3)
             .Include(f => f.Player4)
+            .Include(f => f.HomeTeam)
+            .Include(f => f.AwayTeam)
+            .Include(f => f.CourtPair)
             .OrderBy(f => f.RoundNumber)
             .ThenBy(f => f.ScheduledAt)
             .ToListAsync();
@@ -2182,6 +2301,9 @@
             .Include(f => f.Player2)
             .Include(f => f.Player3)
             .Include(f => f.Player4)
+            .Include(f => f.HomeTeam)
+            .Include(f => f.AwayTeam)
+            .Include(f => f.CourtPair)
             .OrderBy(f => f.RoundNumber)
             .ThenBy(f => f.ScheduledAt)
             .ToListAsync();
@@ -2193,6 +2315,14 @@
 
     private static string FixturePlayers(CompetitionFixture f)
     {
+        // Team fixtures: show team names
+        if (f.HomeTeamId.HasValue || f.AwayTeamId.HasValue)
+        {
+            var home = f.HomeTeam?.Name ?? "TBD";
+            var away = f.AwayTeam?.Name ?? "TBD";
+            return $"{home} vs {away}";
+        }
+
         var side1 = new[] { f.Player1?.DisplayName, f.Player3?.DisplayName }
             .Where(n => n != null).DefaultIfEmpty("TBD").Aggregate((a, b) => $"{a} & {b}");
         var side2 = new[] { f.Player2?.DisplayName, f.Player4?.DisplayName }

--- a/DropShot/Components/Pages/TeamMatchScoring.razor
+++ b/DropShot/Components/Pages/TeamMatchScoring.razor
@@ -1,0 +1,218 @@
+@page "/team-match/{FixtureId:int}"
+@rendermode InteractiveServer
+
+@using DropShot.Data
+@using DropShot.Models
+@using DropShot.Services
+@using Microsoft.EntityFrameworkCore
+@using MudBlazor
+
+@inject IDbContextFactory<MyDbContext> DbFactory
+@inject NavigationManager Navigation
+
+<MudProviders />
+
+@if (_loading)
+{
+    <MudProgressLinear Indeterminate="true" Color="Color.Primary" />
+}
+else if (_fixture == null)
+{
+    <MudAlert Severity="Severity.Error">Fixture not found.</MudAlert>
+}
+else
+{
+    <MudContainer MaxWidth="MaxWidth.Large" Class="py-4">
+        @* Header *@
+        <MudPaper Class="pa-4 mb-4" Elevation="2">
+            <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
+                <MudStack Spacing="0">
+                    <MudText Typo="Typo.h5">@_fixture.Competition?.CompetitionName</MudText>
+                    <MudText Typo="Typo.subtitle1" Color="Color.Tertiary">
+                        @(_fixture.HomeTeam?.Name ?? "Home") vs @(_fixture.AwayTeam?.Name ?? "Away")
+                        @if (!string.IsNullOrEmpty(_fixture.FixtureLabel))
+                        {
+                            <span> — @_fixture.FixtureLabel</span>
+                        }
+                    </MudText>
+                </MudStack>
+                <MudChip T="string" Size="Size.Large" Color="@(_allComplete ? Color.Success : Color.Primary)">
+                    @_homeScore — @_awayScore
+                </MudChip>
+            </MudStack>
+        </MudPaper>
+
+        @* Phase 1: Gender Doubles *@
+        <MudText Typo="Typo.h6" Class="mb-2">Phase 1 — Gender Doubles</MudText>
+        <MudGrid Spacing="3" Class="mb-4">
+            <MudItem xs="12" md="6">
+                <MudText Typo="Typo.subtitle2" Class="mb-1">Court 1 — Men's Doubles</MudText>
+                @foreach (var s in _sets.Where(s => s.SetType == TeamMatchSetType.MensDoubles))
+                {
+                    @RenderSet(s)
+                }
+            </MudItem>
+            <MudItem xs="12" md="6">
+                <MudText Typo="Typo.subtitle2" Class="mb-1">Court 2 — Women's Doubles</MudText>
+                @foreach (var s in _sets.Where(s => s.SetType == TeamMatchSetType.WomensDoubles))
+                {
+                    @RenderSet(s)
+                }
+            </MudItem>
+        </MudGrid>
+
+        @* Phase 2: Mixed Doubles *@
+        <MudText Typo="Typo.h6" Class="mb-2">Phase 2 — Mixed Doubles</MudText>
+        <MudGrid Spacing="3" Class="mb-4">
+            <MudItem xs="12" md="6">
+                <MudText Typo="Typo.subtitle2" Class="mb-1">Court 1 — A-Grade Mixed</MudText>
+                @foreach (var s in _sets.Where(s => s.SetType == TeamMatchSetType.MixedDoublesA))
+                {
+                    @RenderSet(s)
+                }
+            </MudItem>
+            <MudItem xs="12" md="6">
+                <MudText Typo="Typo.subtitle2" Class="mb-1">Court 2 — B-Grade Mixed</MudText>
+                @foreach (var s in _sets.Where(s => s.SetType == TeamMatchSetType.MixedDoublesB))
+                {
+                    @RenderSet(s)
+                }
+            </MudItem>
+        </MudGrid>
+
+        @if (_allComplete)
+        {
+            <MudAlert Severity="Severity.Success" Class="mt-4">
+                Match complete: @(_fixture.HomeTeam?.Name) @_homeScore — @_awayScore @(_fixture.AwayTeam?.Name)
+                @if (_homeScore == _awayScore)
+                {
+                    <span> (Draw)</span>
+                }
+            </MudAlert>
+        }
+
+        <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.ArrowBack"
+                   Href="@($"/competition/{_fixture.CompetitionId}/view")">
+            Back to Competition
+        </MudButton>
+    </MudContainer>
+}
+
+@code {
+    [Parameter] public int FixtureId { get; set; }
+
+    private CompetitionFixture? _fixture;
+    private List<TeamMatchSet> _sets = [];
+    private bool _loading = true;
+    private int _homeScore;
+    private int _awayScore;
+    private bool _allComplete;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadData();
+        _loading = false;
+    }
+
+    private async Task LoadData()
+    {
+        await using var db = DbFactory.CreateDbContext();
+        _fixture = await db.CompetitionFixtures
+            .Include(f => f.Competition)
+            .Include(f => f.HomeTeam)
+            .Include(f => f.AwayTeam)
+            .Include(f => f.CourtPair)
+            .FirstOrDefaultAsync(f => f.CompetitionFixtureId == FixtureId);
+
+        if (_fixture == null) return;
+
+        _sets = await db.TeamMatchSets
+            .Where(s => s.CompetitionFixtureId == FixtureId)
+            .Include(s => s.HomePlayer1)
+            .Include(s => s.HomePlayer2)
+            .Include(s => s.AwayPlayer1)
+            .Include(s => s.AwayPlayer2)
+            .OrderBy(s => s.SetNumber)
+            .ToListAsync();
+
+        ComputeScores();
+    }
+
+    private void ComputeScores()
+    {
+        if (_fixture?.HomeTeamId != null && _fixture?.AwayTeamId != null)
+        {
+            (_homeScore, _awayScore) = TeamMatchService.ComputeScore(
+                _sets, _fixture.HomeTeamId.Value, _fixture.AwayTeamId.Value);
+        }
+        _allComplete = _sets.Count == 8 && TeamMatchService.AllSetsComplete(_sets);
+    }
+
+    private bool CanStart(TeamMatchSet set)
+    {
+        if (set.IsComplete || set.SavedMatchId.HasValue) return false;
+
+        // First set on each court can always start
+        // Within same SetType (same court pair), sets are sequential
+        var sameType = _sets.Where(s => s.SetType == set.SetType).OrderBy(s => s.SetNumber).ToList();
+        var idx = sameType.IndexOf(set);
+        if (idx == 0) return true;
+        return sameType[idx - 1].IsComplete;
+    }
+
+    private void StartSet(TeamMatchSet set)
+    {
+        var returnUrl = $"/team-match/{FixtureId}";
+        Navigation.NavigateTo(
+            $"/tennisscore?TeamMatchSetId={set.TeamMatchSetId}&BestOfOverride=1&ReturnUrl={Uri.EscapeDataString(returnUrl)}&AutoStart=true");
+    }
+
+    private void ResumeSet(TeamMatchSet set)
+    {
+        if (set.SavedMatchId.HasValue)
+        {
+            var returnUrl = $"/team-match/{FixtureId}";
+            Navigation.NavigateTo($"/match/{set.SavedMatchId}?ReturnUrl={Uri.EscapeDataString(returnUrl)}");
+        }
+    }
+
+    private RenderFragment RenderSet(TeamMatchSet set) => __builder =>
+    {
+        <MudCard Class="mb-2" Outlined="true">
+            <MudCardContent>
+                <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
+                    <MudStack Spacing="0">
+                        <MudText Typo="Typo.body2">
+                            Set @set.SetNumber:
+                            @(set.HomePlayer1?.DisplayName) & @(set.HomePlayer2?.DisplayName)
+                            vs
+                            @(set.AwayPlayer1?.DisplayName) & @(set.AwayPlayer2?.DisplayName)
+                        </MudText>
+                    </MudStack>
+                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                        @if (set.IsComplete)
+                        {
+                            <MudChip T="string" Size="Size.Small" Color="Color.Success">
+                                @set.HomeGames — @set.AwayGames
+                            </MudChip>
+                        }
+                        else if (set.SavedMatchId.HasValue)
+                        {
+                            <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Warning"
+                                       OnClick="@(() => ResumeSet(set))">Resume</MudButton>
+                        }
+                        else if (CanStart(set))
+                        {
+                            <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary"
+                                       OnClick="@(() => StartSet(set))">Start</MudButton>
+                        }
+                        else
+                        {
+                            <MudChip T="string" Size="Size.Small" Color="Color.Default">Waiting</MudChip>
+                        }
+                    </MudStack>
+                </MudStack>
+            </MudCardContent>
+        </MudCard>
+    };
+}

--- a/DropShot/Components/Pages/ViewCompetition.razor
+++ b/DropShot/Components/Pages/ViewCompetition.razor
@@ -121,7 +121,38 @@ else
     }
 
     @* ── League Table (round-robin stages only) ──────────────── *@
-    @if (_leagueTable.Any())
+    @if (_teamLeagueTable.Any())
+    {
+        <MudDivider Class="my-4" />
+        <MudText Typo="Typo.h5" Class="mb-3">Team League Table</MudText>
+        <MudTable Items="@_teamLeagueTable" Dense="true" Hover="true" Class="mb-4">
+            <HeaderContent>
+                <MudTh>Pos</MudTh>
+                <MudTh>Team</MudTh>
+                <MudTh>Captain</MudTh>
+                <MudTh>P</MudTh>
+                <MudTh>W</MudTh>
+                <MudTh>D</MudTh>
+                <MudTh>L</MudTh>
+                <MudTh>SW</MudTh>
+                <MudTh>SA</MudTh>
+                <MudTh>Pts</MudTh>
+            </HeaderContent>
+            <RowTemplate>
+                <MudTd>@(_teamLeagueTable.IndexOf(context) + 1)</MudTd>
+                <MudTd Style="font-weight:500">@context.TeamName</MudTd>
+                <MudTd>@(context.CaptainName ?? "—")</MudTd>
+                <MudTd>@context.Played</MudTd>
+                <MudTd>@context.Won</MudTd>
+                <MudTd>@context.Drawn</MudTd>
+                <MudTd>@context.Lost</MudTd>
+                <MudTd>@context.SetsWon</MudTd>
+                <MudTd>@context.SetsAgainst</MudTd>
+                <MudTd Style="font-weight:bold">@context.Points</MudTd>
+            </RowTemplate>
+        </MudTable>
+    }
+    else if (_leagueTable.Any())
     {
         <MudDivider Class="my-4" />
         <MudText Typo="Typo.h5" Class="mb-3">League Table</MudText>
@@ -149,7 +180,7 @@ else
     <MudDivider Class="my-4" />
     <MudText Typo="Typo.h5" Class="mb-3">Competitors</MudText>
 
-    @if (_competition.CompetitionFormat == CompetitionFormat.Team && _teams.Any())
+    @if (_competition.CompetitionFormat is CompetitionFormat.Team or CompetitionFormat.MixedTeam && _teams.Any())
     {
         @foreach (var team in _teams)
         {
@@ -232,6 +263,9 @@ else
     private record LeagueRow(int PlayerId, string PlayerName, int Played, int Won, int Lost, int Points);
     private List<LeagueRow> _leagueTable = [];
 
+    private record TeamLeagueRow(int TeamId, string TeamName, string? CaptainName, int Played, int Won, int Drawn, int Lost, int SetsWon, int SetsAgainst, int Points);
+    private List<TeamLeagueRow> _teamLeagueTable = [];
+
 #pragma warning disable CS8714 // Null keys are intentionally used for unstaged fixtures
     private Dictionary<string?, List<CompetitionFixture>> _fixturesByStage = [];
 #pragma warning restore CS8714
@@ -252,7 +286,10 @@ else
             .Include(c => c.Fixtures).ThenInclude(f => f.Player2)
             .Include(c => c.Fixtures).ThenInclude(f => f.Player3)
             .Include(c => c.Fixtures).ThenInclude(f => f.Player4)
-            .Include(c => c.Teams)
+            .Include(c => c.Fixtures).ThenInclude(f => f.HomeTeam)
+            .Include(c => c.Fixtures).ThenInclude(f => f.AwayTeam)
+            .Include(c => c.Fixtures).ThenInclude(f => f.TeamMatchSets)
+            .Include(c => c.Teams).ThenInclude(t => t.Captain)
             .AsNoTracking()
             .FirstOrDefaultAsync(c => c.CompetitionID == Id);
 
@@ -331,6 +368,55 @@ else
                     .ThenBy(r => r.Lost)
                     .ToList();
             }
+
+            // Team league table for MixedTeam format
+            if (_competition.CompetitionFormat == CompetitionFormat.MixedTeam && rrStageIds.Any())
+            {
+                var tPlayed = _teams.ToDictionary(t => t.CompetitionTeamId, _ => 0);
+                var tWon = _teams.ToDictionary(t => t.CompetitionTeamId, _ => 0);
+                var tDrawn = _teams.ToDictionary(t => t.CompetitionTeamId, _ => 0);
+                var tLost = _teams.ToDictionary(t => t.CompetitionTeamId, _ => 0);
+                var tSetsWon = _teams.ToDictionary(t => t.CompetitionTeamId, _ => 0);
+                var tSetsAgainst = _teams.ToDictionary(t => t.CompetitionTeamId, _ => 0);
+
+                foreach (var f in _fixtures.Where(f =>
+                    f.CompetitionStageId.HasValue &&
+                    rrStageIds.Contains(f.CompetitionStageId.Value) &&
+                    f.Status == FixtureStatus.Completed &&
+                    f.HomeTeamId.HasValue && f.AwayTeamId.HasValue))
+                {
+                    int hid = f.HomeTeamId!.Value;
+                    int aid = f.AwayTeamId!.Value;
+                    if (!tPlayed.ContainsKey(hid) || !tPlayed.ContainsKey(aid)) continue;
+
+                    var completed = f.TeamMatchSets.Where(s => s.IsComplete).ToList();
+                    int hw = completed.Count(s => s.WinnerTeamId == hid);
+                    int aw = completed.Count(s => s.WinnerTeamId == aid);
+
+                    tPlayed[hid]++;
+                    tPlayed[aid]++;
+                    tSetsWon[hid] += hw;
+                    tSetsAgainst[hid] += aw;
+                    tSetsWon[aid] += aw;
+                    tSetsAgainst[aid] += hw;
+
+                    if (hw > aw) { tWon[hid]++; tLost[aid]++; }
+                    else if (aw > hw) { tWon[aid]++; tLost[hid]++; }
+                    else { tDrawn[hid]++; tDrawn[aid]++; }
+                }
+
+                _teamLeagueTable = _teams
+                    .Select(t => new TeamLeagueRow(
+                        t.CompetitionTeamId, t.Name, t.Captain?.DisplayName,
+                        tPlayed[t.CompetitionTeamId], tWon[t.CompetitionTeamId],
+                        tDrawn[t.CompetitionTeamId], tLost[t.CompetitionTeamId],
+                        tSetsWon[t.CompetitionTeamId], tSetsAgainst[t.CompetitionTeamId],
+                        tSetsWon[t.CompetitionTeamId]))
+                    .OrderByDescending(r => r.Points)
+                    .ThenByDescending(r => r.SetsWon - r.SetsAgainst)
+                    .ThenBy(r => r.SetsAgainst)
+                    .ToList();
+            }
         }
 
         _loading = false;
@@ -338,6 +424,13 @@ else
 
     private static string FixturePlayers(CompetitionFixture f)
     {
+        if (f.HomeTeamId.HasValue || f.AwayTeamId.HasValue)
+        {
+            var home = f.HomeTeam?.Name ?? "TBD";
+            var away = f.AwayTeam?.Name ?? "TBD";
+            return $"{home} vs {away}";
+        }
+
         var side1 = new[] { f.Player1?.DisplayName, f.Player3?.DisplayName }
             .Where(n => n != null).DefaultIfEmpty("TBD").Aggregate((a, b) => $"{a} & {b}");
         var side2 = new[] { f.Player2?.DisplayName, f.Player4?.DisplayName }
@@ -347,6 +440,11 @@ else
 
     private string? WinnerName(CompetitionFixture f)
     {
+        if (f.WinnerTeamId.HasValue)
+        {
+            var team = f.WinnerTeamId == f.HomeTeamId ? f.HomeTeam : f.AwayTeam;
+            return team?.Name is { } tn ? $"Winner: {tn}" : null;
+        }
         if (!f.WinnerPlayerId.HasValue) return null;
         var all = new[] { f.Player1, f.Player2, f.Player3, f.Player4 };
         return all.FirstOrDefault(p => p?.PlayerId == f.WinnerPlayerId)?.DisplayName is { } n

--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -620,8 +620,12 @@
     [Parameter] public int MatchId { get; set; }
     [SupplyParameterFromQuery] public int? FixtureId { get; set; }
     [SupplyParameterFromQuery] public bool? AutoStart { get; set; }
+    [SupplyParameterFromQuery] public int? TeamMatchSetId { get; set; }
+    [SupplyParameterFromQuery] public int? BestOfOverride { get; set; }
+    [SupplyParameterFromQuery] public string? ReturnUrl { get; set; }
     private int _savedMatchId;
     private CompetitionFixture? _competitionFixture;
+    private TeamMatchSet? _teamMatchSet;
     private bool _autoStartPending;
 
     private List<string> _states = [];
@@ -778,15 +782,36 @@
             }
         }
 
+        // Load TeamMatchSet from query param (starting a set from a team match page)
+        if (TeamMatchSetId > 0 && _teamMatchSet == null)
+        {
+            _teamMatchSet = await DbContext.TeamMatchSets
+                .Include(s => s.Fixture).ThenInclude(f => f.Competition)
+                .Include(s => s.HomePlayer1)
+                .Include(s => s.HomePlayer2)
+                .Include(s => s.AwayPlayer1)
+                .Include(s => s.AwayPlayer2)
+                .FirstOrDefaultAsync(s => s.TeamMatchSetId == TeamMatchSetId);
+
+            if (_teamMatchSet != null)
+            {
+                _value  = _teamMatchSet.HomePlayer1?.DisplayName ?? "";
+                _value2 = _teamMatchSet.AwayPlayer1?.DisplayName ?? "";
+                _value3 = _teamMatchSet.HomePlayer2?.DisplayName ?? "";
+                _value4 = _teamMatchSet.AwayPlayer2?.DisplayName ?? "";
+                Label_Switch1 = true; // always doubles
+            }
+        }
+
         // Auto-start: skip wizard and go straight to match when all info is available
-        if (AutoStart == true && _competitionFixture != null
+        if (AutoStart == true && (_competitionFixture != null || _teamMatchSet != null)
             && !string.IsNullOrEmpty(_value) && !string.IsNullOrEmpty(_value2))
         {
-            _state.BestOf = _competitionFixture.Competition?.BestOf ?? 3;
+            _state.BestOf = BestOfOverride ?? _competitionFixture?.Competition?.BestOf ?? 3;
             _state.GameScoring = true;
             _state.UnlimitedDeuce = true;
             _state.GamesFirstTo = 6;
-            _selectedCourtId = _competitionFixture.CourtId;
+            _selectedCourtId = _competitionFixture?.CourtId;
             _serverChoice = "random";
             _autoStartPending = true;
         }
@@ -912,6 +937,54 @@
                 await CompetitionProgressionService.TryAdvanceAsync(dbc3, _competitionFixture.CompetitionId, fx.CompetitionFixtureId);
             }
         }
+
+        // When a team match set ends, record the result and check if all 8 sets are done
+        if (_state.IsMatchEnded && _teamMatchSet != null)
+        {
+            using var dbc4 = DbFactory.CreateDbContext();
+            var tms = await dbc4.TeamMatchSets
+                .Include(s => s.Fixture)
+                .FirstOrDefaultAsync(s => s.TeamMatchSetId == _teamMatchSet.TeamMatchSetId);
+            if (tms != null && !tms.IsComplete)
+            {
+                tms.IsComplete = true;
+                tms.SavedMatchId = _savedMatchId;
+
+                // Get the final set score
+                var lastSet = _state.SetScores.LastOrDefault();
+                if (lastSet != null)
+                {
+                    tms.HomeGames = lastSet.UserGames;
+                    tms.AwayGames = lastSet.OpponentGames;
+                }
+
+                bool homeSideWon = (_state.UserSets > _state.OppSets);
+                tms.WinnerTeamId = homeSideWon ? tms.Fixture.HomeTeamId : tms.Fixture.AwayTeamId;
+                await dbc4.SaveChangesAsync();
+
+                // Check if all 8 sets for the parent fixture are now complete
+                var allSets = await dbc4.TeamMatchSets
+                    .Where(s => s.CompetitionFixtureId == tms.CompetitionFixtureId)
+                    .ToListAsync();
+
+                if (TeamMatchService.AllSetsComplete(allSets) && tms.Fixture.HomeTeamId.HasValue && tms.Fixture.AwayTeamId.HasValue)
+                {
+                    var (homeScore, awayScore) = TeamMatchService.ComputeScore(
+                        allSets, tms.Fixture.HomeTeamId.Value, tms.Fixture.AwayTeamId.Value);
+                    var fx = await dbc4.CompetitionFixtures.FindAsync(tms.CompetitionFixtureId);
+                    if (fx != null)
+                    {
+                        fx.Status = FixtureStatus.Completed;
+                        fx.ResultSummary = $"{homeScore}-{awayScore}";
+                        fx.WinnerTeamId = homeScore > awayScore ? fx.HomeTeamId
+                                        : awayScore > homeScore ? fx.AwayTeamId
+                                        : null; // 4-4 draw
+                        await dbc4.SaveChangesAsync();
+                        await CompetitionProgressionService.TryAdvanceAsync(dbc4, fx.CompetitionId, fx.CompetitionFixtureId);
+                    }
+                }
+            }
+        }
     }
 
     private async Task SaveHistory()
@@ -1014,7 +1087,9 @@
 
     private void NavigateAfterMatch()
     {
-        if (_competitionFixture != null)
+        if (!string.IsNullOrEmpty(ReturnUrl))
+            Navigation.NavigateTo(ReturnUrl);
+        else if (_competitionFixture != null)
             Navigation.NavigateTo($"/competition/{_competitionFixture.CompetitionId}/view");
         else
             Navigation.NavigateTo("/match");

--- a/DropShot/Controllers/CompetitionsController.cs
+++ b/DropShot/Controllers/CompetitionsController.cs
@@ -66,7 +66,9 @@ public class CompetitionsController(
                 p.PlayerId, p.Player?.DisplayName ?? "",
                 (DropShot.Shared.ParticipantStatus)p.Status,
                 p.RegisteredAt, p.TeamId, p.Team?.Name,
-                p.Player?.MobileNumber)).ToList());
+                p.Player?.MobileNumber,
+                (DropShot.Shared.PlayerGrade?)p.Grade,
+                (DropShot.Shared.PlayerSex?)p.Player?.Sex)).ToList());
     }
 
     [HttpPost]
@@ -232,9 +234,12 @@ public class CompetitionsController(
         await using var db = dbFactory.CreateDbContext();
         var teams = await db.CompetitionTeams
             .Where(t => t.CompetitionId == id)
+            .Include(t => t.Captain)
             .OrderBy(t => t.Name)
             .ToListAsync();
-        return teams.Select(t => new CompetitionTeamDto(t.CompetitionTeamId, t.CompetitionId, t.Name)).ToList();
+        return teams.Select(t => new CompetitionTeamDto(
+            t.CompetitionTeamId, t.CompetitionId, t.Name,
+            t.CaptainPlayerId, t.Captain?.DisplayName)).ToList();
     }
 
     [HttpPost("{id:int}/teams")]
@@ -302,6 +307,9 @@ public class CompetitionsController(
             .Include(f => f.Player2)
             .Include(f => f.Player3)
             .Include(f => f.Player4)
+            .Include(f => f.HomeTeam)
+            .Include(f => f.AwayTeam)
+            .Include(f => f.CourtPair)
             .OrderBy(f => f.RoundNumber).ThenBy(f => f.ScheduledAt)
             .ToListAsync();
         return fixtures.Select(ToFixtureDto).ToList();
@@ -404,7 +412,9 @@ public class CompetitionsController(
         await using var db = dbFactory.CreateDbContext();
         var comp = await db.Competition
             .Include(c => c.Stages.OrderBy(s => s.StageOrder))
-            .Include(c => c.Participants)
+            .Include(c => c.Participants).ThenInclude(p => p.Player)
+            .Include(c => c.Teams)
+            .Include(c => c.CourtPairs)
             .Include(c => c.MatchWindows).ThenInclude(w => w.Court)
             .FirstOrDefaultAsync(c => c.CompetitionID == id);
         if (comp is null) return NotFound();
@@ -462,15 +472,85 @@ public class CompetitionsController(
             {
                 case DropShot.Models.StageType.RoundRobin:
                 {
-                    var players = activePlayers.ToList();
-                    for (int i = 0; i < players.Count; i++)
+                    if (comp.CompetitionFormat == DropShot.Models.CompetitionFormat.MixedTeam)
                     {
-                        for (int j = i + 1; j < players.Count; j++)
+                        // Team round-robin using circle method
+                        var teamIds = comp.Teams.Select(t => t.CompetitionTeamId).ToList();
+                        var courtPairIds = comp.CourtPairs.Select(cp => cp.CourtPairId).ToList();
+                        int cpIdx = 0;
+
+                        // Circle method: fix team[0], rotate rest
+                        int n = teamIds.Count;
+                        bool hasOdd = n % 2 != 0;
+                        if (hasOdd) teamIds.Add(-1); // BYE sentinel
+                        int total = teamIds.Count;
+                        int rounds = total - 1;
+
+                        // Load all team members for set creation
+                        var allMembers = comp.Participants
+                            .Where(p => p.TeamId != null && p.Player != null
+                                && (p.Status == DropShot.Models.ParticipantStatus.Registered
+                                    || p.Status == DropShot.Models.ParticipantStatus.Confirmed))
+                            .ToList();
+
+                        for (int round = 0; round < rounds; round++)
                         {
-                            var fixture = NewFixture(id, stage.CompetitionStageId);
-                            fixture.Player1Id = players[i];
-                            fixture.Player2Id = players[j];
-                            db.CompetitionFixtures.Add(fixture);
+                            for (int match = 0; match < total / 2; match++)
+                            {
+                                int home = (match == 0) ? 0 : (round + match) % (total - 1) + 1;
+                                int away = (total - 1) - match;
+                                if (match == 0) away = (round % (total - 1)) + 1;
+
+                                // Correct circle method indices
+                                home = match == 0 ? 0 : ((round + match - 1) % (total - 1)) + 1;
+                                away = ((round + total - 1 - match) % (total - 1)) + 1;
+                                if (match == 0) { home = 0; away = ((round) % (total - 1)) + 1; }
+
+                                int homeTeamId = teamIds[home];
+                                int awayTeamId = teamIds[away];
+
+                                if (homeTeamId == -1 || awayTeamId == -1) continue; // BYE
+
+                                var fixture = NewFixture(id, stage.CompetitionStageId);
+                                fixture.HomeTeamId = homeTeamId;
+                                fixture.AwayTeamId = awayTeamId;
+
+                                if (courtPairIds.Count > 0)
+                                {
+                                    fixture.CourtPairId = courtPairIds[cpIdx % courtPairIds.Count];
+                                    cpIdx++;
+                                }
+
+                                db.CompetitionFixtures.Add(fixture);
+                                await db.SaveChangesAsync(); // Need ID for TeamMatchSets
+
+                                // Create 8 TeamMatchSet rows
+                                var homeMembers = allMembers.Where(m => m.TeamId == homeTeamId).ToList();
+                                var awayMembers = allMembers.Where(m => m.TeamId == awayTeamId).ToList();
+
+                                if (homeMembers.Count == 4 && awayMembers.Count == 4
+                                    && homeMembers.All(m => m.Grade != null && m.Player?.Sex != null)
+                                    && awayMembers.All(m => m.Grade != null && m.Player?.Sex != null))
+                                {
+                                    var sets = TeamMatchService.CreateSetsForFixture(
+                                        fixture.CompetitionFixtureId, homeMembers, awayMembers);
+                                    db.TeamMatchSets.AddRange(sets);
+                                }
+                            }
+                        }
+                    }
+                    else
+                    {
+                        var players = activePlayers.ToList();
+                        for (int i = 0; i < players.Count; i++)
+                        {
+                            for (int j = i + 1; j < players.Count; j++)
+                            {
+                                var fixture = NewFixture(id, stage.CompetitionStageId);
+                                fixture.Player1Id = players[i];
+                                fixture.Player2Id = players[j];
+                                db.CompetitionFixtures.Add(fixture);
+                            }
                         }
                     }
                     break;
@@ -478,17 +558,9 @@ public class CompetitionsController(
 
                 case DropShot.Models.StageType.Knockout:
                 {
-                    // Smart knockout: generates exactly the right rounds based on player count.
-                    // No Byes, no power-of-2 bracket inflation.
-                    //
-                    //  n >= 8  →  Quarter-Finals (top 8, 4 matches) + 2 SF placeholders + Final
-                    //  n >= 4  →  Semi-Finals (top 4, 2 matches) + Final placeholder
-                    //  n >= 2  →  Final only (2 players)
-                    //
-                    // Players are seeded from the RR league table when results exist,
-                    // otherwise from registration order.
-
-                    int n = activePlayers.Count;
+                    int n = comp.CompetitionFormat == DropShot.Models.CompetitionFormat.MixedTeam
+                        ? comp.Teams.Count
+                        : activePlayers.Count;
                     if (n < 2) break;
 
                     if (n >= 8)
@@ -704,5 +776,268 @@ public class CompetitionsController(
         f.Player2Id, f.Player2?.DisplayName,
         f.Player3Id, f.Player3?.DisplayName,
         f.Player4Id, f.Player4?.DisplayName,
-        f.ResultSummary, f.WinnerPlayerId);
+        f.ResultSummary, f.WinnerPlayerId,
+        f.HomeTeamId, f.HomeTeam?.Name,
+        f.AwayTeamId, f.AwayTeam?.Name,
+        f.WinnerTeamId, f.CourtPairId, f.CourtPair?.Name);
+
+    // ── Mixed Team Tennis Endpoints ──────────────────────────────────────────
+
+    [HttpPut("{id:int}/participants/{playerId:int}/grade")]
+    public async Task<IActionResult> SetParticipantGrade(
+        int id, int playerId, [FromBody] SetParticipantGradeRequest req)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var comp = await db.Competition.FindAsync(id);
+        if (comp is null) return NotFound();
+        if (!await authzService.CanEditCompetitionAsync(User, comp.HostClubId)) return Forbid();
+
+        var cp = await db.CompetitionParticipants.FindAsync(id, playerId);
+        if (cp is null) return NotFound();
+        cp.Grade = (DropShot.Models.PlayerGrade)req.Grade;
+        await db.SaveChangesAsync();
+        return Ok();
+    }
+
+    [HttpPut("{id:int}/teams/{teamId:int}/captain")]
+    public async Task<IActionResult> SetTeamCaptain(
+        int id, int teamId, [FromBody] SetTeamCaptainRequest req)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var comp = await db.Competition.FindAsync(id);
+        if (comp is null) return NotFound();
+        if (!await authzService.CanEditCompetitionAsync(User, comp.HostClubId)) return Forbid();
+
+        var team = await db.CompetitionTeams.FindAsync(teamId);
+        if (team is null || team.CompetitionId != id) return NotFound();
+
+        var isMember = await db.CompetitionParticipants
+            .AnyAsync(cp => cp.CompetitionId == id && cp.PlayerId == req.CaptainPlayerId && cp.TeamId == teamId);
+        if (!isMember)
+            return BadRequest(new { message = "Captain must be a member of the team." });
+
+        team.CaptainPlayerId = req.CaptainPlayerId;
+        await db.SaveChangesAsync();
+        return Ok();
+    }
+
+    [HttpPost("{id:int}/teams/{teamId:int}/validate")]
+    public async Task<ActionResult<TeamValidationResultDto>> ValidateTeam(int id, int teamId)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var members = await db.CompetitionParticipants
+            .Where(cp => cp.CompetitionId == id && cp.TeamId == teamId
+                && (cp.Status == DropShot.Models.ParticipantStatus.Registered
+                    || cp.Status == DropShot.Models.ParticipantStatus.Confirmed))
+            .Include(cp => cp.Player)
+            .ToListAsync();
+
+        var errors = new List<string>();
+        if (members.Count != 4)
+            errors.Add($"Team must have exactly 4 active members (has {members.Count}).");
+
+        foreach (var m in members)
+        {
+            if (m.Player?.Sex == null) errors.Add($"{m.Player?.DisplayName ?? "Unknown"} has no sex assigned.");
+            if (m.Grade == null) errors.Add($"{m.Player?.DisplayName ?? "Unknown"} has no grade assigned.");
+        }
+
+        if (errors.Count == 0)
+        {
+            var maleA = members.Count(m => m.Player?.Sex == DropShot.Models.PlayerSex.Male && m.Grade == DropShot.Models.PlayerGrade.A);
+            var femaleA = members.Count(m => m.Player?.Sex == DropShot.Models.PlayerSex.Female && m.Grade == DropShot.Models.PlayerGrade.A);
+            var maleB = members.Count(m => m.Player?.Sex == DropShot.Models.PlayerSex.Male && m.Grade == DropShot.Models.PlayerGrade.B);
+            var femaleB = members.Count(m => m.Player?.Sex == DropShot.Models.PlayerSex.Female && m.Grade == DropShot.Models.PlayerGrade.B);
+
+            if (maleA != 1) errors.Add($"Need exactly 1 Male A player (has {maleA}).");
+            if (femaleA != 1) errors.Add($"Need exactly 1 Female A player (has {femaleA}).");
+            if (maleB != 1) errors.Add($"Need exactly 1 Male B player (has {maleB}).");
+            if (femaleB != 1) errors.Add($"Need exactly 1 Female B player (has {femaleB}).");
+        }
+
+        return new TeamValidationResultDto(errors.Count == 0, errors);
+    }
+
+    // ── Court Pairs ──────────────────────────────────────────────────────────
+
+    [HttpGet("{id:int}/courtpairs")]
+    public async Task<ActionResult<List<CourtPairDto>>> GetCourtPairs(int id)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var pairs = await db.CourtPairs
+            .Where(cp => cp.CompetitionId == id)
+            .Include(cp => cp.Court1)
+            .Include(cp => cp.Court2)
+            .OrderBy(cp => cp.Name)
+            .ToListAsync();
+        return pairs.Select(cp => new CourtPairDto(
+            cp.CourtPairId, cp.CompetitionId,
+            cp.Court1Id, cp.Court1.Name,
+            cp.Court2Id, cp.Court2.Name,
+            cp.Name)).ToList();
+    }
+
+    [HttpPost("{id:int}/courtpairs")]
+    public async Task<ActionResult<CourtPairDto>> AddCourtPair(int id, [FromBody] SaveCourtPairRequest req)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var comp = await db.Competition.FindAsync(id);
+        if (comp is null) return NotFound();
+        if (!await authzService.CanEditCompetitionAsync(User, comp.HostClubId)) return Forbid();
+
+        var cp = new CourtPair
+        {
+            CompetitionId = id,
+            Court1Id = req.Court1Id,
+            Court2Id = req.Court2Id,
+            Name = req.Name.Trim()
+        };
+        db.CourtPairs.Add(cp);
+        await db.SaveChangesAsync();
+
+        await db.Entry(cp).Reference(c => c.Court1).LoadAsync();
+        await db.Entry(cp).Reference(c => c.Court2).LoadAsync();
+        return new CourtPairDto(cp.CourtPairId, cp.CompetitionId,
+            cp.Court1Id, cp.Court1.Name, cp.Court2Id, cp.Court2.Name, cp.Name);
+    }
+
+    [HttpPut("{id:int}/courtpairs/{courtPairId:int}")]
+    public async Task<IActionResult> UpdateCourtPair(int id, int courtPairId, [FromBody] SaveCourtPairRequest req)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var comp = await db.Competition.FindAsync(id);
+        if (comp is null) return NotFound();
+        if (!await authzService.CanEditCompetitionAsync(User, comp.HostClubId)) return Forbid();
+
+        var cp = await db.CourtPairs.FindAsync(courtPairId);
+        if (cp is null || cp.CompetitionId != id) return NotFound();
+        cp.Court1Id = req.Court1Id;
+        cp.Court2Id = req.Court2Id;
+        cp.Name = req.Name.Trim();
+        await db.SaveChangesAsync();
+        return Ok();
+    }
+
+    [HttpDelete("{id:int}/courtpairs/{courtPairId:int}")]
+    public async Task<IActionResult> DeleteCourtPair(int id, int courtPairId)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var comp = await db.Competition.FindAsync(id);
+        if (comp is null) return NotFound();
+        if (!await authzService.CanEditCompetitionAsync(User, comp.HostClubId)) return Forbid();
+
+        var cp = await db.CourtPairs.FindAsync(courtPairId);
+        if (cp is null || cp.CompetitionId != id) return NotFound();
+        db.CourtPairs.Remove(cp);
+        await db.SaveChangesAsync();
+        return NoContent();
+    }
+
+    // ── Team Match Sets ──────────────────────────────────────────────────────
+
+    [HttpGet("{id:int}/fixtures/{fixtureId:int}/sets")]
+    public async Task<ActionResult<List<TeamMatchSetDto>>> GetTeamMatchSets(int id, int fixtureId)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var sets = await db.TeamMatchSets
+            .Where(s => s.CompetitionFixtureId == fixtureId && s.Fixture.CompetitionId == id)
+            .Include(s => s.HomePlayer1)
+            .Include(s => s.HomePlayer2)
+            .Include(s => s.AwayPlayer1)
+            .Include(s => s.AwayPlayer2)
+            .OrderBy(s => s.SetNumber)
+            .ToListAsync();
+
+        return sets.Select(s => new TeamMatchSetDto(
+            s.TeamMatchSetId, s.CompetitionFixtureId, s.SetNumber,
+            (DropShot.Shared.TeamMatchPhase)s.Phase,
+            (DropShot.Shared.TeamMatchSetType)s.SetType,
+            s.CourtNumber,
+            s.HomePlayer1Id, s.HomePlayer1?.DisplayName,
+            s.HomePlayer2Id, s.HomePlayer2?.DisplayName,
+            s.AwayPlayer1Id, s.AwayPlayer1?.DisplayName,
+            s.AwayPlayer2Id, s.AwayPlayer2?.DisplayName,
+            s.HomeGames, s.AwayGames, s.WinnerTeamId,
+            s.IsComplete, s.SavedMatchId)).ToList();
+    }
+
+    // ── Team League Table ────────────────────────────────────────────────────
+
+    [HttpGet("{id:int}/teamleaguetable")]
+    public async Task<ActionResult<List<TeamLeagueTableEntryDto>>> GetTeamLeagueTable(int id)
+    {
+        await using var db = dbFactory.CreateDbContext();
+
+        var rrStageIds = await db.CompetitionStages
+            .Where(s => s.CompetitionId == id && s.StageType == DropShot.Models.StageType.RoundRobin)
+            .Select(s => s.CompetitionStageId)
+            .ToListAsync();
+
+        if (rrStageIds.Count == 0) return Ok(new List<TeamLeagueTableEntryDto>());
+
+        var fixtures = await db.CompetitionFixtures
+            .Where(f => f.CompetitionId == id
+                && f.CompetitionStageId != null
+                && rrStageIds.Contains(f.CompetitionStageId!.Value)
+                && f.Status == DropShot.Models.FixtureStatus.Completed
+                && f.HomeTeamId != null && f.AwayTeamId != null)
+            .Include(f => f.TeamMatchSets)
+            .ToListAsync();
+
+        var teams = await db.CompetitionTeams
+            .Where(t => t.CompetitionId == id)
+            .Include(t => t.Captain)
+            .ToListAsync();
+
+        var stats = teams.ToDictionary(t => t.CompetitionTeamId, t => new
+        {
+            t.Name,
+            CaptainName = t.Captain?.DisplayName,
+            Played = 0, Won = 0, Drawn = 0, Lost = 0, SetsWon = 0, SetsAgainst = 0
+        });
+
+        // Use mutable counters
+        var played = teams.ToDictionary(t => t.CompetitionTeamId, _ => 0);
+        var won = teams.ToDictionary(t => t.CompetitionTeamId, _ => 0);
+        var drawn = teams.ToDictionary(t => t.CompetitionTeamId, _ => 0);
+        var lost = teams.ToDictionary(t => t.CompetitionTeamId, _ => 0);
+        var setsWon = teams.ToDictionary(t => t.CompetitionTeamId, _ => 0);
+        var setsAgainst = teams.ToDictionary(t => t.CompetitionTeamId, _ => 0);
+
+        foreach (var f in fixtures)
+        {
+            int homeId = f.HomeTeamId!.Value;
+            int awayId = f.AwayTeamId!.Value;
+            if (!played.ContainsKey(homeId) || !played.ContainsKey(awayId)) continue;
+
+            var completedSets = f.TeamMatchSets.Where(s => s.IsComplete).ToList();
+            int homeSetsWon = completedSets.Count(s => s.WinnerTeamId == homeId);
+            int awaySetsWon = completedSets.Count(s => s.WinnerTeamId == awayId);
+
+            played[homeId]++;
+            played[awayId]++;
+            setsWon[homeId] += homeSetsWon;
+            setsAgainst[homeId] += awaySetsWon;
+            setsWon[awayId] += awaySetsWon;
+            setsAgainst[awayId] += homeSetsWon;
+
+            if (homeSetsWon > awaySetsWon) { won[homeId]++; lost[awayId]++; }
+            else if (awaySetsWon > homeSetsWon) { won[awayId]++; lost[homeId]++; }
+            else { drawn[homeId]++; drawn[awayId]++; }
+        }
+
+        var entries = teams
+            .Select(t => new TeamLeagueTableEntryDto(
+                t.CompetitionTeamId, t.Name, t.Captain?.DisplayName,
+                played[t.CompetitionTeamId], won[t.CompetitionTeamId],
+                drawn[t.CompetitionTeamId], lost[t.CompetitionTeamId],
+                setsWon[t.CompetitionTeamId], setsAgainst[t.CompetitionTeamId],
+                setsWon[t.CompetitionTeamId]))
+            .OrderByDescending(e => e.Points)
+            .ThenByDescending(e => e.SetsWon - e.SetsAgainst)
+            .ThenBy(e => e.SetsAgainst)
+            .ToList();
+
+        return entries;
+    }
 }

--- a/DropShot/Data/Migrations/20260410231339_AddMixedTeamTennis.Designer.cs
+++ b/DropShot/Data/Migrations/20260410231339_AddMixedTeamTennis.Designer.cs
@@ -4,6 +4,7 @@ using DropShot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DropShot.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260410231339_AddMixedTeamTennis")]
+    partial class AddMixedTeamTennis
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DropShot/Data/Migrations/20260410231339_AddMixedTeamTennis.cs
+++ b/DropShot/Data/Migrations/20260410231339_AddMixedTeamTennis.cs
@@ -1,0 +1,337 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropShot.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMixedTeamTennis : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "CaptainPlayerId",
+                table: "CompetitionTeams",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<byte>(
+                name: "Grade",
+                table: "CompetitionParticipants",
+                type: "tinyint",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "AwayTeamId",
+                table: "CompetitionFixtures",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "CourtPairId",
+                table: "CompetitionFixtures",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "HomeTeamId",
+                table: "CompetitionFixtures",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "WinnerTeamId",
+                table: "CompetitionFixtures",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "CourtPairs",
+                columns: table => new
+                {
+                    CourtPairId = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    CompetitionId = table.Column<int>(type: "int", nullable: false),
+                    Court1Id = table.Column<int>(type: "int", nullable: false),
+                    Court2Id = table.Column<int>(type: "int", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CourtPairs", x => x.CourtPairId);
+                    table.ForeignKey(
+                        name: "FK_CourtPairs_Competition_CompetitionId",
+                        column: x => x.CompetitionId,
+                        principalTable: "Competition",
+                        principalColumn: "CompetitionID",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_CourtPairs_Courts_Court1Id",
+                        column: x => x.Court1Id,
+                        principalTable: "Courts",
+                        principalColumn: "CourtId",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_CourtPairs_Courts_Court2Id",
+                        column: x => x.Court2Id,
+                        principalTable: "Courts",
+                        principalColumn: "CourtId",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "TeamMatchSets",
+                columns: table => new
+                {
+                    TeamMatchSetId = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    CompetitionFixtureId = table.Column<int>(type: "int", nullable: false),
+                    SetNumber = table.Column<int>(type: "int", nullable: false),
+                    Phase = table.Column<byte>(type: "tinyint", nullable: false),
+                    SetType = table.Column<byte>(type: "tinyint", nullable: false),
+                    CourtNumber = table.Column<int>(type: "int", nullable: false),
+                    HomePlayer1Id = table.Column<int>(type: "int", nullable: true),
+                    HomePlayer2Id = table.Column<int>(type: "int", nullable: true),
+                    AwayPlayer1Id = table.Column<int>(type: "int", nullable: true),
+                    AwayPlayer2Id = table.Column<int>(type: "int", nullable: true),
+                    HomeGames = table.Column<int>(type: "int", nullable: true),
+                    AwayGames = table.Column<int>(type: "int", nullable: true),
+                    WinnerTeamId = table.Column<int>(type: "int", nullable: true),
+                    IsComplete = table.Column<bool>(type: "bit", nullable: false),
+                    SavedMatchId = table.Column<int>(type: "int", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TeamMatchSets", x => x.TeamMatchSetId);
+                    table.ForeignKey(
+                        name: "FK_TeamMatchSets_CompetitionFixtures_CompetitionFixtureId",
+                        column: x => x.CompetitionFixtureId,
+                        principalTable: "CompetitionFixtures",
+                        principalColumn: "CompetitionFixtureId",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_TeamMatchSets_CompetitionTeams_WinnerTeamId",
+                        column: x => x.WinnerTeamId,
+                        principalTable: "CompetitionTeams",
+                        principalColumn: "CompetitionTeamId");
+                    table.ForeignKey(
+                        name: "FK_TeamMatchSets_Players_AwayPlayer1Id",
+                        column: x => x.AwayPlayer1Id,
+                        principalTable: "Players",
+                        principalColumn: "PlayerId",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_TeamMatchSets_Players_AwayPlayer2Id",
+                        column: x => x.AwayPlayer2Id,
+                        principalTable: "Players",
+                        principalColumn: "PlayerId",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_TeamMatchSets_Players_HomePlayer1Id",
+                        column: x => x.HomePlayer1Id,
+                        principalTable: "Players",
+                        principalColumn: "PlayerId",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_TeamMatchSets_Players_HomePlayer2Id",
+                        column: x => x.HomePlayer2Id,
+                        principalTable: "Players",
+                        principalColumn: "PlayerId",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_TeamMatchSets_SavedMatch_SavedMatchId",
+                        column: x => x.SavedMatchId,
+                        principalTable: "SavedMatch",
+                        principalColumn: "SavedMatchId",
+                        onDelete: ReferentialAction.SetNull);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CompetitionTeams_CaptainPlayerId",
+                table: "CompetitionTeams",
+                column: "CaptainPlayerId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CompetitionFixtures_AwayTeamId",
+                table: "CompetitionFixtures",
+                column: "AwayTeamId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CompetitionFixtures_CourtPairId",
+                table: "CompetitionFixtures",
+                column: "CourtPairId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CompetitionFixtures_HomeTeamId",
+                table: "CompetitionFixtures",
+                column: "HomeTeamId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CompetitionFixtures_WinnerTeamId",
+                table: "CompetitionFixtures",
+                column: "WinnerTeamId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CourtPairs_CompetitionId",
+                table: "CourtPairs",
+                column: "CompetitionId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CourtPairs_Court1Id",
+                table: "CourtPairs",
+                column: "Court1Id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CourtPairs_Court2Id",
+                table: "CourtPairs",
+                column: "Court2Id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TeamMatchSets_AwayPlayer1Id",
+                table: "TeamMatchSets",
+                column: "AwayPlayer1Id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TeamMatchSets_AwayPlayer2Id",
+                table: "TeamMatchSets",
+                column: "AwayPlayer2Id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TeamMatchSets_CompetitionFixtureId",
+                table: "TeamMatchSets",
+                column: "CompetitionFixtureId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TeamMatchSets_HomePlayer1Id",
+                table: "TeamMatchSets",
+                column: "HomePlayer1Id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TeamMatchSets_HomePlayer2Id",
+                table: "TeamMatchSets",
+                column: "HomePlayer2Id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TeamMatchSets_SavedMatchId",
+                table: "TeamMatchSets",
+                column: "SavedMatchId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TeamMatchSets_WinnerTeamId",
+                table: "TeamMatchSets",
+                column: "WinnerTeamId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CompetitionFixtures_CompetitionTeams_AwayTeamId",
+                table: "CompetitionFixtures",
+                column: "AwayTeamId",
+                principalTable: "CompetitionTeams",
+                principalColumn: "CompetitionTeamId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CompetitionFixtures_CompetitionTeams_HomeTeamId",
+                table: "CompetitionFixtures",
+                column: "HomeTeamId",
+                principalTable: "CompetitionTeams",
+                principalColumn: "CompetitionTeamId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CompetitionFixtures_CompetitionTeams_WinnerTeamId",
+                table: "CompetitionFixtures",
+                column: "WinnerTeamId",
+                principalTable: "CompetitionTeams",
+                principalColumn: "CompetitionTeamId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CompetitionFixtures_CourtPairs_CourtPairId",
+                table: "CompetitionFixtures",
+                column: "CourtPairId",
+                principalTable: "CourtPairs",
+                principalColumn: "CourtPairId",
+                onDelete: ReferentialAction.SetNull);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CompetitionTeams_Players_CaptainPlayerId",
+                table: "CompetitionTeams",
+                column: "CaptainPlayerId",
+                principalTable: "Players",
+                principalColumn: "PlayerId",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_CompetitionFixtures_CompetitionTeams_AwayTeamId",
+                table: "CompetitionFixtures");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_CompetitionFixtures_CompetitionTeams_HomeTeamId",
+                table: "CompetitionFixtures");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_CompetitionFixtures_CompetitionTeams_WinnerTeamId",
+                table: "CompetitionFixtures");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_CompetitionFixtures_CourtPairs_CourtPairId",
+                table: "CompetitionFixtures");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_CompetitionTeams_Players_CaptainPlayerId",
+                table: "CompetitionTeams");
+
+            migrationBuilder.DropTable(
+                name: "CourtPairs");
+
+            migrationBuilder.DropTable(
+                name: "TeamMatchSets");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CompetitionTeams_CaptainPlayerId",
+                table: "CompetitionTeams");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CompetitionFixtures_AwayTeamId",
+                table: "CompetitionFixtures");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CompetitionFixtures_CourtPairId",
+                table: "CompetitionFixtures");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CompetitionFixtures_HomeTeamId",
+                table: "CompetitionFixtures");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CompetitionFixtures_WinnerTeamId",
+                table: "CompetitionFixtures");
+
+            migrationBuilder.DropColumn(
+                name: "CaptainPlayerId",
+                table: "CompetitionTeams");
+
+            migrationBuilder.DropColumn(
+                name: "Grade",
+                table: "CompetitionParticipants");
+
+            migrationBuilder.DropColumn(
+                name: "AwayTeamId",
+                table: "CompetitionFixtures");
+
+            migrationBuilder.DropColumn(
+                name: "CourtPairId",
+                table: "CompetitionFixtures");
+
+            migrationBuilder.DropColumn(
+                name: "HomeTeamId",
+                table: "CompetitionFixtures");
+
+            migrationBuilder.DropColumn(
+                name: "WinnerTeamId",
+                table: "CompetitionFixtures");
+        }
+    }
+}

--- a/DropShot/Data/MyDbContext.cs
+++ b/DropShot/Data/MyDbContext.cs
@@ -36,6 +36,8 @@ namespace DropShot.Data
         public DbSet<UserPlayer> UserPlayers { get; set; }
         public DbSet<RoleSwitchLog> RoleSwitchLogs { get; set; }
         public DbSet<Event> Events { get; set; }
+        public DbSet<CourtPair> CourtPairs { get; set; }
+        public DbSet<TeamMatchSet> TeamMatchSets { get; set; }
 
         protected override void OnModelCreating(ModelBuilder builder)
         {
@@ -188,6 +190,11 @@ namespace DropShot.Data
                       .WithMany(c => c.Teams)
                       .HasForeignKey(t => t.CompetitionId)
                       .OnDelete(DeleteBehavior.Cascade);
+
+                entity.HasOne(t => t.Captain)
+                      .WithMany()
+                      .HasForeignKey(t => t.CaptainPlayerId)
+                      .OnDelete(DeleteBehavior.Restrict);
             });
 
             // ── CompetitionParticipant ───────────────────────────────────────────
@@ -195,6 +202,7 @@ namespace DropShot.Data
             {
                 entity.HasKey(cp => new { cp.CompetitionId, cp.PlayerId });
                 entity.Property(cp => cp.Status).HasConversion<byte>();
+                entity.Property(cp => cp.Grade).HasConversion<byte?>();
 
                 entity.HasOne(cp => cp.Competition)
                       .WithMany(c => c.Participants)
@@ -256,6 +264,16 @@ namespace DropShot.Data
                 entity.HasOne(f => f.SavedMatch)
                       .WithMany()
                       .HasForeignKey(f => f.SavedMatchId)
+                      .OnDelete(DeleteBehavior.SetNull);
+
+                // Mixed Team Tennis FKs — all NoAction to avoid multi-cascade through Competition
+                entity.HasOne(f => f.HomeTeam).WithMany().HasForeignKey(f => f.HomeTeamId).OnDelete(DeleteBehavior.NoAction);
+                entity.HasOne(f => f.AwayTeam).WithMany().HasForeignKey(f => f.AwayTeamId).OnDelete(DeleteBehavior.NoAction);
+                entity.HasOne(f => f.WinnerTeam).WithMany().HasForeignKey(f => f.WinnerTeamId).OnDelete(DeleteBehavior.NoAction);
+
+                entity.HasOne(f => f.CourtPair)
+                      .WithMany()
+                      .HasForeignKey(f => f.CourtPairId)
                       .OnDelete(DeleteBehavior.SetNull);
             });
 
@@ -434,6 +452,55 @@ namespace DropShot.Data
                       .WithMany()
                       .HasForeignKey(up => up.PlayerId)
                       .OnDelete(DeleteBehavior.Cascade);
+            });
+
+            // ── CourtPair ───────────────────────────────────────────────────────
+            builder.Entity<CourtPair>(entity =>
+            {
+                entity.Property(cp => cp.Name).HasMaxLength(100).IsRequired();
+
+                entity.HasOne(cp => cp.Competition)
+                      .WithMany(c => c.CourtPairs)
+                      .HasForeignKey(cp => cp.CompetitionId)
+                      .OnDelete(DeleteBehavior.Cascade);
+
+                entity.HasOne(cp => cp.Court1)
+                      .WithMany()
+                      .HasForeignKey(cp => cp.Court1Id)
+                      .OnDelete(DeleteBehavior.Restrict);
+
+                entity.HasOne(cp => cp.Court2)
+                      .WithMany()
+                      .HasForeignKey(cp => cp.Court2Id)
+                      .OnDelete(DeleteBehavior.Restrict);
+            });
+
+            // ── TeamMatchSet ───────────────────────────────────────────────────
+            builder.Entity<TeamMatchSet>(entity =>
+            {
+                entity.Property(s => s.Phase).HasConversion<byte>();
+                entity.Property(s => s.SetType).HasConversion<byte>();
+
+                entity.HasOne(s => s.Fixture)
+                      .WithMany(f => f.TeamMatchSets)
+                      .HasForeignKey(s => s.CompetitionFixtureId)
+                      .OnDelete(DeleteBehavior.Cascade);
+
+                // Multiple player FKs — all Restrict
+                entity.HasOne(s => s.HomePlayer1).WithMany().HasForeignKey(s => s.HomePlayer1Id).OnDelete(DeleteBehavior.Restrict);
+                entity.HasOne(s => s.HomePlayer2).WithMany().HasForeignKey(s => s.HomePlayer2Id).OnDelete(DeleteBehavior.Restrict);
+                entity.HasOne(s => s.AwayPlayer1).WithMany().HasForeignKey(s => s.AwayPlayer1Id).OnDelete(DeleteBehavior.Restrict);
+                entity.HasOne(s => s.AwayPlayer2).WithMany().HasForeignKey(s => s.AwayPlayer2Id).OnDelete(DeleteBehavior.Restrict);
+
+                entity.HasOne(s => s.WinnerTeam)
+                      .WithMany()
+                      .HasForeignKey(s => s.WinnerTeamId)
+                      .OnDelete(DeleteBehavior.NoAction);
+
+                entity.HasOne(s => s.SavedMatch)
+                      .WithMany()
+                      .HasForeignKey(s => s.SavedMatchId)
+                      .OnDelete(DeleteBehavior.SetNull);
             });
 
             // ── RoleSwitchLog ───────────────────────────────────────────────────

--- a/DropShot/Models/Competition.cs
+++ b/DropShot/Models/Competition.cs
@@ -5,7 +5,8 @@
         Singles = 1,
         Doubles = 2,
         Team = 3,
-        MixedDoubles = 4
+        MixedDoubles = 4,
+        MixedTeam = 5
     }
 
     public class Competition
@@ -35,5 +36,6 @@
         public ICollection<CompetitionTeam> Teams { get; set; } = [];
         public ICollection<CompetitionMatchWindow> MatchWindows { get; set; } = [];
         public ICollection<CompetitionAdmin> Admins { get; set; } = [];
+        public ICollection<CourtPair> CourtPairs { get; set; } = [];
     }
 }

--- a/DropShot/Models/CompetitionFixture.cs
+++ b/DropShot/Models/CompetitionFixture.cs
@@ -37,6 +37,12 @@ public class CompetitionFixture
     public int? OriginalWinnerPlayerId { get; set; }
     public bool ResultModifiedByAdmin { get; set; }
 
+    // Mixed Team Tennis fields
+    public int? HomeTeamId { get; set; }
+    public int? AwayTeamId { get; set; }
+    public int? WinnerTeamId { get; set; }
+    public int? CourtPairId { get; set; }
+
     public Competition Competition { get; set; } = null!;
     public CompetitionStage? Stage { get; set; }
     public Court? Court { get; set; }
@@ -45,4 +51,9 @@ public class CompetitionFixture
     public Player? Player3 { get; set; }
     public Player? Player4 { get; set; }
     public SavedMatch? SavedMatch { get; set; }
+    public CompetitionTeam? HomeTeam { get; set; }
+    public CompetitionTeam? AwayTeam { get; set; }
+    public CompetitionTeam? WinnerTeam { get; set; }
+    public CourtPair? CourtPair { get; set; }
+    public ICollection<TeamMatchSet> TeamMatchSets { get; set; } = [];
 }

--- a/DropShot/Models/CompetitionParticipant.cs
+++ b/DropShot/Models/CompetitionParticipant.cs
@@ -15,6 +15,7 @@ public class CompetitionParticipant
     public DateTime RegisteredAt { get; set; } = DateTime.UtcNow;
     public ParticipantStatus Status { get; set; } = ParticipantStatus.Registered;
     public int? TeamId { get; set; }
+    public PlayerGrade? Grade { get; set; }
 
     public Competition Competition { get; set; } = null!;
     public Player Player { get; set; } = null!;

--- a/DropShot/Models/CompetitionTeam.cs
+++ b/DropShot/Models/CompetitionTeam.cs
@@ -5,7 +5,9 @@ public class CompetitionTeam
     public int CompetitionTeamId { get; set; }
     public int CompetitionId { get; set; }
     public string Name { get; set; } = "";
+    public int? CaptainPlayerId { get; set; }
 
     public Competition Competition { get; set; } = null!;
+    public Player? Captain { get; set; }
     public ICollection<CompetitionParticipant> Participants { get; set; } = [];
 }

--- a/DropShot/Models/CourtPair.cs
+++ b/DropShot/Models/CourtPair.cs
@@ -1,0 +1,14 @@
+namespace DropShot.Models;
+
+public class CourtPair
+{
+    public int CourtPairId { get; set; }
+    public int CompetitionId { get; set; }
+    public int Court1Id { get; set; }
+    public int Court2Id { get; set; }
+    public string Name { get; set; } = "";
+
+    public Competition Competition { get; set; } = null!;
+    public Court Court1 { get; set; } = null!;
+    public Court Court2 { get; set; } = null!;
+}

--- a/DropShot/Models/TeamMatchEnums.cs
+++ b/DropShot/Models/TeamMatchEnums.cs
@@ -1,0 +1,21 @@
+namespace DropShot.Models;
+
+public enum PlayerGrade : byte
+{
+    A = 1,
+    B = 2
+}
+
+public enum TeamMatchPhase : byte
+{
+    GenderDoubles = 1,
+    MixedDoubles = 2
+}
+
+public enum TeamMatchSetType : byte
+{
+    MensDoubles = 1,
+    WomensDoubles = 2,
+    MixedDoublesA = 3,
+    MixedDoublesB = 4
+}

--- a/DropShot/Models/TeamMatchSet.cs
+++ b/DropShot/Models/TeamMatchSet.cs
@@ -1,0 +1,30 @@
+namespace DropShot.Models;
+
+public class TeamMatchSet
+{
+    public int TeamMatchSetId { get; set; }
+    public int CompetitionFixtureId { get; set; }
+    public int SetNumber { get; set; }
+    public TeamMatchPhase Phase { get; set; }
+    public TeamMatchSetType SetType { get; set; }
+    public int CourtNumber { get; set; } // 1 or 2
+
+    public int? HomePlayer1Id { get; set; }
+    public int? HomePlayer2Id { get; set; }
+    public int? AwayPlayer1Id { get; set; }
+    public int? AwayPlayer2Id { get; set; }
+
+    public int? HomeGames { get; set; }
+    public int? AwayGames { get; set; }
+    public int? WinnerTeamId { get; set; }
+    public bool IsComplete { get; set; }
+    public int? SavedMatchId { get; set; }
+
+    public CompetitionFixture Fixture { get; set; } = null!;
+    public Player? HomePlayer1 { get; set; }
+    public Player? HomePlayer2 { get; set; }
+    public Player? AwayPlayer1 { get; set; }
+    public Player? AwayPlayer2 { get; set; }
+    public CompetitionTeam? WinnerTeam { get; set; }
+    public SavedMatch? SavedMatch { get; set; }
+}

--- a/DropShot/Services/CompetitionProgressionService.cs
+++ b/DropShot/Services/CompetitionProgressionService.cs
@@ -23,11 +23,16 @@ public static class CompetitionProgressionService
             .FirstOrDefaultAsync(f => f.CompetitionFixtureId == completedFixtureId);
 
         if (fixture is null || fixture.Status != FixtureStatus.Completed) return;
-        if (!fixture.WinnerPlayerId.HasValue) return;
         if (!fixture.CompetitionStageId.HasValue) return;
 
         var stage = fixture.Stage;
         if (stage is null) return;
+
+        // Check if this is a team fixture (MixedTeam format)
+        bool isTeamFixture = fixture.HomeTeamId.HasValue;
+
+        // For non-team fixtures, require a player winner
+        if (!isTeamFixture && !fixture.WinnerPlayerId.HasValue) return;
 
         var allStages = await db.CompetitionStages
             .Where(s => s.CompetitionId == competitionId)
@@ -35,9 +40,19 @@ public static class CompetitionProgressionService
             .ToListAsync();
 
         if (stage.StageType == StageType.RoundRobin)
-            await TryAdvanceFromRoundRobinAsync(db, competitionId, allStages);
+        {
+            if (isTeamFixture)
+                await TryAdvanceTeamFromRoundRobinAsync(db, competitionId, allStages);
+            else
+                await TryAdvanceFromRoundRobinAsync(db, competitionId, allStages);
+        }
         else
-            await TryAdvanceKnockoutRoundAsync(db, competitionId, fixture, stage, allStages);
+        {
+            if (isTeamFixture)
+                await TryAdvanceTeamKnockoutRoundAsync(db, competitionId, fixture, stage, allStages);
+            else
+                await TryAdvanceKnockoutRoundAsync(db, competitionId, fixture, stage, allStages);
+        }
     }
 
     // ── RoundRobin → first knockout round ────────────────────────────────────
@@ -201,6 +216,212 @@ public static class CompetitionProgressionService
 
         AssignWinners(targetFixtures, winners);
         await db.SaveChangesAsync();
+    }
+
+    // ── Team RoundRobin → first knockout round ────────────────────────────────
+
+    private static async Task TryAdvanceTeamFromRoundRobinAsync(
+        MyDbContext db, int competitionId, List<CompetitionStage> allStages)
+    {
+        var rrStageIds = allStages
+            .Where(s => s.StageType == StageType.RoundRobin)
+            .Select(s => s.CompetitionStageId).ToHashSet();
+
+        var rrFixtures = await db.CompetitionFixtures
+            .Where(f => f.CompetitionId == competitionId
+                     && f.CompetitionStageId.HasValue
+                     && rrStageIds.Contains(f.CompetitionStageId.Value))
+            .Include(f => f.TeamMatchSets)
+            .ToListAsync();
+
+        bool allDone = rrFixtures.All(f =>
+            f.Status == FixtureStatus.Completed ||
+            f.Status == FixtureStatus.Walkover   ||
+            f.Status == FixtureStatus.Cancelled);
+
+        if (!allDone) return;
+
+        var firstKoStage = allStages
+            .Where(s => s.StageType is StageType.Knockout or StageType.QuarterFinal or StageType.SemiFinal)
+            .OrderBy(s => s.StageOrder)
+            .FirstOrDefault();
+
+        if (firstKoStage is null) return;
+
+        var targetFixtures = await db.CompetitionFixtures
+            .Where(f => f.CompetitionId == competitionId
+                     && f.CompetitionStageId == firstKoStage.CompetitionStageId
+                     && (firstKoStage.StageType != StageType.Knockout || f.RoundNumber == 1)
+                     && f.HomeTeamId == null && f.AwayTeamId == null
+                     && f.Status == FixtureStatus.Scheduled)
+            .OrderBy(f => f.FixtureLabel)
+            .ToListAsync();
+
+        if (!targetFixtures.Any()) return;
+
+        // Rank teams by sets won
+        var teamIds = await db.CompetitionTeams
+            .Where(t => t.CompetitionId == competitionId)
+            .Select(t => t.CompetitionTeamId)
+            .ToListAsync();
+
+        var setsWon = teamIds.ToDictionary(tid => tid, _ => 0);
+        var setsAgainst = teamIds.ToDictionary(tid => tid, _ => 0);
+
+        foreach (var f in rrFixtures.Where(f => f.Status == FixtureStatus.Completed
+                    && f.HomeTeamId.HasValue && f.AwayTeamId.HasValue))
+        {
+            int hid = f.HomeTeamId!.Value;
+            int aid = f.AwayTeamId!.Value;
+            if (!setsWon.ContainsKey(hid) || !setsWon.ContainsKey(aid)) continue;
+
+            var completed = f.TeamMatchSets.Where(s => s.IsComplete).ToList();
+            int hw = completed.Count(s => s.WinnerTeamId == hid);
+            int aw = completed.Count(s => s.WinnerTeamId == aid);
+
+            setsWon[hid] += hw;
+            setsAgainst[hid] += aw;
+            setsWon[aid] += aw;
+            setsAgainst[aid] += hw;
+        }
+
+        var seeded = teamIds
+            .OrderByDescending(tid => setsWon[tid])
+            .ThenByDescending(tid => setsWon[tid] - setsAgainst[tid])
+            .ThenBy(tid => setsAgainst[tid])
+            .Take(targetFixtures.Count * 2)
+            .ToList();
+
+        AssignTeamWinners(targetFixtures, seeded);
+
+        // Create TeamMatchSet rows for the newly assigned knockout fixtures
+        await CreateTeamMatchSetsForFixtures(db, competitionId, targetFixtures);
+
+        await db.SaveChangesAsync();
+    }
+
+    // ── Team knockout round → next round ────────────────────────────────────
+
+    private static async Task TryAdvanceTeamKnockoutRoundAsync(
+        MyDbContext db, int competitionId,
+        CompetitionFixture completedFixture, CompetitionStage stage,
+        List<CompetitionStage> allStages)
+    {
+        IQueryable<CompetitionFixture> sourceQuery = db.CompetitionFixtures
+            .Where(f => f.CompetitionId == competitionId
+                     && f.CompetitionStageId == completedFixture.CompetitionStageId);
+
+        if (stage.StageType == StageType.Knockout)
+        {
+            if (!completedFixture.RoundNumber.HasValue) return;
+            sourceQuery = sourceQuery.Where(f => f.RoundNumber == completedFixture.RoundNumber);
+        }
+
+        var sourceFixtures = await sourceQuery.ToListAsync();
+
+        bool allDone = sourceFixtures.All(f =>
+            f.Status == FixtureStatus.Completed ||
+            f.Status == FixtureStatus.Walkover   ||
+            f.Status == FixtureStatus.Cancelled);
+
+        if (!allDone) return;
+
+        var winners = sourceFixtures
+            .OrderBy(f => f.FixtureLabel)
+            .Where(f => f.WinnerTeamId.HasValue)
+            .Select(f => f.WinnerTeamId!.Value)
+            .ToList();
+
+        if (!winners.Any()) return;
+
+        List<CompetitionFixture> targetFixtures;
+
+        if (stage.StageType == StageType.Knockout)
+        {
+            int nextRound = completedFixture.RoundNumber!.Value + 1;
+            targetFixtures = await db.CompetitionFixtures
+                .Where(f => f.CompetitionId == competitionId
+                         && f.CompetitionStageId == completedFixture.CompetitionStageId
+                         && f.RoundNumber == nextRound
+                         && f.HomeTeamId == null && f.AwayTeamId == null
+                         && f.Status == FixtureStatus.Scheduled)
+                .OrderBy(f => f.FixtureLabel)
+                .ToListAsync();
+        }
+        else
+        {
+            var nextStage = allStages
+                .Where(s => s.StageOrder > stage.StageOrder)
+                .OrderBy(s => s.StageOrder)
+                .FirstOrDefault();
+
+            if (nextStage is null) return;
+
+            targetFixtures = await db.CompetitionFixtures
+                .Where(f => f.CompetitionId == competitionId
+                         && f.CompetitionStageId == nextStage.CompetitionStageId
+                         && f.HomeTeamId == null && f.AwayTeamId == null
+                         && f.Status == FixtureStatus.Scheduled)
+                .OrderBy(f => f.FixtureLabel)
+                .ToListAsync();
+        }
+
+        if (!targetFixtures.Any()) return;
+
+        AssignTeamWinners(targetFixtures, winners);
+
+        await CreateTeamMatchSetsForFixtures(db, competitionId, targetFixtures);
+
+        await db.SaveChangesAsync();
+    }
+
+    // ── Team helper: assign teams to knockout fixtures ──────────────────────
+
+    internal static void AssignTeamWinners(List<CompetitionFixture> targets, List<int> teamIds)
+    {
+        int n = targets.Count;
+        if (teamIds.Count <= n)
+        {
+            for (int i = 0; i < n; i++)
+                targets[i].HomeTeamId = i < teamIds.Count ? teamIds[i] : null;
+            return;
+        }
+
+        for (int i = 0; i < n; i++)
+        {
+            int p2Idx = 2 * n - 1 - i;
+            targets[i].HomeTeamId = i < teamIds.Count ? teamIds[i] : null;
+            targets[i].AwayTeamId = p2Idx < teamIds.Count ? teamIds[p2Idx] : null;
+        }
+    }
+
+    // ── Helper: create TeamMatchSet rows for newly assigned fixtures ────────
+
+    private static async Task CreateTeamMatchSetsForFixtures(
+        MyDbContext db, int competitionId, List<CompetitionFixture> fixtures)
+    {
+        foreach (var fx in fixtures.Where(f => f.HomeTeamId.HasValue && f.AwayTeamId.HasValue))
+        {
+            var homeMembers = await db.CompetitionParticipants
+                .Where(cp => cp.CompetitionId == competitionId && cp.TeamId == fx.HomeTeamId
+                    && (cp.Status == ParticipantStatus.Registered || cp.Status == ParticipantStatus.Confirmed))
+                .Include(cp => cp.Player)
+                .ToListAsync();
+
+            var awayMembers = await db.CompetitionParticipants
+                .Where(cp => cp.CompetitionId == competitionId && cp.TeamId == fx.AwayTeamId
+                    && (cp.Status == ParticipantStatus.Registered || cp.Status == ParticipantStatus.Confirmed))
+                .Include(cp => cp.Player)
+                .ToListAsync();
+
+            if (homeMembers.Count == 4 && awayMembers.Count == 4
+                && homeMembers.All(m => m.Grade != null && m.Player?.Sex != null)
+                && awayMembers.All(m => m.Grade != null && m.Player?.Sex != null))
+            {
+                var sets = TeamMatchService.CreateSetsForFixture(fx.CompetitionFixtureId, homeMembers, awayMembers);
+                db.TeamMatchSets.AddRange(sets);
+            }
+        }
     }
 
     // ── Helper: bracket-pair winners into target fixtures ────────────────────

--- a/DropShot/Services/TeamMatchService.cs
+++ b/DropShot/Services/TeamMatchService.cs
@@ -1,0 +1,84 @@
+using DropShot.Models;
+
+namespace DropShot.Services;
+
+public static class TeamMatchService
+{
+    /// <summary>
+    /// Creates the 8 TeamMatchSet rows for a team fixture based on team compositions.
+    /// </summary>
+    public static List<TeamMatchSet> CreateSetsForFixture(
+        int fixtureId,
+        List<CompetitionParticipant> homeMembers,
+        List<CompetitionParticipant> awayMembers)
+    {
+        var homeMaleA = homeMembers.First(m => m.Player!.Sex == PlayerSex.Male && m.Grade == PlayerGrade.A);
+        var homeFemaleA = homeMembers.First(m => m.Player!.Sex == PlayerSex.Female && m.Grade == PlayerGrade.A);
+        var homeMaleB = homeMembers.First(m => m.Player!.Sex == PlayerSex.Male && m.Grade == PlayerGrade.B);
+        var homeFemaleB = homeMembers.First(m => m.Player!.Sex == PlayerSex.Female && m.Grade == PlayerGrade.B);
+
+        var awayMaleA = awayMembers.First(m => m.Player!.Sex == PlayerSex.Male && m.Grade == PlayerGrade.A);
+        var awayFemaleA = awayMembers.First(m => m.Player!.Sex == PlayerSex.Female && m.Grade == PlayerGrade.A);
+        var awayMaleB = awayMembers.First(m => m.Player!.Sex == PlayerSex.Male && m.Grade == PlayerGrade.B);
+        var awayFemaleB = awayMembers.First(m => m.Player!.Sex == PlayerSex.Female && m.Grade == PlayerGrade.B);
+
+        return
+        [
+            // Phase 1 — Gender Doubles
+            // Sets 1-2: Men's Doubles on Court 1
+            MakeSet(fixtureId, 1, TeamMatchPhase.GenderDoubles, TeamMatchSetType.MensDoubles, 1,
+                homeMaleA.PlayerId, homeMaleB.PlayerId, awayMaleA.PlayerId, awayMaleB.PlayerId),
+            MakeSet(fixtureId, 2, TeamMatchPhase.GenderDoubles, TeamMatchSetType.MensDoubles, 1,
+                homeMaleA.PlayerId, homeMaleB.PlayerId, awayMaleA.PlayerId, awayMaleB.PlayerId),
+
+            // Sets 3-4: Women's Doubles on Court 2
+            MakeSet(fixtureId, 3, TeamMatchPhase.GenderDoubles, TeamMatchSetType.WomensDoubles, 2,
+                homeFemaleA.PlayerId, homeFemaleB.PlayerId, awayFemaleA.PlayerId, awayFemaleB.PlayerId),
+            MakeSet(fixtureId, 4, TeamMatchPhase.GenderDoubles, TeamMatchSetType.WomensDoubles, 2,
+                homeFemaleA.PlayerId, homeFemaleB.PlayerId, awayFemaleA.PlayerId, awayFemaleB.PlayerId),
+
+            // Phase 2 — Mixed Doubles
+            // Sets 5-6: A-Grade Mixed on Court 1
+            MakeSet(fixtureId, 5, TeamMatchPhase.MixedDoubles, TeamMatchSetType.MixedDoublesA, 1,
+                homeMaleA.PlayerId, homeFemaleA.PlayerId, awayMaleA.PlayerId, awayFemaleA.PlayerId),
+            MakeSet(fixtureId, 6, TeamMatchPhase.MixedDoubles, TeamMatchSetType.MixedDoublesA, 1,
+                homeMaleA.PlayerId, homeFemaleA.PlayerId, awayMaleA.PlayerId, awayFemaleA.PlayerId),
+
+            // Sets 7-8: B-Grade Mixed on Court 2
+            MakeSet(fixtureId, 7, TeamMatchPhase.MixedDoubles, TeamMatchSetType.MixedDoublesB, 2,
+                homeMaleB.PlayerId, homeFemaleB.PlayerId, awayMaleB.PlayerId, awayFemaleB.PlayerId),
+            MakeSet(fixtureId, 8, TeamMatchPhase.MixedDoubles, TeamMatchSetType.MixedDoublesB, 2,
+                homeMaleB.PlayerId, homeFemaleB.PlayerId, awayMaleB.PlayerId, awayFemaleB.PlayerId),
+        ];
+    }
+
+    private static TeamMatchSet MakeSet(
+        int fixtureId, int setNumber, TeamMatchPhase phase, TeamMatchSetType setType,
+        int courtNumber, int hp1, int hp2, int ap1, int ap2) => new()
+    {
+        CompetitionFixtureId = fixtureId,
+        SetNumber = setNumber,
+        Phase = phase,
+        SetType = setType,
+        CourtNumber = courtNumber,
+        HomePlayer1Id = hp1,
+        HomePlayer2Id = hp2,
+        AwayPlayer1Id = ap1,
+        AwayPlayer2Id = ap2
+    };
+
+    public static (int homeScore, int awayScore) ComputeScore(
+        IEnumerable<TeamMatchSet> sets, int homeTeamId, int awayTeamId)
+    {
+        int home = 0, away = 0;
+        foreach (var s in sets.Where(s => s.IsComplete))
+        {
+            if (s.WinnerTeamId == homeTeamId) home++;
+            else if (s.WinnerTeamId == awayTeamId) away++;
+        }
+        return (home, away);
+    }
+
+    public static bool AllSetsComplete(IEnumerable<TeamMatchSet> sets)
+        => sets.All(s => s.IsComplete);
+}


### PR DESCRIPTION
## Summary
- Adds `CompetitionFormat.MixedTeam` — teams of 4 (1 Male A, 1 Female A, 1 Male B, 1 Female B) play 8 sets across 2 courts in 2 phases (gender doubles then mixed doubles by grade)
- Each set is a standalone `SavedMatch` (best-of-1) linked to a `TeamMatchSet`, keeping the existing scoring system fully intact
- New models (`CourtPair`, `TeamMatchSet`), services (`TeamMatchService`), and page (`/team-match/{id}`) with two-court side-by-side scoring view
- Extended scheduling (circle-method team round-robin), progression (team-based RR→KO and KO→KO advancement), and admin/public UI (grade/captain assignment, team validation, team league table with P/W/D/L/SW/SA/Pts)

## Test plan
- [ ] Create a MixedTeam competition, add 8+ participants, assign sex/grade/teams
- [ ] Validate team compositions (exactly 1 MA, 1 FA, 1 MB, 1 FB per team)
- [ ] Schedule fixtures — verify 8 TeamMatchSet rows created per fixture with correct player assignments
- [ ] Play through individual sets via TennisScore (best-of-1) — verify scores recorded back to TeamMatchSet
- [ ] Complete all 8 sets — verify fixture marked Completed with X-Y summary
- [ ] Verify team league table displays correctly with sets won/against
- [ ] Verify knockout progression seeds top teams correctly
- [ ] Run `dotnet ef database update` to apply migration on staging DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)