### PR TITLE
Add Club Players and scope competition dropdown to club

### DIFF
--- a/DropShot/Components/Layout/NavMenu.razor
+++ b/DropShot/Components/Layout/NavMenu.razor
@@ -60,9 +60,18 @@
                     </div>
 
                     <div class="nav-item">
-                        <NavLink class="nav-link" href="players/mine">
-                            <MudIcon Icon="@Icons.Material.Filled.RecentActors" Class="nav-icon" /> <span class="nav-label">My Players</span>
-                        </NavLink>
+                        @if (_isClubAdminActive)
+                        {
+                            <NavLink class="nav-link" href="players/club">
+                                <MudIcon Icon="@Icons.Material.Filled.Groups" Class="nav-icon" /> <span class="nav-label">Club Players</span>
+                            </NavLink>
+                        }
+                        else
+                        {
+                            <NavLink class="nav-link" href="players/mine">
+                                <MudIcon Icon="@Icons.Material.Filled.RecentActors" Class="nav-icon" /> <span class="nav-label">My Players</span>
+                            </NavLink>
+                        }
                     </div>
                 </Authorized>
             </AuthorizeView>
@@ -157,6 +166,7 @@
 @code {
     private string? currentUrl;
     private string? _avatarPath;
+    private bool _isClubAdminActive;
 
     [CascadingParameter]
     private HttpContext? HttpContext { get; set; }
@@ -177,6 +187,10 @@
                     .Select(u => u.ProfileImagePath)
                     .FirstOrDefaultAsync();
             }
+
+            var activeRole = HttpContext.Request.Cookies["ActiveRole"];
+            _isClubAdminActive = string.Equals(activeRole, "ClubAdmin", StringComparison.OrdinalIgnoreCase)
+                                 && HttpContext.User.IsInRole("ClubAdmin");
         }
     }
 

