### PR TITLE
Add admin ability to delete match results

### DIFF
--- a/DropShot/Components/Pages/ViewCompetition.razor
+++ b/DropShot/Components/Pages/ViewCompetition.razor
@@ -5,11 +5,17 @@
 @using Microsoft.AspNetCore.Authorization
 @using DropShot.Data
 @using DropShot.Models
+@using DropShot.Services
 @using DropShot.Shared.Extensions
 @using Microsoft.EntityFrameworkCore
+@using System.Security.Claims
 
 @inject IDbContextFactory<MyDbContext> DbFactory
 @inject NavigationManager Nav
+@inject ClubAuthorizationService AuthzService
+@inject AuthenticationStateProvider AuthStateProvider
+@inject IDialogService DialogService
+@inject ISnackbar Snackbar
 
 <MudProviders />
 
@@ -85,6 +91,10 @@ else
                     <MudTh>Court</MudTh>
                     <MudTh>Status</MudTh>
                     <MudTh>Result</MudTh>
+                    @if (_canEdit)
+                    {
+                        <MudTh></MudTh>
+                    }
                 </HeaderContent>
                 <RowTemplate>
                     <MudTd DataLabel="Date / Time">@(context.ScheduledAt?.ToString("dd MMM yyyy HH:mm") ?? "—")</MudTd>
@@ -116,6 +126,19 @@ else
                             <MudText Typo="Typo.caption" Color="Color.Secondary">—</MudText>
                         }
                     </MudTd>
+                    @if (_canEdit)
+                    {
+                        <MudTd DataLabel="Actions">
+                            @if (context.Status == FixtureStatus.Completed || context.Status == FixtureStatus.AwaitingVerification)
+                            {
+                                <MudTooltip Text="Delete result and return match to upcoming">
+                                    <MudIconButton Icon="@Icons.Material.Filled.DeleteForever"
+                                                   Color="Color.Error" Size="Size.Small"
+                                                   OnClick="@(() => ConfirmDeleteResultAsync(context))" />
+                                </MudTooltip>
+                            }
+                        </MudTd>
+                    }
                 </RowTemplate>
             </MudTable>
         }
@@ -256,6 +279,7 @@ else
     [Parameter] public int Id { get; set; }
 
     private bool _loading = true;
+    private bool _canEdit;
     private Competition? _competition;
     private List<CompetitionFixture> _fixtures = [];
     private List<CompetitionParticipant> _participants = [];
@@ -275,6 +299,10 @@ else
     {
         _loading = true;
         await using var db = DbFactory.CreateDbContext();
+
+        var authState = await AuthStateProvider.GetAuthenticationStateAsync();
+        _canEdit = await AuthzService.CanEditCompetitionAsync(authState.User,
+            (await db.Competition.FindAsync(Id))?.HostClubId);
 
         _competition = await db.Competition
             .Include(c => c.HostClub)
@@ -470,4 +498,121 @@ else
         ParticipantStatus.Disqualified => Color.Error,
         _ => Color.Default
     };
