### PR TITLE
Persist match config and add First-To set mode

### DIFF
--- a/DropShot/Components/MatchSetupWizard.razor
+++ b/DropShot/Components/MatchSetupWizard.razor
@@ -238,13 +238,30 @@
 
             <MudDivider Class="my-3" />
 
-            <MudNumericField @bind-Value="_bestOf" Label="Best of (sets)"
-                             Variant="Variant.Outlined" Min="1" Max="7"
-                             Style="max-width: 160px;" Class="mb-2" />
+            <MudSelect T="int" @bind-Value="_bestOf" Label="Best of (sets)"
+                       Variant="Variant.Outlined"
+                       Style="max-width: 160px;" Class="mb-2">
+                <MudSelectItem T="int" Value="1">1</MudSelectItem>
+                <MudSelectItem T="int" Value="3">3</MudSelectItem>
+                <MudSelectItem T="int" Value="5">5</MudSelectItem>
+                <MudSelectItem T="int" Value="7">7</MudSelectItem>
+            </MudSelect>
 
             <MudNumericField @bind-Value="_gamesPerSet" Label="Games per set"
                              Variant="Variant.Outlined" Min="1" Max="12"
                              Style="max-width: 160px;" Class="mb-2" />
+
+            <MudText Typo="Typo.subtitle2" Class="mb-1">Set wins on</MudText>
+            <MudRadioGroup @bind-Value="_setWinMode">
+                <MudStack Row="true" Spacing="2">
+                    <MudTooltip Text="Standard tennis: must win by 2 clear games; tie-break at games-all.">
+                        <MudRadio Value="SetWinMode.WinBy2" Color="Color.Primary">Win by 2</MudRadio>
+                    </MudTooltip>
+                    <MudTooltip Text="First player to reach the games-per-set target wins the set.">
+                        <MudRadio Value="SetWinMode.FirstTo" Color="Color.Primary">First to</MudRadio>
+                    </MudTooltip>
+                </MudStack>
+            </MudRadioGroup>
 
             <div class="d-flex justify-space-between mt-3">
                 <MudButton Variant="Variant.Text" Color="Color.Default"
@@ -336,6 +353,7 @@
     private int _deuceLimit = 1;
     private int _bestOf = 3;
     private int _gamesPerSet = 6;
+    private SetWinMode _setWinMode = SetWinMode.WinBy2;
 
     // Auth / players
     private Player? _myPlayer;
@@ -829,6 +847,7 @@
             DeuceLimit = _unlimitedDeuce ? 0 : _deuceLimit,
             BestOf = _bestOf,
             GamesPerSet = _gamesPerSet,
+            SetWinMode = _setWinMode,
             ServerChoice = "random"
         });
     }
@@ -850,6 +869,7 @@
         public int DeuceLimit { get; set; }
         public int BestOf { get; set; } = 3;
         public int GamesPerSet { get; set; } = 6;
+        public SetWinMode SetWinMode { get; set; } = SetWinMode.WinBy2;
         public string ServerChoice { get; set; } = "random";
     }
 }

--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -532,6 +532,8 @@
         _state.BestOf = result.BestOf;
         _state.GamesFirstTo = result.GamesPerSet;
         _state.UnlimitedDeuce = result.UnlimitedDeuce;
+        _state.DeuceLimit = result.DeuceLimit;
+        _state.SetWinMode = result.SetWinMode;
 
         _showServerSelect = true;
         return Task.CompletedTask;
@@ -582,7 +584,12 @@
             Player3 = _value3,
             Player4 = _value4,
             CourtId = _selectedCourtId,
-            GameScoring = _state.GameScoring
+            GameScoring = _state.GameScoring,
+            BestOf = _state.BestOf,
+            GamesFirstTo = _state.GamesFirstTo,
+            UnlimitedDeuce = _state.UnlimitedDeuce,
+            DeuceLimit = _state.DeuceLimit,
+            SetWinMode = _state.SetWinMode
         };
 
         if (_serverChoice == "random")
@@ -863,6 +870,11 @@
                 if (history.Any())
                     ScoreService.RestoreFromGameState(_state, history.Peek());
                 _state.GameScoring = CurrentMatch.GameScoring;
+                _state.BestOf = CurrentMatch.BestOf;
+                _state.GamesFirstTo = CurrentMatch.GamesFirstTo;
+                _state.UnlimitedDeuce = CurrentMatch.UnlimitedDeuce;
+                _state.DeuceLimit = CurrentMatch.DeuceLimit;
+                _state.SetWinMode = CurrentMatch.SetWinMode;
                 Label_Switch1 = !string.IsNullOrEmpty(CurrentMatch.Player3);
                 _savedMatchId = savedMatch.SavedMatchId;
                 _selectedCourtId = savedMatch.CourtId;

--- a/DropShot/Models/Match.cs
+++ b/DropShot/Models/Match.cs
@@ -11,4 +11,11 @@ public class Match
     public bool Complete { get; set; }
     public int? CourtId { get; set; }
     public bool GameScoring { get; set; } = true;
