### PR TITLE
Add dedicated server selection screen

### DIFF
--- a/DropShot/Components/MatchSetupWizard.razor
+++ b/DropShot/Components/MatchSetupWizard.razor
@@ -246,23 +246,6 @@
                              Variant="Variant.Outlined" Min="1" Max="12"
                              Style="max-width: 160px;" Class="mb-2" />
 
-            <MudDivider Class="my-3" />
-
-            <MudText Typo="Typo.subtitle2" Class="mb-1">Who serves first?</MudText>
-            <MudRadioGroup @bind-Value="_serverChoice">
-                <MudRadio Value="@("random")" Color="Color.Primary">Random Coin Toss</MudRadio>
-                @if (_isDoubles)
-                {
-                    <MudRadio Value="@("player1")" Color="Color.Primary">Team A (@PlayerName(0) & @PlayerName(1)) serves first</MudRadio>
-                    <MudRadio Value="@("player2")" Color="Color.Primary">Team B (@PlayerName(2) & @PlayerName(3)) serves first</MudRadio>
-                }
-                else
-                {
-                    <MudRadio Value="@("player1")" Color="Color.Primary">@PlayerName(0) serves first</MudRadio>
-                    <MudRadio Value="@("player2")" Color="Color.Primary">@PlayerName(1) serves first</MudRadio>
-                }
-            </MudRadioGroup>
-
             <div class="d-flex justify-space-between mt-3">
                 <MudButton Variant="Variant.Text" Color="Color.Default"
                            StartIcon="@Icons.Material.Filled.ArrowBack"
@@ -352,7 +335,6 @@
     private bool _unlimitedDeuce = true;
     private int _deuceLimit = 1;
     private int _bestOf = 3;
-    private string _serverChoice = "random";
     private int _gamesPerSet = 6;
 
     // Auth / players
@@ -847,7 +829,7 @@
             DeuceLimit = _unlimitedDeuce ? 0 : _deuceLimit,
             BestOf = _bestOf,
             GamesPerSet = _gamesPerSet,
-            ServerChoice = _serverChoice
+            ServerChoice = "random"
         });
     }
 

--- a/DropShot/Components/ServerSelectScreen.razor
+++ b/DropShot/Components/ServerSelectScreen.razor
@@ -1,0 +1,46 @@
+@using MudBlazor
+
+<div class="server-select-overlay">
+    <div class="server-select-content">
+        <MudIcon Icon="@Icons.Material.Filled.SportsTennis" Size="Size.Large"
+                 Style="color: #00e6b4; font-size: 64px; margin-bottom: 8px;" />
+
+        <MudText Typo="Typo.h4" Style="color: white; font-weight: 600; letter-spacing: 1px;">
+            Who will serve first?
+        </MudText>
+
+        <div class="server-select-options">
+            <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                       Size="Size.Large" Class="server-select-btn"
+                       StartIcon="@Icons.Material.Filled.Person"
+                       OnClick="@(() => OnSelected("player2"))">
+                @OpponentLabel
+            </MudButton>
+
+            <MudButton Variant="Variant.Filled" Color="Color.Success"
+                       Size="Size.Large" Class="server-select-btn"
+                       StartIcon="@Icons.Material.Filled.Person"
+                       OnClick="@(() => OnSelected("player1"))">
+                @UserLabel
+            </MudButton>
+
+            <MudButton Variant="Variant.Outlined" Color="Color.Warning"
+                       Size="Size.Large" Class="server-select-btn"
+                       StartIcon="@Icons.Material.Filled.Casino"
+                       OnClick="@(() => OnSelected("random"))">
+                Spin
+            </MudButton>
+        </div>
+    </div>
+</div>
+
+@code {
+    [Parameter] public string UserLabel { get; set; } = "You";
+    [Parameter] public string OpponentLabel { get; set; } = "Opponent";
+    [Parameter] public EventCallback<string> OnServerSelected { get; set; }
+
+    private async Task OnSelected(string choice)
+    {
+        await OnServerSelected.InvokeAsync(choice);
+    }
+}

