### PR TITLE
Fix score alignment with player name labels

### DIFF
--- a/DropShot/Components/TennisScore.razor.css
+++ b/DropShot/Components/TennisScore.razor.css
@@ -278,18 +278,15 @@
 
 /* Short player name next to score */
 .score-player-name {
-    display: inline-block;
-    width: 90px;
-    text-align: right;
+    flex: 0 0 90px;
+    text-align: left;
     font-size: 14px;
     font-weight: 500;
     color: rgba(255, 255, 255, 0.7);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    flex-shrink: 0;
     margin-right: 6px;
-    vertical-align: middle;
 }
 
 /* Completed set scores */


### PR DESCRIPTION
## Summary
- Fix score misalignment by using `flex: 0 0 90px` to enforce fixed-width name labels
- Left-align names within the fixed box so scores always start at the same position

## Test plan
- [ ] Verify scores align when player names have different lengths
- [ ] Verify long names are truncated with ellipsis

🤖 Generated with [Claude Code](https://claude.com/claude-code)