### PR TITLE
Record match completion date and show casual matches in recent results

### DIFF
--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -1968,6 +1968,7 @@
 
             // Reset fixture
             fx.Status = FixtureStatus.Scheduled;
+            fx.CompletedAt = null;
             fx.ResultSummary = null;
             fx.WinnerPlayerId = null;
             fx.WinnerTeamId = null;

--- a/DropShot/Components/Pages/Competitions.razor
+++ b/DropShot/Components/Pages/Competitions.razor
@@ -683,6 +683,7 @@
         if (fx == null) return;
 
         fx.Status = FixtureStatus.Completed;
+        fx.CompletedAt = DateTime.UtcNow;
         fx.VerificationToken = null;
         await db.SaveChangesAsync();
 

--- a/DropShot/Components/Pages/Home.razor
+++ b/DropShot/Components/Pages/Home.razor
@@ -203,7 +203,7 @@
             </MudItem>
         }
 
-        @if (_recentResults.Any())
+        @if (_recentItems.Any())
         {
             <MudItem xs="12" md="@(_upcomingFixtures.Any() ? 5 : 12)">
                 <MudCard>
@@ -217,24 +217,57 @@
                     </MudCardHeader>
                     <MudCardContent Class="pa-0">
                         <MudStack Spacing="0">
-                            @foreach (var fixture in _recentResults)
+                            @foreach (var item in _recentItems)
                             {
                                 <div style="padding: 8px 16px; border-bottom: 1px solid var(--mud-palette-lines-default);">
-                                    @if (fixture.Competition != null)
+                                    @if (item.Fixture != null)
                                     {
-                                        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="mb-1">
-                                            <MudText Typo="Typo.caption" Style="font-weight:500">@fixture.Competition.CompetitionName</MudText>
-                                            @if (!string.IsNullOrEmpty(fixture.FixtureLabel))
-                                            {
-                                                <MudText Typo="Typo.caption" Color="Color.Secondary">@fixture.FixtureLabel</MudText>
-                                            }
-                                            @if (fixture.ScheduledAt.HasValue)
-                                            {
-                                                <MudText Typo="Typo.caption" Color="Color.Secondary" Style="margin-left:auto">@fixture.ScheduledAt.Value.ToString("dd MMM yyyy")</MudText>
-                                            }
-                                        </MudStack>
+                                        var fixture = item.Fixture!;
+                                        @if (fixture.Competition != null)
+                                        {
+                                            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="mb-1">
+                                                <MudText Typo="Typo.caption" Style="font-weight:500">@fixture.Competition.CompetitionName</MudText>
+                                                @if (!string.IsNullOrEmpty(fixture.FixtureLabel))
+                                                {
+                                                    <MudText Typo="Typo.caption" Color="Color.Secondary">@fixture.FixtureLabel</MudText>
+                                                }
+                                                @{
+                                                    var resultDate = fixture.CompletedAt ?? fixture.ScheduledAt;
+                                                }
+                                                @if (resultDate.HasValue)
+                                                {
+                                                    <MudText Typo="Typo.caption" Color="Color.Secondary" Style="margin-left:auto">@resultDate.Value.ToString("dd MMM yyyy")</MudText>
+                                                }
+                                            </MudStack>
+                                        }
+                                        <ResultCard Fixture="fixture" Compact="true" />
                                     }
-                                    <ResultCard Fixture="fixture" Compact="true" />
+                                    else if (item.CasualMatch != null)
+                                    {
+                                        var casual = item.CasualMatch!;
+                                        string p1 = casual.Player3 != null
+                                            ? (casual.Player1 ?? "TBD") + " & " + casual.Player3
+                                            : (casual.Player1 ?? "TBD");
+                                        string p2 = casual.Player4 != null
+                                            ? (casual.Player2 ?? "TBD") + " & " + casual.Player4
+                                            : (casual.Player2 ?? "TBD");
+                                        bool p1Winner = casual.WinnerPlayerId.HasValue
+                                            && (casual.WinnerPlayerId == casual.Player1Id || casual.WinnerPlayerId == casual.Player3Id);
+                                        bool p2Winner = casual.WinnerPlayerId.HasValue
+                                            && (casual.WinnerPlayerId == casual.Player2Id || casual.WinnerPlayerId == casual.Player4Id);
+                                        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="mb-1">
+                                            <MudText Typo="Typo.caption" Style="font-weight:500">Casual Match</MudText>
+                                            <MudText Typo="Typo.caption" Color="Color.Secondary" Style="margin-left:auto">@item.Date.ToString("dd MMM yyyy")</MudText>
+                                        </MudStack>
+                                        <div class="result-card result-card-compact">
+                                            <div class="rc-player-row @(p1Winner ? "rc-winner" : "")">
+                                                <div class="rc-name">@p1</div>
+                                            </div>
+                                            <div class="rc-player-row @(p2Winner ? "rc-winner" : "")">
+                                                <div class="rc-name">@p2</div>
+                                            </div>
+                                        </div>
+                                    }
                                 </div>
                             }
                         </MudStack>
@@ -259,6 +292,9 @@
     private List<CompetitionFixture> _upcomingFixtures = [];
     private List<CompetitionFixture> _pendingReviews = [];
     private List<CompetitionFixture> _recentResults = [];
+    private List<RecentMatchItem> _recentItems = [];
+
+    private sealed record RecentMatchItem(DateTime Date, CompetitionFixture? Fixture, SavedMatch? CasualMatch);
     private bool _showUpgradeBanner;
     private bool _eligibleForUpgradeBanner;
     private bool _isAuthenticated;
@@ -325,9 +361,29 @@
             .Where(f => (f.Player1Id == pid || f.Player2Id == pid || f.Player3Id == pid || f.Player4Id == pid)
                      && f.Status == FixtureStatus.Completed
                      && f.ResultSummary != null)
-            .OrderByDescending(f => f.ScheduledAt)
+            .OrderByDescending(f => f.CompletedAt ?? f.ScheduledAt)
             .Take(6)
             .ToListAsync();
+
+        // Recently completed casual matches (SavedMatch rows not linked to a fixture)
+        var linkedSavedMatchIds = db.CompetitionFixtures
+            .Where(f => f.SavedMatchId != null)
+            .Select(f => f.SavedMatchId!.Value);
+
+        var recentCasuals = await db.SavedMatch
+            .Where(m => m.Complete
+                     && (m.Player1Id == pid || m.Player2Id == pid || m.Player3Id == pid || m.Player4Id == pid)
+                     && !linkedSavedMatchIds.Contains(m.SavedMatchId))
+            .OrderByDescending(m => m.CompletedAt ?? m.CreatedAt)
+            .Take(6)
+            .ToListAsync();
+
+        _recentItems = _recentResults
+            .Select(f => new RecentMatchItem(f.CompletedAt ?? f.ScheduledAt ?? DateTime.MinValue, f, null))
+            .Concat(recentCasuals.Select(m => new RecentMatchItem(m.CompletedAt ?? m.CreatedAt, null, m)))
+            .OrderByDescending(i => i.Date)
+            .Take(6)
+            .ToList();
     }
 
     private async Task OpenSubmitScoreAsync(CompetitionFixture fixture)
