### PR TITLE
Fix undo past initial server selection corrupting match history

### DIFF
--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -1196,10 +1196,10 @@
 
     private async Task UndoLastPoint()
     {
-        if (history.Any())
-            history.Pop();
-        if (history.Any())
-            ScoreService.RestoreFromGameState(_state, history.Peek());
+        if (history.Count <= 1)
+            return;
+        history.Pop();
+        ScoreService.RestoreFromGameState(_state, history.Peek());
         if (CurrentMatch != null)
             CurrentMatch.Complete = false;
         _state.IsMatchEnded = false;


### PR DESCRIPTION
## Summary
- Prevent the undo history stack from being emptied below the initial match state
- Previously, undoing too many times would remove the baseline state (which stores the server choice), causing subsequent undos to silently fail and corrupting the match state

## Test plan
- [ ] Start a match, select a server, score a few points
- [ ] Undo all points — verify you can't undo past the start
- [ ] Score more points and verify undo still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)