### PR TITLE
Add competition start/stop lifecycle

### DIFF
--- a/DropShot.Maui/Components/Pages/Competitions.razor
+++ b/DropShot.Maui/Components/Pages/Competitions.razor
@@ -48,6 +48,10 @@ else
                 <RowTemplate>
                     <MudTd>
                         @context.CompetitionName
+                        @if (!context.IsStarted)
+                        {
+                            <MudChip T="string" Size="Size.Small" Color="Color.Default" Variant="Variant.Outlined">Not Started</MudChip>
+                        }
                         @if (context.IsArchived)
                         {
                             <MudChip T="string" Size="Size.Small" Color="Color.Warning" Variant="Variant.Outlined">Archived</MudChip>

--- a/DropShot.Maui/Services/ApiService.cs
+++ b/DropShot.Maui/Services/ApiService.cs
@@ -94,6 +94,16 @@ public class ApiService(HttpClient http)
 
     private record ArchiveResult(bool IsArchived);
 
+    public async Task<bool> ToggleStartedCompetitionAsync(int id)
+    {
+        var r = await http.PutAsync($"api/competitions/{id}/start", null);
+        r.EnsureSuccessStatusCode();
+        var result = await r.Content.ReadFromJsonAsync<StartResult>();
+        return result?.IsStarted ?? false;
+    }
+
+    private record StartResult(bool IsStarted);
+
     public async Task DeleteCompetitionAsync(int id)
     {
         var r = await http.DeleteAsync($"api/competitions/{id}");

--- a/DropShot.Shared/Dtos/CompetitionDtos.cs
+++ b/DropShot.Shared/Dtos/CompetitionDtos.cs
@@ -16,7 +16,8 @@ public record CompetitionDto(
     string? RulesSetName,
     int? EventId,
     string? EventName,
-    bool IsArchived = false);
+    bool IsArchived = false,
+    bool IsStarted = false);
 
 public record CompetitionDetailDto(
     int CompetitionId,
@@ -36,7 +37,8 @@ public record CompetitionDetailDto(
     string? EventName,
     List<CompetitionStageDto> Stages,
     List<CompetitionParticipantDto> Participants,
-    bool IsArchived = false);
+    bool IsArchived = false,
+    bool IsStarted = false);
 
 public record CompetitionStageDto(
     int CompetitionStageId,

--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -41,6 +41,19 @@
     }
     @if (IsEdit)
     {
+        @if (_canEdit)
+        {
+            <MudButton Variant="@(_isStarted ? Variant.Outlined : Variant.Filled)"
+                       Color="@(_isStarted ? Color.Warning : Color.Success)"
+                       StartIcon="@(_isStarted ? Icons.Material.Filled.Stop : Icons.Material.Filled.PlayArrow)"
+                       OnClick="ToggleStartedAsync">
+                @(_isStarted ? "Stop Competition" : "Start Competition")
+            </MudButton>
+        }
+        else if (!_isStarted)
+        {
+            <MudChip T="string" Color="Color.Warning" Variant="Variant.Outlined">Not Started</MudChip>
+        }
         <MudButton Variant="Variant.Outlined" Color="Color.Info" StartIcon="@Icons.Material.Filled.Visibility"
                    OnClick="@(() => Nav.NavigateTo($"/competition/{Id}/view"))">
             View Competition
@@ -936,6 +949,7 @@
     private string? _serverError;
     private bool IsEdit => Id != 0;
     private bool _nameOverride;
+    private bool _isStarted;
     private int _activeTabIndex;
 
     private CompetitionFormModel Model { get; set; } = new();
@@ -1145,6 +1159,7 @@
             if (comp is null) { _serverError = $"Competition {Id} not found."; return; }
 
             _canEdit = await AuthzService.CanEditCompetitionAsync(authState.User, comp.HostClubId, Id);
+            _isStarted = comp.IsStarted;
             _nameOverride = true; // Existing competition — preserve its name
 
             Model = new CompetitionFormModel
@@ -1259,6 +1274,19 @@
         catch (DbUpdateException ex) { _serverError = "Database error: " + ex.InnerException?.Message ?? ex.Message; }
         catch (Exception ex) { _serverError = ex.Message; }
         finally { _isSaving = false; }
+    }
+
+    private async Task ToggleStartedAsync()
+    {
+        await using var db = DbFactory.CreateDbContext();
+        var comp = await db.Competition.FindAsync(Id);
+        if (comp is null) return;
+
+        comp.IsStarted = !comp.IsStarted;
+        await db.SaveChangesAsync();
+        _isStarted = comp.IsStarted;
+
+        Snackbar.Add(_isStarted ? "Competition started." : "Competition stopped.", Severity.Success);
     }
 
     // ── Add New Entity Helpers ─────────────────────────────────────────────

--- a/DropShot/Components/Pages/Competitions.razor
+++ b/DropShot/Components/Pages/Competitions.razor
@@ -52,10 +52,17 @@
                     <MudTd DataLabel="Host Club">@(context.HostClub?.Name ?? "—")</MudTd>
                     <MudTd DataLabel="Dates">@FormatDates(context)</MudTd>
                     <MudTd>
-                        <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Info"
-                                   OnClick="@(() => Nav.NavigateTo($"/competition/{context.CompetitionID}/view"))">
-                            View
-                        </MudButton>
+                        @if (context.IsStarted)
+                        {
+                            <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Info"
+                                       OnClick="@(() => Nav.NavigateTo($"/competition/{context.CompetitionID}/view"))">
+                                View
+                            </MudButton>
+                        }
+                        else
+                        {
+                            <MudChip T="string" Size="Size.Small" Color="Color.Info" Variant="Variant.Outlined">Entered</MudChip>
+                        }
                     </MudTd>
                 </RowTemplate>
             </MudTable>
@@ -83,10 +90,13 @@
                     <MudTd DataLabel="Dates">@FormatDates(context)</MudTd>
                     <MudTd>
                         <MudStack Row="true" Spacing="1">
-                            <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Info"
-                                       OnClick="@(() => Nav.NavigateTo($"/competition/{context.CompetitionID}/view"))">
-                                View
-                            </MudButton>
+                            @if (context.IsStarted)
+                            {
+                                <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Info"
+                                           OnClick="@(() => Nav.NavigateTo($"/competition/{context.CompetitionID}/view"))">
+                                    View
+                                </MudButton>
+                            }
                             <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary"
                                        OnClick="@(() => EnterCompetitionAsync(context))">
                                 Enter
@@ -203,6 +213,10 @@
                 </TemplateColumn>
                 <TemplateColumn CellClass="d-flex justify-end gap-2">
                     <CellTemplate>
+                        @if (!context.Item.IsStarted)
+                        {
+                            <MudChip T="string" Size="Size.Small" Color="Color.Default" Variant="Variant.Outlined">Not Started</MudChip>
+                        }
                         @if (context.Item.IsArchived)
                         {
                             <MudChip T="string" Size="Size.Small" Color="Color.Warning" Variant="Variant.Outlined">Archived</MudChip>
@@ -285,6 +299,10 @@
                                     <tr>
                                         <td>
                                             @comp.CompetitionName
+                                            @if (!comp.IsStarted)
+                                            {
+                                                <MudChip T="string" Size="Size.Small" Color="Color.Default" Variant="Variant.Outlined">Not Started</MudChip>
+                                            }
                                             @if (comp.IsArchived)
                                             {
                                                 <MudChip T="string" Size="Size.Small" Color="Color.Warning" Variant="Variant.Outlined">Archived</MudChip>
@@ -350,6 +368,10 @@
                                     <tr>
                                         <td>
                                             @comp.CompetitionName
+                                            @if (!comp.IsStarted)
+                                            {
+                                                <MudChip T="string" Size="Size.Small" Color="Color.Default" Variant="Variant.Outlined">Not Started</MudChip>
+                                            }
                                             @if (comp.IsArchived)
                                             {
                                                 <MudChip T="string" Size="Size.Small" Color="Color.Warning" Variant="Variant.Outlined">Archived</MudChip>
@@ -476,7 +498,8 @@
                 HostClubId = c.HostClubId,
                 EventId = c.EventId,
                 Event = c.Event,
-                IsArchived = c.IsArchived
+                IsArchived = c.IsArchived,
+                IsStarted = c.IsStarted
             })
             .ToListAsync();
 

--- a/DropShot/Components/Pages/ViewCompetition.razor
+++ b/DropShot/Components/Pages/ViewCompetition.razor
@@ -6,10 +6,13 @@
 @using DropShot.Data
 @using DropShot.Models
 @using DropShot.Shared.Extensions
+@using DropShot.Services
 @using Microsoft.EntityFrameworkCore
 
 @inject IDbContextFactory<MyDbContext> DbFactory
 @inject NavigationManager Nav
+@inject ClubAuthorizationService AuthzService
+@inject AuthenticationStateProvider AuthStateProvider
 
 <MudProviders />
 
@@ -20,6 +23,10 @@
 else if (_competition == null)
 {
     <MudAlert Severity="Severity.Error">Competition not found.</MudAlert>
+}
+else if (!_competition.IsStarted && !_canEdit)
+{
+    <MudAlert Severity="Severity.Info" Class="mb-4">This competition has not started yet. Check back later.</MudAlert>
 }
 else
 {
@@ -256,6 +263,7 @@ else
     [Parameter] public int Id { get; set; }
 
     private bool _loading = true;
+    private bool _canEdit;
     private Competition? _competition;
     private List<CompetitionFixture> _fixtures = [];
     private List<CompetitionParticipant> _participants = [];
@@ -296,6 +304,8 @@ else
 
         if (_competition != null)
         {
+            var authState = await AuthStateProvider.GetAuthenticationStateAsync();
+            _canEdit = await AuthzService.CanEditCompetitionAsync(authState.User, _competition.HostClubId, _competition.CompetitionID);
             _fixtures = _competition.Fixtures
                 .OrderBy(f => f.ScheduledAt)
                 .ThenBy(f => f.RoundNumber ?? 0)

--- a/DropShot/Controllers/CompetitionsController.cs
+++ b/DropShot/Controllers/CompetitionsController.cs
@@ -73,7 +73,8 @@ public class CompetitionsController(
                 p.Player?.MobileNumber,
                 (DropShot.Shared.PlayerGrade?)p.Grade,
                 (DropShot.Shared.PlayerSex?)p.Player?.Sex)).ToList(),
-            c.IsArchived);
+            c.IsArchived,
+            c.IsStarted);
     }
 
     [HttpPost]
