### PR TITLE
Render casual matches with ResultCard for matching styles

### DIFF
--- a/DropShot/Components/Pages/Home.razor
+++ b/DropShot/Components/Pages/Home.razor
@@ -244,42 +244,11 @@
                                     }
                                     else if (item.CasualMatch != null)
                                     {
-                                        var casual = item.CasualMatch!;
-                                        string p1 = !string.IsNullOrWhiteSpace(casual.Player3)
-                                            ? (casual.Player1 ?? "TBD") + " & " + casual.Player3
-                                            : (casual.Player1 ?? "TBD");
-                                        string p2 = !string.IsNullOrWhiteSpace(casual.Player4)
-                                            ? (casual.Player2 ?? "TBD") + " & " + casual.Player4
-                                            : (casual.Player2 ?? "TBD");
-                                        bool p1Winner = casual.WinnerPlayerId.HasValue
-                                            && (casual.WinnerPlayerId == casual.Player1Id || casual.WinnerPlayerId == casual.Player3Id);
-                                        bool p2Winner = casual.WinnerPlayerId.HasValue
-                                            && (casual.WinnerPlayerId == casual.Player2Id || casual.WinnerPlayerId == casual.Player4Id);
-                                        var casualSets = ParseCasualSets(casual.MatchJson);
                                         <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="mb-1">
                                             <MudText Typo="Typo.caption" Style="font-weight:500">Casual Match</MudText>
                                             <MudText Typo="Typo.caption" Color="Color.Secondary" Style="margin-left:auto">@item.Date.ToString("dd MMM yyyy")</MudText>
                                         </MudStack>
-                                        <div class="result-card result-card-compact">
-                                            <div class="rc-player-row @(p1Winner ? "rc-winner" : "")">
-                                                <div class="rc-name">@p1</div>
-                                                <div class="rc-sets">
-                                                    @foreach (var set in casualSets)
-                                                    {
-                                                        <span class="rc-set-score">@set.P1</span>
-                                                    }
-                                                </div>
-                                            </div>
-                                            <div class="rc-player-row @(p2Winner ? "rc-winner" : "")">
-                                                <div class="rc-name">@p2</div>
-                                                <div class="rc-sets">
-                                                    @foreach (var set in casualSets)
-                                                    {
-                                                        <span class="rc-set-score">@set.P2</span>
-                                                    }
-                                                </div>
-                                            </div>
-                                        </div>
+                                        <ResultCard CasualMatch="item.CasualMatch" Compact="true" />
                                     }
                                 </div>
                             }
@@ -447,26 +416,6 @@
         _showUpgradeBanner = false;
         var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString();
         await JS.InvokeVoidAsync("localStorage.setItem", "upgradeBannerDismissed", now);
-    }
-
-    private static List<(string P1, string P2)> ParseCasualSets(string? matchJson)
-    {
-        if (string.IsNullOrWhiteSpace(matchJson)) return [];
-        try
-        {
-            var match = JsonConvert.DeserializeObject<DropShot.Models.Match>(matchJson);
-            // HistoryList is serialized from a Stack, so the most recent state is FIRST
-            var latest = match?.HistoryList?.FirstOrDefault();
-            if (latest?.SetScores == null || latest.SetScores.Count == 0) return [];
-            return latest.SetScores
-                .OrderBy(s => s.SetNumber)
-                .Select(s => (s.UserGames.ToString(), s.OpponentGames.ToString()))
-                .ToList();
-        }
-        catch
-        {
-            return [];
-        }
     }
 
     private static Color StatusColor(FixtureStatus s) => s switch

--- a/DropShot/Components/ResultCard.razor
+++ b/DropShot/Components/ResultCard.razor
@@ -1,7 +1,8 @@
 @using DropShot.Models
+@using Newtonsoft.Json
 
 <div class="@CardClass">
