### PR TITLE
Fix false-positive downstream block when deleting fixture result

### DIFF
--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -1885,19 +1885,37 @@
             var oldWinnerTeamId = fx.WinnerTeamId;
             bool isTeamFixture = fx.HomeTeamId.HasValue;
 
-            // Block if downstream fixtures have progressed
+            // Block if downstream fixtures (later stage, or later round in the same stage) have progressed
             if (oldWinnerPlayerId.HasValue || oldWinnerTeamId.HasValue)
             {
+                var currentStageOrder = fx.Stage?.StageOrder;
+                var currentRound = fx.RoundNumber;
+
                 var downstream = await db.CompetitionFixtures
+                    .Include(f => f.Stage)
                     .Where(f => f.CompetitionId == fx.CompetitionId
                         && f.CompetitionFixtureId != fx.CompetitionFixtureId
                         && (f.Status == FixtureStatus.InProgress || f.Status == FixtureStatus.Completed
                             || f.Status == FixtureStatus.AwaitingVerification))
                     .ToListAsync();
 
+                bool IsDownstream(CompetitionFixture f)
+                {
+                    if (currentStageOrder.HasValue && f.Stage != null
+                        && f.Stage.StageOrder > currentStageOrder.Value)
+                        return true;
+                    if (f.CompetitionStageId == fx.CompetitionStageId
+                        && currentRound.HasValue && f.RoundNumber.HasValue
+                        && f.RoundNumber.Value > currentRound.Value)
+                        return true;
+                    return false;
+                }
+
                 bool blocked = isTeamFixture
-                    ? downstream.Any(f => f.HomeTeamId == oldWinnerTeamId || f.AwayTeamId == oldWinnerTeamId)
-                    : downstream.Any(f => f.Player1Id == oldWinnerPlayerId || f.Player2Id == oldWinnerPlayerId);
+                    ? downstream.Any(f => IsDownstream(f)
+                        && (f.HomeTeamId == oldWinnerTeamId || f.AwayTeamId == oldWinnerTeamId))
+                    : downstream.Any(f => IsDownstream(f)
+                        && (f.Player1Id == oldWinnerPlayerId || f.Player2Id == oldWinnerPlayerId));
 
                 if (blocked)
                 {

--- a/DropShot/Controllers/CompetitionsController.cs
+++ b/DropShot/Controllers/CompetitionsController.cs
@@ -483,21 +483,40 @@ public class CompetitionsController(
         var oldWinnerTeamId = fixture.WinnerTeamId;
         bool isTeamFixture = fixture.HomeTeamId.HasValue;
 
-        // Check for downstream fixtures that have already progressed beyond Scheduled
+        // Check for downstream fixtures (later stage, or later round in the same stage)
+        // that have already progressed beyond Scheduled.
         if (oldWinnerPlayerId.HasValue || oldWinnerTeamId.HasValue)
         {
+            var currentStageOrder = fixture.Stage?.StageOrder;
+            var currentRound = fixture.RoundNumber;
+
             var downstreamFixtures = await db.CompetitionFixtures
+                .Include(f => f.Stage)
                 .Where(f => f.CompetitionId == id
                     && f.CompetitionFixtureId != fixtureId
                     && (f.Status == FixtureStatus.InProgress || f.Status == FixtureStatus.Completed
                         || f.Status == FixtureStatus.AwaitingVerification))
                 .ToListAsync();
 
+            bool IsDownstream(CompetitionFixture f)
+            {
+                // Later stage
+                if (currentStageOrder.HasValue && f.Stage != null
+                    && f.Stage.StageOrder > currentStageOrder.Value)
+                    return true;
+                // Same stage, later round
+                if (f.CompetitionStageId == fixture.CompetitionStageId
+                    && currentRound.HasValue && f.RoundNumber.HasValue
+                    && f.RoundNumber.Value > currentRound.Value)
+                    return true;
+                return false;
+            }
+
             bool blocked = isTeamFixture
-                ? downstreamFixtures.Any(f =>
-                    f.HomeTeamId == oldWinnerTeamId || f.AwayTeamId == oldWinnerTeamId)
-                : downstreamFixtures.Any(f =>
-                    f.Player1Id == oldWinnerPlayerId || f.Player2Id == oldWinnerPlayerId);
+                ? downstreamFixtures.Any(f => IsDownstream(f)
+                    && (f.HomeTeamId == oldWinnerTeamId || f.AwayTeamId == oldWinnerTeamId))
+                : downstreamFixtures.Any(f => IsDownstream(f)
+                    && (f.Player1Id == oldWinnerPlayerId || f.Player2Id == oldWinnerPlayerId));
 
             if (blocked)
                 return BadRequest(new { message = "Cannot delete this result because the winner has already been placed in a downstream match that is in progress or completed. Delete that result first." });


### PR DESCRIPTION
## Summary
- The 'downstream match in progress' check when deleting a fixture result scanned every non-Scheduled fixture in the competition for the winner, so prior-round knockout matches and sibling round-robin matches falsely blocked deletion.
- Restrict the check to genuinely downstream fixtures: later stage (higher `StageOrder`), or later round within the same stage.
- Applied in both the API (`CompetitionsController.DeleteFixtureResult`) and the Blazor page (`CompetitionPage.DeleteFixture`).

## Test plan
- [ ] Complete a round-robin match, then delete the result — should succeed even if the same player has other completed matches.
- [ ] In a knockout, delete a 2nd-round result whose winner has not advanced yet — should succeed (previous round is upstream).
- [ ] In a knockout, advance the winner into a later-round fixture that is InProgress/Completed, then attempt to delete — should still be blocked with the existing message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)