@@ -415,6 +471,7 @@
         if (fx == null) return;
 
         fx.Status = FixtureStatus.Completed;
+        fx.CompletedAt = DateTime.UtcNow;
         fx.VerificationToken = null;
         await db.SaveChangesAsync();
 

--- a/DropShot/Components/Pages/VerifyResult.razor
+++ b/DropShot/Components/Pages/VerifyResult.razor
@@ -253,6 +253,7 @@
             }
 
             fx.Status = FixtureStatus.Completed;
+            fx.CompletedAt = DateTime.UtcNow;
             fx.VerificationToken = null;
             await db.SaveChangesAsync();
 

--- a/DropShot/Components/Pages/ViewCompetition.razor
+++ b/DropShot/Components/Pages/ViewCompetition.razor
@@ -97,7 +97,7 @@ else
                     <MudTh>Result</MudTh>
                 </HeaderContent>
                 <RowTemplate>
-                    <MudTd DataLabel="Date / Time">@(context.ScheduledAt?.ToString("dd MMM yyyy HH:mm") ?? "—")</MudTd>
+                    <MudTd DataLabel="Date / Time">@(((context.Status == FixtureStatus.Completed || context.Status == FixtureStatus.AwaitingVerification) ? (context.CompletedAt ?? context.ScheduledAt) : context.ScheduledAt)?.ToString("dd MMM yyyy HH:mm") ?? "—")</MudTd>
                     <MudTd DataLabel="Match">@(context.FixtureLabel ?? "—")</MudTd>
                     <MudTd DataLabel="Players">@FixturePlayers(context)</MudTd>
                     <MudTd DataLabel="Court">@(context.Court?.Name ?? "—")</MudTd>

