### PR TITLE
Add spacing between Play and Submit Score buttons on home page

### DIFF
--- a/DropShot/Components/Pages/Home.razor
+++ b/DropShot/Components/Pages/Home.razor
@@ -183,7 +183,7 @@
                                     <MudChip T="string" Size="Size.Small" Color="@StatusColor(context.Status)">@context.Status</MudChip>
                                 </MudTd>
                                 <MudTd>
-                                    <MudStack Row="true" Spacing="1">
+                                    <MudStack Row="true" Spacing="2">
                                         <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary"
                                                    StartIcon="@Icons.Material.Filled.PlayArrow"
                                                    OnClick="@(() => Navigation.NavigateTo($"/match/0?fixtureId={context.CompetitionFixtureId}&autoStart=true"))">


### PR DESCRIPTION
## Summary
- Bumps `MudStack` spacing from 1 to 2 for the action buttons in the upcoming matches list on the home page

## Test plan
- [ ] Visit home page as a player with upcoming matches; verify visible gap between Play and Submit Score buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)