@@ -117,6 +118,20 @@ public class CompetitionsController(
         comp.IsArchived = !comp.IsArchived;
         await db.SaveChangesAsync();
         return Ok(new { comp.IsArchived });
+    }
+
+    [HttpPut("{id:int}/start")]
+    public async Task<IActionResult> ToggleStarted(int id)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var comp = await db.Competition.FindAsync(id);
+        if (comp is null) return NotFound();
+        if (!await authzService.CanEditCompetitionAsync(User, comp.HostClubId, comp.CompetitionID))
+            return Forbid();
+
+        comp.IsStarted = !comp.IsStarted;
+        await db.SaveChangesAsync();
+        return Ok(new { comp.IsStarted });
     }
 
     [HttpDelete("{id:int}")]
@@ -906,7 +921,7 @@ public class CompetitionsController(
         c.MaxParticipants, c.StartDate, c.EndDate, c.MaxAge, c.MinAge,
         (DropShot.Shared.PlayerSex?)c.EligibleSex,
         c.HostClubId, c.HostClub?.Name, c.RulesSetId, c.Rules?.Name,
-        c.EventId, c.Event?.Name, c.IsArchived);
+        c.EventId, c.Event?.Name, c.IsArchived, c.IsStarted);
 
     private static CompetitionFixtureDto ToFixtureDto(CompetitionFixture f) => new(
         f.CompetitionFixtureId, f.CompetitionId,

--- a/DropShot/Data/Migrations/20260414175134_AddCompetitionIsStarted.Designer.cs
+++ b/DropShot/Data/Migrations/20260414175134_AddCompetitionIsStarted.Designer.cs
@@ -4,6 +4,7 @@ using DropShot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DropShot.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260414175134_AddCompetitionIsStarted")]
+    partial class AddCompetitionIsStarted
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DropShot/Data/Migrations/20260414175134_AddCompetitionIsStarted.cs
+++ b/DropShot/Data/Migrations/20260414175134_AddCompetitionIsStarted.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropShot.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCompetitionIsStarted : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsStarted",
+                table: "Competition",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsStarted",
+                table: "Competition");
+        }
+    }
+}