--- a/DropShot/Components/Pages/ClubPlayers.razor
+++ b/DropShot/Components/Pages/ClubPlayers.razor
@@ -1,0 +1,353 @@
+@page "/players/club"
+@rendermode InteractiveServer
+@attribute [Authorize(Roles = "ClubAdmin,Admin,SuperAdmin")]
+@using Microsoft.AspNetCore.Authorization
+@using Microsoft.EntityFrameworkCore
+@using System.Security.Claims
+@using DropShot.Models
+@using DropShot.Data
+@using DropShot.Services
+
+@inject IDbContextFactory<MyDbContext> DbFactory
+@inject AuthenticationStateProvider AuthStateProvider
+@inject IHttpContextAccessor HttpContextAccessor
+@inject ISnackbar Snackbar
+
+<MudProviders />
+
+<MudText Typo="Typo.h4" Class="mb-4">Club Players</MudText>
+
+@if (_activeClubId is null)
+{
+    <MudAlert Severity="Severity.Warning">
+        No club is currently selected. You may not be an administrator of any club.
+    </MudAlert>
+}
+else
+{
+    <MudText Typo="Typo.subtitle1" Class="mb-3">Managing: <strong>@_clubName</strong></MudText>
+
+    <MudStack Row="true" Spacing="2" Class="mb-4">
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Filled.PersonAdd"
+                   OnClick="OpenCreateDialog">
+            Add Light Player
+        </MudButton>
+        <MudButton Variant="Variant.Outlined" Color="Color.Primary" StartIcon="@Icons.Material.Filled.Search"
+                   OnClick="OpenAddExistingDialog">
+            Add Existing Player
+        </MudButton>
+    </MudStack>
+
+    <MudTextField @bind-Value="_searchText" Placeholder="Search club players..."
+                  Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search"
+                  Immediate="true" Class="mb-4" />
+
+    <MudTable Items="@_players" Hover="true" Breakpoint="Breakpoint.Sm" Loading="@_loading"
+              Filter="@(row => FilterPlayers(row))">
+        <HeaderContent>
+            <MudTh>Player</MudTh>
+            <MudTh>First Name</MudTh>
+            <MudTh>Last Name</MudTh>
+            <MudTh>Actions</MudTh>
+        </HeaderContent>
+        <RowTemplate>
+            <MudTd DataLabel="Player">
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                    <MudText>@context.DisplayName</MudText>
+                    @if (!context.IsLight)
+                    {
+                        <MudIcon Icon="@Icons.Material.Filled.Verified" Color="Color.Success" Size="Size.Small"
+                                 Title="Verified player" />
+                    }
+                </MudStack>
+            </MudTd>
+            <MudTd DataLabel="First Name">@(context.FirstName ?? "—")</MudTd>
+            <MudTd DataLabel="Last Name">@(context.LastName ?? "—")</MudTd>
+            <MudTd DataLabel="Actions">
+                @if (context.IsLight && context.IsClubOwned)
+                {
+                    <MudTooltip Text="Edit">
+                        <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="Size.Small"
+                                       OnClick="@(() => OpenEditDialog(context))" />
+                    </MudTooltip>
+                }
+                <MudTooltip Text="Remove from club">
+                    <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small" Color="Color.Error"
+                                   OnClick="@(() => RemoveFromClub(context))" />
+                </MudTooltip>
+            </MudTd>
+        </RowTemplate>
+        <NoRecordsContent>
+            <MudText>No players yet. Add a player to get started.</MudText>
+        </NoRecordsContent>
+    </MudTable>
+}
+
+@* ── Create / Edit Light Player Dialog ─────────────────────── *@
+<MudDialog @bind-Visible="_showPlayerDialog">
+    <TitleContent>@(_editingPlayerId.HasValue ? "Edit Player" : "Add Light Player")</TitleContent>
+    <DialogContent>
+        <MudGrid Spacing="2">
+            <MudItem xs="12">
+                <MudTextField @bind-Value="_form.DisplayName" Label="Display Name" Variant="Variant.Outlined"
+                              Required="true" Immediate="true" />
+            </MudItem>
+            <MudItem xs="6">
+                <MudTextField @bind-Value="_form.FirstName" Label="First Name" Variant="Variant.Outlined" />
+            </MudItem>
+            <MudItem xs="6">
+                <MudTextField @bind-Value="_form.LastName" Label="Last Name" Variant="Variant.Outlined" />
+            </MudItem>
+            <MudItem xs="12">
+                <MudTextField @bind-Value="_form.Email" Label="Email (optional)" Variant="Variant.Outlined"
+                              InputType="InputType.Email" />
+            </MudItem>
+        </MudGrid>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@(() => _showPlayerDialog = false)">Cancel</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                   Disabled="@string.IsNullOrWhiteSpace(_form.DisplayName)"
+                   OnClick="SavePlayer">
+            @(_editingPlayerId.HasValue ? "Save" : "Add")
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
+@* ── Add Existing Player Dialog ────────────────────────────── *@
+<MudDialog @bind-Visible="_showAddExistingDialog">
+    <TitleContent>Add Existing Player to Club</TitleContent>
+    <DialogContent>
+        <MudTextField @bind-Value="_existingSearch" Placeholder="Search by name..."
+                      Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search"
+                      Immediate="true" TextChanged="OnExistingSearchChanged" Class="mb-2" />
+        @if (_existingResults.Count > 0)
+        {
+            <MudList T="Player" Dense="true">
+                @foreach (var p in _existingResults)
+                {
+                    <MudListItem T="Player" OnClick="@(() => AddExistingPlayer(p))">
+                        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                            @if (!p.IsLight)
+                            {
+                                <MudIcon Icon="@Icons.Material.Filled.Verified" Color="Color.Success" Size="Size.Small" />
+                            }
+                            <MudText>@p.DisplayName</MudText>
+                        </MudStack>
+                    </MudListItem>
+                }
+            </MudList>
+        }
+        else if (!string.IsNullOrWhiteSpace(_existingSearch))
+        {
+            <MudText Typo="Typo.caption" Color="Color.Secondary">No matching players.</MudText>
+        }
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@(() => _showAddExistingDialog = false)">Close</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    private record PlayerRow(int PlayerId, string DisplayName, string? FirstName, string? LastName, bool IsLight, bool IsClubOwned);
+
+    private bool _loading = true;
+    private List<PlayerRow> _players = [];
+    private string _searchText = "";
+    private string? _userId;
+    private int? _activeClubId;
+    private string _clubName = "";
+
+    private bool _showPlayerDialog;
+    private int? _editingPlayerId;
+    private PlayerForm _form = new();
+
+    private bool _showAddExistingDialog;
+    private string _existingSearch = "";
+    private List<Player> _existingResults = [];
+
+    private sealed class PlayerForm
+    {
+        public string DisplayName { get; set; } = "";
+        public string? FirstName { get; set; }
+        public string? LastName { get; set; }
+        public string? Email { get; set; }
+    }
+
+    private bool FilterPlayers(PlayerRow row) =>
+        string.IsNullOrWhiteSpace(_searchText) ||
+        row.DisplayName.Contains(_searchText, StringComparison.OrdinalIgnoreCase) ||
+        (row.FirstName ?? "").Contains(_searchText, StringComparison.OrdinalIgnoreCase) ||
+        (row.LastName ?? "").Contains(_searchText, StringComparison.OrdinalIgnoreCase);
+
+    protected override async Task OnInitializedAsync()
+    {
+        var authState = await AuthStateProvider.GetAuthenticationStateAsync();
+        _userId = authState.User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (_userId is null) return;
+
+        await using var db = DbFactory.CreateDbContext();
+        _activeClubId = await ActiveClubResolver.GetActiveClubIdAsync(db, _userId, HttpContextAccessor.HttpContext);
+        if (_activeClubId is not null)
+        {
+            _clubName = await db.Clubs
+                .Where(c => c.ClubId == _activeClubId.Value)
+                .Select(c => c.Name)
+                .FirstOrDefaultAsync() ?? "";
+        }
+        await LoadPlayers();
+    }
+
+    private async Task LoadPlayers()
+    {
+        _loading = true;
+        if (_activeClubId is null) { _players = []; _loading = false; return; }
+
+        await using var db = DbFactory.CreateDbContext();
+        _players = await db.ClubPlayers
+            .Where(cp => cp.ClubId == _activeClubId.Value)
+            .Join(db.Players, cp => cp.PlayerId, p => p.PlayerId,
+                (cp, p) => new PlayerRow(
+                    p.PlayerId, p.DisplayName, p.FirstName, p.LastName,
+                    p.IsLight, p.CreatedByClubId == _activeClubId.Value))
+            .OrderBy(p => p.DisplayName)
+            .ToListAsync();
+        _loading = false;
+    }
+
+    private void OpenCreateDialog()
+    {
+        _editingPlayerId = null;
+        _form = new PlayerForm();
+        _showPlayerDialog = true;
+    }
+
+    private void OpenEditDialog(PlayerRow row)
+    {
+        _editingPlayerId = row.PlayerId;
+        _form = new PlayerForm
+        {
+            DisplayName = row.DisplayName,
+            FirstName = row.FirstName,
+            LastName = row.LastName
+        };
+        _showPlayerDialog = true;
+    }
+
+    private async Task SavePlayer()
+    {
+        if (_activeClubId is null || string.IsNullOrWhiteSpace(_form.DisplayName)) return;
+
+        await using var db = DbFactory.CreateDbContext();
+
+        if (_editingPlayerId.HasValue)
+        {
+            var p = await db.Players.FindAsync(_editingPlayerId.Value);
+            if (p is { IsLight: true } && p.CreatedByClubId == _activeClubId.Value)
+            {
+                p.DisplayName = _form.DisplayName.Trim();
+                p.FirstName = NullIfEmpty(_form.FirstName);
+                p.LastName = NullIfEmpty(_form.LastName);
+                p.Email = NullIfEmpty(_form.Email);
+                await db.SaveChangesAsync();
+                Snackbar.Add("Player updated.", Severity.Success);
+            }
+        }
+        else
+        {
+            var newPlayer = new Player
+            {
+                DisplayName = _form.DisplayName.Trim(),
+                FirstName = NullIfEmpty(_form.FirstName),
+                LastName = NullIfEmpty(_form.LastName),
+                Email = NullIfEmpty(_form.Email),
+                IsLight = true,
+                CreatedByClubId = _activeClubId.Value
+            };
+            db.Players.Add(newPlayer);
+            await db.SaveChangesAsync();
+
+            db.ClubPlayers.Add(new ClubPlayer
+            {
+                ClubId = _activeClubId.Value,
+                PlayerId = newPlayer.PlayerId
+            });
+            await db.SaveChangesAsync();
+            Snackbar.Add("Player added to club.", Severity.Success);
+        }
+
+        _showPlayerDialog = false;
+        await LoadPlayers();
+    }
+
+    private void OpenAddExistingDialog()
+    {
+        _existingSearch = "";
+        _existingResults = [];
+        _showAddExistingDialog = true;
+    }
+
+    private async Task OnExistingSearchChanged(string value)
+    {
+        _existingSearch = value;
+        if (string.IsNullOrWhiteSpace(value) || _activeClubId is null)
+        {
+            _existingResults = [];
+            return;
+        }
+
+        await using var db = DbFactory.CreateDbContext();
+        var alreadyInClub = await db.ClubPlayers
+            .Where(cp => cp.ClubId == _activeClubId.Value)
+            .Select(cp => cp.PlayerId)
+            .ToListAsync();
+
+        _existingResults = await db.Players
+            .Where(p => !alreadyInClub.Contains(p.PlayerId)
+                        && !p.IsLight
+                        && p.DisplayName.Contains(value))
+            .OrderBy(p => p.DisplayName)
+            .Take(10)
+            .ToListAsync();
+    }
+
+    private async Task AddExistingPlayer(Player p)
+    {
+        if (_activeClubId is null) return;
+
+        await using var db = DbFactory.CreateDbContext();
+        var exists = await db.ClubPlayers.AnyAsync(cp => cp.ClubId == _activeClubId.Value && cp.PlayerId == p.PlayerId);
+        if (!exists)
+        {
+            db.ClubPlayers.Add(new ClubPlayer { ClubId = _activeClubId.Value, PlayerId = p.PlayerId });
+            await db.SaveChangesAsync();
+            Snackbar.Add($"{p.DisplayName} added to club.", Severity.Success);
+        }
+        _showAddExistingDialog = false;
+        await LoadPlayers();
+    }
+
+    private async Task RemoveFromClub(PlayerRow row)
+    {
+        if (_activeClubId is null) return;
+
+        await using var db = DbFactory.CreateDbContext();
+        var cp = await db.ClubPlayers.FindAsync(_activeClubId.Value, row.PlayerId);
+        if (cp is not null)
+        {
+            db.ClubPlayers.Remove(cp);
+            // If the player is a club-owned lite player and only belonged to this club, delete the Player too.
+            if (row.IsLight && row.IsClubOwned)
+            {
+                var player = await db.Players.FindAsync(row.PlayerId);
+                if (player is not null) db.Players.Remove(player);
+            }
+            await db.SaveChangesAsync();
+            Snackbar.Add("Player removed from club.", Severity.Info);
+        }
+        await LoadPlayers();
+    }
+
+    private static string? NullIfEmpty(string? s) =>
+        string.IsNullOrWhiteSpace(s) ? null : s.Trim();
+}

