### PR TITLE
Add short player names next to scores on scoring screen

### DIFF
--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -199,6 +199,8 @@
                         <span class="serve-indicator-empty"></span>
                     }
 
+                    <span class="score-player-name">@GetUserShortName()</span>
+
                     @* Completed set scores (muted) *@
                     @foreach (var set in _state.SetScores)
                     {
@@ -230,6 +232,8 @@
                     {
                         <span class="serve-indicator-empty"></span>
                     }
+
+                    <span class="score-player-name">@GetOpponentShortName()</span>
 
                     @foreach (var set in _state.SetScores)
                     {
@@ -597,6 +601,24 @@
                 ? $"{CurrentMatch.Player3} & {CurrentMatch.Player4}"
                 : CurrentMatch.Player2;
         return Label_Switch1 ? $"{_value3} & {_value4}" : _value2;
+    }
+
+    private string GetUserShortName()
+    {
+        if (CurrentMatch != null)
+            return !string.IsNullOrEmpty(CurrentMatch.Player3)
+                ? $"{CurrentMatch.Player1.GetShortName()} & {CurrentMatch.Player2.GetShortName()}"
+                : CurrentMatch.Player1.GetShortName();
+        return Label_Switch1 ? $"{_value.GetShortName()} & {_value2.GetShortName()}" : _value.GetShortName();
+    }
+
+    private string GetOpponentShortName()
+    {
+        if (CurrentMatch != null)
+            return !string.IsNullOrEmpty(CurrentMatch.Player3)
+                ? $"{CurrentMatch.Player3.GetShortName()} & {CurrentMatch.Player4.GetShortName()}"
+                : CurrentMatch.Player2.GetShortName();
+        return Label_Switch1 ? $"{_value3.GetShortName()} & {_value4.GetShortName()}" : _value2.GetShortName();
     }
 
     private string? GetPlayerAvatar(string? playerName)

--- a/DropShot/Components/TennisScore.razor.css
+++ b/DropShot/Components/TennisScore.razor.css
@@ -276,6 +276,22 @@
     flex-shrink: 0;
 }
 
+/* Short player name next to score */
+.score-player-name {
+    display: inline-block;
+    width: 90px;
+    text-align: right;
+    font-size: 14px;
+    font-weight: 500;
+    color: rgba(255, 255, 255, 0.7);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex-shrink: 0;
+    margin-right: 6px;
+    vertical-align: middle;
+}
+
 /* Completed set scores */
 .set-score {
     display: inline-block;

--- a/DropShot/Models/StringExtensions.cs
+++ b/DropShot/Models/StringExtensions.cs
@@ -15,5 +15,21 @@
           .Where(x => x.Length >= 1 && char.IsLetter(x[0]))
           .Select(x => char.ToUpper(x[0])));
         }
+
+        /// <summary>
+        /// Returns "FirstName S." where S is the first initial of the surname,
+        /// or just the first name if no surname is present.
+        /// </summary>
+        public static string GetShortName(this string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                return string.Empty;
+
+            var parts = value.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length == 1)
+                return parts[0];
+
+            return $"{parts[0]} {char.ToUpper(parts[^1][0])}.";
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Adds "FirstName S." labels beside each score row on the scoring screen so it's easy to tell whose score is whose
- Uses a fixed-width element to prevent layout jumping when score values change
- Full player names remain displayed in the match header
- Handles both singles and doubles matches

## Test plan
- [ ] Start a singles match and verify short names appear next to each score row
- [ ] Start a doubles match and verify both player short names show (e.g. "Alan B. & John S.")
- [ ] Verify scores don't jump/shift when points change
- [ ] Verify full names still display in the header
- [ ] Test with long player names to confirm ellipsis truncation works
- [ ] Test in landscape mode on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)