### PR TITLE
Add Cancel/Save/Discard options to End Match dialog

### DIFF
--- a/DropShot/Components/EndMatch.razor
+++ b/DropShot/Components/EndMatch.razor
@@ -2,10 +2,15 @@
     <TitleContent>
         End Match
     </TitleContent>
-    
+
+    <DialogContent>
+        <MudText Typo="Typo.body1">What would you like to do with this match?</MudText>
+    </DialogContent>
+
     <DialogActions>
         <MudButton OnClick="Cancel">Cancel</MudButton>
-        <MudButton Color="Color.Primary" OnClick="Submit">End Match</MudButton>
+        <MudButton Color="Color.Error" Variant="Variant.Outlined" OnClick="Discard">Discard</MudButton>
+        <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="Save">Save</MudButton>
     </DialogActions>
 </MudDialog>
 
@@ -13,7 +18,9 @@
     [CascadingParameter]
     private IMudDialogInstance MudDialog { get; set; } = default!;
 
-    private void Submit() => MudDialog.Close(DialogResult.Ok(true));
+    private void Save() => MudDialog.Close(DialogResult.Ok("save"));
+
+    private void Discard() => MudDialog.Close(DialogResult.Ok("discard"));
 
     private void Cancel() => MudDialog.Cancel();
 }

--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -437,10 +437,14 @@
 
     private async Task OpenDialogAsync(DialogOptions options)
     {
-        var dialog = await DialogService.ShowAsync<EndMatch>("Delete Server", options);
+        var dialog = await DialogService.ShowAsync<EndMatch>("End Match", options);
         var result = await dialog.Result;
 
-        if (result is not null && !result.Canceled)
+        if (result is null || result.Canceled) return;
+
+        var action = result.Data?.ToString();
+
+        if (action == "save")
         {
             OnExpandCollapseClick();
             _state.IsMatchEnded = true;
@@ -449,6 +453,13 @@
             StopTimer();
             StartMatchEndCountdown();
             await SaveHistory();
+        }
+        else if (action == "discard")
+        {
+            OnExpandCollapseClick();
+            StopTimer();
+            await DiscardMatch();
+            NavigateAfterMatch();
         }
     }
 
@@ -1185,6 +1196,48 @@
             Navigation.NavigateTo($"/competition/{_competitionFixture.CompetitionId}/view");
         else
             Navigation.NavigateTo("/match");
+    }
+
+    private async Task DiscardMatch()
+    {
+        if (_savedMatchId > 0)
+        {
+            using var dbc = DbFactory.CreateDbContext();
+            var match = await dbc.SavedMatch.FindAsync(_savedMatchId);
+            if (match != null)
+            {
+                // Reset any linked competition fixture back to scheduled
+                if (_competitionFixture != null)
+                {
+                    var fx = await dbc.CompetitionFixtures.FindAsync(_competitionFixture.CompetitionFixtureId);
+                    if (fx != null)
+                    {
+                        fx.Status = FixtureStatus.Scheduled;
+                        fx.SavedMatchId = null;
+                        fx.WinnerPlayerId = null;
+                        fx.WinnerTeamId = null;
+                        fx.ResultSummary = null;
+                    }
+                }
+
+                // Reset any linked team match set
+                if (_teamMatchSet != null)
+                {
+                    var tms = await dbc.TeamMatchSets.FindAsync(_teamMatchSet.TeamMatchSetId);
+                    if (tms != null)
+                    {
+                        tms.IsComplete = false;
+                        tms.SavedMatchId = null;
+                        tms.HomeGames = null;
+                        tms.AwayGames = null;
+                        tms.WinnerTeamId = null;
+                    }
+                }
+
+                dbc.SavedMatch.Remove(match);
+                await dbc.SaveChangesAsync();
+            }
+        }
     }
 
     public async ValueTask DisposeAsync()


### PR DESCRIPTION
## Summary
- Replaces the simple confirm/cancel End Match dialog with three options: **Cancel**, **Save**, and **Discard**
- **Save** preserves existing behavior (saves result, updates fixtures, shows winner overlay)
- **Discard** deletes the saved match record and resets any linked competition fixture or team match set back to Scheduled, allowing the match to be restarted or manually scored

## Test plan
- [ ] Start a match, click End Match, verify all three buttons appear
- [ ] Click Cancel — should return to the match with no changes
- [ ] Click Save — should save the match result as before (winner overlay, fixture updated)
- [ ] Click Discard — should navigate away without saving; verify the match no longer appears in saved matches and any linked fixture is reset to Scheduled

🤖 Generated with [Claude Code](https://claude.com/claude-code)