### PR TITLE
Block non-editors from accessing competition edit view

### DIFF
--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -1159,6 +1159,11 @@
             if (comp is null) { _serverError = $"Competition {Id} not found."; return; }
 
             _canEdit = await AuthzService.CanEditCompetitionAsync(authState.User, comp.HostClubId, Id);
+            if (!_canEdit)
+            {
+                Nav.NavigateTo($"/competition/{Id}/view", replace: true);
+                return;
+            }
             _isStarted = comp.IsStarted;
             _nameOverride = true; // Existing competition — preserve its name
 
@@ -1215,6 +1220,11 @@
             // Admins and ClubAdmins can create new competitions
             _canEdit = await AuthzService.IsAdminAsync(authState.User)
                 || (await AuthzService.GetAdminClubIdsAsync(authState.User)).Count > 0;
+            if (!_canEdit)
+            {
+                Nav.NavigateTo("/", replace: true);
+                return;
+            }
             Model = new CompetitionFormModel { EventId = EventId };
             _stages = [];
             _participants = [];

--- a/DropShot/Components/Pages/ViewCompetition.razor
+++ b/DropShot/Components/Pages/ViewCompetition.razor
@@ -33,11 +33,14 @@ else
     @* ── Header ─────────────────────────────────────────────── *@
     <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="mb-4">
         <MudText Typo="Typo.h4" Style="flex:1">@_competition.CompetitionName</MudText>
-        <MudButton Variant="Variant.Outlined" Color="Color.Default"
-                   StartIcon="@Icons.Material.Filled.Edit"
-                   OnClick="@(() => Nav.NavigateTo($"/competition/{Id}"))">
-            Edit
-        </MudButton>
+        @if (_canEdit)
+        {
+            <MudButton Variant="Variant.Outlined" Color="Color.Default"
+                       StartIcon="@Icons.Material.Filled.Edit"
+                       OnClick="@(() => Nav.NavigateTo($"/competition/{Id}"))">
+                Edit
+            </MudButton>
+        }
     </MudStack>
 
     <MudGrid Spacing="3" Class="mb-4">


### PR DESCRIPTION
## Summary
- Hide the Edit button on the competition view page for users who lack edit permission
- Redirect non-editors away from the competition edit page so they can't delete fixtures or access other edit-only controls

## Test plan
- [ ] Sign in as a standard user, view a competition — Edit button should not appear
- [ ] Navigate directly to `/competition/{id}` as a standard user — should redirect to the view page
- [ ] Sign in as an admin / club admin — Edit button visible, edit page accessible as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)