### PR TITLE
Add scoreboard-style result cards and recent results on home page

### DIFF
--- a/DropShot/Components/Pages/Home.razor
+++ b/DropShot/Components/Pages/Home.razor
@@ -55,66 +55,27 @@
                 </MudStack>
             </CardHeaderContent>
         </MudCardHeader>
-        <MudCardContent Class="pa-0">
-            <MudTable Items="@_pendingReviews" Dense="true" Hover="true" Breakpoint="Breakpoint.Sm"
-                      GroupBy="@(new TableGroupDefinition<CompetitionFixture>
-                      {
-                          GroupName = "Competition",
-                          Selector = f => f.Competition?.CompetitionName ?? "Unknown",
-                          Expandable = true,
-                          IsInitiallyExpanded = true
-                      })">
-                <HeaderContent>
-                    <MudTh>Match</MudTh>
-                    <MudTh>Players</MudTh>
-                    <MudTh>Submitted Score</MudTh>
-                    <MudTh>Winner</MudTh>
-                    <MudTh Style="width:180px"></MudTh>
-                </HeaderContent>
-                <GroupHeaderTemplate>
-                    <MudTh colspan="5">
-                        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
-                            <MudIcon Icon="@Icons.Material.Filled.EmojiEvents" Size="Size.Small" Color="Color.Primary" />
-                            <MudText Typo="Typo.subtitle1" Style="font-weight:600">@context.Key</MudText>
-                            <MudChip T="string" Size="Size.Small" Color="Color.Warning">@context.Items.Count() pending</MudChip>
-                        </MudStack>
-                    </MudTh>
-                </GroupHeaderTemplate>
-                <RowTemplate>
-                    <MudTd DataLabel="Match">
-                        <MudText Typo="Typo.body2">@(context.FixtureLabel ?? "Match")</MudText>
-                        @if (context.ScheduledAt.HasValue)
-                        {
-                            <MudText Typo="Typo.caption" Color="Color.Secondary">@context.ScheduledAt.Value.ToString("dd MMM yyyy")</MudText>
-                        }
-                    </MudTd>
-                    <MudTd DataLabel="Players">
-                        <MudText Typo="Typo.body2">@ReviewFixturePlayers(context)</MudText>
-                    </MudTd>
-                    <MudTd DataLabel="Score">
-                        <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Color="Color.Dark">
-                            @(context.ResultSummary ?? "—")
-                        </MudChip>
-                    </MudTd>
-                    <MudTd DataLabel="Winner">
-                        <MudText Typo="Typo.body2" Style="font-weight:500">@ReviewWinnerName(context)</MudText>
-                    </MudTd>
-                    <MudTd>
-                        <MudStack Row="true" Spacing="1">
+        <MudCardContent>
+            <MudGrid>
+                @foreach (var fixture in _pendingReviews)
+                {
+                    <MudItem xs="12" sm="6" md="4">
+                        <ResultCard Fixture="fixture" />
+                        <MudStack Row="true" Spacing="1" Class="mt-2" Justify="Justify.Center">
                             <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Success"
                                        StartIcon="@Icons.Material.Filled.CheckCircle"
-                                       OnClick="@(() => QuickApproveReviewAsync(context))">
+                                       OnClick="@(() => QuickApproveReviewAsync(fixture))">
                                 Approve
                             </MudButton>
                             <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Warning"
                                        StartIcon="@Icons.Material.Filled.Edit"
-                                       OnClick="@(() => OpenReviewDialogAsync(context))">
+                                       OnClick="@(() => OpenReviewDialogAsync(fixture))">
                                 Review
                             </MudButton>
                         </MudStack>
-                    </MudTd>
-                </RowTemplate>
-            </MudTable>
+                    </MudItem>
+                }
+            </MudGrid>
         </MudCardContent>
     </MudCard>
 }
@@ -187,6 +148,30 @@
     </MudCardContent>
 </MudCard>
 