--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -308,7 +308,45 @@
                                      ToStringFunc="@(p => p?.DisplayName ?? "")"
                                      ValueChanged="AddParticipant" ResetValueOnEmptyText="true"
                                      Variant="Variant.Outlined" Dense="true" Style="max-width:260px" />
+                    @if (Model.HostClubId.HasValue)
+                    {
+                        <MudTooltip Text="Add a new light player to this club and competition">
+                            <MudButton Variant="Variant.Outlined" Color="Color.Primary"
+                                       StartIcon="@Icons.Material.Filled.PersonAdd"
+                                       OnClick="OpenNewPlayerDialog">Add new</MudButton>
+                        </MudTooltip>
+                    }
                 </MudStack>
+
+                <MudDialog @bind-Visible="_showNewPlayerDialog">
+                    <TitleContent>Add New Club Player</TitleContent>
+                    <DialogContent>
+                        <MudGrid Spacing="2">
+                            <MudItem xs="12">
+                                <MudTextField @bind-Value="_newPlayerForm.DisplayName" Label="Display Name"
+                                              Variant="Variant.Outlined" Required="true" Immediate="true" />
+                            </MudItem>
+                            <MudItem xs="6">
+                                <MudTextField @bind-Value="_newPlayerForm.FirstName" Label="First Name"
+                                              Variant="Variant.Outlined" />
+                            </MudItem>
+                            <MudItem xs="6">
+                                <MudTextField @bind-Value="_newPlayerForm.LastName" Label="Last Name"
+                                              Variant="Variant.Outlined" />
+                            </MudItem>
+                            <MudItem xs="12">
+                                <MudTextField @bind-Value="_newPlayerForm.Email" Label="Email (optional)"
+                                              Variant="Variant.Outlined" InputType="InputType.Email" />
+                            </MudItem>
+                        </MudGrid>
+                    </DialogContent>
+                    <DialogActions>
+                        <MudButton OnClick="@(() => _showNewPlayerDialog = false)">Cancel</MudButton>
+                        <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                                   Disabled="@string.IsNullOrWhiteSpace(_newPlayerForm.DisplayName)"
+                                   OnClick="CreateAndAddClubPlayer">Add</MudButton>
+                    </DialogActions>
+                </MudDialog>
 
                 <MudTable Items="@_participants" Dense="true" Hover="true">
                     <HeaderContent>
