### PR TITLE
Clear scoring-active lock when showing match setup

### DIFF
--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -987,6 +987,13 @@
                 _restoreFullscreen = false;
                 await SetScoringFullscreen(true);
             }
+            else if (CurrentMatch == null)
+            {
+                // Make sure the body scoring-active lock (overflow:hidden, fixed
+                // viewport height) isn't left over from a previous match — otherwise
+                // the setup screen can't scroll and extends behind the footer.
+                await SetScoringFullscreen(false);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- The body.scoring-active class sets overflow:hidden + fixed 100svh height, which is correct during scoring but leaks into the setup screen if the user navigates back from an in-progress match
- That made the setup screen un-scrollable — longer wizards (multi-player doubles, competition presets) hid the Start button behind the footer with no way to reach it
- Explicitly clear the class on first render whenever no match is active

## Test plan
- [ ] Start a match, navigate back to /match/0 — setup screen scrolls normally
- [ ] Load /tennisscore cold — setup scrolls normally
- [ ] Actually starting a match still enters fullscreen scoring mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)