-    @if (!Compact && Fixture.Competition != null)
+    @if (!Compact && Fixture?.Competition != null)
     {
         <div class="rc-header">
             <span class="rc-comp">@Fixture.Competition.CompetitionName</span>
@@ -46,30 +47,90 @@
 </div>
 
 @code {
-    [Parameter, EditorRequired] public CompetitionFixture Fixture { get; set; } = default!;
+    [Parameter] public CompetitionFixture? Fixture { get; set; }
+    [Parameter] public SavedMatch? CasualMatch { get; set; }
     [Parameter] public bool Compact { get; set; }
 
     private string CardClass => Compact ? "result-card result-card-compact" : "result-card";
 
     private List<(string P1, string P2)> _sets = [];
 
-    private string Player1Name => Fixture.Player3 != null
-        ? $"{Fixture.Player1?.DisplayName ?? "TBD"} & {Fixture.Player3?.DisplayName ?? "TBD"}"
-        : Fixture.Player1?.DisplayName ?? "TBD";
+    private string Player1Name
+    {
+        get
+        {
+            if (Fixture != null)
+            {
+                return Fixture.Player3 != null
+                    ? $"{Fixture.Player1?.DisplayName ?? "TBD"} & {Fixture.Player3?.DisplayName ?? "TBD"}"
+                    : Fixture.Player1?.DisplayName ?? "TBD";
+            }
+            if (CasualMatch != null)
+            {
+                return !string.IsNullOrWhiteSpace(CasualMatch.Player3)
+                    ? (CasualMatch.Player1 ?? "TBD") + " & " + CasualMatch.Player3
+                    : (CasualMatch.Player1 ?? "TBD");
+            }
+            return "TBD";
+        }
+    }
 
-    private string Player2Name => Fixture.Player4 != null
-        ? $"{Fixture.Player2?.DisplayName ?? "TBD"} & {Fixture.Player4?.DisplayName ?? "TBD"}"
-        : Fixture.Player2?.DisplayName ?? "TBD";
+    private string Player2Name
+    {
+        get
+        {
+            if (Fixture != null)
+            {
+                return Fixture.Player4 != null
+                    ? $"{Fixture.Player2?.DisplayName ?? "TBD"} & {Fixture.Player4?.DisplayName ?? "TBD"}"
+                    : Fixture.Player2?.DisplayName ?? "TBD";
+            }
+            if (CasualMatch != null)
+            {
+                return !string.IsNullOrWhiteSpace(CasualMatch.Player4)
+                    ? (CasualMatch.Player2 ?? "TBD") + " & " + CasualMatch.Player4
+                    : (CasualMatch.Player2 ?? "TBD");
+            }
+            return "TBD";
+        }
+    }
 
-    private bool IsPlayer1Winner => Fixture.WinnerPlayerId.HasValue
-        && Fixture.WinnerPlayerId == Fixture.Player1Id;
+    private bool IsPlayer1Winner
+    {
+        get
+        {
+            if (Fixture != null)
+                return Fixture.WinnerPlayerId.HasValue && Fixture.WinnerPlayerId == Fixture.Player1Id;
+            if (CasualMatch != null)
+                return CasualMatch.WinnerPlayerId.HasValue
+                    && (CasualMatch.WinnerPlayerId == CasualMatch.Player1Id
+                        || CasualMatch.WinnerPlayerId == CasualMatch.Player3Id);
+            return false;
+        }
+    }
 
-    private bool IsPlayer2Winner => Fixture.WinnerPlayerId.HasValue
-        && Fixture.WinnerPlayerId == Fixture.Player2Id;
+    private bool IsPlayer2Winner
+    {
+        get
+        {
+            if (Fixture != null)
+                return Fixture.WinnerPlayerId.HasValue && Fixture.WinnerPlayerId == Fixture.Player2Id;
+            if (CasualMatch != null)
+                return CasualMatch.WinnerPlayerId.HasValue
+                    && (CasualMatch.WinnerPlayerId == CasualMatch.Player2Id
+                        || CasualMatch.WinnerPlayerId == CasualMatch.Player4Id);
+            return false;
+        }
+    }
 
     protected override void OnParametersSet()
     {
-        _sets = ParseResultSummary(Fixture.ResultSummary);
+        if (Fixture != null)
+            _sets = ParseResultSummary(Fixture.ResultSummary);
+        else if (CasualMatch != null)
+            _sets = ParseCasualSets(CasualMatch.MatchJson);
+        else
+            _sets = [];
     }
 
     private static List<(string P1, string P2)> ParseResultSummary(string? summary)
@@ -87,5 +148,25 @@
                 result.Add((scores[0].Trim(), scores[1].Trim()));
         }
         return result;
+    }
+
+    private static List<(string P1, string P2)> ParseCasualSets(string? matchJson)
+    {
+        if (string.IsNullOrWhiteSpace(matchJson)) return [];
+        try
+        {
+            var match = JsonConvert.DeserializeObject<Match>(matchJson);
+            // HistoryList is serialized from a Stack, so index 0 is the most recent state
+            var latest = match?.HistoryList?.FirstOrDefault();
+            if (latest?.SetScores == null || latest.SetScores.Count == 0) return [];
+            return latest.SetScores
+                .OrderBy(s => s.SetNumber)
+                .Select(s => (s.UserGames.ToString(), s.OpponentGames.ToString()))
+                .ToList();
+        }
+        catch
+        {
+            return [];
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Casual match scores were showing but unstyled because `ResultCard.razor.css` is scoped
- Extended `ResultCard` to accept a `SavedMatch` alongside `CompetitionFixture`
- `Home.razor` now renders casual matches with `<ResultCard CasualMatch=... Compact=true />` so they match competition results

## Test plan
- [ ] Casual match rows look identical in style to competition match rows on the home page