### PR TITLE
Add invite-a-friend flow for lite players

### DIFF
--- a/DropShot/Components/Account/Pages/Register.razor
+++ b/DropShot/Components/Account/Pages/Register.razor
@@ -77,6 +77,9 @@
     [SupplyParameterFromQuery]
     private string? ReturnUrl { get; set; }
 
+    [SupplyParameterFromQuery]
+    private Guid? InviteToken { get; set; }
+
     private string? Message => identityErrors is null ? null : $"Error: {string.Join(", ", identityErrors.Select(error => error.Description))}";
 
     protected override async Task OnInitializedAsync()
@@ -111,7 +114,47 @@
         var userIdStr = await UserManager.GetUserIdAsync(user);
         await using (var db = await DbFactory.CreateDbContextAsync())
         {
-            var player = await db.Players.FirstOrDefaultAsync(p =>
+            // If the user arrived via an invite link, claim the invited light player first.
+            if (InviteToken is Guid token && token != Guid.Empty)
+            {
+                var invite = await db.PlayerInvitations
+                    .FirstOrDefaultAsync(i => i.Token == token && i.AcceptedAt == null);
+                if (invite is not null)
+                {
+                    var invited = await db.Players.FirstOrDefaultAsync(p =>
+                        p.PlayerId == invite.LightPlayerId && p.IsLight && p.UserId == null);
+                    if (invited is not null)
+                    {
+                        invited.IsLight = false;
+                        invited.UserId = userIdStr;
+                        invited.Email = Input.Email;
+                        if (string.IsNullOrWhiteSpace(invited.DisplayName))
+                            invited.DisplayName = Input.DisplayName;
+                        invite.AcceptedAt = DateTime.UtcNow;
+                        invite.AcceptedByUserId = userIdStr;
+
+                        // Bookmark the now-verified player for the user who sent the invite,
+                        // so they keep seeing them in "My Players".
+                        var inviterAlreadyBookmarked = await db.UserPlayers.AnyAsync(up =>
+                            up.UserId == invite.CreatedByUserId && up.PlayerId == invited.PlayerId);
+                        if (!inviterAlreadyBookmarked)
+                        {
+                            db.UserPlayers.Add(new Models.UserPlayer
+                            {
+                                UserId = invite.CreatedByUserId,
+                                PlayerId = invited.PlayerId
+                            });
+                        }
+
+                        await db.SaveChangesAsync();
+                        linkedPlayer = true;
+                        Logger.LogInformation("Claimed invited light player {PlayerId} for new user {Email}.",
+                            invited.PlayerId, Input.Email);
+                    }
+                }
+            }
+
+            var player = linkedPlayer ? null : await db.Players.FirstOrDefaultAsync(p =>
                 p.Email == Input.Email && p.UserId == null);
             if (player is not null)
             {

--- a/DropShot/Components/Pages/Invite.razor
+++ b/DropShot/Components/Pages/Invite.razor
@@ -1,0 +1,235 @@
+@page "/invite/{token:guid}"
+@rendermode InteractiveServer
+@using System.Security.Claims
+@using Microsoft.AspNetCore.Components.Authorization
+@using Microsoft.EntityFrameworkCore
+@using DropShot.Data
+@using DropShot.Models
+
+@inject IDbContextFactory<MyDbContext> DbFactory
+@inject AuthenticationStateProvider AuthStateProvider
+@inject NavigationManager NavigationManager
+
+<MudProviders />
+
+<MudContainer MaxWidth="MaxWidth.Small" Class="mt-8">
+    @if (_loading)
+    {
+        <MudProgressCircular Indeterminate="true" />
+    }
+    else if (!string.IsNullOrEmpty(_errorMessage))
+    {
+        <MudAlert Severity="Severity.Error" Class="mb-3">@_errorMessage</MudAlert>
+        <MudButton Href="/" Variant="Variant.Outlined">Back home</MudButton>
+    }
+    else if (_merged)
+    {
+        <MudAlert Severity="Severity.Success" Class="mb-3">
+            Invitation accepted. Match history for "@_lightPlayerName" has been merged into your player record.
+        </MudAlert>
+        <MudButton Href="/players/mine" Variant="Variant.Filled" Color="Color.Primary">
+            Go to My Players
+        </MudButton>
+    }
+    else if (_needsAuthChoice)
+    {
+        <MudText Typo="Typo.h5" Class="mb-3">You've been invited to DropShot</MudText>
+        <MudText Typo="Typo.body1" Class="mb-4">
+            Accept this invitation to claim the player record for <b>@_lightPlayerName</b>.
+            Any existing match history will be transferred to your account.
+        </MudText>
+        <MudStack Row="true" Spacing="2">
+            <MudButton Href="@_registerUrl" Variant="Variant.Filled" Color="Color.Primary">
+                Create account
+            </MudButton>
+            <MudButton Href="@_loginUrl" Variant="Variant.Outlined" Color="Color.Primary">
+                Log in to existing account
+            </MudButton>
+        </MudStack>
+    }
+    else if (_needsConfirm)
+    {
+        <MudText Typo="Typo.h5" Class="mb-3">Accept invitation?</MudText>
+        <MudText Typo="Typo.body1" Class="mb-4">
+            Match history for <b>@_lightPlayerName</b> will be merged into your player record
+            (<b>@_currentPlayerName</b>). The @_lightPlayerName record will be removed.
+        </MudText>
+        <MudStack Row="true" Spacing="2">
+            <MudButton OnClick="AcceptInvite" Variant="Variant.Filled" Color="Color.Primary"
+                       Disabled="@_accepting">
+                @(_accepting ? "Accepting…" : "Accept invitation")
+            </MudButton>
+            <MudButton Href="/" Variant="Variant.Outlined" Disabled="@_accepting">Cancel</MudButton>
+        </MudStack>
+    }
+</MudContainer>
+
+@code {
+    [Parameter] public Guid Token { get; set; }
+
+    private bool _loading = true;
+    private string? _errorMessage;
+    private bool _merged;
+    private bool _needsAuthChoice;
+    private bool _needsConfirm;
+    private bool _accepting;
+    private string _lightPlayerName = "";
+    private string _currentPlayerName = "";
+    private string _registerUrl = "";
+    private string _loginUrl = "";
+    private int _lightPlayerId;
+    private string? _userId;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await using var db = DbFactory.CreateDbContext();
+        var invite = await db.PlayerInvitations
+            .Include(i => i.LightPlayer)
+            .FirstOrDefaultAsync(i => i.Token == Token);
+
+        if (invite is null)
+        {
+            _errorMessage = "This invitation link isn't valid.";
+            _loading = false;
+            return;
+        }
+
+        if (invite.AcceptedAt != null)
+        {
+            _errorMessage = "This invitation has already been accepted.";
+            _loading = false;
+            return;
+        }
+
+        if (invite.LightPlayer is null || !invite.LightPlayer.IsLight)
+        {
+            _errorMessage = "This invitation is no longer valid — the player record has changed.";
+            _loading = false;
+            return;
+        }
+
+        _lightPlayerName = invite.LightPlayer.DisplayName;
+        _lightPlayerId = invite.LightPlayerId;
+
+        var authState = await AuthStateProvider.GetAuthenticationStateAsync();
+        var isAuthenticated = authState.User.Identity?.IsAuthenticated == true;
+
+        if (!isAuthenticated)
+        {
+            _registerUrl = $"/Account/Register?inviteToken={Token}";
+            _loginUrl = $"/Account/Login?ReturnUrl={Uri.EscapeDataString($"/invite/{Token}")}";
+            _needsAuthChoice = true;
+            _loading = false;
+            return;
+        }
+
+        _userId = authState.User.FindFirstValue(ClaimTypes.NameIdentifier);
+
+        if (invite.CreatedByUserId == _userId)
+        {
+            _errorMessage = "You can't accept an invitation that you sent yourself.";
+            _loading = false;
+            return;
+        }
+
+        var currentPlayer = await db.Players
+            .FirstOrDefaultAsync(p => p.UserId == _userId && !p.IsLight);
+
+        if (currentPlayer is null)
+        {
+            _errorMessage = "Your account isn't linked to a player record. Please contact support.";
+            _loading = false;
+            return;
+        }
+
+        if (currentPlayer.PlayerId == invite.LightPlayerId)
+        {
+            _errorMessage = "You can't accept an invitation for your own player record.";
+            _loading = false;
+            return;
+        }
+
+        _currentPlayerName = currentPlayer.DisplayName;
+        _needsConfirm = true;
+        _loading = false;
+    }
+
+    private async Task AcceptInvite()
+    {
+        _accepting = true;
+
+        await using var db = DbFactory.CreateDbContext();
+
+        var invite = await db.PlayerInvitations
+            .FirstOrDefaultAsync(i => i.Token == Token && i.AcceptedAt == null);
+        if (invite is null)
+        {
+            _errorMessage = "Invitation is no longer valid.";
+            _needsConfirm = false;
+            _accepting = false;
+            return;
+        }
+
+        var lightPlayer = await db.Players.FindAsync(invite.LightPlayerId);
+        if (lightPlayer is not { IsLight: true })
+        {
+            _errorMessage = "The invited player record is no longer available.";
+            _needsConfirm = false;
+            _accepting = false;
+            return;
+        }
+
+        var currentPlayer = await db.Players
+            .FirstOrDefaultAsync(p => p.UserId == _userId && !p.IsLight);
+        if (currentPlayer is null)
+        {
+            _errorMessage = "Your account isn't linked to a player record.";
+            _needsConfirm = false;
+            _accepting = false;
+            return;
+        }
+
+        var lightId = lightPlayer.PlayerId;
+        var verifiedId = currentPlayer.PlayerId;
+
+        // Migrate SavedMatch references from light player to the user's verified player
+        var affected = await db.SavedMatch
+            .Where(m => m.Player1Id == lightId || m.Player2Id == lightId ||
+                        m.Player3Id == lightId || m.Player4Id == lightId ||
+                        m.WinnerPlayerId == lightId)
+            .ToListAsync();
+        foreach (var m in affected)
+        {
+            if (m.Player1Id == lightId) m.Player1Id = verifiedId;
+            if (m.Player2Id == lightId) m.Player2Id = verifiedId;
+            if (m.Player3Id == lightId) m.Player3Id = verifiedId;
+            if (m.Player4Id == lightId) m.Player4Id = verifiedId;
+            if (m.WinnerPlayerId == lightId) m.WinnerPlayerId = verifiedId;
+        }
+
+        // Mark the invitation accepted before removing the light player — the cascade delete
+        // on LightPlayerId will remove the invitation row anyway, but the audit fields are
+        // set in case that behavior is relaxed later.
+        invite.AcceptedAt = DateTime.UtcNow;
+        invite.AcceptedByUserId = _userId;
+
+        // Bookmark the now-merged player for the inviter so they keep seeing them.
+        var inviterAlreadyBookmarked = await db.UserPlayers.AnyAsync(up =>
+            up.UserId == invite.CreatedByUserId && up.PlayerId == verifiedId);
+        if (!inviterAlreadyBookmarked)
+        {
+            db.UserPlayers.Add(new UserPlayer
+            {
+                UserId = invite.CreatedByUserId,
+                PlayerId = verifiedId
+            });
+        }
+
+        db.Players.Remove(lightPlayer);
+        await db.SaveChangesAsync();
+
+        _merged = true;
+        _needsConfirm = false;
+        _accepting = false;
+    }
+}

--- a/DropShot/Components/Pages/MyPlayers.razor
+++ b/DropShot/Components/Pages/MyPlayers.razor
@@ -13,6 +13,9 @@
 @inject ISnackbar Snackbar
 @inject IDialogService DialogService
 @inject FuzzySearchService FuzzySearch
+@inject NavigationManager NavigationManager
+@inject IJSRuntime JS
+@inject EmailService EmailService
 
 <MudProviders />
 
@@ -39,11 +42,7 @@
         <MudTd DataLabel="Player">
             <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
                 <MudText>@context.DisplayName</MudText>
-                @if (context.IsLight)
-                {
-                    <MudChip T="string" Size="Size.Small" Color="Color.Default" Variant="Variant.Outlined">Light</MudChip>
-                }
-                else
+                @if (!context.IsLight)
                 {
                     <MudIcon Icon="@Icons.Material.Filled.Verified" Color="Color.Success" Size="Size.Small"
                              Title="Verified player" />
@@ -59,9 +58,9 @@
                     <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="Size.Small"
                                    OnClick="@(() => OpenEditDialog(context))" />
                 </MudTooltip>
-                <MudTooltip Text="Link to verified player">
-                    <MudIconButton Icon="@Icons.Material.Filled.Link" Size="Size.Small" Color="Color.Info"
-                                   OnClick="@(() => OpenLinkDialog(context))" />
+                <MudTooltip Text="Invite to join">
+                    <MudIconButton Icon="@Icons.Material.Filled.PersonAddAlt1" Size="Size.Small" Color="Color.Info"
+                                   OnClick="@(() => OpenInviteDialog(context))" />
                 </MudTooltip>
                 <MudTooltip Text="Delete">
                     <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small" Color="Color.Error"
@@ -181,6 +180,44 @@
     </DialogActions>
 </MudDialog>
 
+@* ── Invite Player Dialog ─────────────────────────────────── *@
+<MudDialog @bind-Visible="_showInviteDialog">
+    <TitleContent>Invite "@_invitingPlayer?.DisplayName" to join</TitleContent>
+    <DialogContent>
+        <MudText Typo="Typo.body2" Class="mb-3">
+            Send an invite link. When they register, their new account will be linked to this player
+            and any existing match history will be transferred.
+        </MudText>
+
+        @if (!string.IsNullOrEmpty(_inviteLink))
+        {
+            <MudTextField Value="@_inviteLink" Label="Invite link" Variant="Variant.Outlined"
+                          ReadOnly="true" Class="mb-3" />
+
+            <MudStack Row="true" Spacing="2" Class="mb-4">
+                <MudButton Variant="Variant.Outlined" Color="Color.Primary"
+                           StartIcon="@Icons.Material.Filled.ContentCopy"
+                           OnClick="CopyInviteLink">Copy link</MudButton>
+            </MudStack>
+
+            <MudDivider Class="mb-3" />
+
+            <MudText Typo="Typo.subtitle2" Class="mb-2">Or email the link</MudText>
+            <MudTextField @bind-Value="_inviteEmail" Label="Recipient email" Variant="Variant.Outlined"
+                          InputType="InputType.Email" Immediate="true" Class="mb-2" />
+        }
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@(() => _showInviteDialog = false)">Close</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                   StartIcon="@Icons.Material.Filled.Email"
+                   Disabled="@(_sendingInvite || string.IsNullOrWhiteSpace(_inviteEmail))"
+                   OnClick="SendInviteEmail">
+            @(_sendingInvite ? "Sending…" : "Send email")
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
 @code {
     private record PlayerRow(int PlayerId, string DisplayName, string? FirstName, string? LastName, bool IsLight);
 
@@ -206,6 +243,14 @@
     private List<FuzzySearchResult> _linkSuggestions = [];
     private FuzzySearchResult? _selectedLinkPlayer;
     private CancellationTokenSource? _linkDebounce;
+
+    // Invite dialog
+    private bool _showInviteDialog;
+    private PlayerRow? _invitingPlayer;
+    private string _inviteLink = "";
+    private Guid _inviteToken;
+    private string _inviteEmail = "";
+    private bool _sendingInvite;
 
     private sealed class LightPlayerForm
     {
@@ -558,4 +603,100 @@
 
     private static string? NullIfEmpty(string? s) =>
         string.IsNullOrWhiteSpace(s) ? null : s.Trim();
+
+    // ── Invite ──────────────────────────────────────────────────
+
+    private async Task OpenInviteDialog(PlayerRow player)
+    {
+        _invitingPlayer = player;
+        _inviteEmail = "";
+        _sendingInvite = false;
+
+        // Reuse an existing unaccepted invitation if one exists, otherwise create a new one.
+        await using var db = DbFactory.CreateDbContext();
+        var existing = await db.PlayerInvitations
+            .Where(i => i.LightPlayerId == player.PlayerId
+                     && i.CreatedByUserId == _userId
+                     && i.AcceptedAt == null)
+            .OrderByDescending(i => i.CreatedAt)
+            .FirstOrDefaultAsync();
+
+        if (existing is not null)
+        {
+            _inviteToken = existing.Token;
+        }
+        else
+        {
+            var invite = new PlayerInvitation
+            {
+                Token = Guid.NewGuid(),
+                LightPlayerId = player.PlayerId,
+                CreatedByUserId = _userId!,
+                CreatedAt = DateTime.UtcNow
+            };
+            db.PlayerInvitations.Add(invite);
+            await db.SaveChangesAsync();
+            _inviteToken = invite.Token;
+        }
+
+        var inviteUri = NavigationManager.ToAbsoluteUri($"invite/{_inviteToken}");
+        _inviteLink = inviteUri.AbsoluteUri;
+        _showInviteDialog = true;
+    }
+
+    private async Task CopyInviteLink()
+    {
+        if (string.IsNullOrEmpty(_inviteLink)) return;
+        try
+        {
+            await JS.InvokeVoidAsync("navigator.clipboard.writeText", _inviteLink);
+            Snackbar.Add("Invite link copied to clipboard.", Severity.Success);
+        }
+        catch
+        {
+            Snackbar.Add("Couldn't copy automatically — please copy the link manually.", Severity.Warning);
+        }
+    }
+
+    private async Task SendInviteEmail()
+    {
+        if (_invitingPlayer is null || string.IsNullOrWhiteSpace(_inviteEmail)) return;
+        if (!new System.ComponentModel.DataAnnotations.EmailAddressAttribute().IsValid(_inviteEmail))
+        {
+            Snackbar.Add("Please enter a valid email address.", Severity.Error);
+            return;
+        }
+
+        _sendingInvite = true;
+        try
+        {
+            await using var db = DbFactory.CreateDbContext();
+            var invite = await db.PlayerInvitations.FirstOrDefaultAsync(i => i.Token == _inviteToken);
+            if (invite is not null)
+            {
+                invite.SentToEmail = _inviteEmail.Trim();
+                await db.SaveChangesAsync();
+            }
+
+            var subject = $"You've been invited to join DropShot as \"{_invitingPlayer.DisplayName}\"";
+            var body =
+                $"Hi,\n\nYou've been invited to join DropShot as \"{_invitingPlayer.DisplayName}\". " +
+                $"Click the link below to register. Your new account will be linked to the existing " +
+                $"player record and any match history will be transferred automatically.\n\n" +
+                $"{_inviteLink}\n\n" +
+                $"If you weren't expecting this, you can safely ignore it.";
+
+            await EmailService.SendEmailAsync(_inviteEmail.Trim(), subject, body);
+            Snackbar.Add($"Invite sent to {_inviteEmail.Trim()}.", Severity.Success);
+            _showInviteDialog = false;
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Failed to send email: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _sendingInvite = false;
+        }
+    }
 }

--- a/DropShot/Data/Migrations/20260414232455_AddPlayerInvitations.Designer.cs
+++ b/DropShot/Data/Migrations/20260414232455_AddPlayerInvitations.Designer.cs
@@ -4,6 +4,7 @@ using DropShot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DropShot.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260414232455_AddPlayerInvitations")]
+    partial class AddPlayerInvitations
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DropShot/Data/Migrations/20260414232455_AddPlayerInvitations.cs
+++ b/DropShot/Data/Migrations/20260414232455_AddPlayerInvitations.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropShot.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPlayerInvitations : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PlayerInvitations",
+                columns: table => new
+                {
+                    PlayerInvitationId = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Token = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    LightPlayerId = table.Column<int>(type: "int", nullable: false),
+                    CreatedByUserId = table.Column<string>(type: "nvarchar(450)", maxLength: 450, nullable: false),
+                    SentToEmail = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    AcceptedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    AcceptedByUserId = table.Column<string>(type: "nvarchar(450)", maxLength: 450, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PlayerInvitations", x => x.PlayerInvitationId);
+                    table.ForeignKey(
+                        name: "FK_PlayerInvitations_AspNetUsers_CreatedByUserId",
+                        column: x => x.CreatedByUserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_PlayerInvitations_Players_LightPlayerId",
+                        column: x => x.LightPlayerId,
+                        principalTable: "Players",
+                        principalColumn: "PlayerId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PlayerInvitations_CreatedByUserId",
+                table: "PlayerInvitations",
+                column: "CreatedByUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PlayerInvitations_LightPlayerId",
+                table: "PlayerInvitations",
+                column: "LightPlayerId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PlayerInvitations_Token",
+                table: "PlayerInvitations",
+                column: "Token",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PlayerInvitations");
+        }
+    }
+}

--- a/DropShot/Data/MyDbContext.cs
+++ b/DropShot/Data/MyDbContext.cs
@@ -38,10 +38,31 @@ namespace DropShot.Data
         public DbSet<Event> Events { get; set; }
         public DbSet<CourtPair> CourtPairs { get; set; }
         public DbSet<TeamMatchSet> TeamMatchSets { get; set; }
+        public DbSet<PlayerInvitation> PlayerInvitations { get; set; }
 
         protected override void OnModelCreating(ModelBuilder builder)
         {
             base.OnModelCreating(builder);
+
+            // ── PlayerInvitation ────────────────────────────────────────────────
+            builder.Entity<PlayerInvitation>(entity =>
+            {
+                entity.Property(i => i.CreatedByUserId).HasMaxLength(450).IsRequired();
+                entity.Property(i => i.AcceptedByUserId).HasMaxLength(450);
+                entity.Property(i => i.SentToEmail).HasMaxLength(256);
+                entity.HasIndex(i => i.Token).IsUnique();
+                entity.HasIndex(i => i.CreatedByUserId);
+
+                entity.HasOne(i => i.LightPlayer)
+                      .WithMany()
+                      .HasForeignKey(i => i.LightPlayerId)
+                      .OnDelete(DeleteBehavior.Cascade);
+
+                entity.HasOne(i => i.CreatedByUser)
+                      .WithMany()
+                      .HasForeignKey(i => i.CreatedByUserId)
+                      .OnDelete(DeleteBehavior.Restrict);
+            });
 
             // ── Player ──────────────────────────────────────────────────────────
             builder.Entity<Player>(entity =>

--- a/DropShot/Models/PlayerInvitation.cs
+++ b/DropShot/Models/PlayerInvitation.cs
@@ -1,0 +1,21 @@
+using DropShot.Data;
+
+namespace DropShot.Models;
+
+public class PlayerInvitation
+{
+    public int PlayerInvitationId { get; set; }
+    public Guid Token { get; set; } = Guid.NewGuid();
+
+    public int LightPlayerId { get; set; }
+    public Player? LightPlayer { get; set; }
+
+    public string CreatedByUserId { get; set; } = "";
+    public ApplicationUser? CreatedByUser { get; set; }
+
+    public string? SentToEmail { get; set; }
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime? AcceptedAt { get; set; }
+    public string? AcceptedByUserId { get; set; }
+}


### PR DESCRIPTION
## Summary
- Remove the "Light" chip and replace the "Link to verified player" action on My Players with an **Invite** button that opens a dialog with Copy-link and Email-link options.
- New `PlayerInvitation` entity (token, light player, inviter, sent-to email, accepted audit) with EF migration `AddPlayerInvitations`.
- New `/invite/{token}` landing page that branches on auth state:
  - **Anonymous** → choose Register (existing `?inviteToken=` path) or Log in (returns to invite page after sign-in).
  - **Logged-in user with their own verified Player** → confirmation screen that merges the lite player's `SavedMatch` history into the existing Player, deletes the lite record, and bookmarks the merged player for the inviter.
- `Register.razor` still honors `?inviteToken=` for the new-account branch and now also bookmarks the merged player for the inviter.

## Test plan
- [ ] `dotnet ef database update` applies the new migration cleanly
- [ ] My Players: Invite dialog opens, copy-link writes to clipboard, email send uses ACS / logs in simulation mode
- [ ] Anonymous recipient → `/invite/{token}` offers Register and Login; Register path claims lite player on account creation
- [ ] Already-registered recipient → `/invite/{token}` shows merge confirmation, merge transfers match history and removes the lite player
- [ ] Invalid / already-accepted / self-invite tokens each show a specific error

🤖 Generated with [Claude Code](https://claude.com/claude-code)