### PR TITLE
Fix site logo shifting down when hamburger menu opened

### DIFF
--- a/DropShot/Components/Layout/NavMenu.razor.css
+++ b/DropShot/Components/Layout/NavMenu.razor.css
@@ -271,7 +271,6 @@
 @media (max-width: 640.98px) {
     .top-row {
         position: relative;
-        flex-wrap: wrap;
     }
 
     .navbar-toggler {
@@ -285,10 +284,14 @@
     .nav-content {
         display: none;
         flex-direction: column;
+        position: absolute;
+        top: 3.5rem;
+        left: 0;
         width: 100%;
         max-height: calc(100vh - 3.5rem);
         overflow-y: auto;
         background-image: linear-gradient(120deg, rgb(5, 98, 103) 0%, rgb(5, 39, 103) 70%);
+        z-index: 100;
     }
 
     .navbar-toggler:checked ~ .nav-content {


### PR DESCRIPTION
## Summary
- Removed `flex-wrap: wrap` from mobile `.top-row` so the navbar stays at its fixed 3.5rem height
- Made `.nav-content` use `position: absolute` to overlay below the navbar instead of expanding it and pushing the logo down

## Test plan
- [ ] Open site on mobile viewport (<641px)
- [ ] Click hamburger menu and verify logo stays in place
- [ ] Verify menu content displays correctly below the navbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)