### PR TITLE
Fix archive controls visible when browsing as standard user

### DIFF
--- a/DropShot/Services/ClubAuthorizationService.cs
+++ b/DropShot/Services/ClubAuthorizationService.cs
@@ -48,8 +48,11 @@ public class ClubAuthorizationService(
     /// <summary>Returns the list of ClubIds the user is an administrator of.</summary>
     public async Task<List<int>> GetAdminClubIdsAsync(ClaimsPrincipal user)
     {
-        var userId = userManager.GetUserId(user);
+        var (userId, roles) = GetUserAndRoles(user);
         if (userId is null) return [];
+
+        // If the active role is plain User, they have no club admin privileges
+        if (roles.Count == 1 && roles[0] == "User") return [];
 
         await using var db = dbFactory.CreateDbContext();
         return await db.ClubAdministrators
@@ -64,6 +67,9 @@ public class ClubAuthorizationService(
         var (userId, roles) = GetUserAndRoles(user);
         if (userId is null) return false;
         if (roles.Contains("Admin") || roles.Contains("SuperAdmin")) return true;
+
+        // Plain User role has no club admin privileges
+        if (roles.Count == 1 && roles[0] == "User") return false;
 
         await using var db = dbFactory.CreateDbContext();
         return await db.ClubAdministrators
@@ -84,6 +90,9 @@ public class ClubAuthorizationService(
         if (userId is null) return false;
         if (roles.Contains("Admin") || roles.Contains("SuperAdmin")) return true;
 
+        // Plain User role has no competition admin privileges
+        if (roles.Count == 1 && roles[0] == "User") return false;
+
         if (competitionId.HasValue)
         {
             await using var db = dbFactory.CreateDbContext();
@@ -102,8 +111,11 @@ public class ClubAuthorizationService(
     /// <summary>Returns the set of CompetitionIds the user is a per-competition admin of.</summary>
     public async Task<HashSet<int>> GetEditableCompetitionIdsAsync(ClaimsPrincipal user)
     {
-        var userId = userManager.GetUserId(user);
+        var (userId, roles) = GetUserAndRoles(user);
         if (userId is null) return [];
+
+        // If the active role is plain User, they have no competition admin privileges
+        if (roles.Count == 1 && roles[0] == "User") return [];
 
         await using var db = dbFactory.CreateDbContext();
         return (await db.CompetitionAdmins


### PR DESCRIPTION
## Summary
- When an admin toggled to browse as a standard user, the archive/unarchive buttons and "Show Archived" checkbox on the Competitions page remained visible
- Root cause: `ClubAuthorizationService` methods queried the DB for club/competition admin records by userId without checking the active role, so `_isUserView` stayed false
- Added early-return checks in all four affected methods to return empty results when the active role is plain "User"

## Test plan
- [ ] Log in as an admin user with ClubAdmin/CompetitionAdmin assignments
- [ ] Switch role to "User" via the role switcher
- [ ] Navigate to Competitions page — should see the standard user view (My Competitions / Available to Enter) with no archive controls
- [ ] Switch back to admin role — archive controls should reappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)