--- a/DropShot/DropShot.csproj
+++ b/DropShot/DropShot.csproj
@@ -18,6 +18,10 @@
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.*" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.*" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.*">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.*" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.*" />
     <PackageReference Include="MudBlazor" Version="8.15.0" />

--- a/DropShot/Models/Competition.cs
+++ b/DropShot/Models/Competition.cs
@@ -27,6 +27,7 @@
         public int BestOf { get; set; } = 3;
         public bool RequireVerification { get; set; } = false;
         public bool IsArchived { get; set; } = false;
+        public bool IsStarted { get; set; } = false;
 
         public RulesSet? Rules { get; set; }
         public Club? HostClub { get; set; }


### PR DESCRIPTION
## Summary
- Adds `IsStarted` boolean field to competitions with EF Core migration
- Admins get a Start/Stop button on the competition edit page to control visibility
- Standard users see "Entered" chip (no View button) for unstarted competitions in My Competitions
- Available competitions only show "Enter" button (no View) until started
- Direct URL access to `/competition/{id}/view` blocked for non-admins when not started
- "Not Started" chip shown in admin competition lists across all views
- MAUI app updated with matching IsStarted support

## Test plan
- [ ] Create a competition as admin — verify it shows "Not Started" chip
- [ ] Click "Start Competition" — verify chip disappears and button changes to "Stop Competition"
- [ ] As standard user, enter an unstarted competition — verify it appears in My Competitions with "Entered" chip and no View button
- [ ] Start the competition as admin — verify user now sees View button
- [ ] Navigate directly to `/competition/{id}/view` as standard user for unstarted comp — verify blocked with message

🤖 Generated with [Claude Code](https://claude.com/claude-code)