### PR TITLE
Fix CourtPair FK cascade path error in migration

### DIFF
--- a/DropShot/Data/Migrations/20260411084558_AddMixedTeamTennis.Designer.cs
+++ b/DropShot/Data/Migrations/20260411084558_AddMixedTeamTennis.Designer.cs
@@ -12,7 +12,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DropShot.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    [Migration("20260410231339_AddMixedTeamTennis")]
+    [Migration("20260411084558_AddMixedTeamTennis")]
     partial class AddMixedTeamTennis
     {
         /// <inheritdoc />
@@ -1505,7 +1505,7 @@ namespace DropShot.Migrations
                     b.HasOne("DropShot.Models.CourtPair", "CourtPair")
                         .WithMany()
                         .HasForeignKey("CourtPairId")
-                        .OnDelete(DeleteBehavior.SetNull);
+                        .OnDelete(DeleteBehavior.NoAction);
 
                     b.HasOne("DropShot.Models.CompetitionTeam", "HomeTeam")
                         .WithMany()

--- a/DropShot/Data/Migrations/20260411084558_AddMixedTeamTennis.cs
+++ b/DropShot/Data/Migrations/20260411084558_AddMixedTeamTennis.cs
@@ -248,8 +248,7 @@ namespace DropShot.Migrations
                 table: "CompetitionFixtures",
                 column: "CourtPairId",
                 principalTable: "CourtPairs",
-                principalColumn: "CourtPairId",
-                onDelete: ReferentialAction.SetNull);
+                principalColumn: "CourtPairId");
 
             migrationBuilder.AddForeignKey(
                 name: "FK_CompetitionTeams_Players_CaptainPlayerId",

--- a/DropShot/Data/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/DropShot/Data/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -1502,7 +1502,7 @@ namespace DropShot.Migrations
                     b.HasOne("DropShot.Models.CourtPair", "CourtPair")
                         .WithMany()
                         .HasForeignKey("CourtPairId")
-                        .OnDelete(DeleteBehavior.SetNull);
+                        .OnDelete(DeleteBehavior.NoAction);
 
                     b.HasOne("DropShot.Models.CompetitionTeam", "HomeTeam")
                         .WithMany()

--- a/DropShot/Data/MyDbContext.cs
+++ b/DropShot/Data/MyDbContext.cs
@@ -274,7 +274,7 @@ namespace DropShot.Data
                 entity.HasOne(f => f.CourtPair)
                       .WithMany()
                       .HasForeignKey(f => f.CourtPairId)
-                      .OnDelete(DeleteBehavior.SetNull);
+                      .OnDelete(DeleteBehavior.NoAction);
             });
 
             // ── CompetitionMatchWindow ───────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Changes `CompetitionFixture.CourtPairId` FK from `ON DELETE SET NULL` to `ON DELETE NO ACTION` to fix SQL Server multiple cascade path error
- The original migration (#241) fails on deploy because `Competition → CourtPairs (CASCADE)` and `Competition → CompetitionFixtures (CASCADE)` creates a cycle with `SET NULL`

## Test plan
- [ ] `dotnet ef database update` completes without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)