### PR TITLE
Hide role banner on match pages to prevent flicker

### DIFF
--- a/DropShot/Components/Shared/RoleBanner.razor
+++ b/DropShot/Components/Shared/RoleBanner.razor
@@ -9,7 +9,7 @@
 @inject IDbContextFactory<MyDbContext> DbFactory
 @inject NavigationManager NavigationManager
 
-@if (_grantedRoles.Count > 1)
+@if (_grantedRoles.Count > 1 && !_isMatchPage)
 {
     <div class="role-banner">
         <span>Browsing as: <strong>@_activeRole</strong></span>
@@ -33,6 +33,7 @@
     private List<string> _grantedRoles = [];
     private string _activeRole = "";
     private string _currentUrl = "/";
+    private bool _isMatchPage;
 
     protected override async Task OnInitializedAsync()
     {
@@ -40,6 +41,8 @@
         if (httpContext?.User.Identity?.IsAuthenticated != true) return;
 
         _currentUrl = "/" + NavigationManager.ToBaseRelativePath(NavigationManager.Uri);
+        _isMatchPage = _currentUrl.StartsWith("/match/", StringComparison.OrdinalIgnoreCase)
+                    || _currentUrl.Equals("/tennisscore", StringComparison.OrdinalIgnoreCase);
 
         var userId = httpContext.User.FindFirstValue(ClaimTypes.NameIdentifier);
         if (userId is null) return;


### PR DESCRIPTION
## Summary
- Skip rendering the "Browsing as" role banner server-side on match routes (`/match/{id}` and `/tennisscore`)
- Previously the banner rendered in the initial HTML then was hidden by JS adding `scoring-active` class, causing a visible flicker

## Test plan
- [ ] Navigate to `/match/{id}` — banner should not appear at all
- [ ] Navigate to `/tennisscore` — banner should not appear at all
- [ ] Navigate to `/match` (admin list) — banner should still appear for multi-role users
- [ ] Other pages — banner still works normally for users with multiple roles

🤖 Generated with [Claude Code](https://claude.com/claude-code)