### PR TITLE
Show set scores for casual matches in recent results

### DIFF
--- a/DropShot/Components/Pages/Home.razor
+++ b/DropShot/Components/Pages/Home.razor
@@ -255,6 +255,7 @@
                                             && (casual.WinnerPlayerId == casual.Player1Id || casual.WinnerPlayerId == casual.Player3Id);
                                         bool p2Winner = casual.WinnerPlayerId.HasValue
                                             && (casual.WinnerPlayerId == casual.Player2Id || casual.WinnerPlayerId == casual.Player4Id);
+                                        var casualSets = ParseCasualSets(casual.MatchJson);
                                         <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="mb-1">
                                             <MudText Typo="Typo.caption" Style="font-weight:500">Casual Match</MudText>
                                             <MudText Typo="Typo.caption" Color="Color.Secondary" Style="margin-left:auto">@item.Date.ToString("dd MMM yyyy")</MudText>
@@ -262,9 +263,21 @@
                                         <div class="result-card result-card-compact">
                                             <div class="rc-player-row @(p1Winner ? "rc-winner" : "")">
                                                 <div class="rc-name">@p1</div>
+                                                <div class="rc-sets">
+                                                    @foreach (var set in casualSets)
+                                                    {
+                                                        <span class="rc-set-score">@set.P1</span>
+                                                    }
+                                                </div>
                                             </div>
                                             <div class="rc-player-row @(p2Winner ? "rc-winner" : "")">
                                                 <div class="rc-name">@p2</div>
+                                                <div class="rc-sets">
+                                                    @foreach (var set in casualSets)
+                                                    {
+                                                        <span class="rc-set-score">@set.P2</span>
+                                                    }
+                                                </div>
                                             </div>
                                         </div>
                                     }
@@ -434,6 +447,25 @@
         _showUpgradeBanner = false;
         var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString();
         await JS.InvokeVoidAsync("localStorage.setItem", "upgradeBannerDismissed", now);
+    }
+
+    private static List<(string P1, string P2)> ParseCasualSets(string? matchJson)
+    {
+        if (string.IsNullOrWhiteSpace(matchJson)) return [];
+        try
+        {
+            var match = JsonConvert.DeserializeObject<DropShot.Models.Match>(matchJson);
+            var last = match?.HistoryList?.LastOrDefault();
+            if (last?.SetScores == null) return [];
+            return last.SetScores
+                .OrderBy(s => s.SetNumber)
+                .Select(s => (s.UserGames.ToString(), s.OpponentGames.ToString()))
+                .ToList();
+        }
+        catch
+        {
+            return [];
+        }
     }
 
     private static Color StatusColor(FixtureStatus s) => s switch


### PR DESCRIPTION
## Summary
- Casual matches in 'My Recent Results' showed player names but no scores
- Parse `SavedMatch.MatchJson` to extract the final `GameState.SetScores` and render them using the same `rc-sets` markup as `ResultCard`

## Test plan
- [ ] Complete a casual match and confirm set scores appear on the home page alongside player names