@@ -960,6 +998,7 @@
     private List<CompetitionStage> _stages = [];
     private List<CompetitionParticipant> _participants = [];
     private List<Player> _allPlayers = [];
+    private List<Player> _clubPlayers = [];
     private List<CompetitionFixture> _fixtures = [];
     private List<CompetitionTeam> _teams = [];
     private List<Court> _courts = [];
@@ -1197,6 +1236,11 @@
             if (comp.HostClubId.HasValue)
             {
                 _courts = await db.Courts.Where(c => c.ClubId == comp.HostClubId.Value).OrderBy(c => c.Name).ToListAsync();
+                _clubPlayers = await db.ClubPlayers
+                    .Where(cp => cp.ClubId == comp.HostClubId.Value)
+                    .Join(db.Players, cp => cp.PlayerId, p => p.PlayerId, (cp, p) => p)
+                    .OrderBy(p => p.DisplayName)
+                    .ToListAsync();
                 _clubTemplates = await db.ClubSchedulingTemplates
                     .Include(t => t.Windows)
                     .Where(t => t.ClubId == comp.HostClubId.Value)
@@ -1568,11 +1612,69 @@
     private Task<IEnumerable<Player>> SearchPlayers(string text, CancellationToken ct)
     {
         var alreadyIn = _participants.Select(p => p.PlayerId).ToHashSet();
-        var results = _allPlayers
+        // Host club's players only; fall back to all players if no host club is set.
+        var source = Model.HostClubId.HasValue ? _clubPlayers : _allPlayers;
+        var results = source
             .Where(p => !alreadyIn.Contains(p.PlayerId) &&
                         (string.IsNullOrWhiteSpace(text) || p.DisplayName.Contains(text, StringComparison.OrdinalIgnoreCase)))
             .Take(10);
         return Task.FromResult(results);
+    }
+
+    // ── Add new club player from competition page ────────────────────────────
+    private bool _showNewPlayerDialog;
+    private NewPlayerForm _newPlayerForm = new();
+
+    private sealed class NewPlayerForm
+    {
+        public string DisplayName { get; set; } = "";
+        public string? FirstName { get; set; }
+        public string? LastName { get; set; }
+        public string? Email { get; set; }
+    }
+
+    private void OpenNewPlayerDialog()
+    {
+        _newPlayerForm = new NewPlayerForm();
+        _showNewPlayerDialog = true;
+    }
+
+    private async Task CreateAndAddClubPlayer()
+    {
+        if (!Model.HostClubId.HasValue || string.IsNullOrWhiteSpace(_newPlayerForm.DisplayName)) return;
+        var clubId = Model.HostClubId.Value;
+
+        await using var db = DbFactory.CreateDbContext();
+        var newPlayer = new Player
+        {
+            DisplayName = _newPlayerForm.DisplayName.Trim(),
+            FirstName = string.IsNullOrWhiteSpace(_newPlayerForm.FirstName) ? null : _newPlayerForm.FirstName!.Trim(),
+            LastName = string.IsNullOrWhiteSpace(_newPlayerForm.LastName) ? null : _newPlayerForm.LastName!.Trim(),
+            Email = string.IsNullOrWhiteSpace(_newPlayerForm.Email) ? null : _newPlayerForm.Email!.Trim(),
+            IsLight = true,
+            CreatedByClubId = clubId
+        };
+        db.Players.Add(newPlayer);
+        await db.SaveChangesAsync();
+
+        db.ClubPlayers.Add(new ClubPlayer { ClubId = clubId, PlayerId = newPlayer.PlayerId });
+
+        var cp = new CompetitionParticipant
+        {
+            CompetitionId = Id,
+            PlayerId = newPlayer.PlayerId,
+            RegisteredAt = DateTime.UtcNow,
+            Status = ParticipantStatus.Registered
+        };
+        db.CompetitionParticipants.Add(cp);
+        await db.SaveChangesAsync();
+
+        _allPlayers.Add(newPlayer);
+        _clubPlayers.Add(newPlayer);
+        cp.Player = newPlayer;
+        _participants.Add(cp);
+        _showNewPlayerDialog = false;
+        Snackbar.Add($"{newPlayer.DisplayName} added to club and competition.", Severity.Success);
     }
 
     private async Task AddParticipant(Player player)

--- a/DropShot/Components/Shared/RoleBanner.razor
+++ b/DropShot/Components/Shared/RoleBanner.razor
@@ -26,6 +26,24 @@
                 </select>
             </form>
         }
