### PR TITLE
Fix footer overlap on mobile scoring screen, add fullscreen toggle

### DIFF
--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -116,6 +116,12 @@
 @if (loaded && @CurrentMatch != null)
 {
     <section class="bg-tennis overlay-dark">
+        @* Fullscreen toggle — small overlay button in the top-right corner *@
+        <button class="fullscreen-toggle no-zoom-element" @onclick="ToggleImmersive"
+                aria-label="@(_isImmersive ? "Exit fullscreen" : "Enter fullscreen")">
+            <MudIcon Icon="@(_isImmersive ? Icons.Material.Filled.FullscreenExit : Icons.Material.Filled.Fullscreen)"
+                     Size="Size.Medium" />
+        </button>
         @* #8 — Settings as a slide-out drawer instead of a collapse that pushes content *@
         <MudDrawer @bind-Open="_expanded" Anchor="Anchor.End" Variant="DrawerVariant.Temporary" Width="320px" Elevation="4">
             <MudDrawerHeader>
@@ -650,6 +656,8 @@
         _showCoinToss = false;
         await InvokeAsync(StateHasChanged);
         await SetScoringFullscreen(true);
+        _isImmersive = true;
+        await SetImmersive(true);
 
         // #7 — Start the match timer
         StartTimer();
@@ -986,6 +994,8 @@
             {
                 _restoreFullscreen = false;
                 await SetScoringFullscreen(true);
+                _isImmersive = true;
+                await SetImmersive(true);
             }
             else if (CurrentMatch == null)
             {
@@ -998,11 +1008,28 @@
     }
 
     private bool _restoreFullscreen;
+    private bool _isImmersive = true;
 
     private async Task SetScoringFullscreen(bool enabled)
     {
         var action = enabled ? "add" : "remove";
         await JS.InvokeVoidAsync("eval", $"document.body.classList.{action}('scoring-active')");
+        // When leaving scoring, always drop the immersive lock too so the
+        // top navbar reappears on the setup screen.
+        if (!enabled)
+            await SetImmersive(false);
+    }
+
+    private async Task SetImmersive(bool enabled)
+    {
+        var action = enabled ? "add" : "remove";
+        await JS.InvokeVoidAsync("eval", $"document.body.classList.{action}('scoring-immersive')");
+    }
+
+    private async Task ToggleImmersive()
+    {
+        _isImmersive = !_isImmersive;
+        await SetImmersive(_isImmersive);
     }
 
     private Stack<GameState> history = new(new[] { new GameState(0, 0, 0, 0, 0, 0, false, 0, false, 0, 0, new List<SetScore>(), DateTime.Now, false, "", "") });

--- a/DropShot/Components/TennisScore.razor.css
+++ b/DropShot/Components/TennisScore.razor.css
@@ -6,6 +6,33 @@
     touch-action: pan-x pan-y;
 }
 
+/* ── Fullscreen toggle (top-right overlay) ─────────────────── */
+
+.fullscreen-toggle {
+    position: absolute;
+    top: max(8px, env(safe-area-inset-top));
+    right: max(8px, env(safe-area-inset-right));
+    z-index: 20;
+    width: 40px;
+    height: 40px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(255, 255, 255, 0.08);
+    color: rgba(255, 255, 255, 0.75);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    border-radius: 50%;
+    cursor: pointer;
+    touch-action: manipulation;
+    transition: background 0.2s, color 0.2s, border-color 0.2s;
+}
+
+    .fullscreen-toggle:hover {
+        background: rgba(255, 255, 255, 0.18);
+        color: white;
+        border-color: rgba(255, 255, 255, 0.35);
+    }
+
 /* ── Main Score Container ──────────────────────────────────── */
 
 .score-container {

--- a/DropShot/wwwroot/app.css
+++ b/DropShot/wwwroot/app.css
@@ -153,6 +153,20 @@ body.scoring-active .role-banner {
     display: none !important;
 }
 
+/* Hide the site footer while a match is being scored — otherwise on
+   mobile it sits on top of the scoring controls and makes the screen
+   unusable. */
+body.scoring-active footer.site-footer {
+    display: none !important;
+}
+
+/* Scoring-immersive mode — additionally hides the top navbar so the
+   scoring view fills the entire viewport. User-toggleable via the
+   fullscreen button on the scoring screen. */
+body.scoring-immersive .top-navbar {
+    display: none !important;
+}
+
 /* Legacy — keep for external scoreboard page if still used */
 body.scoreboard-fullscreen .sidebar,
 body.scoreboard-fullscreen .role-banner,


### PR DESCRIPTION
## Summary
- Hides the site footer while a match is being scored — on mobile it was sitting on top of the scoring controls and making the screen unusable
- Restores a user-toggleable fullscreen mode via a small icon button in the top-right of the scoring view, which additionally hides the top navbar
- Immersive mode turns on automatically when a match starts or is restored, and is cleared on dispose / return to setup

## Test plan
- [ ] Start a new match on mobile — footer is gone; scoring controls are reachable
- [ ] Tap the fullscreen-exit icon top-right — top navbar reappears; tap the fullscreen icon to re-enter immersive mode
- [ ] End the match / navigate away — top navbar, role banner, and footer all reappear on the setup screen
- [ ] Reload mid-match (/match/{id}) — immersive mode restores and layout is intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)