### PR TITLE
Increase score player name font size

### DIFF
--- a/DropShot/Components/TennisScore.razor.css
+++ b/DropShot/Components/TennisScore.razor.css
@@ -280,7 +280,7 @@
 .score-player-name {
     flex: 0 0 90px;
     text-align: left;
-    font-size: 14px;
+    font-size: 18px;
     font-weight: 500;
     color: rgba(255, 255, 255, 0.7);
     overflow: hidden;


### PR DESCRIPTION
## Summary
- Bump player name label font from 14px to 18px for better readability

🤖 Generated with [Claude Code](https://claude.com/claude-code)