### PR TITLE
Add register-by date and restrict competition visibility

### DIFF
--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -142,6 +142,9 @@
                         <MudItem xs="12" sm="6">
                             <MudDatePicker @bind-Date="Model.EndDateDt" Label="End Date (optional)" DateFormat="dd/MM/yyyy" />
                         </MudItem>
+                        <MudItem xs="12" sm="6">
+                            <MudDatePicker @bind-Date="Model.RegisterByDateDt" Label="Register By (optional)" DateFormat="dd/MM/yyyy" />
+                        </MudItem>
                     </MudGrid>
 
                     <MudNumericField @bind-Value="Model.MaxParticipants" Label="Max Participants (optional)"
@@ -1048,6 +1051,7 @@
         public int? MaxParticipants { get; set; }
         public DateTime? StartDateDt { get; set; }
         public DateTime? EndDateDt { get; set; }
+        public DateTime? RegisterByDateDt { get; set; }
         public int? MaxAge { get; set; }
         public int? MinAge { get; set; }
         public PlayerSex? EligibleSex { get; set; }
@@ -1174,6 +1178,7 @@
                 MaxParticipants = comp.MaxParticipants,
                 StartDateDt = comp.StartDate,
                 EndDateDt = comp.EndDate,
+                RegisterByDateDt = comp.RegisterByDate,
                 MaxAge = comp.MaxAge,
                 MinAge = comp.MinAge,
                 EligibleSex = comp.EligibleSex,
@@ -1418,6 +1423,7 @@
         comp.MaxParticipants = Model.MaxParticipants;
         comp.StartDate = Model.StartDateDt;
         comp.EndDate = Model.EndDateDt;
+        comp.RegisterByDate = Model.RegisterByDateDt;
         comp.MaxAge = Model.MaxAge;
         comp.MinAge = Model.MinAge;
         comp.EligibleSex = format is CompetitionFormat.MixedDoubles or CompetitionFormat.MixedTeam

--- a/DropShot/Components/Pages/Competitions.razor
+++ b/DropShot/Components/Pages/Competitions.razor
@@ -81,6 +81,7 @@
                     <MudTh>Format</MudTh>
                     <MudTh>Host Club</MudTh>
                     <MudTh>Dates</MudTh>
+                    <MudTh>Register By</MudTh>
                     <MudTh></MudTh>
                 </HeaderContent>
                 <RowTemplate>
@@ -88,20 +89,12 @@
                     <MudTd DataLabel="Format">@context.CompetitionFormat.ToDisplayName()</MudTd>
                     <MudTd DataLabel="Host Club">@(context.HostClub?.Name ?? "—")</MudTd>
                     <MudTd DataLabel="Dates">@FormatDates(context)</MudTd>
+                    <MudTd DataLabel="Register By">@(context.RegisterByDate?.ToString("dd MMM yyyy") ?? "—")</MudTd>
                     <MudTd>
-                        <MudStack Row="true" Spacing="1">
-                            @if (context.IsStarted)
-                            {
-                                <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Info"
-                                           OnClick="@(() => Nav.NavigateTo($"/competition/{context.CompetitionID}/view"))">
-                                    View
-                                </MudButton>
-                            }
-                            <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary"
-                                       OnClick="@(() => EnterCompetitionAsync(context))">
-                                Enter
-                            </MudButton>
-                        </MudStack>
+                        <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary"
+                                   OnClick="@(() => EnterCompetitionAsync(context))">
+                            Enter
+                        </MudButton>
                     </MudTd>
                 </RowTemplate>
             </MudTable>
@@ -563,10 +556,13 @@
             .ThenBy(c => c.CompetitionName)
             .ToListAsync();
 
+        var today = DateTime.UtcNow.Date;
         var candidates = await dbc.Competition
             .Include(c => c.HostClub)
             .Include(c => c.Event)
-            .Where(c => !enteredIds.Contains(c.CompetitionID) && !c.IsArchived)
+            .Where(c => !enteredIds.Contains(c.CompetitionID) && !c.IsArchived && !c.IsStarted)
+            .Where(c => !c.StartDate.HasValue || c.StartDate.Value >= today)
+            .Where(c => !c.RegisterByDate.HasValue || c.RegisterByDate.Value >= today)
             .OrderBy(c => c.StartDate)
             .ThenBy(c => c.CompetitionName)
             .ToListAsync();
