### PR TITLE
Fix build: remove stale selection reference

### DIFF
--- a/DropShot/Components/MatchSetupWizard.razor
+++ b/DropShot/Components/MatchSetupWizard.razor
@@ -133,13 +133,6 @@
                     </MudAlert>
                 }
 
-                @if (selection is { IsLight: true })
-                {
-                    <MudAlert Severity="Severity.Info" Dense="true" Class="mt-2">
-                        Light player — match results will be linked to their full profile when they register.
-                    </MudAlert>
-                }
-
                 <MudButton Size="Size.Small" Variant="Variant.Text" Color="Color.Default"
                            StartIcon="@Icons.Material.Filled.Add" Class="mt-2"
                            OnClick="CreateLightPlayerInline">


### PR DESCRIPTION
## Summary
- Removes orphaned `selection` variable reference that was added by a concurrent PR merge but no longer exists after the player list redesign

## Test plan
- [x] Build succeeds locally with `dotnet build --configuration Release`

🤖 Generated with [Claude Code](https://claude.com/claude-code)