### PR TITLE
Fix match setup layout and widen upcoming matches

### DIFF
--- a/DropShot/Components/MatchSetupWizard.razor
+++ b/DropShot/Components/MatchSetupWizard.razor
@@ -10,7 +10,7 @@
 @inject ISnackbar Snackbar
 @inject IDialogService DialogService
 
-<MudStack Spacing="3" Class="pa-2" Style="max-width: 600px;">
+<MudStack Spacing="3">
 
     @* ── Step 0: Match Type ──────────────────────────────── *@
     @if (_currentStep > 0)
@@ -20,7 +20,7 @@
     else
     {
         <MudPaper Class="pa-4" Elevation="2">
-            <MudText Typo="Typo.h6" Class="mb-3">Match Type</MudText>
+            <MudText Typo="Typo.h6" Class="mb-3">Start a Match</MudText>
             <MudRadioGroup @bind-Value="_isDoubles">
                 <MudRadio Value="false" Color="Color.Primary">Singles</MudRadio>
                 <MudRadio Value="true" Color="Color.Primary">Doubles</MudRadio>

--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -62,7 +62,7 @@
 
 @if (loaded && CurrentMatch == null && !_showCoinToss && !_showServerSelect)
 {
-    <div style="max-width: 700px; margin: 0 auto;">
+    <div style="max-width: 800px; margin: 0 auto; padding: 1.5rem 0 2rem;">
         @if (_upcomingFixtures.Any())
         {
             <MudCard Class="mb-4">


### PR DESCRIPTION
## Summary
- Give the match setup wrapper top/bottom padding and widen it to 800px so content clears the header and doesn't extend under the footer
- Remove the wizard's inner 600px/pa-2 constraints so it fills the wrapper at the same width as the upcoming matches card (also fixes the cramped-looking doubled horizontal padding on mobile)
- Rename the Step 0 heading from "Match Type" to "Start a Match"

## Test plan
- [ ] Load `/tennisscore` — setup wizard sits below header with breathing room and is fully visible above footer
- [ ] Upcoming matches card and setup wizard are the same width
- [ ] Heading reads "Start a Match"
- [ ] Check on mobile viewport — no excessive horizontal padding

🤖 Generated with [Claude Code](https://claude.com/claude-code)