### PR TITLE
Fix auto-start for direct play from upcoming matches

### DIFF
--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -89,7 +89,7 @@
                             <MudTd>
                                 <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary"
                                            StartIcon="@Icons.Material.Filled.PlayArrow"
-                                           Href="@($"/match/0?fixtureId={context.CompetitionFixtureId}&autoStart=true")">
+                                           OnClick="@(() => Navigation.NavigateTo($"/match/0?fixtureId={context.CompetitionFixtureId}&autoStart=true", forceLoad: true))">
                                     Play
                                 </MudButton>
                             </MudTd>


### PR DESCRIPTION
## Summary
- Fix the "Play" button on the upcoming matches list to use `forceLoad: true` navigation
- Without this, Blazor's enhanced navigation doesn't re-initialize the component when navigating from `/match/0` to `/match/0?fixtureId=X&autoStart=true`, so the auto-start logic never executes

## Test plan
- [ ] Click "Play" on an upcoming match from the match setup screen — match should start directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)