### PR TITLE
Fix casual match set scores reading wrong end of HistoryList

### DIFF
--- a/DropShot/Components/Pages/Home.razor
+++ b/DropShot/Components/Pages/Home.razor
@@ -455,9 +455,10 @@
         try
         {
             var match = JsonConvert.DeserializeObject<DropShot.Models.Match>(matchJson);
-            var last = match?.HistoryList?.LastOrDefault();
-            if (last?.SetScores == null) return [];
-            return last.SetScores
+            // HistoryList is serialized from a Stack, so the most recent state is FIRST
+            var latest = match?.HistoryList?.FirstOrDefault();
+            if (latest?.SetScores == null || latest.SetScores.Count == 0) return [];
+            return latest.SetScores
                 .OrderBy(s => s.SetNumber)
                 .Select(s => (s.UserGames.ToString(), s.OpponentGames.ToString()))
                 .ToList();


### PR DESCRIPTION
## Summary
- Follow-up to #288: set scores still not showing for casual matches
- `HistoryList` is serialized from a `Stack`, so index 0 is the most recent `GameState`; using `LastOrDefault()` returned the initial empty state, so `SetScores` was always empty
- Switched to `FirstOrDefault()`

## Test plan
- [ ] Complete a casual match and confirm set scores now appear on the home page