### PR TITLE
Remove duplicate role switcher from nav menu

### DIFF
--- a/DropShot/Components/Layout/NavMenu.razor
+++ b/DropShot/Components/Layout/NavMenu.razor
@@ -121,9 +121,6 @@
                                 <MudIcon Icon="@Icons.Material.Filled.Person" Class="nav-icon" /> Account
                             </a>
                             <div class="nav-dropdown-item">
-                                <DropShot.Components.Shared.RoleSwitcher />
-                            </div>
-                            <div class="nav-dropdown-item">
                                 <form action="Account/Logout" method="post">
                                     <AntiforgeryToken />
                                     <input type="hidden" name="ReturnUrl" value="@currentUrl" />


### PR DESCRIPTION
## Summary
- Removed the role switcher dropdown from the user menu since it already exists on the RoleBanner bar
- Eliminates duplicate UI for role switching

## Test plan
- [ ] Verify role switcher still works on the RoleBanner bar
- [ ] Verify the user dropdown menu no longer shows a role switcher
- [ ] Confirm logout and other menu items still function correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)