### PR TITLE
Refine ResultCard: side-by-side layout and compact mode for lists

### DIFF
--- a/DropShot/Components/Pages/Home.razor
+++ b/DropShot/Components/Pages/Home.razor
@@ -148,78 +148,101 @@
     </MudCardContent>
 </MudCard>
 
-@if (_recentResults.Any())
+@if (_upcomingFixtures.Any() || _recentResults.Any())
 {
-    <MudCard Class="mt-4">
-        <MudCardHeader>
-            <CardHeaderContent>
-                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
-                    <MudIcon Icon="@Icons.Material.Filled.EmojiEvents" Color="Color.Primary" />
-                    <MudText Typo="Typo.h6">My Recent Results</MudText>
-                </MudStack>
-            </CardHeaderContent>
-        </MudCardHeader>
-        <MudCardContent>
-            <MudGrid>
-                @foreach (var fixture in _recentResults)
-                {
-                    <MudItem xs="12" sm="6" md="4">
-                        <ResultCard Fixture="fixture" />
-                    </MudItem>
-                }
-            </MudGrid>
-        </MudCardContent>
-    </MudCard>
-}
+    <MudGrid Class="mt-4">
+        @if (_upcomingFixtures.Any())
+        {
+            <MudItem xs="12" md="@(_recentResults.Any() ? 7 : 12)">
+                <MudCard>
+                    <MudCardHeader>
+                        <CardHeaderContent>
+                            <MudText Typo="Typo.h6">Your Upcoming Matches</MudText>
+                        </CardHeaderContent>
+                    </MudCardHeader>
+                    <MudCardContent Class="pa-0">
+                        <MudTable Items="@_upcomingFixtures" Dense="true" Hover="true">
+                            <HeaderContent>
+                                <MudTh>Date / Time</MudTh>
+                                <MudTh>Competition</MudTh>
+                                <MudTh>Opponent(s)</MudTh>
+                                <MudTh>Status</MudTh>
+                                <MudTh></MudTh>
+                            </HeaderContent>
+                            <RowTemplate>
+                                <MudTd DataLabel="Date / Time">@(context.ScheduledAt?.ToString("dd MMM yyyy HH:mm") ?? "—")</MudTd>
+                                <MudTd DataLabel="Competition">
+                                    <MudText Typo="Typo.body2" Style="font-weight:500">@(context.Competition?.CompetitionName ?? "—")</MudText>
+                                    @if (!string.IsNullOrEmpty(context.FixtureLabel))
+                                    {
+                                        <MudText Typo="Typo.caption" Color="Color.Secondary">@context.FixtureLabel</MudText>
+                                    }
+                                </MudTd>
+                                <MudTd DataLabel="Opponent(s)">@FixtureOpponents(context)</MudTd>
+                                <MudTd DataLabel="Status">
+                                    <MudChip T="string" Size="Size.Small" Color="@StatusColor(context.Status)">@context.Status</MudChip>
+                                </MudTd>
+                                <MudTd>
+                                    <MudStack Row="true" Spacing="1">
+                                        <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary"
+                                                   StartIcon="@Icons.Material.Filled.PlayArrow"
+                                                   OnClick="@(() => Navigation.NavigateTo($"/match/0?fixtureId={context.CompetitionFixtureId}&autoStart=true"))">
+                                            Play
+                                        </MudButton>
+                                        <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Secondary"
+                                                   StartIcon="@Icons.Material.Filled.Edit"
+                                                   OnClick="@(() => OpenSubmitScoreAsync(context))">
+                                            Submit Score
+                                        </MudButton>
+                                    </MudStack>
+                                </MudTd>
+                            </RowTemplate>
+                        </MudTable>
+                    </MudCardContent>
+                </MudCard>
+            </MudItem>
+        }
 
