### PR TITLE
Fix EF Design assembly version mismatch causing deploy failure

### DIFF
--- a/DropShot/DropShot.csproj
+++ b/DropShot/DropShot.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.*" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.*" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.*" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.*" />
     <PackageReference Include="MudBlazor" Version="8.15.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />


### PR DESCRIPTION
## Summary
- `Microsoft.EntityFrameworkCore.Design` was resolving to **8.0.0** as a transitive dependency while all other EF packages were 10.0.x
- This caused `TypeLoadException: Method 'Identifier' in CSharpHelper does not have an implementation` during `dotnet ef database update`
- Added explicit `Microsoft.EntityFrameworkCore.Design` 10.0.* package reference to pin the correct version

## Test plan
- [ ] Deploy workflow completes — `dotnet ef database update` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)