### PR TITLE
Add Player ID references to SavedMatch and light player claim flow

### DIFF
--- a/DropShot/Components/Account/Pages/Register.razor
+++ b/DropShot/Components/Account/Pages/Register.razor
@@ -120,7 +120,25 @@
                 linkedPlayer = true;
                 Logger.LogInformation("Linked new user {Email} to existing player record.", Input.Email);
             }
-            else
+
+            // Auto-claim a light player with matching display name
+            if (!linkedPlayer)
+            {
+                var lightMatch = await db.Players.FirstOrDefaultAsync(p =>
+                    p.IsLight && p.UserId == null &&
+                    p.DisplayName == Input.DisplayName);
+                if (lightMatch != null)
+                {
+                    lightMatch.IsLight = false;
+                    lightMatch.UserId = userIdStr;
+                    lightMatch.Email = Input.Email;
+                    await db.SaveChangesAsync();
+                    linkedPlayer = true;
+                    Logger.LogInformation("Claimed light player record for {DisplayName}.", Input.DisplayName);
+                }
+            }
+
+            if (!linkedPlayer)
             {
                 var newPlayer = new Models.Player
                 {

--- a/DropShot/Components/MatchSetupWizard.razor
+++ b/DropShot/Components/MatchSetupWizard.razor
@@ -141,6 +141,13 @@
                     }
                 }
 
+                @if (selection is { IsLight: true })
+                {
+                    <MudAlert Severity="Severity.Info" Dense="true" Class="mt-2">
+                        Light player — match results will be linked to their full profile when they register.
+                    </MudAlert>
+                }
+
                 <MudButton Size="Size.Small" Variant="Variant.Text" Color="Color.Default"
                            StartIcon="@Icons.Material.Filled.Add" Class="mt-2"
                            OnClick="@(() => CreateLightPlayerInline(playerNumber))">

--- a/DropShot/Components/Pages/LeagueTable.razor
+++ b/DropShot/Components/Pages/LeagueTable.razor
@@ -42,24 +42,37 @@
         await using var dbc = DbFactory.CreateDbContext();
         var matches = await dbc.SavedMatch
             .Where(m => m.Complete && m.Player1 != null)
-            .Select(m => new { m.Player1, m.Player2, m.WinnerName })
+            .Select(m => new { m.Player1, m.Player2, m.Player1Id, m.Player2Id, m.WinnerName, m.WinnerPlayerId })
             .ToListAsync();
+
+        // Resolve Player IDs to current display names
+        var allPlayerIds = matches
+            .SelectMany(m => new[] { m.Player1Id, m.Player2Id, m.WinnerPlayerId })
+            .Where(id => id.HasValue).Select(id => id!.Value)
+            .Distinct().ToList();
+        var playerNames = await dbc.Players
+            .Where(p => allPlayerIds.Contains(p.PlayerId))
+            .ToDictionaryAsync(p => p.PlayerId, p => p.DisplayName);
+
+        string Resolve(string? name, int? id) =>
+            id.HasValue && playerNames.TryGetValue(id.Value, out var n) ? n : name ?? "";
 
         var stats = new Dictionary<string, (int Played, int Won)>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var m in matches)
         {
-            var players = new[] { m.Player1, m.Player2 }
+            var players = new[] { Resolve(m.Player1, m.Player1Id), Resolve(m.Player2, m.Player2Id) }
                 .Where(p => !string.IsNullOrEmpty(p));
 
             foreach (var p in players)
             {
-                if (!stats.ContainsKey(p!)) stats[p!] = (0, 0);
-                stats[p!] = (stats[p!].Played + 1, stats[p!].Won);
+                if (!stats.ContainsKey(p)) stats[p] = (0, 0);
+                stats[p] = (stats[p].Played + 1, stats[p].Won);
             }
 
-            if (!string.IsNullOrEmpty(m.WinnerName) && stats.ContainsKey(m.WinnerName))
-                stats[m.WinnerName] = (stats[m.WinnerName].Played, stats[m.WinnerName].Won + 1);
+            var winner = Resolve(m.WinnerName, m.WinnerPlayerId);
+            if (!string.IsNullOrEmpty(winner) && stats.ContainsKey(winner))
+                stats[winner] = (stats[winner].Played, stats[winner].Won + 1);
         }
 
         Elements = stats

