### PR TITLE
Restrict Players page to SuperAdmin, move My Players to main nav

### DIFF
--- a/DropShot/Components/Layout/NavMenu.razor
+++ b/DropShot/Components/Layout/NavMenu.razor
@@ -60,11 +60,19 @@
                     </div>
 
                     <div class="nav-item">
-                        <NavLink class="nav-link" href="players">
-                            <MudIcon Icon="@Icons.Material.Filled.People" Class="nav-icon" /> <span class="nav-label">Players</span>
+                        <NavLink class="nav-link" href="players/mine">
+                            <MudIcon Icon="@Icons.Material.Filled.RecentActors" Class="nav-icon" /> <span class="nav-label">My Players</span>
                         </NavLink>
                     </div>
                 </Authorized>
+            </AuthorizeView>
+
+            <AuthorizeView Roles="SuperAdmin">
+                <div class="nav-item">
+                    <NavLink class="nav-link" href="players">
+                        <MudIcon Icon="@Icons.Material.Filled.People" Class="nav-icon" /> <span class="nav-label">Players</span>
+                    </NavLink>
+                </div>
             </AuthorizeView>
 
             <AuthorizeView Roles="Admin,SuperAdmin">
@@ -113,9 +121,6 @@
                         <div class="nav-dropdown-menu">
                             <NavLink class="nav-link" href="upgrade">
                                 <MudIcon Icon="@Icons.Material.Filled.Star" Class="nav-icon" /> Upgrade
-                            </NavLink>
-                            <NavLink class="nav-link" href="players/mine">
-                                <MudIcon Icon="@Icons.Material.Filled.RecentActors" Class="nav-icon" /> My Players
                             </NavLink>
                             <a class="nav-link" href="Account/Manage" data-enhance-nav="false">
                                 <MudIcon Icon="@Icons.Material.Filled.Person" Class="nav-icon" /> Account

--- a/DropShot/Components/Pages/Players.razor
+++ b/DropShot/Components/Pages/Players.razor
@@ -1,6 +1,6 @@
 @page "/players"
 @rendermode InteractiveServer
-@attribute [Authorize]
+@attribute [Authorize(Roles = "SuperAdmin")]
 @using Microsoft.AspNetCore.Authorization
 @using Microsoft.EntityFrameworkCore
 @using DropShot.Models


### PR DESCRIPTION
## Summary
- Restricted `/players` route to SuperAdmin role only
- Moved "My Players" link from user dropdown to main navigation for all authenticated users
- Added separate "Players" link in main nav visible only to SuperAdmin

## Test plan
- [ ] Log in as a non-SuperAdmin user — verify "My Players" appears in main nav and "/players" is inaccessible
- [ ] Log in as SuperAdmin — verify both "My Players" and "Players" appear in main nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)