+@if (_recentResults.Any())
+{
+    <MudCard Class="mt-4">
+        <MudCardHeader>
+            <CardHeaderContent>
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                    <MudIcon Icon="@Icons.Material.Filled.EmojiEvents" Color="Color.Primary" />
+                    <MudText Typo="Typo.h6">My Recent Results</MudText>
+                </MudStack>
+            </CardHeaderContent>
+        </MudCardHeader>
+        <MudCardContent>
+            <MudGrid>
+                @foreach (var fixture in _recentResults)
+                {
+                    <MudItem xs="12" sm="6" md="4">
+                        <ResultCard Fixture="fixture" />
+                    </MudItem>
+                }
+            </MudGrid>
+        </MudCardContent>
+    </MudCard>
+}
+
 @if (_upcomingFixtures.Any())
 {
     <MudCard Class="mt-4">
@@ -250,6 +235,7 @@
 
     private List<CompetitionFixture> _upcomingFixtures = [];
     private List<CompetitionFixture> _pendingReviews = [];
+    private List<CompetitionFixture> _recentResults = [];
     private bool _showUpgradeBanner;
     private bool _eligibleForUpgradeBanner;
     private bool _isAuthenticated;
@@ -305,6 +291,19 @@
             .Where(f => (f.Player1Id == pid || f.Player2Id == pid || f.Player3Id == pid || f.Player4Id == pid)
                      && (f.Status == FixtureStatus.Scheduled || f.Status == FixtureStatus.InProgress))
             .OrderBy(f => f.ScheduledAt)
+            .ToListAsync();
+
+        _recentResults = await db.CompetitionFixtures
+            .Include(f => f.Competition)
+            .Include(f => f.Player1)
+            .Include(f => f.Player2)
+            .Include(f => f.Player3)
+            .Include(f => f.Player4)
+            .Where(f => (f.Player1Id == pid || f.Player2Id == pid || f.Player3Id == pid || f.Player4Id == pid)
+                     && f.Status == FixtureStatus.Completed
+                     && f.ResultSummary != null)
+            .OrderByDescending(f => f.ScheduledAt)
+            .Take(6)
             .ToListAsync();
     }
 

--- a/DropShot/Components/Pages/ViewCompetition.razor
+++ b/DropShot/Components/Pages/ViewCompetition.razor
@@ -95,11 +95,10 @@ else
                         <MudChip T="string" Size="Size.Small" Color="@StatusColor(context.Status)">@context.Status</MudChip>
                     </MudTd>
                     <MudTd DataLabel="Result">
