### PR TITLE
Fix trailing ampersand in singles casual match results

### DIFF
--- a/DropShot/Components/Pages/Home.razor
+++ b/DropShot/Components/Pages/Home.razor
@@ -245,10 +245,10 @@
                                     else if (item.CasualMatch != null)
                                     {
                                         var casual = item.CasualMatch!;
-                                        string p1 = casual.Player3 != null
+                                        string p1 = !string.IsNullOrWhiteSpace(casual.Player3)
                                             ? (casual.Player1 ?? "TBD") + " & " + casual.Player3
                                             : (casual.Player1 ?? "TBD");
-                                        string p2 = casual.Player4 != null
+                                        string p2 = !string.IsNullOrWhiteSpace(casual.Player4)
                                             ? (casual.Player2 ?? "TBD") + " & " + casual.Player4
                                             : (casual.Player2 ?? "TBD");
                                         bool p1Winner = casual.WinnerPlayerId.HasValue


### PR DESCRIPTION
## Summary
- Singles casual matches save `Player3`/`Player4` as empty strings (not null), so the recent results on the home page treated them as doubles and appended a trailing " & ".
- Changed the check to `!string.IsNullOrWhiteSpace(...)` so singles render correctly.

## Test plan
- [ ] Play a singles casual match and confirm recent results show just the player name without a trailing "&".
- [ ] Play a doubles casual match and confirm both partners still display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)