+
+    // Match configuration — persisted with the match so it survives refresh/restore.
+    public int BestOf { get; set; } = 3;
+    public int GamesFirstTo { get; set; } = 6;
+    public bool UnlimitedDeuce { get; set; } = true;
+    public int DeuceLimit { get; set; } = 1;
+    public SetWinMode SetWinMode { get; set; } = SetWinMode.WinBy2;
 }

--- a/DropShot/Models/TennisMatchState.cs
+++ b/DropShot/Models/TennisMatchState.cs
@@ -1,5 +1,13 @@
 namespace DropShot.Models;
 
+public enum SetWinMode : byte
+{
+    /// <summary>Standard tennis — win by 2 games, tie-break at GamesFirstTo all.</summary>
+    WinBy2 = 0,
+    /// <summary>First player to reach GamesFirstTo wins the set (no tie-break).</summary>
+    FirstTo = 1
+}
+
 public class TennisMatchState
 {
     // Scores
@@ -19,5 +27,7 @@ public class TennisMatchState
     public int BestOf { get; set; } = 3;
     public int GamesFirstTo { get; set; } = 6;
     public bool UnlimitedDeuce { get; set; } = true;
+    public int DeuceLimit { get; set; } = 1;
+    public SetWinMode SetWinMode { get; set; } = SetWinMode.WinBy2;
     public bool GameScoring { get; set; } = true;
 }

--- a/DropShot/Services/TennisScoreService.cs
+++ b/DropShot/Services/TennisScoreService.cs
@@ -44,33 +44,21 @@ public class TennisScoreService
         if (s.UserPoints >= 4 || s.OppPoints >= 4)
         {
             int diff = s.UserPoints - s.OppPoints;
+            bool shouldEnd = Math.Abs(diff) >= 2;
 
-            if (s.UnlimitedDeuce)
+            // Deuce limit: once the configured number of deuces has been played,
+            // the next point decides the game (sudden death).
+            if (!shouldEnd && !s.UnlimitedDeuce && s.DeuceCount >= Math.Max(1, s.DeuceLimit) && diff != 0)
+                shouldEnd = true;
+
+            if (shouldEnd)
             {
-                if (diff >= 2)
-                {
+                if (diff > 0)
                     s.UserGames++;
-                    ResetGame(s);
-                    CheckSet(s);
-                }
-                else if (diff <= -2)
-                {
+                else
                     s.OppGames++;
-                    ResetGame(s);
-                    CheckSet(s);
-                }
-            }
-            else
-            {
-                if (diff == 2 || diff == -2 || (diff == 1 && s.OppPoints > 3) || (diff == -1 && s.UserPoints > 3))
-                {
-                    if (diff > 0)
-                        s.UserGames++;
-                    else
-                        s.OppGames++;
-                    ResetGame(s);
-                    CheckSet(s);
-                }
+                ResetGame(s);
+                CheckSet(s);
             }
         }
 
@@ -80,6 +68,22 @@ public class TennisScoreService
 
     public void CheckSet(TennisMatchState s)
     {
+        // First-to-N: whoever reaches GamesFirstTo first wins the set (no tie-break).
+        if (s.SetWinMode == SetWinMode.FirstTo)
+        {
+            if (s.UserGames >= s.GamesFirstTo || s.OppGames >= s.GamesFirstTo)
+            {
+                if (s.UserGames > s.OppGames)
+                    s.UserSets++;
+                else
+                    s.OppSets++;
+
+                EndSet(s);
+            }
+            return;
+        }
+
+        // Win-by-2 (standard tennis): tie-break on reaching GamesFirstTo-all.
         if (s.UserGames == s.GamesFirstTo && s.OppGames == s.GamesFirstTo)
         {
             s.IsTieBreak = true;


### PR DESCRIPTION
## Summary
- Match configuration (BestOf, GamesFirstTo, UnlimitedDeuce, DeuceLimit, SetWinMode) now persists on `Match` so it survives save/reload — previously every restored match fell back to best-of-3 / games-to-6 / unlimited deuce.
- `DeuceLimit` is now honoured in `TennisScoreService.CheckGame`: after the configured number of deuces, the next point wins (the setting was effectively ignored before).
- "Best Of" is now an odd-only dropdown (1/3/5/7) and there is a new "Set wins on" choice — **Win by 2** (default, tie-break at games-all) or **First to** N games (no tie-break).

## Test plan
- [ ] Start a match with Best of 5 / games-to-4 / limited deuce (max 2) — verify it actually plays as best-of-5 and the 3rd deuce decides the game.
- [ ] Refresh the scoring page mid-match — config still applies after restore.
- [ ] Pick "First to" with games-to-8 — first to 8 games wins the set, no tie-break.
- [ ] Pick "Win by 2" with games-to-6 — tie-break triggers at 6-6 (existing behaviour).
- [ ] Competition fixture with BestOf=5 autoplayed via `/tennisscore?autoStart=true` still honours the competition's BestOf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)