### PR TITLE
Add competition archive/delete and format display names

### DIFF
--- a/DropShot.Maui/Components/Pages/CompetitionDialog.razor
+++ b/DropShot.Maui/Components/Pages/CompetitionDialog.razor
@@ -1,3 +1,4 @@
+@using DropShot.Shared.Extensions
 @inject ApiService Api
 
 <MudDialog>
@@ -10,7 +11,7 @@
                        Variant="Variant.Outlined" T="CompetitionFormat">
                 @foreach (CompetitionFormat f in Enum.GetValues<CompetitionFormat>())
                 {
-                    <MudSelectItem Value="f">@f</MudSelectItem>
+                    <MudSelectItem Value="f">@f.ToDisplayName()</MudSelectItem>
                 }
             </MudSelect>
 

--- a/DropShot.Maui/Components/Pages/Competitions.razor
+++ b/DropShot.Maui/Components/Pages/Competitions.razor
@@ -1,5 +1,6 @@
 @page "/competitions"
 @attribute [Authorize]
+@using DropShot.Shared.Extensions
 @inject ApiService Api
 @inject AuthService Auth
 @inject ISnackbar Snackbar
@@ -22,6 +23,7 @@ else
                       Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search"
                       Immediate="true" Clearable="true" Variant="Variant.Outlined"
                       Class="flex-grow-1" />
+        <MudCheckBox @bind-Value="_showArchived" Label="Archived" Color="Color.Warning" Dense="true" />
         @if (Auth.IsAdmin)
         {
             <MudButton StartIcon="@Icons.Material.Filled.Add" Variant="Variant.Filled"
@@ -44,8 +46,14 @@ else
                     }
                 </HeaderContent>
                 <RowTemplate>
-                    <MudTd>@context.CompetitionName</MudTd>
-                    <MudTd>@context.CompetitionFormat</MudTd>
+                    <MudTd>
+                        @context.CompetitionName
+                        @if (context.IsArchived)
+                        {
+                            <MudChip T="string" Size="Size.Small" Color="Color.Warning" Variant="Variant.Outlined">Archived</MudChip>
+                        }
+                    </MudTd>
+                    <MudTd>@context.CompetitionFormat.ToDisplayName()</MudTd>
                     <MudTd>@(context.StartDate?.ToString("dd MMM yyyy") ?? "—")</MudTd>
                     <MudTd>@(context.HostClubName ?? "—")</MudTd>
                     <MudTd>
@@ -59,11 +67,20 @@ else
                     <MudTd>
                         @if (Auth.IsAdmin || Auth.CanEditCompetition(context.HostClubId))
                         {
-                            <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="Size.Small"
-                                           OnClick="@(() => OpenEditDialog(context))" />
-                            <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small"
-                                           Color="Color.Error"
-                                           OnClick="@(() => DeleteAsync(context))" />
+                            @if (!context.IsArchived)
+                            {
+                                <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="Size.Small"
+                                               OnClick="@(() => OpenEditDialog(context))" />
+                            }
+                            <MudIconButton Icon="@(context.IsArchived ? Icons.Material.Filled.Unarchive : Icons.Material.Filled.Archive)"
+                                           Size="Size.Small" Color="Color.Warning"
+                                           OnClick="@(() => ToggleArchiveAsync(context))" />
+                            @if (context.IsArchived)
+                            {
+                                <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small"
+                                               Color="Color.Error"
+                                               OnClick="@(() => DeleteAsync(context))" />
+                            }
                         }
                     </MudTd>
                 </RowTemplate>