-@if (_upcomingFixtures.Any())
-{
-    <MudCard Class="mt-4">
-        <MudCardHeader>
-            <CardHeaderContent>
-                <MudText Typo="Typo.h6">Your Upcoming Matches</MudText>
-            </CardHeaderContent>
-        </MudCardHeader>
-        <MudCardContent Class="pa-0">
-            <MudTable Items="@_upcomingFixtures" Dense="true" Hover="true">
-                <HeaderContent>
-                    <MudTh>Date / Time</MudTh>
-                    <MudTh>Competition</MudTh>
-                    <MudTh>Opponent(s)</MudTh>
-                    <MudTh>Status</MudTh>
-                    <MudTh></MudTh>
-                </HeaderContent>
-                <RowTemplate>
-                    <MudTd DataLabel="Date / Time">@(context.ScheduledAt?.ToString("dd MMM yyyy HH:mm") ?? "—")</MudTd>
-                    <MudTd DataLabel="Competition">
-                        <MudText Typo="Typo.body2" Style="font-weight:500">@(context.Competition?.CompetitionName ?? "—")</MudText>
-                        @if (!string.IsNullOrEmpty(context.FixtureLabel))
-                        {
-                            <MudText Typo="Typo.caption" Color="Color.Secondary">@context.FixtureLabel</MudText>
-                        }
-                    </MudTd>
-                    <MudTd DataLabel="Opponent(s)">@FixtureOpponents(context)</MudTd>
-                    <MudTd DataLabel="Status">
-                        <MudChip T="string" Size="Size.Small" Color="@StatusColor(context.Status)">@context.Status</MudChip>
-                    </MudTd>
-                    <MudTd>
-                        <MudStack Row="true" Spacing="1">
-                            <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary"
-                                       StartIcon="@Icons.Material.Filled.PlayArrow"
-                                       OnClick="@(() => Navigation.NavigateTo($"/match/0?fixtureId={context.CompetitionFixtureId}&autoStart=true"))">
-                                Play
-                            </MudButton>
-                            <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Secondary"
-                                       StartIcon="@Icons.Material.Filled.Edit"
-                                       OnClick="@(() => OpenSubmitScoreAsync(context))">
-                                Submit Score
-                            </MudButton>
+        @if (_recentResults.Any())
+        {
+            <MudItem xs="12" md="@(_upcomingFixtures.Any() ? 5 : 12)">
+                <MudCard>
+                    <MudCardHeader>
+                        <CardHeaderContent>
+                            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                                <MudIcon Icon="@Icons.Material.Filled.EmojiEvents" Color="Color.Primary" />
+                                <MudText Typo="Typo.h6">My Recent Results</MudText>
+                            </MudStack>
+                        </CardHeaderContent>
+                    </MudCardHeader>
+                    <MudCardContent Class="pa-0">
+                        <MudStack Spacing="0">
+                            @foreach (var fixture in _recentResults)
+                            {
+                                <div style="padding: 8px 16px; border-bottom: 1px solid var(--mud-palette-lines-default);">
+                                    @if (fixture.Competition != null)
+                                    {
+                                        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="mb-1">
+                                            <MudText Typo="Typo.caption" Style="font-weight:500">@fixture.Competition.CompetitionName</MudText>
+                                            @if (!string.IsNullOrEmpty(fixture.FixtureLabel))
+                                            {
+                                                <MudText Typo="Typo.caption" Color="Color.Secondary">@fixture.FixtureLabel</MudText>
+                                            }
+                                            @if (fixture.ScheduledAt.HasValue)
+                                            {
+                                                <MudText Typo="Typo.caption" Color="Color.Secondary" Style="margin-left:auto">@fixture.ScheduledAt.Value.ToString("dd MMM yyyy")</MudText>
+                                            }
+                                        </MudStack>
+                                    }
+                                    <ResultCard Fixture="fixture" Compact="true" />
+                                </div>
+                            }
                         </MudStack>
-                    </MudTd>
-                </RowTemplate>
-            </MudTable>
-        </MudCardContent>
-    </MudCard>
+                    </MudCardContent>
+                </MudCard>
+            </MudItem>
+        }
+    </MudGrid>
 }
 
 @code {

--- a/DropShot/Components/Pages/ViewCompetition.razor
+++ b/DropShot/Components/Pages/ViewCompetition.razor
@@ -98,7 +98,7 @@ else
                         @if ((context.Status == FixtureStatus.Completed || context.Status == FixtureStatus.AwaitingVerification)
                              && !string.IsNullOrEmpty(context.ResultSummary))
                         {
-                            <ResultCard Fixture="context" />
+                            <ResultCard Fixture="context" Compact="true" />
                             @if (context.ResultModifiedByAdmin)
                             {
                                 <MudTooltip Text="@($"Original: {context.OriginalResultSummary}")">

--- a/DropShot/Components/ResultCard.razor
+++ b/DropShot/Components/ResultCard.razor
@@ -1,7 +1,7 @@
 @using DropShot.Models
 
-<div class="result-card">
-    @if (Fixture.Competition != null)
+<div class="@CardClass">
+    @if (!Compact && Fixture.Competition != null)
     {
         <div class="rc-header">
             <span class="rc-comp">@Fixture.Competition.CompetitionName</span>
@@ -26,7 +26,10 @@
         </div>
     </div>
 
-    <div class="rc-separator">v</div>
+    @if (!Compact)
+    {
+        <div class="rc-separator">v</div>
+    }
 
     <div class="rc-player-row @(IsPlayer2Winner ? "rc-winner" : "")">
         <div class="rc-name">@Player2Name</div>
@@ -41,6 +44,9 @@
 
 @code {
     [Parameter, EditorRequired] public CompetitionFixture Fixture { get; set; } = default!;
+    [Parameter] public bool Compact { get; set; }
+
+    private string CardClass => Compact ? "result-card result-card-compact" : "result-card";
 
     private List<(string P1, string P2)> _sets = [];
 

--- a/DropShot/Components/ResultCard.razor.css
+++ b/DropShot/Components/ResultCard.razor.css
@@ -93,3 +93,29 @@
     font-style: italic;
     line-height: 1;
 }
+
+/* ── Compact variant (for use inside tables/lists) ──────────── */
+.result-card-compact {
+    min-width: unset;
+    border: none;
+    border-radius: 0;
+    background-color: transparent;
+}
+
+.result-card-compact .rc-player-row {
+    padding: 2px 0;
+    min-height: unset;
+}
+
+.result-card-compact .rc-player-row.rc-winner {
+    background-color: transparent;
+}
+
+.result-card-compact .rc-name {
+    font-size: 0.8rem;
+}
+
+.result-card-compact .rc-set-score {
+    width: 22px;
+    font-size: 0.8rem;
+}


### PR DESCRIPTION
## Summary
- Recent results now display beside upcoming matches on desktop (md+), stacking below on mobile
- Results listed one per row in date order (latest first) instead of a grid
- Added `Compact` parameter to `ResultCard` that removes the header and "v" separator for use in tables/lists where that context is already shown
- ViewCompetition uses the compact variant in its result column

## Test plan
- [ ] On desktop, verify recent results appear to the right of upcoming matches
- [ ] On mobile, verify they stack below
- [ ] Verify results are ordered latest first
- [ ] Verify compact ResultCard in ViewCompetition shows scores without header/separator
- [ ] Verify the full ResultCard still shows header and separator on the home page

🤖 Generated with [Claude Code](https://claude.com/claude-code)