+        @if (_activeRole.Equals("ClubAdmin", StringComparison.OrdinalIgnoreCase) && _adminClubs.Count > 1)
+        {
+            <form action="Account/SwitchClub" method="post" data-enhance-nav="false" style="display: inline; margin-left: 0.5rem;">
+                <AntiforgeryToken />
+                <input type="hidden" name="returnUrl" value="@_currentUrl" />
+                <span>Club:</span>
+                <select name="clubId" class="role-banner-select" onchange="this.form.submit()">
+                    @foreach (var club in _adminClubs)
+                    {
+                        <option value="@club.ClubId" selected="@(club.ClubId == _activeClubId)">@club.Name</option>
+                    }
+                </select>
+            </form>
+        }
+        else if (_activeRole.Equals("ClubAdmin", StringComparison.OrdinalIgnoreCase) && _adminClubs.Count == 1)
+        {
+            <span style="margin-left: 0.5rem;">Club: <strong>@_adminClubs[0].Name</strong></span>
+        }
     </div>
 }
 
@@ -34,6 +52,10 @@
     private string _activeRole = "";
     private string _currentUrl = "/";
     private bool _isMatchPage;
+    private List<ClubInfo> _adminClubs = [];
+    private int? _activeClubId;
+
+    private record ClubInfo(int ClubId, string Name);
 
     protected override async Task OnInitializedAsync()
     {
@@ -58,5 +80,24 @@
         _activeRole = httpContext.Request.Cookies["ActiveRole"] ?? _grantedRoles[0];
         if (!_grantedRoles.Contains(_activeRole, StringComparer.OrdinalIgnoreCase))
             _activeRole = _grantedRoles[0];
+
+        if (_activeRole.Equals("ClubAdmin", StringComparison.OrdinalIgnoreCase))
+        {
+            _adminClubs = await db.ClubAdministrators
+                .Where(ca => ca.UserId == userId)
+                .Join(db.Clubs, ca => ca.ClubId, c => c.ClubId, (ca, c) => new ClubInfo(c.ClubId, c.Name))
+                .OrderBy(c => c.Name)
+                .ToListAsync();
+
+            if (int.TryParse(httpContext.Request.Cookies["ActiveClubId"], out var cookieClubId)
+                && _adminClubs.Any(c => c.ClubId == cookieClubId))
+            {
+                _activeClubId = cookieClubId;
+            }
+            else if (_adminClubs.Count > 0)
+            {
+                _activeClubId = _adminClubs[0].ClubId;
+            }
+        }
     }
 }