--- a/DropShot/Components/ResultCard.razor
+++ b/DropShot/Components/ResultCard.razor
@@ -9,9 +9,12 @@
             {
                 <span class="rc-label">@Fixture.FixtureLabel</span>
             }
-            @if (Fixture.ScheduledAt.HasValue)
+            @{
+                var resultDate = Fixture.CompletedAt ?? Fixture.ScheduledAt;
+            }
+            @if (resultDate.HasValue)
             {
-                <span class="rc-date">@Fixture.ScheduledAt.Value.ToString("dd MMM yyyy")</span>
+                <span class="rc-date">@resultDate.Value.ToString("dd MMM yyyy")</span>
             }
         </div>
     }

--- a/DropShot/Components/ReviewResultDialog.razor
+++ b/DropShot/Components/ReviewResultDialog.razor
@@ -215,6 +215,7 @@
             }
 
             fx.Status = FixtureStatus.Completed;
+            fx.CompletedAt = DateTime.UtcNow;
             fx.VerificationToken = null;
 
             await db.SaveChangesAsync();

--- a/DropShot/Components/SubmitScoreDialog.razor
+++ b/DropShot/Components/SubmitScoreDialog.razor
@@ -232,6 +232,7 @@
                     fx.Status            = FixtureStatus.Completed;
                     fx.VerificationToken = null;
                 }
+                fx.CompletedAt = DateTime.UtcNow;
 
                 await db.SaveChangesAsync();
 

--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -1023,7 +1023,12 @@
         }
 
         matchToSave.MatchJson = JsonConvert.SerializeObject(CurrentMatch);
+        bool wasComplete = matchToSave.Complete;
         matchToSave.Complete = CurrentMatch.Complete;
+        if (matchToSave.Complete && !wasComplete)
+            matchToSave.CompletedAt = DateTime.UtcNow;
+        else if (!matchToSave.Complete)
+            matchToSave.CompletedAt = null;
         matchToSave.Player1 = CurrentMatch.Player1;
         matchToSave.Player2 = CurrentMatch.Player2;
         matchToSave.Player3 = CurrentMatch.Player3;
@@ -1058,6 +1063,7 @@
             if (fx != null && fx.Status != FixtureStatus.Completed)
             {
                 fx.Status = FixtureStatus.Completed;
+                fx.CompletedAt = DateTime.UtcNow;
                 fx.SavedMatchId = _savedMatchId;
                 bool userSideWon = _state.UserSets > _state.OppSets;
                 fx.WinnerPlayerId = userSideWon ? _competitionFixture.Player1Id : _competitionFixture.Player2Id;
@@ -1106,6 +1112,7 @@
                     if (fx != null)
                     {
                         fx.Status = FixtureStatus.Completed;
+                        fx.CompletedAt = DateTime.UtcNow;
                         fx.ResultSummary = $"{homeScore}-{awayScore}";
                         fx.WinnerTeamId = homeScore > awayScore ? fx.HomeTeamId
                                         : awayScore > homeScore ? fx.AwayTeamId
@@ -1241,6 +1248,7 @@
                     if (fx != null)
                     {
                         fx.Status = FixtureStatus.Scheduled;
+                        fx.CompletedAt = null;
                         fx.SavedMatchId = null;
                         fx.WinnerPlayerId = null;
                         fx.WinnerTeamId = null;

--- a/DropShot/Controllers/CompetitionsController.cs
+++ b/DropShot/Controllers/CompetitionsController.cs
@@ -574,6 +574,7 @@ public class CompetitionsController(
 
         // Reset the fixture
         fixture.Status = FixtureStatus.Scheduled;
+        fixture.CompletedAt = null;
         fixture.ResultSummary = null;
         fixture.WinnerPlayerId = null;
         fixture.WinnerTeamId = null;

--- a/DropShot/Data/Migrations/20260414234114_AddFixtureCompletedAt.Designer.cs
+++ b/DropShot/Data/Migrations/20260414234114_AddFixtureCompletedAt.Designer.cs
@@ -4,16 +4,19 @@ using DropShot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace DropShot.Migrations
+namespace DropShot.Data.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260414234114_AddFixtureCompletedAt")]
+    partial class AddFixtureCompletedAt
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -1040,9 +1043,6 @@ namespace DropShot.Migrations
 
                     b.Property<bool>("Complete")
                         .HasColumnType("bit");
-
-                    b.Property<DateTime?>("CompletedAt")
-                        .HasColumnType("datetime2");
 
                     b.Property<int?>("CourtId")
                         .HasColumnType("int");

--- a/DropShot/Data/Migrations/20260414234114_AddFixtureCompletedAt.cs
+++ b/DropShot/Data/Migrations/20260414234114_AddFixtureCompletedAt.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropShot.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFixtureCompletedAt : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "CompletedAt",
+                table: "CompetitionFixtures",
+                type: "datetime2",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CompletedAt",
+                table: "CompetitionFixtures");
+        }
+    }
+}