--- a/DropShot/Components/Pages/MyPlayers.razor
+++ b/DropShot/Components/Pages/MyPlayers.razor
@@ -140,7 +140,7 @@
     <TitleContent>Link "@_linkingPlayer?.DisplayName" to a Verified Player</TitleContent>
     <DialogContent>
         <MudText Typo="Typo.body2" Class="mb-3">
-            Linking will replace this player with the verified player record. The light player will be deleted.
+            Linking will transfer match history to the verified player and remove the light player record.
         </MudText>
 
         <MudTextField @bind-Value="_linkSearch" Label="Search verified players" Variant="Variant.Outlined"
@@ -391,6 +391,15 @@
         var p = await db.Players.FindAsync(player.PlayerId);
         if (p is { IsLight: true, CreatedByUserId: var cuid } && cuid == _userId)
         {
+            var hasMatches = await db.SavedMatch.AnyAsync(m =>
+                m.Player1Id == p.PlayerId || m.Player2Id == p.PlayerId ||
+                m.Player3Id == p.PlayerId || m.Player4Id == p.PlayerId);
+            if (hasMatches)
+            {
+                Snackbar.Add("This player has match history. Use 'Link' to transfer their records to a verified player.", Severity.Warning);
+                return;
+            }
+
             db.Players.Remove(p);
             await db.SaveChangesAsync();
             Snackbar.Add("Player deleted.", Severity.Warning);
@@ -445,7 +454,7 @@
 
         var confirmed = await DialogService.ShowMessageBox(
             "Link Player?",
-            $"This will delete the player \"{_linkingPlayer.DisplayName}\" and use \"{_selectedLinkPlayer.DisplayName}\" (verified) in its place.",
+            $"Match history for \"{_linkingPlayer.DisplayName}\" will be transferred to \"{_selectedLinkPlayer.DisplayName}\" (verified).",
             yesText: "Link", cancelText: "Cancel");
 
         if (confirmed != true) return;
@@ -454,6 +463,23 @@
         var lightPlayer = await db.Players.FindAsync(_linkingPlayer.PlayerId);
         if (lightPlayer is { IsLight: true, CreatedByUserId: var cuid } && cuid == _userId)
         {
+            // Migrate SavedMatch references from light player to verified player
+            var lightId = lightPlayer.PlayerId;
+            var verifiedId = _selectedLinkPlayer.PlayerId;
+            var affected = await db.SavedMatch
+                .Where(m => m.Player1Id == lightId || m.Player2Id == lightId ||
+                            m.Player3Id == lightId || m.Player4Id == lightId ||
+                            m.WinnerPlayerId == lightId)
+                .ToListAsync();
+            foreach (var m in affected)
+            {
+                if (m.Player1Id == lightId) m.Player1Id = verifiedId;
+                if (m.Player2Id == lightId) m.Player2Id = verifiedId;
+                if (m.Player3Id == lightId) m.Player3Id = verifiedId;
+                if (m.Player4Id == lightId) m.Player4Id = verifiedId;
+                if (m.WinnerPlayerId == lightId) m.WinnerPlayerId = verifiedId;
+            }
+
             db.Players.Remove(lightPlayer);
 
             // Bookmark the verified player so they appear in My Players
@@ -469,7 +495,7 @@
             }
 
             await db.SaveChangesAsync();
-            Snackbar.Add($"Linked to \"{_selectedLinkPlayer.DisplayName}\".", Severity.Success);
+            Snackbar.Add($"Linked to \"{_selectedLinkPlayer.DisplayName}\". Match history transferred.", Severity.Success);
         }
 
         _showLinkDialog = false;
@@ -482,7 +508,7 @@
 
         var confirmed = await DialogService.ShowMessageBox(
             "Link Player?",
-            $"This will delete this player and use \"{fullPlayer.DisplayName}\" (verified) in its place.",
+            $"Match history will be transferred to \"{fullPlayer.DisplayName}\" (verified).",
             yesText: "Link", cancelText: "Cancel");
 
         if (confirmed != true) return;