@@ -610,6 +606,23 @@
     private async Task EnterCompetitionAsync(Competition comp)
     {
         if (_userPlayer == null) return;
+
+        var today = DateTime.UtcNow.Date;
+        if (comp.IsStarted)
+        {
+            Snackbar.Add("This competition has already started.", Severity.Warning);
+            return;
+        }
+        if (comp.StartDate.HasValue && comp.StartDate.Value < today)
+        {
+            Snackbar.Add("This competition has already started.", Severity.Warning);
+            return;
+        }
+        if (comp.RegisterByDate.HasValue && comp.RegisterByDate.Value < today)
+        {
+            Snackbar.Add("Registration for this competition has closed.", Severity.Warning);
+            return;
+        }
 
         await using var db = DbFactory.CreateDbContext();
 

--- a/DropShot/Components/Pages/ViewCompetition.razor
+++ b/DropShot/Components/Pages/ViewCompetition.razor
@@ -2,6 +2,7 @@
 @rendermode InteractiveServer
 @attribute [Authorize]
 
+@using System.Security.Claims
 @using Microsoft.AspNetCore.Authorization
 @using DropShot.Data
 @using DropShot.Models
@@ -27,6 +28,10 @@ else if (_competition == null)
 else if (!_competition.IsStarted && !_canEdit)
 {
     <MudAlert Severity="Severity.Info" Class="mb-4">This competition has not started yet. Check back later.</MudAlert>
+}
+else if (!_canView)
+{
+    <MudAlert Severity="Severity.Warning" Class="mb-4">You can only view this competition if you are registered to play in it.</MudAlert>
 }
 else
 {
@@ -272,6 +277,7 @@ else
 
     private bool _loading = true;
     private bool _canEdit;
+    private bool _canView;
     private Competition? _competition;
     private List<CompetitionFixture> _fixtures = [];
     private List<CompetitionParticipant> _participants = [];
@@ -314,6 +320,23 @@ else
         {
             var authState = await AuthStateProvider.GetAuthenticationStateAsync();
             _canEdit = await AuthzService.CanEditCompetitionAsync(authState.User, _competition.HostClubId, _competition.CompetitionID);
+
+            // Non-editors can only view a competition they are registered for.
+            if (_canEdit)
+            {
+                _canView = true;
+            }
+            else
+            {
+                var userId = authState.User.FindFirstValue(ClaimTypes.NameIdentifier);
+                if (!string.IsNullOrEmpty(userId))
+                {
+                    _canView = await db.CompetitionParticipants
+                        .AnyAsync(cp => cp.CompetitionId == _competition.CompetitionID
+                            && cp.Player!.UserId == userId);
+                }
+            }
+
             _fixtures = _competition.Fixtures
                 .OrderBy(f => f.ScheduledAt)
                 .ThenBy(f => f.RoundNumber ?? 0)

--- a/DropShot/Data/Migrations/20260414234304_AddCompetitionRegisterByDate.Designer.cs
+++ b/DropShot/Data/Migrations/20260414234304_AddCompetitionRegisterByDate.Designer.cs
@@ -4,6 +4,7 @@ using DropShot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DropShot.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260414234304_AddCompetitionRegisterByDate")]
+    partial class AddCompetitionRegisterByDate
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DropShot/Data/Migrations/20260414234304_AddCompetitionRegisterByDate.cs
+++ b/DropShot/Data/Migrations/20260414234304_AddCompetitionRegisterByDate.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropShot.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCompetitionRegisterByDate : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "RegisterByDate",
+                table: "Competition",
+                type: "datetime2",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RegisterByDate",
+                table: "Competition");
+        }
+    }
+}

--- a/DropShot/Models/Competition.cs
+++ b/DropShot/Models/Competition.cs
@@ -18,6 +18,7 @@
         public int? MaxParticipants { get; set; }
         public DateTime? StartDate { get; set; }
         public DateTime? EndDate { get; set; }
+        public DateTime? RegisterByDate { get; set; }
         public int? MaxAge { get; set; }
         public int? MinAge { get; set; }
         public PlayerSex? EligibleSex { get; set; }


### PR DESCRIPTION
## Summary
- Add nullable `RegisterByDate` to Competition (+ EF migration) and expose it on the edit form
- Hide competitions from the "Available to Enter" list once they have started, their start date has passed, or their register-by date has passed; guard the entry action with the same rules
- Restrict the competition view page so non-editors may only view competitions they are registered to play in

## Test plan
- [ ] `dotnet ef database update` applies the new migration
- [ ] Editor can set, save and clear a Register By date on a competition
- [ ] A competition that is started / past start date / past register-by no longer appears in a standard user's Available-to-Enter list
- [ ] A standard user who is not a participant cannot view a started competition
- [ ] A registered participant can view a started competition; editors retain full access

🤖 Generated with [Claude Code](https://claude.com/claude-code)