--- a/DropShot/Components/ServerSelectScreen.razor.css
+++ b/DropShot/Components/ServerSelectScreen.razor.css
@@ -1,0 +1,37 @@
+.server-select-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.92);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 9998;
+}
+
+.server-select-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 24px;
+    padding: 32px;
+    max-width: 400px;
+    width: 100%;
+}
+
+.server-select-options {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    width: 100%;
+    margin-top: 8px;
+}
+
+::deep .server-select-btn {
+    width: 100%;
+    padding: 16px 24px !important;
+    font-size: 18px !important;
+    font-weight: 600 !important;
+    letter-spacing: 0.5px;
+    border-radius: 12px !important;
+    text-transform: none !important;
+}

--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -29,6 +29,13 @@
 
 <MudProviders />
 
+@if (_showServerSelect)
+{
+    <ServerSelectScreen UserLabel="@GetUserDisplayName()"
+                        OpponentLabel="@GetOpponentDisplayName()"
+                        OnServerSelected="HandleServerSelected" />
+}
+
 @if (_showCoinToss)
 {
     <div class="coin-toss-overlay">
@@ -53,7 +60,7 @@
     </div>
 }
 
-@if (loaded && CurrentMatch == null && !_showCoinToss)
+@if (loaded && CurrentMatch == null && !_showCoinToss && !_showServerSelect)
 {
     <div style="max-width: 700px; margin: 0 auto;">
         @if (_upcomingFixtures.Any())
@@ -494,13 +501,14 @@
     public bool Label_Switch1 { get; set; } = false;
 
     private string _serverChoice = "random";
+    private bool _showServerSelect;
     private bool _showCoinToss;
     private bool _coinAnimating;
     private bool _coinTossUserServes;
     private string _coinTossWinnerName = string.Empty;
     private Match? _pendingMatch;
 
-    private async Task HandleSetupComplete(MatchSetupWizard.MatchSetupResult result)
+    private Task HandleSetupComplete(MatchSetupWizard.MatchSetupResult result)
     {
         _value = result.Player1;
         _value2 = result.Player2;
@@ -518,8 +526,15 @@
         _state.BestOf = result.BestOf;
         _state.GamesFirstTo = result.GamesPerSet;
         _state.UnlimitedDeuce = result.UnlimitedDeuce;
-        _serverChoice = result.ServerChoice;
 
+        _showServerSelect = true;
+        return Task.CompletedTask;
+    }
+
+    private async Task HandleServerSelected(string choice)
+    {
+        _serverChoice = choice;
+        _showServerSelect = false;
         await ButtonOnClick();
     }
 
@@ -713,7 +728,6 @@
     private int _savedMatchId;
     private CompetitionFixture? _competitionFixture;
     private TeamMatchSet? _teamMatchSet;
-    private bool _autoStartPending;
     private List<CompetitionFixture> _upcomingFixtures = [];
 
     private List<string> _states = [];
@@ -915,7 +929,7 @@
             }
         }
 
-        // Auto-start: skip wizard and go straight to match when all info is available
+        // Auto-start: skip wizard and show server selection screen
         if (AutoStart == true && (_competitionFixture != null || _teamMatchSet != null)
             && !string.IsNullOrEmpty(_value) && !string.IsNullOrEmpty(_value2))
         {
@@ -924,12 +938,11 @@
             _state.UnlimitedDeuce = true;
             _state.GamesFirstTo = 6;
             _selectedCourtId = _competitionFixture?.CourtId;
-            _serverChoice = "random";
             _player1Id = _competitionFixture?.Player1Id;
             _player2Id = _competitionFixture?.Player2Id;
             _player3Id = _competitionFixture?.Player3Id;
             _player4Id = _competitionFixture?.Player4Id;
-            _autoStartPending = true;
+            _showServerSelect = true;
         }
 
         _courts = await DbContext.Courts
@@ -967,13 +980,6 @@
                     .Build();
 
                 await hubConnection.StartAsync();
-            }
-
-            if (_autoStartPending)
-            {
-                _autoStartPending = false;
-                await ButtonOnClick();
-                await InvokeAsync(StateHasChanged);
             }
 
             if (_restoreFullscreen)


### PR DESCRIPTION
## Summary
- Moved "Who serves first?" out of the match setup wizard into a dedicated full-screen overlay
- New screen shows three options: Opponent, You, and Spin with a clean layout
- Autostart matches now show this screen instead of defaulting to random coin toss

## Test plan
- [ ] Start a new match via the setup wizard — server select screen should appear after settings
- [ ] Start a match via autostart (Play button on fixture) — server select screen should appear
- [ ] Select "Opponent" or "You" — match should start immediately with that server
- [ ] Select "Spin" — coin toss animation should play before match starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)