@@ -93,7 +110,7 @@ else
                                     {
                                         <tr>
                                             <td>@comp.CompetitionName</td>
-                                            <td>@comp.CompetitionFormat</td>
+                                            <td>@comp.CompetitionFormat.ToDisplayName()</td>
                                             <td>
                                                 @if (Auth.IsAdmin || Auth.CanEditCompetition(comp.HostClubId))
                                                 {
@@ -131,7 +148,7 @@ else
                                     {
                                         <tr>
                                             <td>@comp.CompetitionName</td>
-                                            <td>@comp.CompetitionFormat</td>
+                                            <td>@comp.CompetitionFormat.ToDisplayName()</td>
                                             <td>
                                                 @if (Auth.IsAdmin || Auth.CanEditCompetition(comp.HostClubId))
                                                 {
@@ -157,18 +174,21 @@ else
     private bool _loading = true;
     private string? _error;
     private string _search = "";
+    private bool _showArchived;
     private int _activeTab;
 
     private IEnumerable<CompetitionDto> FilteredCompetitions => _competitions is null
         ? []
-        : _competitions.Where(c => string.IsNullOrWhiteSpace(_search)
-            || c.CompetitionName.Contains(_search, StringComparison.OrdinalIgnoreCase));
+        : _competitions.Where(c =>
+            (_showArchived || !c.IsArchived) &&
+            (string.IsNullOrWhiteSpace(_search)
+            || c.CompetitionName.Contains(_search, StringComparison.OrdinalIgnoreCase)));
 
     protected override async Task OnInitializedAsync()
     {
         try
         {
-            _competitions = await Api.GetCompetitionsAsync();
+            _competitions = await Api.GetCompetitionsAsync(includeArchived: true);
             _events = await Api.GetEventsAsync();
         }
         catch (Exception ex)
@@ -230,11 +250,35 @@ else
         }
     }
 
+    private async Task ToggleArchiveAsync(CompetitionDto comp)
+    {
+        try
+        {
+            var isArchived = await Api.ToggleArchiveCompetitionAsync(comp.CompetitionId);
+            var idx = _competitions?.FindIndex(c => c.CompetitionId == comp.CompetitionId) ?? -1;
+            if (idx >= 0)
+            {
+                _competitions![idx] = comp with { IsArchived = isArchived };
+            }
+            Snackbar.Add(isArchived ? $"'{comp.CompetitionName}' archived." : $"'{comp.CompetitionName}' restored.", Severity.Success);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+    }
+
     private async Task DeleteAsync(CompetitionDto comp)
     {
+        if (!comp.IsArchived)
+        {
+            Snackbar.Add("Competition must be archived before it can be deleted.", Severity.Warning);
+            return;
+        }
+
         var confirmed = await Dialog.ShowMessageBoxAsync(
             "Delete Competition",
-            $"Delete \"{comp.CompetitionName}\"? This cannot be undone.",
+            $"Permanently delete \"{comp.CompetitionName}\"? This will remove all participants, fixtures, stages, and teams. This cannot be undone.",
             yesText: "Delete", cancelText: "Cancel");
         if (confirmed != true) return;
 

--- a/DropShot.Maui/Services/ApiService.cs
+++ b/DropShot.Maui/Services/ApiService.cs
@@ -69,8 +69,8 @@ public class ApiService(HttpClient http)
 
     // ── Competitions ─────────────────────────────────────────────────────────
 
-    public async Task<List<CompetitionDto>> GetCompetitionsAsync() =>
-        await http.GetFromJsonAsync<List<CompetitionDto>>("api/competitions") ?? [];
+    public async Task<List<CompetitionDto>> GetCompetitionsAsync(bool includeArchived = false) =>
+        await http.GetFromJsonAsync<List<CompetitionDto>>($"api/competitions?includeArchived={includeArchived}") ?? [];
 
     public Task<CompetitionDetailDto?> GetCompetitionAsync(int id) =>
         http.GetFromJsonAsync<CompetitionDetailDto>($"api/competitions/{id}");
@@ -83,6 +83,16 @@ public class ApiService(HttpClient http)
         r.EnsureSuccessStatusCode();
         return await r.Content.ReadFromJsonAsync<CompetitionDto>();
     }
+
+    public async Task<bool> ToggleArchiveCompetitionAsync(int id)
+    {
+        var r = await http.PutAsync($"api/competitions/{id}/archive", null);
+        r.EnsureSuccessStatusCode();
+        var result = await r.Content.ReadFromJsonAsync<ArchiveResult>();
+        return result?.IsArchived ?? false;
+    }
+
+    private record ArchiveResult(bool IsArchived);
 
     public async Task DeleteCompetitionAsync(int id)
     {

--- a/DropShot.Shared/Dtos/CompetitionDtos.cs
+++ b/DropShot.Shared/Dtos/CompetitionDtos.cs
@@ -15,7 +15,8 @@ public record CompetitionDto(
     int? RulesSetId,
     string? RulesSetName,
     int? EventId,
-    string? EventName);
+    string? EventName,
+    bool IsArchived = false);
 
 public record CompetitionDetailDto(
     int CompetitionId,
@@ -34,7 +35,8 @@ public record CompetitionDetailDto(
     int? EventId,
     string? EventName,
     List<CompetitionStageDto> Stages,
-    List<CompetitionParticipantDto> Participants);
+    List<CompetitionParticipantDto> Participants,
+    bool IsArchived = false);
 
 public record CompetitionStageDto(
     int CompetitionStageId,

--- a/DropShot.Shared/EnumExtensions.cs
+++ b/DropShot.Shared/EnumExtensions.cs
@@ -1,0 +1,26 @@
+using System.Text;
+
+namespace DropShot.Shared.Extensions;
+
+public static class EnumExtensions
+{
+    /// <summary>
+    /// Converts a PascalCase enum value to a spaced display name.
+    /// e.g. MixedDoubles → "Mixed Doubles", MixedTeam → "Mixed Team"
+    /// </summary>
+    public static string ToDisplayName<T>(this T value) where T : struct, Enum
+    {
+        var name = value.ToString();
+        if (name.Length <= 1) return name;
+
+        var sb = new StringBuilder(name.Length + 4);
+        sb.Append(name[0]);
+        for (int i = 1; i < name.Length; i++)
+        {
+            if (char.IsUpper(name[i]))
+                sb.Append(' ');
+            sb.Append(name[i]);
+        }
+        return sb.ToString();
+    }
+}

--- a/DropShot/Components/Pages/Clubs.razor
+++ b/DropShot/Components/Pages/Clubs.razor
@@ -6,6 +6,7 @@
 @using DropShot.Models
 @using DropShot.Data
 @using DropShot.Services
+@using DropShot.Shared.Extensions
 @inject IDbContextFactory<MyDbContext> DbFactory
 @inject ISnackbar Snackbar
 @inject ClubAuthorizationService AuthzService
@@ -313,7 +314,7 @@
                         <MudSelect @bind-Value="ct.Format" Label="Format" Variant="Variant.Outlined" Margin="Margin.Dense" Clearable="true">
                             @foreach (CompetitionFormat f in Enum.GetValues<CompetitionFormat>())
                             {
-                                <MudSelectItem T="CompetitionFormat?" Value="@((CompetitionFormat?)f)">@f</MudSelectItem>
+                                <MudSelectItem T="CompetitionFormat?" Value="@((CompetitionFormat?)f)">@f.ToDisplayName()</MudSelectItem>
                             }
                         </MudSelect>
                     </MudItem>

--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -7,6 +7,7 @@
 @using DropShot.Data
 @using DropShot.Models
 @using DropShot.Services
+@using DropShot.Shared.Extensions
 @using Microsoft.EntityFrameworkCore
 
 @inject IDbContextFactory<MyDbContext> DbFactory
@@ -69,7 +70,7 @@
                                    ValueChanged="@(v => { Model.CompetitionFormat = v; AutoGenerateName(); })">
                             @foreach (CompetitionFormat f in Enum.GetValues<CompetitionFormat>())
                             {
-                                <MudSelectItem Value="@f">@f</MudSelectItem>
+                                <MudSelectItem Value="@f">@f.ToDisplayName()</MudSelectItem>
                             }
                         </MudSelect>
                     </MudItem>

--- a/DropShot/Components/Pages/Competitions.razor
+++ b/DropShot/Components/Pages/Competitions.razor
@@ -7,6 +7,7 @@
 @using DropShot.Data
 @using DropShot.Models
 @using DropShot.Services
+@using DropShot.Shared.Extensions
 @using DropShot.Shared.Dtos
 @using Microsoft.EntityFrameworkCore
 
@@ -47,7 +48,7 @@
                 </HeaderContent>
                 <RowTemplate>
                     <MudTd DataLabel="Name">@context.CompetitionName</MudTd>
-                    <MudTd DataLabel="Format">@context.CompetitionFormat</MudTd>
+                    <MudTd DataLabel="Format">@context.CompetitionFormat.ToDisplayName()</MudTd>
                     <MudTd DataLabel="Host Club">@(context.HostClub?.Name ?? "—")</MudTd>
                     <MudTd DataLabel="Dates">@FormatDates(context)</MudTd>
                     <MudTd>
@@ -77,7 +78,7 @@
                 </HeaderContent>
                 <RowTemplate>
                     <MudTd DataLabel="Name">@context.CompetitionName</MudTd>
-                    <MudTd DataLabel="Format">@context.CompetitionFormat</MudTd>
+                    <MudTd DataLabel="Format">@context.CompetitionFormat.ToDisplayName()</MudTd>
                     <MudTd DataLabel="Host Club">@(context.HostClub?.Name ?? "—")</MudTd>
                     <MudTd DataLabel="Dates">@FormatDates(context)</MudTd>
                     <MudTd>
@@ -175,9 +176,13 @@
 
 @if (!_isUserView)
 {
-<MudTextField @bind-Value="_searchText" Placeholder="Search competitions..."
-              Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search"
-              Immediate="true" Class="mb-4" />
+<MudStack Row="true" AlignItems="AlignItems.Center" Class="mb-4" Spacing="2">
+    <MudTextField @bind-Value="_searchText" Placeholder="Search competitions..."
+                  Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search"
+                  Immediate="true" Class="flex-grow-1" />
+    <MudCheckBox @bind-Value="_showArchived" Label="Show Archived" Color="Color.Warning"
+                 Dense="true" />
+</MudStack>
 
 <MudTabs @bind-ActivePanelIndex="_activeTab" Elevation="0" ApplyEffectsToContainer="true" Class="mb-4">
     <MudTabPanel Text="All Competitions" Icon="@Icons.Material.Filled.List">
@@ -185,7 +190,7 @@
                      QuickFilter="@FilterCompetitions">
             <Columns>
                 <PropertyColumn Property="x => x.CompetitionName" />
-                <PropertyColumn Property="x => x.CompetitionFormat" />
+                <PropertyColumn Property="x => x.CompetitionFormat.ToDisplayName()" Title="Format" />
                 <TemplateColumn Title="Event">
                     <CellTemplate>
                         @if (context.Item.Event != null)
@@ -198,6 +203,10 @@
                 </TemplateColumn>
                 <TemplateColumn CellClass="d-flex justify-end gap-2">
                     <CellTemplate>
+                        @if (context.Item.IsArchived)
+                        {
+                            <MudChip T="string" Size="Size.Small" Color="Color.Warning" Variant="Variant.Outlined">Archived</MudChip>
+                        }
                         <MudButton Size="@Size.Small"
                                    Variant="@Variant.Outlined"
                                    Color="@Color.Info"
@@ -206,12 +215,32 @@
                         </MudButton>
                         @if (CanEdit(context.Item))
                         {
+                            @if (!context.Item.IsArchived)
+                            {
+                                <MudButton Size="@Size.Small"
+                                           Variant="@Variant.Filled"
+                                           Color="@Color.Primary"
+                                           OnClick="@(() => Nav.NavigateTo($"/competition/{context.Item.CompetitionID}"))">
+                                    Edit
+                                </MudButton>
+                            }
                             <MudButton Size="@Size.Small"
-                                       Variant="@Variant.Filled"
-                                       Color="@Color.Primary"
-                                       OnClick="@(() => Nav.NavigateTo($"/competition/{context.Item.CompetitionID}"))">
-                                Edit
+                                       Variant="@Variant.Outlined"
+                                       Color="@(context.Item.IsArchived ? Color.Success : Color.Warning)"
+                                       StartIcon="@(context.Item.IsArchived ? Icons.Material.Filled.Unarchive : Icons.Material.Filled.Archive)"
+                                       OnClick="@(() => ToggleArchiveAsync(context.Item))">
+                                @(context.Item.IsArchived ? "Unarchive" : "Archive")
                             </MudButton>
+                            @if (context.Item.IsArchived)
+                            {
+                                <MudButton Size="@Size.Small"
+                                           Variant="@Variant.Filled"
+                                           Color="@Color.Error"
+                                           StartIcon="@Icons.Material.Filled.Delete"
+                                           OnClick="@(() => DeleteCompetitionAsync(context.Item))">
+                                    Delete
+                                </MudButton>
+                            }
                         }
                     </CellTemplate>
                 </TemplateColumn>
@@ -254,8 +283,14 @@
                                 @foreach (var comp in ev.Competitions.Where(c => FilterCompetitions(c)))
                                 {
                                     <tr>
-                                        <td>@comp.CompetitionName</td>
-                                        <td>@comp.CompetitionFormat</td>
+                                        <td>
+                                            @comp.CompetitionName
+                                            @if (comp.IsArchived)
+                                            {
+                                                <MudChip T="string" Size="Size.Small" Color="Color.Warning" Variant="Variant.Outlined">Archived</MudChip>
+                                            }
+                                        </td>
+                                        <td>@comp.CompetitionFormat.ToDisplayName()</td>
                                         <td class="d-flex justify-end gap-2">
                                             <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Info"
                                                        OnClick="@(() => Nav.NavigateTo($"/competition/{comp.CompetitionID}/view"))">
@@ -263,10 +298,25 @@
                                             </MudButton>
                                             @if (CanEdit(comp))
                                             {
-                                                <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary"
-                                                           OnClick="@(() => Nav.NavigateTo($"/competition/{comp.CompetitionID}"))">
-                                                    Edit
+                                                @if (!comp.IsArchived)
+                                                {
+                                                    <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary"
+                                                               OnClick="@(() => Nav.NavigateTo($"/competition/{comp.CompetitionID}"))">
+                                                        Edit
+                                                    </MudButton>
+                                                }
+                                                <MudButton Size="Size.Small" Variant="Variant.Outlined"
+                                                           Color="@(comp.IsArchived ? Color.Success : Color.Warning)"
+                                                           OnClick="@(() => ToggleArchiveAsync(comp))">
+                                                    @(comp.IsArchived ? "Unarchive" : "Archive")
                                                 </MudButton>
+                                                @if (comp.IsArchived)
+                                                {
+                                                    <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Error"
+                                                               OnClick="@(() => DeleteCompetitionAsync(comp))">
+                                                        Delete
+                                                    </MudButton>
+                                                }
                                             }
                                         </td>
                                     </tr>
@@ -298,8 +348,14 @@
                                 @foreach (var comp in _ungroupedCompetitions.Where(c => FilterCompetitions(c)))
                                 {
                                     <tr>
-                                        <td>@comp.CompetitionName</td>
-                                        <td>@comp.CompetitionFormat</td>
+                                        <td>
+                                            @comp.CompetitionName
+                                            @if (comp.IsArchived)
+                                            {
+                                                <MudChip T="string" Size="Size.Small" Color="Color.Warning" Variant="Variant.Outlined">Archived</MudChip>
+                                            }
+                                        </td>
+                                        <td>@comp.CompetitionFormat.ToDisplayName()</td>
                                         <td class="d-flex justify-end gap-2">
                                             <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Info"
                                                        OnClick="@(() => Nav.NavigateTo($"/competition/{comp.CompetitionID}/view"))">
@@ -307,10 +363,25 @@
                                             </MudButton>
                                             @if (CanEdit(comp))
                                             {
-                                                <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary"
-                                                           OnClick="@(() => Nav.NavigateTo($"/competition/{comp.CompetitionID}"))">
-                                                    Edit
+                                                @if (!comp.IsArchived)
+                                                {
+                                                    <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary"
+                                                               OnClick="@(() => Nav.NavigateTo($"/competition/{comp.CompetitionID}"))">
+                                                        Edit
+                                                    </MudButton>
+                                                }
+                                                <MudButton Size="Size.Small" Variant="Variant.Outlined"
+                                                           Color="@(comp.IsArchived ? Color.Success : Color.Warning)"
+                                                           OnClick="@(() => ToggleArchiveAsync(comp))">
+                                                    @(comp.IsArchived ? "Unarchive" : "Archive")
                                                 </MudButton>
+                                                @if (comp.IsArchived)
+                                                {
+                                                    <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Error"
+                                                               OnClick="@(() => DeleteCompetitionAsync(comp))">
+                                                        Delete
+                                                    </MudButton>
+                                                }
                                             }
                                         </td>
                                     </tr>
@@ -345,6 +416,7 @@
     private List<EventGroup> _events = [];
     private List<Competition> _ungroupedCompetitions = [];
     private string _searchText = "";
+    private bool _showArchived;
     private bool _isAdmin;
     private int _activeTab;
     private List<CompetitionFixture> _pendingFixtures = [];
@@ -363,9 +435,10 @@
     }
 
     private bool FilterCompetitions(Competition c) =>
-        string.IsNullOrWhiteSpace(_searchText) ||
+        (_showArchived || !c.IsArchived) &&
+        (string.IsNullOrWhiteSpace(_searchText) ||
         (c.CompetitionName ?? "").Contains(_searchText, StringComparison.OrdinalIgnoreCase) ||
-        c.CompetitionFormat.ToString().Contains(_searchText, StringComparison.OrdinalIgnoreCase);
+        c.CompetitionFormat.ToDisplayName().Contains(_searchText, StringComparison.OrdinalIgnoreCase));
 
     protected override async Task OnInitializedAsync()
     {
@@ -402,7 +475,8 @@
                 CompetitionFormat = c.CompetitionFormat,
                 HostClubId = c.HostClubId,
                 EventId = c.EventId,
-                Event = c.Event
+                Event = c.Event,
+                IsArchived = c.IsArchived
             })
             .ToListAsync();
 
@@ -469,7 +543,7 @@
         var candidates = await dbc.Competition
             .Include(c => c.HostClub)
             .Include(c => c.Event)
-            .Where(c => !enteredIds.Contains(c.CompetitionID))
+            .Where(c => !enteredIds.Contains(c.CompetitionID) && !c.IsArchived)
             .OrderBy(c => c.StartDate)
             .ThenBy(c => c.CompetitionName)
             .ToListAsync();
@@ -672,5 +746,55 @@
 
         Snackbar.Add($"Event '{ev.Name}' created with {createdComps.Count} competition(s).", Severity.Success);
         _activeTab = 1; // Switch to "By Event" tab
+    }
+
+    private async Task ToggleArchiveAsync(Competition comp)
+    {
+        await using var db = DbFactory.CreateDbContext();
+        var entity = await db.Competition.FindAsync(comp.CompetitionID);
+        if (entity is null) return;
+
+        entity.IsArchived = !entity.IsArchived;
+        await db.SaveChangesAsync();
+        comp.IsArchived = entity.IsArchived;
+
+        Snackbar.Add(comp.IsArchived
+            ? $"'{comp.CompetitionName}' archived."
+            : $"'{comp.CompetitionName}' restored.", Severity.Success);
+    }
+
+    private async Task DeleteCompetitionAsync(Competition comp)
+    {
+        var confirm = await DialogService.ShowMessageBox(
+            "Delete Competition",
+            $"Are you sure you want to permanently delete '{comp.CompetitionName}'? This will remove all participants, fixtures, stages, and teams. This action cannot be undone.",
+            yesText: "Delete", cancelText: "Cancel");
+
+        if (confirm != true) return;
+
+        await using var db = DbFactory.CreateDbContext();
+
+        // Remove child entities with Restrict/NoAction FK to avoid violations
+        var teamMatchSets = await db.TeamMatchSets
+            .Where(s => s.Fixture.CompetitionId == comp.CompetitionID)
+            .ToListAsync();
+        db.TeamMatchSets.RemoveRange(teamMatchSets);
+
+        var fixtures = await db.CompetitionFixtures
+            .Where(f => f.CompetitionId == comp.CompetitionID)
+            .ToListAsync();
+        db.CompetitionFixtures.RemoveRange(fixtures);
+
+        var entity = await db.Competition.FindAsync(comp.CompetitionID);
+        if (entity is null) return;
+        db.Competition.Remove(entity);
+        await db.SaveChangesAsync();
+
+        _competitions.Remove(comp);
+        foreach (var ev in _events)
+            ev.Competitions.Remove(comp);
+        _ungroupedCompetitions.Remove(comp);
+
+        Snackbar.Add($"'{comp.CompetitionName}' deleted.", Severity.Success);
     }
 }

--- a/DropShot/Components/Pages/ViewCompetition.razor
+++ b/DropShot/Components/Pages/ViewCompetition.razor
@@ -5,6 +5,7 @@
 @using Microsoft.AspNetCore.Authorization
 @using DropShot.Data
 @using DropShot.Models
+@using DropShot.Shared.Extensions
 @using Microsoft.EntityFrameworkCore
 
 @inject IDbContextFactory<MyDbContext> DbFactory
@@ -35,7 +36,7 @@ else
     <MudGrid Spacing="3" Class="mb-4">
         <MudItem xs="6" sm="3">
             <MudText Typo="Typo.caption" Color="Color.Secondary">Format</MudText>
-            <MudText Typo="Typo.body1">@_competition.CompetitionFormat</MudText>
+            <MudText Typo="Typo.body1">@_competition.CompetitionFormat.ToDisplayName()</MudText>
         </MudItem>
         @if (_competition.StartDate.HasValue || _competition.EndDate.HasValue)
         {

--- a/DropShot/Components/Pages/ViewEvent.razor
+++ b/DropShot/Components/Pages/ViewEvent.razor
@@ -5,6 +5,7 @@
 @using Microsoft.AspNetCore.Authorization
 @using DropShot.Data
 @using DropShot.Models
+@using DropShot.Shared.Extensions
 @using Microsoft.EntityFrameworkCore
 
 @inject IDbContextFactory<MyDbContext> DbFactory
@@ -72,7 +73,7 @@ else
             {
                 <tr>
                     <td>@comp.CompetitionName</td>
-                    <td>@comp.CompetitionFormat</td>
+                    <td>@comp.CompetitionFormat.ToDisplayName()</td>
                     <td>
                         @{
                             var parts = new List<string>();

--- a/DropShot/Controllers/CompetitionsController.cs
+++ b/DropShot/Controllers/CompetitionsController.cs
@@ -17,7 +17,8 @@ public class CompetitionsController(
 {
     [HttpGet]
     public async Task<ActionResult<List<CompetitionDto>>> GetAll(
-        [FromQuery] int skip = 0, [FromQuery] int take = 50, [FromQuery] int? eventId = null)
+        [FromQuery] int skip = 0, [FromQuery] int take = 50, [FromQuery] int? eventId = null,
+        [FromQuery] bool includeArchived = false)
     {
         await using var db = dbFactory.CreateDbContext();
         var query = db.Competition
@@ -25,6 +26,9 @@ public class CompetitionsController(
             .Include(c => c.Rules)
             .Include(c => c.Event)
             .AsQueryable();
+
+        if (!includeArchived)
+            query = query.Where(c => !c.IsArchived);
 
         if (eventId.HasValue)
             query = query.Where(c => c.EventId == eventId.Value);
@@ -68,7 +72,8 @@ public class CompetitionsController(
                 p.RegisteredAt, p.TeamId, p.Team?.Name,
                 p.Player?.MobileNumber,
                 (DropShot.Shared.PlayerGrade?)p.Grade,
-                (DropShot.Shared.PlayerSex?)p.Player?.Sex)).ToList());
+                (DropShot.Shared.PlayerSex?)p.Player?.Sex)).ToList(),
+            c.IsArchived);
     }
 
     [HttpPost]
@@ -100,13 +105,42 @@ public class CompetitionsController(
         return ToDto(comp);
     }
 
+    [HttpPut("{id:int}/archive")]
+    public async Task<IActionResult> ToggleArchive(int id)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var comp = await db.Competition.FindAsync(id);
+        if (comp is null) return NotFound();
+        if (!await authzService.CanEditCompetitionAsync(User, comp.HostClubId, comp.CompetitionID))
+            return Forbid();
+
+        comp.IsArchived = !comp.IsArchived;
+        await db.SaveChangesAsync();
+        return Ok(new { comp.IsArchived });
+    }
+
     [HttpDelete("{id:int}")]
-    [Authorize(Roles = "Admin")]
     public async Task<IActionResult> Delete(int id)
     {
         await using var db = dbFactory.CreateDbContext();
         var comp = await db.Competition.FindAsync(id);
         if (comp is null) return NotFound();
+        if (!await authzService.CanEditCompetitionAsync(User, comp.HostClubId, comp.CompetitionID))
+            return Forbid();
+        if (!comp.IsArchived)
+            return BadRequest("Competition must be archived before it can be deleted.");
+
+        // Remove child entities that use Restrict/NoAction FK to avoid FK violations
+        var teamMatchSets = await db.TeamMatchSets
+            .Where(s => s.Fixture.CompetitionId == id)
+            .ToListAsync();
+        db.TeamMatchSets.RemoveRange(teamMatchSets);
+
+        var fixtures = await db.CompetitionFixtures
+            .Where(f => f.CompetitionId == id)
+            .ToListAsync();
+        db.CompetitionFixtures.RemoveRange(fixtures);
+
         db.Competition.Remove(comp);
         await db.SaveChangesAsync();
         return NoContent();
@@ -766,7 +800,7 @@ public class CompetitionsController(
         c.MaxParticipants, c.StartDate, c.EndDate, c.MaxAge, c.MinAge,
         (DropShot.Shared.PlayerSex?)c.EligibleSex,
         c.HostClubId, c.HostClub?.Name, c.RulesSetId, c.Rules?.Name,
-        c.EventId, c.Event?.Name);
+        c.EventId, c.Event?.Name, c.IsArchived);
 
     private static CompetitionFixtureDto ToFixtureDto(CompetitionFixture f) => new(
         f.CompetitionFixtureId, f.CompetitionId,

--- a/DropShot/Data/Migrations/20260411113611_AddCompetitionIsArchived.Designer.cs
+++ b/DropShot/Data/Migrations/20260411113611_AddCompetitionIsArchived.Designer.cs
@@ -4,6 +4,7 @@ using DropShot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DropShot.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260411113611_AddCompetitionIsArchived")]
+    partial class AddCompetitionIsArchived
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DropShot/Data/Migrations/20260411113611_AddCompetitionIsArchived.cs
+++ b/DropShot/Data/Migrations/20260411113611_AddCompetitionIsArchived.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropShot.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCompetitionIsArchived : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsArchived",
+                table: "Competition",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsArchived",
+                table: "Competition");
+        }
+    }
+}

