### PR TITLE
Fix LINQ translation errors in club players queries

### DIFF
--- a/DropShot/Components/Pages/ClubPlayers.razor
+++ b/DropShot/Components/Pages/ClubPlayers.razor
@@ -204,14 +204,16 @@ else
         if (_activeClubId is null) { _players = []; _loading = false; return; }
 
         await using var db = DbFactory.CreateDbContext();
-        _players = await db.ClubPlayers
+        var rows = await db.ClubPlayers
             .Where(cp => cp.ClubId == _activeClubId.Value)
             .Join(db.Players, cp => cp.PlayerId, p => p.PlayerId,
-                (cp, p) => new PlayerRow(
-                    p.PlayerId, p.DisplayName, p.FirstName, p.LastName,
-                    p.IsLight, p.CreatedByClubId == _activeClubId.Value))
-            .OrderBy(p => p.DisplayName)
+                (cp, p) => new { p.PlayerId, p.DisplayName, p.FirstName, p.LastName, p.IsLight, p.CreatedByClubId })
+            .OrderBy(x => x.DisplayName)
             .ToListAsync();
+        _players = rows
+            .Select(x => new PlayerRow(x.PlayerId, x.DisplayName, x.FirstName, x.LastName,
+                x.IsLight, x.CreatedByClubId == _activeClubId.Value))
+            .ToList();
         _loading = false;
     }
 

--- a/DropShot/Components/Shared/RoleBanner.razor
+++ b/DropShot/Components/Shared/RoleBanner.razor
@@ -85,8 +85,9 @@
         {
             _adminClubs = await db.ClubAdministrators
                 .Where(ca => ca.UserId == userId)
-                .Join(db.Clubs, ca => ca.ClubId, c => c.ClubId, (ca, c) => new ClubInfo(c.ClubId, c.Name))
+                .Join(db.Clubs, ca => ca.ClubId, c => c.ClubId, (ca, c) => new { c.ClubId, c.Name })
                 .OrderBy(c => c.Name)
+                .Select(c => new ClubInfo(c.ClubId, c.Name))
                 .ToListAsync();
 
             if (int.TryParse(httpContext.Request.Cookies["ActiveClubId"], out var cookieClubId)


### PR DESCRIPTION
## Summary
Fixes InvalidOperationException thrown in `RoleBanner.razor` and `ClubPlayers.razor` — the queries projected entities into record constructors and then applied `OrderBy` over the record, which EF Core cannot translate. Project to an anonymous type, sort in SQL, then materialize the record client-side.

## Test plan
- [ ] Load any page as a ClubAdmin — role banner renders without exception
- [ ] Load `/players/club` — club players table renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)