--- a/DropShot/Data/Migrations/20260415010002_AddClubLitePlayers.Designer.cs
+++ b/DropShot/Data/Migrations/20260415010002_AddClubLitePlayers.Designer.cs
@@ -4,16 +4,19 @@ using DropShot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace DropShot.Migrations
+namespace DropShot.Data.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260415010002_AddClubLitePlayers")]
+    partial class AddClubLitePlayers
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DropShot/Data/Migrations/20260415010002_AddClubLitePlayers.cs
+++ b/DropShot/Data/Migrations/20260415010002_AddClubLitePlayers.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropShot.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddClubLitePlayers : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "CreatedByClubId",
+                table: "Players",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Players_CreatedByClubId",
+                table: "Players",
+                column: "CreatedByClubId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Players_Clubs_CreatedByClubId",
+                table: "Players",
+                column: "CreatedByClubId",
+                principalTable: "Clubs",
+                principalColumn: "ClubId",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Players_Clubs_CreatedByClubId",
+                table: "Players");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Players_CreatedByClubId",
+                table: "Players");
+
+            migrationBuilder.DropColumn(
+                name: "CreatedByClubId",
+                table: "Players");
+        }
+    }
+}

--- a/DropShot/Data/MyDbContext.cs
+++ b/DropShot/Data/MyDbContext.cs
@@ -16,7 +16,7 @@ namespace DropShot.Data
         public DbSet<RulesSetItem> RulesSetItems { get; set; }
         public DbSet<Club> Clubs { get; set; }
         public DbSet<Court> Courts { get; set; }
