### PR TITLE
Fix EF tools version mismatch in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
       run: dotnet build DropShot/DropShot.csproj --configuration Release
 
     - name: Install EF Core tools
-      run: dotnet tool install --global dotnet-ef
+      run: dotnet tool install --global dotnet-ef --version 10.0.*
 
     - name: Apply EF migrations
       run: dotnet ef database update --project DropShot/DropShot.csproj --configuration Release


### PR DESCRIPTION
## Summary
- Pin `dotnet-ef` tool install to `10.0.*` in the deploy workflow to match the project's EF 10.0 packages
- Previously it installed the latest stable (8.x), causing `TypeLoadException: Method 'Identifier' ... does not have an implementation`

## Test plan
- [ ] Deploy workflow succeeds — `dotnet ef database update` no longer throws version mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)