### PR TITLE
Fix mobile navbar during pull-to-refresh

### DIFF
--- a/DropShot/Components/Layout/MainLayout.razor.css
+++ b/DropShot/Components/Layout/MainLayout.razor.css
@@ -26,14 +26,10 @@ main ::deep .content {
 
 @media (max-width: 640.98px) {
     .top-navbar {
-        position: fixed;
+        position: sticky;
         top: 0;
         left: 0;
         right: 0;
-    }
-
-    main {
-        padding-top: 3.5rem;
     }
 }
 


### PR DESCRIPTION
## Summary
- Changed mobile top-navbar from `position: fixed` to `position: sticky` so it moves with the page content during pull-to-refresh, matching the role banner behaviour
- Removed the `padding-top: 3.5rem` compensation on `main` since sticky elements remain in the document flow

## Test plan
- [ ] On mobile PWA, pull down to refresh and verify the top navbar moves with the page content
- [ ] Verify the role banner and top navbar move together during the gesture
- [ ] Verify normal scrolling still keeps the navbar stuck to the top

🤖 Generated with [Claude Code](https://claude.com/claude-code)