@@ -491,6 +517,23 @@
         var lightPlayer = await db.Players.FindAsync(_editingPlayerId.Value);
         if (lightPlayer is { IsLight: true, CreatedByUserId: var cuid } && cuid == _userId)
         {
+            // Migrate SavedMatch references from light player to verified player
+            var lightId = lightPlayer.PlayerId;
+            var verifiedId = fullPlayer.PlayerId;
+            var affected = await db.SavedMatch
+                .Where(m => m.Player1Id == lightId || m.Player2Id == lightId ||
+                            m.Player3Id == lightId || m.Player4Id == lightId ||
+                            m.WinnerPlayerId == lightId)
+                .ToListAsync();
+            foreach (var m in affected)
+            {
+                if (m.Player1Id == lightId) m.Player1Id = verifiedId;
+                if (m.Player2Id == lightId) m.Player2Id = verifiedId;
+                if (m.Player3Id == lightId) m.Player3Id = verifiedId;
+                if (m.Player4Id == lightId) m.Player4Id = verifiedId;
+                if (m.WinnerPlayerId == lightId) m.WinnerPlayerId = verifiedId;
+            }
+
             db.Players.Remove(lightPlayer);
 
             // Bookmark the verified player so they appear in My Players
@@ -506,7 +549,7 @@
             }
 
             await db.SaveChangesAsync();
-            Snackbar.Add($"Linked to \"{fullPlayer.DisplayName}\".", Severity.Success);
+            Snackbar.Add($"Linked to \"{fullPlayer.DisplayName}\". Match history transferred.", Severity.Success);
         }
 
         _showPlayerDialog = false;

--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -449,6 +449,11 @@
         Label_Switch1 = result.IsDoubles;
         _selectedCourtId = result.CourtId;
 
+        _player1Id = result.Player1Id;
+        _player2Id = result.Player2Id;
+        _player3Id = result.Player3Id;
+        _player4Id = result.Player4Id;
+
         _state.GameScoring = result.GameScoring;
         _state.BestOf = result.BestOf;
         _state.GamesFirstTo = result.GamesPerSet;
@@ -594,6 +599,10 @@
             Player2 = CurrentMatch.Player2,
             Player3 = CurrentMatch.Player3,
             Player4 = CurrentMatch.Player4,
+            Player1Id = _player1Id,
+            Player2Id = _player2Id,
+            Player3Id = _player3Id,
+            Player4Id = _player4Id,
             CourtId = (_selectedCourtId is > 0) ? _selectedCourtId : null,
             CreatedAt = DateTime.UtcNow,
             UserId = _currentUserId,
@@ -652,6 +661,10 @@
     private Dictionary<string, int> _playerIdByName = [];
     private Dictionary<string, string> _avatarByName = [];
     private HashSet<int> _friendPlayerIds = [];
+    private int? _player1Id;
+    private int? _player2Id;
+    private int? _player3Id;
+    private int? _player4Id;
     private TennisMatchState _state = new();
     private List<Score> scores = new();
     private HubConnection? hubConnection;
@@ -692,7 +705,9 @@
             .Select(p => new { p.PlayerId, p.DisplayName, AvatarPath = p.User != null ? p.User.ProfileImagePath : null })
             .ToListAsync();
 
-        _playerIdByName = allPlayers.ToDictionary(p => p.DisplayName, p => p.PlayerId);
+        _playerIdByName = allPlayers
+            .GroupBy(p => p.DisplayName)
+            .ToDictionary(g => g.Key, g => g.First().PlayerId);
         _avatarByName = allPlayers
             .Where(p => !string.IsNullOrEmpty(p.AvatarPath))
             .ToDictionary(p => p.DisplayName, p => p.AvatarPath!);
@@ -736,6 +751,10 @@
                 Label_Switch1 = !string.IsNullOrEmpty(CurrentMatch.Player3);
                 _savedMatchId = savedMatch.SavedMatchId;
                 _selectedCourtId = savedMatch.CourtId;
+                _player1Id = savedMatch.Player1Id;
+                _player2Id = savedMatch.Player2Id;
+                _player3Id = savedMatch.Player3Id;
+                _player4Id = savedMatch.Player4Id;
                 _restoreFullscreen = true;
 
                 // Already in progress — hide the tap hint