-                        @if (context.Status == FixtureStatus.Completed || context.Status == FixtureStatus.AwaitingVerification)
+                        @if ((context.Status == FixtureStatus.Completed || context.Status == FixtureStatus.AwaitingVerification)
+                             && !string.IsNullOrEmpty(context.ResultSummary))
                         {
-                            <MudText Typo="Typo.body2" Style="font-weight:500">
-                                @(context.ResultSummary ?? WinnerName(context))
-                            </MudText>
+                            <ResultCard Fixture="context" />
                             @if (context.ResultModifiedByAdmin)
                             {
                                 <MudTooltip Text="@($"Original: {context.OriginalResultSummary}")">
@@ -110,6 +109,12 @@ else
                             {
                                 <MudChip T="string" Size="Size.Small" Color="Color.Secondary" Variant="Variant.Text">Pending</MudChip>
                             }
+                        }
+                        else if (context.Status == FixtureStatus.Completed || context.Status == FixtureStatus.AwaitingVerification)
+                        {
+                            <MudText Typo="Typo.body2" Style="font-weight:500">
+                                @(WinnerName(context))
+                            </MudText>
                         }
                         else
                         {

--- a/DropShot/Components/ResultCard.razor
+++ b/DropShot/Components/ResultCard.razor
@@ -1,0 +1,82 @@
+@using DropShot.Models
+
+<div class="result-card">
+    @if (Fixture.Competition != null)
+    {
+        <div class="rc-header">
+            <span class="rc-comp">@Fixture.Competition.CompetitionName</span>
+            @if (!string.IsNullOrEmpty(Fixture.FixtureLabel))
+            {
+                <span class="rc-label">@Fixture.FixtureLabel</span>
+            }
+            @if (Fixture.ScheduledAt.HasValue)
+            {
+                <span class="rc-date">@Fixture.ScheduledAt.Value.ToString("dd MMM yyyy")</span>
+            }
+        </div>
+    }
+
+    <div class="rc-player-row @(IsPlayer1Winner ? "rc-winner" : "")">
+        <div class="rc-name">@Player1Name</div>
+        <div class="rc-sets">
+            @foreach (var set in _sets)
+            {
+                <span class="rc-set-score">@set.P1</span>
+            }
+        </div>
+    </div>
+
+    <div class="rc-separator">v</div>
+
+    <div class="rc-player-row @(IsPlayer2Winner ? "rc-winner" : "")">
+        <div class="rc-name">@Player2Name</div>
+        <div class="rc-sets">
+            @foreach (var set in _sets)
+            {
+                <span class="rc-set-score">@set.P2</span>
+            }
+        </div>
+    </div>
+</div>
+
+@code {
+    [Parameter, EditorRequired] public CompetitionFixture Fixture { get; set; } = default!;
+
+    private List<(string P1, string P2)> _sets = [];
+
+    private string Player1Name => Fixture.Player3 != null
+        ? $"{Fixture.Player1?.DisplayName ?? "TBD"} & {Fixture.Player3?.DisplayName ?? "TBD"}"
+        : Fixture.Player1?.DisplayName ?? "TBD";
+
+    private string Player2Name => Fixture.Player4 != null
+        ? $"{Fixture.Player2?.DisplayName ?? "TBD"} & {Fixture.Player4?.DisplayName ?? "TBD"}"
+        : Fixture.Player2?.DisplayName ?? "TBD";
+
+    private bool IsPlayer1Winner => Fixture.WinnerPlayerId.HasValue
+        && Fixture.WinnerPlayerId == Fixture.Player1Id;
+
+    private bool IsPlayer2Winner => Fixture.WinnerPlayerId.HasValue
+        && Fixture.WinnerPlayerId == Fixture.Player2Id;
+
+    protected override void OnParametersSet()
+    {
+        _sets = ParseResultSummary(Fixture.ResultSummary);
+    }
+
+    private static List<(string P1, string P2)> ParseResultSummary(string? summary)
+    {
+        if (string.IsNullOrWhiteSpace(summary))
+            return [];
+
+        var result = new List<(string, string)>();
+        var parts = summary.Split(',', StringSplitOptions.TrimEntries);
+        foreach (var part in parts)
+        {
+            // Split on hyphen or en-dash
+            var scores = part.Split(['-', '\u2013'], 2);
+            if (scores.Length == 2)
+                result.Add((scores[0].Trim(), scores[1].Trim()));
+        }
+        return result;
+    }
+}

--- a/DropShot/Components/ResultCard.razor.css
+++ b/DropShot/Components/ResultCard.razor.css
@@ -1,0 +1,95 @@
+.result-card {
+    background-color: #0d1117;
+    color: #ffffff;
+    font-family: Georgia, 'Times New Roman', serif;
+    border: 1px solid #2a2a3a;
+    border-radius: 6px;
+    overflow: hidden;
+    min-width: 220px;
+}
+
+.rc-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 12px;
+    background-color: #0a0e15;
+    border-bottom: 1px solid #2a2a3a;
+    flex-wrap: wrap;
+}
+
+.rc-comp {
+    font-size: 0.7rem;
+    font-family: 'Helvetica Neue', Arial, sans-serif;
+    letter-spacing: 0.12em;
+    color: #c9a84c;
+    text-transform: uppercase;
+}
+
+.rc-label {
+    font-size: 0.65rem;
+    font-family: 'Helvetica Neue', Arial, sans-serif;
+    color: #888888;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+}
+
+.rc-date {
+    font-size: 0.65rem;
+    font-family: 'Helvetica Neue', Arial, sans-serif;
+    color: #666666;
+    margin-left: auto;
+}
+
+.rc-player-row {
+    display: flex;
+    align-items: center;
+    padding: 8px 12px;
+    min-height: 36px;
+}
+
+.rc-player-row.rc-winner {
+    background-color: #131720;
+}
+
+.rc-name {
+    flex: 1;
+    font-size: 0.85rem;
+    font-weight: bold;
+    letter-spacing: 0.03em;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    padding-right: 12px;
+}
+
+.rc-winner .rc-name {
+    color: #c9a84c;
+}
+
+.rc-sets {
+    display: flex;
+    gap: 2px;
+    flex-shrink: 0;
+}
+
+.rc-set-score {
+    display: inline-block;
+    width: 28px;
+    text-align: center;
+    font-size: 0.95rem;
+    font-weight: bold;
+    color: #cccccc;
+}
+
+.rc-winner .rc-set-score {
+    color: #ffffff;
+}
+
+.rc-separator {
+    padding: 0 12px;
+    font-size: 0.65rem;
+    color: #555555;
+    font-style: italic;
+    line-height: 1;
+}


### PR DESCRIPTION
## Summary
- Adds a reusable `ResultCard` component that displays match results in a Wimbledon-inspired scoreboard layout with player names and set scores above/below (winner highlighted in gold)
- Adds a "My Recent Results" section to the home page showing the user's last 6 completed fixtures
- Updates pending reviews on the home page and ViewCompetition fixtures table to use the new card display

## Test plan
- [ ] Verify the home page shows recent results for an authenticated user with completed fixtures
- [ ] Verify the ResultCard correctly parses and displays set scores (e.g. "6–4, 7–5")
- [ ] Verify winner highlighting works correctly
- [ ] Verify doubles matches show both player names with "&"
- [ ] Check pending reviews section still shows Approve/Review buttons
- [ ] Check ViewCompetition page shows ResultCard for completed fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)