+
+    private async Task ConfirmDeleteResultAsync(CompetitionFixture fixture)
+    {
+        var players = FixturePlayers(fixture);
+        var result = await DialogService.ShowMessageBox(
+            "Delete Result",
+            $"Are you sure you want to delete the result for {players}? The match will return to Scheduled status and appear in the players' upcoming matches.",
+            yesText: "Delete", cancelText: "Cancel");
+
+        if (result == true)
+            await DeleteResultAsync(fixture);
+    }
+
+    private async Task DeleteResultAsync(CompetitionFixture fixture)
+    {
+        try
+        {
+            await using var db = DbFactory.CreateDbContext();
+            var fx = await db.CompetitionFixtures
+                .Include(f => f.Stage)
+                .FirstOrDefaultAsync(f => f.CompetitionFixtureId == fixture.CompetitionFixtureId);
+            if (fx == null) { Snackbar.Add("Fixture not found.", Severity.Error); return; }
+
+            if (fx.Status != FixtureStatus.Completed && fx.Status != FixtureStatus.AwaitingVerification)
+            {
+                Snackbar.Add("Only completed or pending-verification results can be deleted.", Severity.Warning);
+                return;
+            }
+
+            var oldWinnerPlayerId = fx.WinnerPlayerId;
+            var oldWinnerTeamId = fx.WinnerTeamId;
+            bool isTeamFixture = fx.HomeTeamId.HasValue;
+
+            // Block if downstream fixtures have progressed
+            if (oldWinnerPlayerId.HasValue || oldWinnerTeamId.HasValue)
+            {
+                var downstreamInProgress = await db.CompetitionFixtures
+                    .Where(f => f.CompetitionId == fx.CompetitionId
+                        && f.CompetitionFixtureId != fx.CompetitionFixtureId
+                        && (f.Status == FixtureStatus.InProgress || f.Status == FixtureStatus.Completed
+                            || f.Status == FixtureStatus.AwaitingVerification))
+                    .ToListAsync();
+
+                bool blocked = isTeamFixture
+                    ? downstreamInProgress.Any(f => f.HomeTeamId == oldWinnerTeamId || f.AwayTeamId == oldWinnerTeamId)
+                    : downstreamInProgress.Any(f => f.Player1Id == oldWinnerPlayerId || f.Player2Id == oldWinnerPlayerId);
+
+                if (blocked)
+                {
+                    Snackbar.Add("Cannot delete: the winner has a downstream match that is in progress or completed. Delete that result first.", Severity.Error);
+                    return;
+                }
+            }
+
+            // Clear winner from next-round Scheduled fixtures
+            if (oldWinnerPlayerId.HasValue)
+            {
+                var nextFixtures = await db.CompetitionFixtures
+                    .Where(f => f.CompetitionId == fx.CompetitionId
+                        && f.CompetitionFixtureId != fx.CompetitionFixtureId
+                        && f.Status == FixtureStatus.Scheduled
+                        && (f.Player1Id == oldWinnerPlayerId || f.Player2Id == oldWinnerPlayerId))
+                    .ToListAsync();
+
+                foreach (var nf in nextFixtures)
+                {
+                    if (nf.Player1Id == oldWinnerPlayerId) nf.Player1Id = null;
+                    if (nf.Player2Id == oldWinnerPlayerId) nf.Player2Id = null;
+                }
+            }
+
+            if (oldWinnerTeamId.HasValue)
+            {
+                var nextFixtures = await db.CompetitionFixtures
+                    .Include(f => f.TeamMatchSets)
+                    .Where(f => f.CompetitionId == fx.CompetitionId
+                        && f.CompetitionFixtureId != fx.CompetitionFixtureId
+                        && f.Status == FixtureStatus.Scheduled
+                        && (f.HomeTeamId == oldWinnerTeamId || f.AwayTeamId == oldWinnerTeamId))
+                    .ToListAsync();
+
+                foreach (var nf in nextFixtures)
+                {
+                    if (nf.HomeTeamId == oldWinnerTeamId) nf.HomeTeamId = null;
+                    if (nf.AwayTeamId == oldWinnerTeamId) nf.AwayTeamId = null;
+                    if (nf.TeamMatchSets.Any())
+                        db.TeamMatchSets.RemoveRange(nf.TeamMatchSets);
+                }
+            }
+
+            // Remove linked SavedMatch
+            if (fx.SavedMatchId.HasValue)
+            {
+                var savedMatch = await db.SavedMatch.FindAsync(fx.SavedMatchId.Value);
+                if (savedMatch != null) db.SavedMatch.Remove(savedMatch);
+                fx.SavedMatchId = null;
+            }
+
+            // Reset fixture
+            fx.Status = FixtureStatus.Scheduled;
+            fx.ResultSummary = null;
+            fx.WinnerPlayerId = null;
+            fx.WinnerTeamId = null;
+            fx.VerificationToken = null;
+            fx.OriginalResultSummary = null;
+            fx.OriginalWinnerPlayerId = null;
+            fx.ResultModifiedByAdmin = false;
+
+            await db.SaveChangesAsync();
+            Snackbar.Add("Result deleted. Match returned to upcoming.", Severity.Success);
+            await OnParametersSetAsync();
+        }
+        catch (Exception)
+        {
+            Snackbar.Add("Failed to delete result. Please try again.", Severity.Error);
+        }
+    }
 }

--- a/DropShot/Controllers/CompetitionsController.cs
+++ b/DropShot/Controllers/CompetitionsController.cs
@@ -448,6 +448,106 @@ public class CompetitionsController(
         return NoContent();
     }
 