@@ -906,7 +925,16 @@
         matchToSave.Player2 = CurrentMatch.Player2;
         matchToSave.Player3 = CurrentMatch.Player3;
         matchToSave.Player4 = CurrentMatch.Player4;
+        matchToSave.Player1Id = _player1Id;
+        matchToSave.Player2Id = _player2Id;
+        matchToSave.Player3Id = _player3Id;
+        matchToSave.Player4Id = _player4Id;
         matchToSave.WinnerName = _state.IsMatchEnded ? _winner : null;
+        if (_state.IsMatchEnded && !string.IsNullOrEmpty(_winner))
+        {
+            _playerIdByName.TryGetValue(_winner, out var winnerId);
+            matchToSave.WinnerPlayerId = winnerId > 0 ? winnerId : null;
+        }
         matchToSave.CourtId = (_selectedCourtId is > 0) ? _selectedCourtId : null;
         if (matchToSave.CreatedAt == default) matchToSave.CreatedAt = DateTime.UtcNow;
         await dbc.SaveChangesAsync();

--- a/DropShot/Data/Migrations/20260411214905_AddSavedMatchPlayerIds.Designer.cs
+++ b/DropShot/Data/Migrations/20260411214905_AddSavedMatchPlayerIds.Designer.cs
@@ -4,6 +4,7 @@ using DropShot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DropShot.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260411214905_AddSavedMatchPlayerIds")]
+    partial class AddSavedMatchPlayerIds
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DropShot/Data/Migrations/20260411214905_AddSavedMatchPlayerIds.cs
+++ b/DropShot/Data/Migrations/20260411214905_AddSavedMatchPlayerIds.cs
@@ -1,0 +1,173 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropShot.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSavedMatchPlayerIds : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Player1Id",
+                table: "SavedMatch",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Player2Id",
+                table: "SavedMatch",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Player3Id",
+                table: "SavedMatch",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Player4Id",
+                table: "SavedMatch",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "WinnerPlayerId",
+                table: "SavedMatch",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SavedMatch_Player1Id",
+                table: "SavedMatch",
+                column: "Player1Id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SavedMatch_Player2Id",
+                table: "SavedMatch",
+                column: "Player2Id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SavedMatch_Player3Id",
+                table: "SavedMatch",
+                column: "Player3Id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SavedMatch_Player4Id",
+                table: "SavedMatch",
+                column: "Player4Id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SavedMatch_WinnerPlayerId",
+                table: "SavedMatch",
+                column: "WinnerPlayerId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_SavedMatch_Players_Player1Id",
+                table: "SavedMatch",
+                column: "Player1Id",
+                principalTable: "Players",
+                principalColumn: "PlayerId",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_SavedMatch_Players_Player2Id",
+                table: "SavedMatch",
+                column: "Player2Id",
+                principalTable: "Players",
+                principalColumn: "PlayerId",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_SavedMatch_Players_Player3Id",
+                table: "SavedMatch",
+                column: "Player3Id",
+                principalTable: "Players",
+                principalColumn: "PlayerId",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_SavedMatch_Players_Player4Id",
+                table: "SavedMatch",
+                column: "Player4Id",
+                principalTable: "Players",
+                principalColumn: "PlayerId",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_SavedMatch_Players_WinnerPlayerId",
+                table: "SavedMatch",
+                column: "WinnerPlayerId",
+                principalTable: "Players",
+                principalColumn: "PlayerId",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_SavedMatch_Players_Player1Id",
+                table: "SavedMatch");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_SavedMatch_Players_Player2Id",
+                table: "SavedMatch");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_SavedMatch_Players_Player3Id",
+                table: "SavedMatch");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_SavedMatch_Players_Player4Id",
+                table: "SavedMatch");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_SavedMatch_Players_WinnerPlayerId",
+                table: "SavedMatch");
+
+            migrationBuilder.DropIndex(
+                name: "IX_SavedMatch_Player1Id",
+                table: "SavedMatch");
+
+            migrationBuilder.DropIndex(
+                name: "IX_SavedMatch_Player2Id",
+                table: "SavedMatch");
+
+            migrationBuilder.DropIndex(
+                name: "IX_SavedMatch_Player3Id",
+                table: "SavedMatch");
+
+            migrationBuilder.DropIndex(
+                name: "IX_SavedMatch_Player4Id",
+                table: "SavedMatch");
+
+            migrationBuilder.DropIndex(
+                name: "IX_SavedMatch_WinnerPlayerId",
+                table: "SavedMatch");
+
+            migrationBuilder.DropColumn(
+                name: "Player1Id",
+                table: "SavedMatch");
+
+            migrationBuilder.DropColumn(
+                name: "Player2Id",
+                table: "SavedMatch");
+
+            migrationBuilder.DropColumn(
+                name: "Player3Id",
+                table: "SavedMatch");
+
+            migrationBuilder.DropColumn(
+                name: "Player4Id",
+                table: "SavedMatch");
+
+            migrationBuilder.DropColumn(
+                name: "WinnerPlayerId",
+                table: "SavedMatch");
+        }
+    }
+}

