### PR TITLE
Fix match page flicker by applying scoring layout during SSR

### DIFF
--- a/DropShot/Components/App.razor
+++ b/DropShot/Components/App.razor
@@ -28,7 +28,7 @@
     <HeadOutlet />
 </head>
 
-<body>
+<body class="@_bodyClass">
     <Routes />
     <script src="_content/MudBlazor/MudBlazor.min.js?v=@(MudBlazor.Metadata.Version)"></script>
     <script src="https://cdn.jsdelivr.net/npm/fuse.js@7.0.0/dist/fuse.min.js"></script>
@@ -42,3 +42,20 @@
 </body>
 
 </html>
+
+@code {
+    private string _bodyClass = "";
+
+    [CascadingParameter]
+    private HttpContext? HttpContext { get; set; }
+
+    protected override void OnInitialized()
+    {
+        var path = HttpContext?.Request.Path.Value ?? "";
+        if (path.StartsWith("/match/", StringComparison.OrdinalIgnoreCase)
+            || path.Equals("/tennisscore", StringComparison.OrdinalIgnoreCase))
+        {
+            _bodyClass = "scoring-active";
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Apply `scoring-active` class to `<body>` during SSR for match routes (`/match/{id}` and `/tennisscore`)
- Previously the navbar, padding, and overflow styles were only changed after JS ran, causing a visible layout flash on every page load/navigation

## Test plan
- [ ] Navigate to a match page — no flicker of navbar/padding/normal layout
- [ ] Navigate away from match and back — no flicker
- [ ] Match end (`DisposeAsync`) still removes `scoring-active` correctly
- [ ] Non-match pages unaffected — normal layout renders as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)