--- a/DropShot/Data/Migrations/20260415000711_AddSavedMatchCompletedAt.Designer.cs
+++ b/DropShot/Data/Migrations/20260415000711_AddSavedMatchCompletedAt.Designer.cs
@@ -4,16 +4,19 @@ using DropShot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace DropShot.Migrations
+namespace DropShot.Data.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260415000711_AddSavedMatchCompletedAt")]
+    partial class AddSavedMatchCompletedAt
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DropShot/Data/Migrations/20260415000711_AddSavedMatchCompletedAt.cs
+++ b/DropShot/Data/Migrations/20260415000711_AddSavedMatchCompletedAt.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropShot.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSavedMatchCompletedAt : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "CompletedAt",
+                table: "SavedMatch",
+                type: "datetime2",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CompletedAt",
+                table: "SavedMatch");
+        }
+    }
+}

--- a/DropShot/Models/CompetitionFixture.cs
+++ b/DropShot/Models/CompetitionFixture.cs
@@ -17,6 +17,7 @@ public class CompetitionFixture
     public int? CompetitionStageId { get; set; }
     public int? CourtId { get; set; }
     public DateTime? ScheduledAt { get; set; }
+    public DateTime? CompletedAt { get; set; }
     public FixtureStatus Status { get; set; } = FixtureStatus.Scheduled;
 
     public int? Player1Id { get; set; }

--- a/DropShot/Models/SavedMatch.cs
+++ b/DropShot/Models/SavedMatch.cs
@@ -16,6 +16,7 @@ public class SavedMatch
     public string? WinnerName { get; set; }
     public int? WinnerPlayerId { get; set; }
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime? CompletedAt { get; set; }
     public int? CourtId { get; set; }
     public string? UserId { get; set; }
     public string? DeviceToken { get; set; }


### PR DESCRIPTION
## Summary
- Adds `CompletedAt` to `CompetitionFixture` and `SavedMatch`, recording the actual date a match finished rather than the scheduled date (or the SavedMatch's `CreatedAt`).
- Views that show completed results now prefer `CompletedAt` (falling back to the scheduled/created date for pre-existing rows): `ResultCard`, Home's recent-results panel, and the completed/awaiting-verification rows of the `ViewCompetition` fixtures table. Home orders recent results by `CompletedAt`.
- The home page's "My Recent Results" panel now also includes the user's standalone casual matches (completed `SavedMatch` rows not linked to a fixture), interleaved with fixture results by completion date.
- Two EF Core migrations add the new columns.

## Test plan
- [ ] Record a competition fixture result on a day different from the scheduled date; confirm the result card and home page display the actual completion date.
- [ ] Delete a result and re-record it; confirm `CompletedAt` is cleared and then reset.
- [ ] Play a casual match through to completion; confirm it appears in "My Recent Results" on the home page with the correct date.
- [ ] Confirm pre-existing completed fixtures/casuals (with null `CompletedAt`) still display their fallback date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)