### PR TITLE
Fix Play button on home screen to auto-start match

### DIFF
--- a/DropShot/Components/Pages/Home.razor
+++ b/DropShot/Components/Pages/Home.razor
@@ -221,7 +221,7 @@
                         <MudStack Row="true" Spacing="1">
                             <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary"
                                        StartIcon="@Icons.Material.Filled.PlayArrow"
-                                       OnClick="@(() => Navigation.NavigateTo($"/match/0?fixtureId={context.CompetitionFixtureId}"))">
+                                       OnClick="@(() => Navigation.NavigateTo($"/match/0?fixtureId={context.CompetitionFixtureId}&autoStart=true"))">
                                 Play
                             </MudButton>
                             <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Secondary"


### PR DESCRIPTION
## Summary
- Added missing `autoStart=true` query parameter to the Play button navigation URL on the home screen
- The button was only passing `fixtureId`, so the match page loaded the fixture but didn't auto-start it

## Test plan
- [ ] Navigate to home screen with upcoming matches
- [ ] Click Play button on an upcoming match
- [ ] Verify the match auto-starts (coin toss animation begins)

🤖 Generated with [Claude Code](https://claude.com/claude-code)