--- a/DropShot/Models/Competition.cs
+++ b/DropShot/Models/Competition.cs
@@ -26,6 +26,7 @@
         public int? EventId { get; set; }
         public int BestOf { get; set; } = 3;
         public bool RequireVerification { get; set; } = false;
+        public bool IsArchived { get; set; } = false;
 
         public RulesSet? Rules { get; set; }
         public Club? HostClub { get; set; }


### PR DESCRIPTION
## Summary
- Club admins can now archive and delete competitions for their club; full admins can archive/delete any competition
- Competitions must be archived before deletion as a safety guard - delete removes all child entities (participants, fixtures, stages, teams, court pairs, match sets)
- Archived competitions are hidden by default with a "Show Archived" toggle
- Format display names now use spaces (e.g. "Mixed Doubles", "Mixed Team" instead of "MixedDoubles", "MixedTeam")

## Test plan
- [ ] Run EF migration `AddCompetitionIsArchived`
- [ ] Verify archived competitions are hidden from default competition list
- [ ] Verify "Show Archived" toggle reveals archived competitions
- [ ] As club admin: archive a competition for your club, then delete it
- [ ] As full admin: archive and delete any competition
- [ ] Verify club admin cannot delete competitions from other clubs
- [ ] Verify delete confirmation dialog appears before permanent deletion
- [ ] Verify format names display with spaces across all pages (Competitions, ViewCompetition, CompetitionPage, Clubs, ViewEvent)
- [ ] Verify MAUI app archive/delete and format display names work

🤖 Generated with [Claude Code](https://claude.com/claude-code)