--- a/DropShot/Data/MyDbContext.cs
+++ b/DropShot/Data/MyDbContext.cs
@@ -373,6 +373,12 @@ namespace DropShot.Data
                       .WithMany()
                       .HasForeignKey(m => m.CourtId)
                       .OnDelete(DeleteBehavior.SetNull);
+
+                entity.HasOne<Player>().WithMany().HasForeignKey(m => m.Player1Id).OnDelete(DeleteBehavior.Restrict);
+                entity.HasOne<Player>().WithMany().HasForeignKey(m => m.Player2Id).OnDelete(DeleteBehavior.Restrict);
+                entity.HasOne<Player>().WithMany().HasForeignKey(m => m.Player3Id).OnDelete(DeleteBehavior.Restrict);
+                entity.HasOne<Player>().WithMany().HasForeignKey(m => m.Player4Id).OnDelete(DeleteBehavior.Restrict);
+                entity.HasOne<Player>().WithMany().HasForeignKey(m => m.WinnerPlayerId).OnDelete(DeleteBehavior.Restrict);
             });
 
             // ── ScoreboardDisplaySetting ─────────────────────────────────────────

--- a/DropShot/Models/SavedMatch.cs
+++ b/DropShot/Models/SavedMatch.cs
@@ -9,7 +9,12 @@ public class SavedMatch
     public string? Player2 { get; set; }
     public string? Player3 { get; set; }
     public string? Player4 { get; set; }
+    public int? Player1Id { get; set; }
+    public int? Player2Id { get; set; }
+    public int? Player3Id { get; set; }
+    public int? Player4Id { get; set; }
     public string? WinnerName { get; set; }
+    public int? WinnerPlayerId { get; set; }
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public int? CourtId { get; set; }
     public string? UserId { get; set; }


### PR DESCRIPTION
## Summary
- Adds `Player1Id`..`Player4Id` and `WinnerPlayerId` nullable FK columns to `SavedMatch`, persisting the Player IDs that `MatchSetupWizard` already computes but were previously discarded
- Changes the light-player "Link to verified" flow to migrate SavedMatch references before deletion, preserving match history
- Auto-claims light players by display name on user registration (in-place upgrade keeps PlayerId stable)
- Updates LeagueTable to resolve Player IDs to current display names with string fallback for legacy records
- Guards light player deletion when match history exists, directing users to Link instead
- Shows info alert in MatchSetupWizard when a light player is selected

## Test plan
- [ ] Apply migration and verify 5 new nullable columns on SavedMatch table
- [ ] Start a match with a light player, verify SavedMatch row has Player1Id/Player2Id populated
- [ ] Resume a saved match and verify player IDs survive reload
- [ ] Create a light player, play a match, link to a verified player — verify SavedMatch refs are remapped
- [ ] Try to delete a light player with match history — verify blocked with warning message
- [ ] Create light player "TestUser", play a match, register with DisplayName "TestUser" — verify auto-claim upgrades the light player and match history is intact
- [ ] Complete a match with Player IDs and verify league table shows correct stats
- [ ] Verify existing SavedMatch rows (NULL Player IDs) still work in league table via string fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)