+    [HttpDelete("{id:int}/fixtures/{fixtureId:int}/result")]
+    public async Task<IActionResult> DeleteFixtureResult(int id, int fixtureId)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var comp = await db.Competition.FindAsync(id);
+        if (comp is null) return NotFound();
+        if (!await authzService.CanEditCompetitionAsync(User, comp.HostClubId)) return Forbid();
+
+        var fixture = await db.CompetitionFixtures
+            .Include(f => f.Stage)
+            .FirstOrDefaultAsync(f => f.CompetitionFixtureId == fixtureId && f.CompetitionId == id);
+        if (fixture is null) return NotFound();
+
+        if (fixture.Status != FixtureStatus.Completed && fixture.Status != FixtureStatus.AwaitingVerification)
+            return BadRequest(new { message = "Only completed or awaiting-verification fixtures can have their result deleted." });
+
+        var oldWinnerPlayerId = fixture.WinnerPlayerId;
+        var oldWinnerTeamId = fixture.WinnerTeamId;
+        bool isTeamFixture = fixture.HomeTeamId.HasValue;
+
+        // Check for downstream fixtures that have already progressed beyond Scheduled
+        if (oldWinnerPlayerId.HasValue || oldWinnerTeamId.HasValue)
+        {
+            var downstreamFixtures = await db.CompetitionFixtures
+                .Where(f => f.CompetitionId == id
+                    && f.CompetitionFixtureId != fixtureId
+                    && (f.Status == FixtureStatus.InProgress || f.Status == FixtureStatus.Completed
+                        || f.Status == FixtureStatus.AwaitingVerification))
+                .ToListAsync();
+
+            bool blocked = isTeamFixture
+                ? downstreamFixtures.Any(f =>
+                    f.HomeTeamId == oldWinnerTeamId || f.AwayTeamId == oldWinnerTeamId)
+                : downstreamFixtures.Any(f =>
+                    f.Player1Id == oldWinnerPlayerId || f.Player2Id == oldWinnerPlayerId);
+
+            if (blocked)
+                return BadRequest(new { message = "Cannot delete this result because the winner has already been placed in a downstream match that is in progress or completed. Delete that result first." });
+        }
+
+        // Clear winner from any next-round Scheduled fixtures
+        if (oldWinnerPlayerId.HasValue)
+        {
+            var nextFixtures = await db.CompetitionFixtures
+                .Where(f => f.CompetitionId == id
+                    && f.CompetitionFixtureId != fixtureId
+                    && f.Status == FixtureStatus.Scheduled
+                    && (f.Player1Id == oldWinnerPlayerId || f.Player2Id == oldWinnerPlayerId))
+                .ToListAsync();
+
+            foreach (var nf in nextFixtures)
+            {
+                if (nf.Player1Id == oldWinnerPlayerId) nf.Player1Id = null;
+                if (nf.Player2Id == oldWinnerPlayerId) nf.Player2Id = null;
+            }
+        }
+
+        if (oldWinnerTeamId.HasValue)
+        {
+            var nextFixtures = await db.CompetitionFixtures
+                .Include(f => f.TeamMatchSets)
+                .Where(f => f.CompetitionId == id
+                    && f.CompetitionFixtureId != fixtureId
+                    && f.Status == FixtureStatus.Scheduled
+                    && (f.HomeTeamId == oldWinnerTeamId || f.AwayTeamId == oldWinnerTeamId))
+                .ToListAsync();
+
+            foreach (var nf in nextFixtures)
+            {
+                if (nf.HomeTeamId == oldWinnerTeamId) nf.HomeTeamId = null;
+                if (nf.AwayTeamId == oldWinnerTeamId) nf.AwayTeamId = null;
+                // Remove auto-generated TeamMatchSets for the cleared fixture
+                if (nf.TeamMatchSets.Any())
+                    db.TeamMatchSets.RemoveRange(nf.TeamMatchSets);
+            }
+        }
+
+        // Remove linked SavedMatch if present
+        if (fixture.SavedMatchId.HasValue)
+        {
+            var savedMatch = await db.SavedMatch.FindAsync(fixture.SavedMatchId.Value);
+            if (savedMatch != null)
+                db.SavedMatch.Remove(savedMatch);
+            fixture.SavedMatchId = null;
+        }
+
+        // Reset the fixture
+        fixture.Status = FixtureStatus.Scheduled;
+        fixture.ResultSummary = null;
+        fixture.WinnerPlayerId = null;
+        fixture.WinnerTeamId = null;
+        fixture.VerificationToken = null;
+        fixture.OriginalResultSummary = null;
+        fixture.OriginalWinnerPlayerId = null;
+        fixture.ResultModifiedByAdmin = false;
+
+        await db.SaveChangesAsync();
+        return Ok();
+    }
+
     [HttpPost("{id:int}/fixtures/schedule")]
     public async Task<IActionResult> ScheduleFixtures(int id)
     {


### PR DESCRIPTION
## Summary
- Adds `DELETE /api/competitions/{id}/fixtures/{fixtureId}/result` endpoint for admins to reset a completed match back to Scheduled
- Adds a delete button in the ViewCompetition fixtures table (visible to admins only) with confirmation dialog
- Handles bracket reversal: clears winner from downstream Scheduled fixtures, blocks if downstream matches are in progress/completed

## Test plan
- [ ] Complete a fixture, verify admin sees delete icon on ViewCompetition page
- [ ] Delete the result, verify fixture returns to Scheduled and appears in player's upcoming matches
- [ ] Verify non-admin users do not see the delete button
- [ ] Test bracket case: complete round-robin, verify knockout slots populated, delete one RR result, verify knockout slots cleared
- [ ] Attempt to delete a result whose winner has a completed downstream match — should show error

🤖 Generated with [Claude Code](https://claude.com/claude-code)