-        public DbSet<ClubMember> ClubMembers { get; set; }
+        public DbSet<ClubPlayer> ClubPlayers { get; set; }
         public DbSet<ClubAdministrator> ClubAdministrators { get; set; }
         public DbSet<CompetitionParticipant> CompetitionParticipants { get; set; }
         public DbSet<CompetitionStage> CompetitionStages { get; set; }
@@ -88,6 +88,12 @@ namespace DropShot.Data
                 entity.HasOne(p => p.CreatedByUser)
                       .WithMany()
                       .HasForeignKey(p => p.CreatedByUserId)
+                      .OnDelete(DeleteBehavior.Restrict);
+
+                entity.HasIndex(p => p.CreatedByClubId);
+                entity.HasOne(p => p.CreatedByClub)
+                      .WithMany()
+                      .HasForeignKey(p => p.CreatedByClubId)
                       .OnDelete(DeleteBehavior.Restrict);
             });
 
@@ -170,13 +176,14 @@ namespace DropShot.Data
                       .OnDelete(DeleteBehavior.Cascade);
             });
 
-            // ── ClubMember ───────────────────────────────────────────────────────
-            builder.Entity<ClubMember>(entity =>
+            // ── ClubPlayer (table kept as "ClubMembers" for backward compatibility) ─
+            builder.Entity<ClubPlayer>(entity =>
             {
+                entity.ToTable("ClubMembers");
                 entity.HasKey(cm => new { cm.ClubId, cm.PlayerId });
 
                 entity.HasOne(cm => cm.Club)
-                      .WithMany(c => c.Members)
+                      .WithMany(c => c.Players)
                       .HasForeignKey(cm => cm.ClubId)
                       .OnDelete(DeleteBehavior.Cascade);
 

--- a/DropShot/Models/Club.cs
+++ b/DropShot/Models/Club.cs
@@ -21,7 +21,7 @@ public class Club
     public string? Website { get; set; }
 
     public ICollection<Court> Courts { get; set; } = [];
-    public ICollection<ClubMember> Members { get; set; } = [];
+    public ICollection<ClubPlayer> Players { get; set; } = [];
     public ICollection<ClubAdministrator> Administrators { get; set; } = [];
     public ICollection<Competition> Competitions { get; set; } = [];
     public ICollection<ClubLadder> Ladders { get; set; } = [];

--- a/DropShot/Models/ClubPlayer.cs
+++ b/DropShot/Models/ClubPlayer.cs
@@ -1,6 +1,6 @@
 namespace DropShot.Models;
 
-public class ClubMember
+public class ClubPlayer
 {
     public int ClubId { get; set; }
     public int PlayerId { get; set; }

--- a/DropShot/Models/Player.cs
+++ b/DropShot/Models/Player.cs
@@ -22,6 +22,9 @@ public class Player
     public string? CreatedByUserId { get; set; }
     public ApplicationUser? CreatedByUser { get; set; }
 
+    public int? CreatedByClubId { get; set; }
+    public Club? CreatedByClub { get; set; }
+
     public string? FirstName { get; set; }
     public string? LastName { get; set; }
     public DateOnly? DateOfBirth { get; set; }
@@ -34,5 +37,5 @@ public class Player
     public ICollection<CompetitionParticipant> CompetitionParticipants { get; set; } = [];
     public ICollection<PlayerFriend> Friends { get; set; } = [];
     public ICollection<PlayerFriend> FriendOf { get; set; } = [];
-    public ICollection<ClubMember> ClubMemberships { get; set; } = [];
+    public ICollection<ClubPlayer> ClubMemberships { get; set; } = [];
 }

--- a/DropShot/Program.cs
+++ b/DropShot/Program.cs
@@ -253,6 +253,38 @@ app.MapPost("/Account/SwitchRole", async (
     return Results.Redirect(returnUrl);
 }).RequireAuthorization();
 
+// ── Club switching for ClubAdmin role (multi-club admins) ────────────────────
+app.MapPost("/Account/SwitchClub", async (
+    HttpContext httpContext,
+    UserManager<ApplicationUser> userManager,
+    IDbContextFactory<MyDbContext> dbFactory) =>
+{
+    var form = await httpContext.Request.ReadFormAsync();
+    var clubIdStr = form["clubId"].ToString();
+    var returnUrl = form["returnUrl"].ToString();
+    if (string.IsNullOrEmpty(returnUrl)) returnUrl = "/";
+
+    var user = await userManager.GetUserAsync(httpContext.User);
+    if (user is null) return Results.Redirect("/Account/Login");
+
+    if (!int.TryParse(clubIdStr, out var clubId))
+        return Results.Redirect(returnUrl);
+
+    await using var db = dbFactory.CreateDbContext();
+    var isAdmin = await db.ClubAdministrators.AnyAsync(ca => ca.UserId == user.Id && ca.ClubId == clubId);
+    if (!isAdmin) return Results.Redirect(returnUrl);
+
+    httpContext.Response.Cookies.Append("ActiveClubId", clubId.ToString(), new CookieOptions
+    {
+        HttpOnly = true,
+        Secure = true,
+        SameSite = SameSiteMode.Strict,
+        Expires = DateTimeOffset.UtcNow.AddDays(30)
+    });
+
+    return Results.Redirect(returnUrl);
+}).RequireAuthorization();
+
 // ── Avatar upload (SSR form POST) ──────────────────────────────────────────
 app.MapPost("/Account/Manage/UploadAvatar", async (
     HttpContext httpContext,

--- a/DropShot/Services/ActiveClubResolver.cs
+++ b/DropShot/Services/ActiveClubResolver.cs
@@ -1,0 +1,30 @@
+using DropShot.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace DropShot.Services;
+
+/// <summary>
+/// Resolves which club a ClubAdmin is currently "acting as" for.
+/// Reads the ActiveClubId cookie and validates it against ClubAdministrator.
+/// </summary>
+public static class ActiveClubResolver
+{
+    public static async Task<int?> GetActiveClubIdAsync(
+        MyDbContext db, string userId, HttpContext? httpContext)
+    {
+        var adminClubIds = await db.ClubAdministrators
+            .Where(ca => ca.UserId == userId)
+            .Select(ca => ca.ClubId)
+            .ToListAsync();
+
+        if (adminClubIds.Count == 0) return null;
+
+        if (int.TryParse(httpContext?.Request.Cookies["ActiveClubId"], out var cookieClubId)
+            && adminClubIds.Contains(cookieClubId))
+        {
+            return cookieClubId;
+        }
+
+        return adminClubIds[0];
+    }
+}


### PR DESCRIPTION
## Summary
- Adds **Club Players** concept (renames unused `ClubMember` → `ClubPlayer`, SQL table kept as `ClubMembers`) covering both lite and registered players attached to a club.
- When `ActiveRole == ClubAdmin`, the nav shows **Club Players** (`/players/club`) instead of **My Players**. New `ClubPlayers.razor` page lets admins add light players, add existing registered players, edit, and remove.
- Adds `Player.CreatedByClubId` so lite players can be club-owned (distinct from user-owned lite players).
- Competition participant dropdown now filters to the **host club's** players only. Adds an **Add new** button that creates a club lite player, adds them to the club, and registers them in one flow.
- Club selector added to `RoleBanner` for admins of multiple clubs; `ActiveClubId` cookie and `POST /Account/SwitchClub` endpoint persist the choice.
- New EF migration `AddClubLitePlayers` adds `Players.CreatedByClubId` column + FK/index.

## Test plan
- [ ] Run `dotnet ef database update` applies cleanly
- [ ] User with only "User" role still sees **My Players** nav, unchanged behaviour
- [ ] User with "ClubAdmin" role active sees **Club Players** nav; switching to "User" role switches back
- [ ] Admin of 2+ clubs sees club selector in role banner; switching updates `/players/club` contents
- [ ] Adding a light player from `/players/club` creates a Player with `IsLight` + `CreatedByClubId` and a ClubPlayers row
- [ ] Adding an existing registered player via search attaches them via ClubPlayers row without creating a new Player
- [ ] On a competition where HostClub is set, the **Add player** autocomplete lists only that club's players
- [ ] **Add new** button on competition page creates a club lite player + club membership + participant in one save
- [ ] Removing a club-owned lite player from `/players/club` deletes both the ClubPlayer row and the Player

🤖 Generated with [Claude Code](https://claude.com/claude-code)