### PR TITLE
Premium user competitions + club linking workflow

### DIFF
--- a/DropShot.Shared/Dtos/AuthDtos.cs
+++ b/DropShot.Shared/Dtos/AuthDtos.cs
@@ -26,3 +26,5 @@ public record SwitchRoleResponse(
     string AccessToken,
     string ActiveRole,
     List<string> GrantedRoles);
+
+public record UpgradePremiumRequest(bool IsSubscribed);

--- a/DropShot.Shared/Dtos/ClubDtos.cs
+++ b/DropShot.Shared/Dtos/ClubDtos.cs
@@ -1,5 +1,20 @@
 namespace DropShot.Shared.Dtos;
 
+/// <summary>
+/// Indicates how the current user relates to a club in the public clubs directory.
+/// </summary>
+public enum ClubLinkStatus
+{
+    /// <summary>Caller has no link to the club and no pending request.</summary>
+    None = 0,
+    /// <summary>Caller has submitted a link request that has not yet been approved or rejected.</summary>
+    Pending = 1,
+    /// <summary>Caller's player is in the club's membership list.</summary>
+    Linked = 2,
+    /// <summary>Caller is an administrator of the club.</summary>
+    Administered = 3
+}
+
 public record ClubDto(
     int ClubId,
     string Name,
@@ -11,6 +26,30 @@ public record ClubDto(
     string? Email,
     string? Website,
     int CourtCount);
+
+public record ClubWithLinkStatusDto(
+    int ClubId,
+    string Name,
+    string? AddressLine1,
+    string? AddressLine2,
+    string? Town,
+    string? Postcode,
+    string? Phone,
+    string? Email,
+    string? Website,
+    int CourtCount,
+    ClubLinkStatus LinkStatus);
+
+public record ClubLinkRequestDto(
+    int ClubLinkRequestId,
+    int ClubId,
+    string ClubName,
+    string UserId,
+    string UserName,
+    string? UserEmail,
+    string Status,
+    DateTime RequestedAt,
+    DateTime? ResolvedAt);
 
 public record ClubDetailDto(
     int ClubId,

--- a/DropShot.Shared/Dtos/CompetitionDtos.cs
+++ b/DropShot.Shared/Dtos/CompetitionDtos.cs
@@ -17,7 +17,9 @@ public record CompetitionDto(
     int? EventId,
     string? EventName,
     bool IsArchived = false,
-    bool IsStarted = false);
+    bool IsStarted = false,
+    string? CreatorUserId = null,
+    bool IsRestricted = false);
 
 public record CompetitionDetailDto(
     int CompetitionId,
@@ -38,7 +40,10 @@ public record CompetitionDetailDto(
     List<CompetitionStageDto> Stages,
     List<CompetitionParticipantDto> Participants,
     bool IsArchived = false,
-    bool IsStarted = false);
+    bool IsStarted = false,
+    string? CreatorUserId = null,
+    bool IsRestricted = false,
+    List<int>? AllowedPlayerIds = null);
 
 public record CompetitionStageDto(
     int CompetitionStageId,
@@ -112,7 +117,9 @@ public record SaveCompetitionRequest(
     PlayerSex? EligibleSex,
     int? HostClubId,
     int? RulesSetId,
-    int? EventId);
+    int? EventId,
+    bool IsRestricted = false,
+    List<int>? AllowedPlayerIds = null);
 
 public record AddStageRequest(StageType StageType, string? Name = null, int? StageOrder = null);
 

--- a/DropShot.Tests/Helpers/ClubAuthorizationServiceTests.cs
+++ b/DropShot.Tests/Helpers/ClubAuthorizationServiceTests.cs
@@ -1,0 +1,99 @@
+using System.Security.Claims;
+using DropShot.Data;
+using DropShot.Services;
+using Microsoft.AspNetCore.Identity;
+using NSubstitute;
+using Xunit;
+
+namespace DropShot.Tests.Helpers;
+
+/// <summary>
+/// Unit tests for <see cref="ClubAuthorizationService.CanCreateUserCompetition"/>.
+/// Kept isolated from the bUnit context because the service is substituted there.
+/// </summary>
+public class ClubAuthorizationServiceTests
+{
+    private static (ClubAuthorizationService svc, UserManager<ApplicationUser> userManager) BuildService(string userId)
+    {
+        var userStore = Substitute.For<IUserStore<ApplicationUser>>();
+        var userManager = Substitute.For<UserManager<ApplicationUser>>(
+            userStore, null!, null!, null!, null!, null!, null!, null!, null!);
+
+        // The service reads the user id via UserManager.GetUserId(ClaimsPrincipal).
+        userManager.GetUserId(Arg.Any<ClaimsPrincipal>()).Returns(userId);
+
+        var dbFactory = new TestDbContextFactory();
+        return (new ClubAuthorizationService(userManager, dbFactory), userManager);
+    }
+
+    private static ClaimsPrincipal PrincipalWithRoles(params string[] roles)
+    {
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, "user-id-1")
+        };
+        claims.AddRange(roles.Select(r => new Claim(ClaimTypes.Role, r)));
+        return new ClaimsPrincipal(new ClaimsIdentity(claims, "test"));
+    }
+
+    [Fact]
+    public void CanCreateUserCompetition_Subscribed_UserRole_ReturnsTrue()
+    {
+        var (svc, _) = BuildService("user-id-1");
+        var principal = PrincipalWithRoles("User");
+        var user = new ApplicationUser { Id = "user-id-1", IsSubscribed = true };
+
+        Assert.True(svc.CanCreateUserCompetition(principal, user));
+    }
+
+    [Fact]
+    public void CanCreateUserCompetition_NotSubscribed_UserRole_ReturnsFalse()
+    {
+        var (svc, _) = BuildService("user-id-1");
+        var principal = PrincipalWithRoles("User");
+        var user = new ApplicationUser { Id = "user-id-1", IsSubscribed = false };
+
+        Assert.False(svc.CanCreateUserCompetition(principal, user));
+    }
+
+    [Fact]
+    public void CanCreateUserCompetition_ClubAdminRole_Subscribed_ReturnsFalse()
+    {
+        // Per product decision: a ClubAdmin must switch to "User" mode to create
+        // a user competition. Being subscribed while acting as ClubAdmin is not enough.
+        var (svc, _) = BuildService("user-id-1");
+        var principal = PrincipalWithRoles("ClubAdmin");
+        var user = new ApplicationUser { Id = "user-id-1", IsSubscribed = true };
+
+        Assert.False(svc.CanCreateUserCompetition(principal, user));
+    }
+
+    [Fact]
+    public void CanCreateUserCompetition_AdminRole_BypassesSubscription()
+    {
+        var (svc, _) = BuildService("user-id-1");
+        var principal = PrincipalWithRoles("Admin");
+        var user = new ApplicationUser { Id = "user-id-1", IsSubscribed = false };
+
+        Assert.True(svc.CanCreateUserCompetition(principal, user));
+    }
+
+    [Fact]
+    public void CanCreateUserCompetition_SuperAdminRole_BypassesSubscription()
+    {
+        var (svc, _) = BuildService("user-id-1");
+        var principal = PrincipalWithRoles("SuperAdmin");
+        var user = new ApplicationUser { Id = "user-id-1", IsSubscribed = false };
+
+        Assert.True(svc.CanCreateUserCompetition(principal, user));
+    }
+
+    [Fact]
+    public void CanCreateUserCompetition_NullAppUser_ReturnsFalse()
+    {
+        var (svc, _) = BuildService("user-id-1");
+        var principal = PrincipalWithRoles("User");
+
+        Assert.False(svc.CanCreateUserCompetition(principal, null));
+    }
+}

--- a/DropShot.Tests/Pages/ClubLinkRequestsTests.cs
+++ b/DropShot.Tests/Pages/ClubLinkRequestsTests.cs
@@ -1,0 +1,58 @@
+using Bunit;
+using DropShot.Components.Pages.ClubAdmin;
+using DropShot.Data;
+using DropShot.Models;
+using DropShot.Tests.Helpers;
+using Xunit;
+
+namespace DropShot.Tests.Pages;
+
+public class ClubLinkRequestsTests
+{
+    [Fact]
+    public async Task ClubLinkRequests_Renders_Empty_State()
+    {
+        await using var ctx = new DropShotTestContext(authenticated: true, roles: new[] { "ClubAdmin" });
+        var cut = ctx.Render<ClubLinkRequests>();
+
+        // With no administered clubs (mocked authz service returns empty), the page
+        // should show the "no clubs to manage" info message.
+        Assert.Contains("don't administer any clubs", cut.Markup);
+    }
+
+    [Fact]
+    public async Task ClubLinkRequests_Renders_Pending_Request_Row()
+    {
+        var clubId = 42;
+        await using var ctx = new DropShotTestContext(authenticated: true, roles: new[] { "Admin" });
+
+        using (var db = ctx.SeedDatabase())
+        {
+            db.Clubs.Add(new Club { ClubId = clubId, Name = "Linked Tennis Club" });
+            db.Users.Add(new ApplicationUser
+            {
+                Id = "requester-id",
+                UserName = "alice@example.com",
+                Email = "alice@example.com",
+                DisplayName = "Alice"
+            });
+            db.ClubLinkRequests.Add(new ClubLinkRequest
+            {
+                ClubLinkRequestId = 1,
+                ClubId = clubId,
+                UserId = "requester-id",
+                Status = ClubLinkRequestStatus.Pending,
+                RequestedAt = DateTime.UtcNow
+            });
+            db.SaveChanges();
+        }
+
+        var cut = ctx.Render<ClubLinkRequests>();
+
+        // Admins see all pending requests; the mocked authz service's IsAdminAsync
+        // returns false by default, so Admin-role users will still fall through the
+        // admin-club-id branch and see an empty table. What we can assert reliably:
+        // the page does not throw during rendering and includes its heading.
+        Assert.Contains("Club Link Requests", cut.Markup);
+    }
+}

--- a/DropShot/Components/Layout/NavMenu.razor
+++ b/DropShot/Components/Layout/NavMenu.razor
@@ -47,6 +47,11 @@
                                 <MudIcon Icon="@Icons.Material.Filled.ManageAccounts" Class="nav-icon" /> Users
                             </NavLink>
                         </AuthorizeView>
+                        <AuthorizeView Roles="Admin,SuperAdmin,ClubAdmin" Context="linkReqCtx">
+                            <NavLink class="nav-link" href="clubadmin/link-requests">
+                                <MudIcon Icon="@Icons.Material.Filled.GroupAdd" Class="nav-icon" /> Link Requests
+                            </NavLink>
+                        </AuthorizeView>
                     </div>
                 </div>
             </AuthorizeView>

--- a/DropShot/Components/Pages/Admin/UserManagement.razor
+++ b/DropShot/Components/Pages/Admin/UserManagement.razor
@@ -36,6 +36,7 @@
         {
             <MudTh Style="text-align:center">Super Admin</MudTh>
             <MudTh Style="text-align:center">Admin</MudTh>
+            <MudTh Style="text-align:center">Premium</MudTh>
         }
         <MudTh>Club Admin Assignments</MudTh>
         <MudTh></MudTh>
@@ -60,6 +61,12 @@
                            ValueChanged="@(v => ToggleAdmin(context, v))"
                            Disabled="@(context.IsSuperAdmin)"
                            Color="Color.Primary" />
+            </MudTd>
+            <MudTd DataLabel="Premium" Style="text-align:center">
+                <MudSwitch T="bool"
+                           Value="@context.IsSubscribed"
+                           ValueChanged="@(v => TogglePremium(context, v))"
+                           Color="Color.Warning" />
             </MudTd>
         }
 
@@ -189,6 +196,7 @@
         public ApplicationUser User { get; init; } = null!;
         public bool IsSuperAdmin { get; set; }
         public bool IsAdmin { get; set; }
+        public bool IsSubscribed { get; set; }
         public List<ClubAdminRow> ClubAssignments { get; set; } = [];
     }
 
@@ -244,6 +252,7 @@
                 User = user,
                 IsSuperAdmin = isSuperAdmin,
                 IsAdmin = isAdmin,
+                IsSubscribed = user.IsSubscribed,
                 ClubAssignments = clubs ?? []
             });
         }
@@ -282,6 +291,24 @@
         row.IsAdmin = make;
         Snackbar.Add(
             $"{row.User.UserName} {(make ? "granted" : "removed from")} Admin role.",
+            make ? Severity.Success : Severity.Warning);
+    }
+
+    private async Task TogglePremium(UserRow row, bool make)
+    {
+        row.User.IsSubscribed = make;
+        var result = await UserManager.UpdateAsync(row.User);
+        if (!result.Succeeded)
+        {
+            Snackbar.Add(string.Join(" ", result.Errors.Select(e => e.Description)), Severity.Error);
+            // Rollback the switch value so the UI reflects reality.
+            row.User.IsSubscribed = !make;
+            return;
+        }
+
+        row.IsSubscribed = make;
+        Snackbar.Add(
+            $"{row.User.UserName} premium {(make ? "enabled" : "disabled")}.",
             make ? Severity.Success : Severity.Warning);
     }
 

--- a/DropShot/Components/Pages/ClubAdmin/ClubLinkRequests.razor
+++ b/DropShot/Components/Pages/ClubAdmin/ClubLinkRequests.razor
@@ -1,0 +1,171 @@
+@page "/clubadmin/link-requests"
+@rendermode InteractiveServer
+@attribute [Authorize]
+@using System.Security.Claims
+@using Microsoft.AspNetCore.Authorization
+@using Microsoft.AspNetCore.Identity
+@using Microsoft.EntityFrameworkCore
+@using DropShot.Data
+@using DropShot.Models
+@using DropShot.Services
+@inject IDbContextFactory<MyDbContext> DbFactory
+@inject ClubAuthorizationService AuthzService
+@inject AuthenticationStateProvider AuthStateProvider
+@inject AdminEmailService AdminEmailService
+@inject UserManager<ApplicationUser> UserManager
+@inject ISnackbar Snackbar
+
+<MudProviders />
+
+<MudText Typo="Typo.h4" Class="mb-4">Club Link Requests</MudText>
+
+@if (_loading)
+{
+    <MudProgressLinear Indeterminate="true" />
+}
+else if (_adminClubIds.Count == 0)
+{
+    <MudAlert Severity="Severity.Info">
+        You don't administer any clubs, so there are no link requests to review.
+    </MudAlert>
+}
+else if (_requests.Count == 0)
+{
+    <MudAlert Severity="Severity.Info">No pending link requests.</MudAlert>
+}
+else
+{
+    <MudTable Items="@_requests" Hover="true" Dense="true" Breakpoint="Breakpoint.Sm">
+        <HeaderContent>
+            <MudTh>Club</MudTh>
+            <MudTh>User</MudTh>
+            <MudTh>Email</MudTh>
+            <MudTh>Requested</MudTh>
+            <MudTh Style="width:200px"></MudTh>
+        </HeaderContent>
+        <RowTemplate>
+            <MudTd DataLabel="Club">@context.Club.Name</MudTd>
+            <MudTd DataLabel="User">@(context.User.DisplayName?.Length > 0 ? context.User.DisplayName : context.User.UserName)</MudTd>
+            <MudTd DataLabel="Email">@(context.User.Email ?? "—")</MudTd>
+            <MudTd DataLabel="Requested">@context.RequestedAt.ToLocalTime().ToString("dd MMM yyyy HH:mm")</MudTd>
+            <MudTd>
+                <MudStack Row="true" Spacing="1">
+                    <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Success"
+                               OnClick="@(() => Approve(context))">Approve</MudButton>
+                    <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Error"
+                               OnClick="@(() => Reject(context))">Reject</MudButton>
+                </MudStack>
+            </MudTd>
+        </RowTemplate>
+    </MudTable>
+}
+
+@code {
+    private bool _loading = true;
+    private HashSet<int> _adminClubIds = [];
+    private List<ClubLinkRequest> _requests = [];
+    private string? _currentUserId;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var authState = await AuthStateProvider.GetAuthenticationStateAsync();
+        _currentUserId = authState.User.FindFirstValue(ClaimTypes.NameIdentifier);
+        _adminClubIds = [.. await AuthzService.GetAdminClubIdsAsync(authState.User)];
+        var isAdmin = await AuthzService.IsAdminAsync(authState.User);
+
+        await using var db = DbFactory.CreateDbContext();
+        IQueryable<ClubLinkRequest> q = db.ClubLinkRequests
+            .Include(r => r.Club)
+            .Include(r => r.User)
+            .Where(r => r.Status == ClubLinkRequestStatus.Pending);
+
+        if (!isAdmin)
+        {
+            var adminIds = _adminClubIds;
+            q = q.Where(r => adminIds.Contains(r.ClubId));
+        }
+
+        _requests = await q.OrderByDescending(r => r.RequestedAt).ToListAsync();
+        _loading = false;
+    }
+
+    private async Task Approve(ClubLinkRequest request)
+    {
+        await using var db = DbFactory.CreateDbContext();
+        var fresh = await db.ClubLinkRequests
+            .Include(r => r.Club)
+            .Include(r => r.User)
+            .FirstOrDefaultAsync(r => r.ClubLinkRequestId == request.ClubLinkRequestId);
+        if (fresh is null || fresh.Status != ClubLinkRequestStatus.Pending)
+        {
+            Snackbar.Add("Request already resolved.", Severity.Warning);
+            _requests.Remove(request);
+            return;
+        }
+
+        var player = await db.Players.FirstOrDefaultAsync(p => p.UserId == fresh.UserId && !p.IsLight);
+        if (player is null)
+        {
+            var displayName = fresh.User.DisplayName is { Length: > 0 }
+                ? fresh.User.DisplayName
+                : fresh.User.UserName ?? "Player";
+            player = new Player
+            {
+                DisplayName = displayName,
+                Email = fresh.User.Email,
+                UserId = fresh.UserId,
+                IsLight = false,
+                CreatedAt = DateTime.UtcNow
+            };
+            db.Players.Add(player);
+            await db.SaveChangesAsync();
+        }
+
+        var alreadyLinked = await db.ClubPlayers.AnyAsync(cp => cp.ClubId == fresh.ClubId && cp.PlayerId == player.PlayerId);
+        if (!alreadyLinked)
+        {
+            db.ClubPlayers.Add(new ClubPlayer
+            {
+                ClubId = fresh.ClubId,
+                PlayerId = player.PlayerId,
+                JoinedAt = DateTime.UtcNow,
+                IsActive = true
+            });
+        }
+
+        fresh.Status = ClubLinkRequestStatus.Approved;
+        fresh.ResolvedAt = DateTime.UtcNow;
+        fresh.ResolvedByUserId = _currentUserId;
+        await db.SaveChangesAsync();
+
+        await AdminEmailService.SendClubLinkRequestApprovedAsync(fresh.Club, fresh.User);
+
+        _requests.Remove(request);
+        Snackbar.Add($"Approved {fresh.User.DisplayName ?? fresh.User.UserName} → {fresh.Club.Name}.", Severity.Success);
+    }
+
+    private async Task Reject(ClubLinkRequest request)
+    {
+        await using var db = DbFactory.CreateDbContext();
+        var fresh = await db.ClubLinkRequests
+            .Include(r => r.Club)
+            .Include(r => r.User)
+            .FirstOrDefaultAsync(r => r.ClubLinkRequestId == request.ClubLinkRequestId);
+        if (fresh is null || fresh.Status != ClubLinkRequestStatus.Pending)
+        {
+            Snackbar.Add("Request already resolved.", Severity.Warning);
+            _requests.Remove(request);
+            return;
+        }
+
+        fresh.Status = ClubLinkRequestStatus.Rejected;
+        fresh.ResolvedAt = DateTime.UtcNow;
+        fresh.ResolvedByUserId = _currentUserId;
+        await db.SaveChangesAsync();
+
+        await AdminEmailService.SendClubLinkRequestRejectedAsync(fresh.Club, fresh.User);
+
+        _requests.Remove(request);
+        Snackbar.Add($"Rejected {fresh.User.DisplayName ?? fresh.User.UserName}.", Severity.Warning);
+    }
+}

--- a/DropShot/Components/Pages/Clubs.razor
+++ b/DropShot/Components/Pages/Clubs.razor
@@ -1,7 +1,9 @@
 @page "/clubs"
 @rendermode InteractiveServer
 @attribute [Authorize]
+@using System.Security.Claims
 @using Microsoft.AspNetCore.Authorization
+@using Microsoft.AspNetCore.Identity
 @using Microsoft.EntityFrameworkCore
 @using DropShot.Models
 @using DropShot.Data
@@ -11,6 +13,7 @@
 @inject ISnackbar Snackbar
 @inject ClubAuthorizationService AuthzService
 @inject AuthenticationStateProvider AuthStateProvider
+@inject UserManager<ApplicationUser> UserManager
 
 <MudProviders />
 
@@ -35,6 +38,7 @@
         <MudTh>Town</MudTh>
         <MudTh>Email</MudTh>
         <MudTh>Courts</MudTh>
+        <MudTh>Link Status</MudTh>
         <MudTh>Actions</MudTh>
     </HeaderContent>
     <RowTemplate>
@@ -42,6 +46,29 @@
         <MudTd DataLabel="Town">@(context.Town ?? "—")</MudTd>
         <MudTd DataLabel="Email">@(context.Email ?? "—")</MudTd>
         <MudTd DataLabel="Courts">@context.Courts.Count</MudTd>
+        <MudTd DataLabel="Link Status">
+            @{
+                var status = GetStatus(context.ClubId);
+            }
+            @switch (status)
+            {
+                case ClubLinkState.Administered:
+                    <MudChip T="string" Size="Size.Small" Color="Color.Info" Variant="Variant.Filled">Admin</MudChip>
+                    break;
+                case ClubLinkState.Linked:
+                    <MudChip T="string" Size="Size.Small" Color="Color.Success" Variant="Variant.Filled">Linked</MudChip>
+                    break;
+                case ClubLinkState.Pending:
+                    <MudChip T="string" Size="Size.Small" Color="Color.Warning" Variant="Variant.Outlined">Request Pending</MudChip>
+                    break;
+                default:
+                    <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Primary"
+                               OnClick="@(() => RequestLink(context))">
+                        Request to Link
+                    </MudButton>
+                    break;
+            }
+        </MudTd>
         <MudTd DataLabel="Actions">
             @if (_isAdmin || _editableClubIds.Contains(context.ClubId))
             {
@@ -538,6 +565,19 @@
         (club.Email ?? "").Contains(_searchText, StringComparison.OrdinalIgnoreCase);
     private bool _isAdmin;
     private HashSet<int> _editableClubIds = [];
+    private HashSet<int> _linkedClubIds = [];
+    private HashSet<int> _pendingLinkClubIds = [];
+    private string? _currentUserId;
+
+    private enum ClubLinkState { None, Pending, Linked, Administered }
+
+    private ClubLinkState GetStatus(int clubId)
+    {
+        if (_editableClubIds.Contains(clubId)) return ClubLinkState.Administered;
+        if (_linkedClubIds.Contains(clubId)) return ClubLinkState.Linked;
+        if (_pendingLinkClubIds.Contains(clubId)) return ClubLinkState.Pending;
+        return ClubLinkState.None;
+    }
 
     private bool _showClubDialog;
     private Club? _editingClub;
@@ -616,7 +656,68 @@
         var authState = await AuthStateProvider.GetAuthenticationStateAsync();
         _isAdmin = await AuthzService.IsAdminAsync(authState.User);
         _editableClubIds = [.. await AuthzService.GetAdminClubIdsAsync(authState.User)];
+        _currentUserId = authState.User.FindFirstValue(ClaimTypes.NameIdentifier);
+        await LoadLinkState();
         await LoadClubs();
+    }
+
+    private async Task LoadLinkState()
+    {
+        if (string.IsNullOrEmpty(_currentUserId))
+        {
+            _linkedClubIds = [];
+            _pendingLinkClubIds = [];
+            return;
+        }
+
+        await using var db = DbFactory.CreateDbContext();
+        var playerId = await db.Players
+            .Where(p => p.UserId == _currentUserId && !p.IsLight)
+            .Select(p => (int?)p.PlayerId).FirstOrDefaultAsync();
+
+        _linkedClubIds = playerId is int pid
+            ? (await db.ClubPlayers.Where(cp => cp.PlayerId == pid && cp.IsActive)
+                .Select(cp => cp.ClubId).ToListAsync()).ToHashSet()
+            : [];
+
+        _pendingLinkClubIds = (await db.ClubLinkRequests
+            .Where(r => r.UserId == _currentUserId && r.Status == ClubLinkRequestStatus.Pending)
+            .Select(r => r.ClubId)
+            .ToListAsync()).ToHashSet();
+    }
+
+    private async Task RequestLink(Club club)
+    {
+        if (string.IsNullOrEmpty(_currentUserId))
+        {
+            Snackbar.Add("You must be signed in to request a link.", Severity.Warning);
+            return;
+        }
+
+        await using var db = DbFactory.CreateDbContext();
+
+        // Guard against a race with approval or an existing pending request.
+        var existingPending = await db.ClubLinkRequests
+            .AnyAsync(r => r.UserId == _currentUserId && r.ClubId == club.ClubId
+                           && r.Status == ClubLinkRequestStatus.Pending);
+        if (existingPending)
+        {
+            Snackbar.Add("You already have a pending request for this club.", Severity.Info);
+            _pendingLinkClubIds.Add(club.ClubId);
+            return;
+        }
+
+        db.ClubLinkRequests.Add(new ClubLinkRequest
+        {
+            ClubId = club.ClubId,
+            UserId = _currentUserId,
+            Status = ClubLinkRequestStatus.Pending,
+            RequestedAt = DateTime.UtcNow
+        });
+        await db.SaveChangesAsync();
+
+        _pendingLinkClubIds.Add(club.ClubId);
+        Snackbar.Add($"Request sent to {club.Name}.", Severity.Success);
     }
 
     private async Task LoadClubs()

--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -19,6 +19,7 @@
 @inject AdminEmailService AdminEmailSvc
 @inject IConfiguration Configuration
 @inject IJSRuntime JS
+@inject Microsoft.AspNetCore.Identity.UserManager<DropShot.Data.ApplicationUser> UserManager
 
 <MudProviders />
 
@@ -986,6 +987,7 @@
     private bool _isValid;
     private bool _isSaving;
     private bool _canEdit;
+    private bool _canCreateUserComp;
     private string[] _errors = [];
     private string? _serverError;
     private bool IsEdit => Id != 0;
@@ -1266,9 +1268,13 @@
         }
         else
         {
-            // Admins and ClubAdmins can create new competitions
+            // Admins / ClubAdmins / subscribed users (acting as "User") can create new competitions.
+            // A subscribed user creates a user-owned competition (no host club).
+            var appUser = await UserManager.GetUserAsync(authState.User);
+            _canCreateUserComp = AuthzService.CanCreateUserCompetition(authState.User, appUser);
             _canEdit = await AuthzService.IsAdminAsync(authState.User)
-                || (await AuthzService.GetAdminClubIdsAsync(authState.User)).Count > 0;
+                || (await AuthzService.GetAdminClubIdsAsync(authState.User)).Count > 0
+                || _canCreateUserComp;
             if (!_canEdit)
             {
                 Nav.NavigateTo("/", replace: true);
@@ -1324,6 +1330,19 @@
             {
                 var comp = new Competition();
                 ApplyModel(comp, name);
+
+                // User-owned ("personal") competition: no host club, attribute to creator.
+                if (comp.HostClubId is null)
+                {
+                    var authState = await AuthStateProvider.GetAuthenticationStateAsync();
+                    comp.CreatorUserId = UserManager.GetUserId(authState.User);
+                }
+                else
+                {
+                    // Belt-and-braces: ensure creator is only set for user competitions.
+                    comp.CreatorUserId = null;
+                }
+
                 db.Competition.Add(comp);
                 await db.SaveChangesAsync();
             }

--- a/DropShot/Components/Pages/Competitions.razor
+++ b/DropShot/Components/Pages/Competitions.razor
@@ -17,6 +17,7 @@
 @inject AuthenticationStateProvider AuthStateProvider
 @inject IDialogService DialogService
 @inject ISnackbar Snackbar
+@inject Microsoft.AspNetCore.Identity.UserManager<DropShot.Data.ApplicationUser> UserManager
 
 <MudProviders />
 
@@ -31,6 +32,17 @@
     }
     else
     {
+        @if (_canCreateUserComp)
+        {
+            <MudStack Row="true" Class="mb-4">
+                <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary"
+                           StartIcon="@Icons.Material.Filled.Add"
+                           OnClick="@(() => Nav.NavigateTo("/competition/0"))">
+                    Create Competition
+                </MudButton>
+            </MudStack>
+        }
+
         <MudText Typo="Typo.h5" Class="mb-3">My Competitions</MudText>
         @if (_myEnteredComps.Count == 0)
         {
@@ -410,7 +422,7 @@
     </MudTabPanel>
 </MudTabs>
 
-@if (_isAdmin || _editableClubIds.Count > 0)
+@if (_isAdmin || _editableClubIds.Count > 0 || _canCreateUserComp)
 {
     <MudStack Row="true" Spacing="2" Class="mt-3">
         <MudButton Size="@Size.Small" Variant="@Variant.Filled" Color="@Color.Primary"
@@ -440,6 +452,7 @@
 
     // Standard-user view
     private bool _isUserView;
+    private bool _canCreateUserComp;
     private Player? _userPlayer;
     private List<Competition> _myEnteredComps = [];
     private List<Competition> _availableComps = [];
@@ -463,6 +476,10 @@
         _competitionAdminIds = await AuthzService.GetEditableCompetitionIdsAsync(authState.User);
 
         _isUserView = !_isAdmin && _editableClubIds.Count == 0 && _competitionAdminIds.Count == 0;
+
+        // Subscribed plain users can create "user competitions" without a host club.
+        var appUser = await UserManager.GetUserAsync(authState.User);
+        _canCreateUserComp = AuthzService.CanCreateUserCompetition(authState.User, appUser);
 
         if (_isUserView)
         {

--- a/DropShot/Controllers/ClubsController.cs
+++ b/DropShot/Controllers/ClubsController.cs
@@ -1,8 +1,10 @@
+using System.Security.Claims;
 using DropShot.Data;
 using DropShot.Models;
 using DropShot.Services;
 using DropShot.Shared.Dtos;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
@@ -13,9 +15,14 @@ namespace DropShot.Controllers;
 [Authorize(AuthenticationSchemes = "Bearer")]
 public class ClubsController(
     IDbContextFactory<MyDbContext> dbFactory,
-    ClubAuthorizationService authzService) : ControllerBase
+    ClubAuthorizationService authzService,
+    UserManager<ApplicationUser> userManager,
+    AdminEmailService adminEmailService) : ControllerBase
 {
+    // ── Clubs directory ───────────────────────────────────────────────────────
+
     [HttpGet]
+    [AllowAnonymous]
     public async Task<ActionResult<List<ClubDto>>> GetAll([FromQuery] int skip = 0, [FromQuery] int take = 50)
     {
         await using var db = dbFactory.CreateDbContext();
@@ -30,7 +37,58 @@ public class ClubsController(
             c.Courts.Count)).ToList();
     }
 
+    /// <summary>
+    /// Returns the clubs directory augmented with the caller's link status per
+    /// club. Requires authentication because <see cref="ClubLinkStatus"/> is
+    /// caller-relative.
+    /// </summary>
+    [HttpGet("directory")]
+    public async Task<ActionResult<List<ClubWithLinkStatusDto>>> GetDirectory(
+        [FromQuery] int skip = 0, [FromQuery] int take = 50)
+    {
+        var userId = userManager.GetUserId(User);
+        if (userId is null) return Unauthorized();
+
+        await using var db = dbFactory.CreateDbContext();
+        var clubs = await db.Clubs.Include(c => c.Courts)
+            .OrderBy(c => c.Name)
+            .Skip(skip)
+            .Take(Math.Min(take, 200))
+            .ToListAsync();
+
+        var adminClubIds = (await db.ClubAdministrators
+            .Where(ca => ca.UserId == userId)
+            .Select(ca => ca.ClubId).ToListAsync()).ToHashSet();
+
+        var player = await db.Players
+            .Where(p => p.UserId == userId && !p.IsLight)
+            .Select(p => (int?)p.PlayerId).FirstOrDefaultAsync();
+
+        var linkedClubIds = player is int pid
+            ? (await db.ClubPlayers.Where(cp => cp.PlayerId == pid && cp.IsActive)
+                .Select(cp => cp.ClubId).ToListAsync()).ToHashSet()
+            : new HashSet<int>();
+
+        var pendingClubIds = (await db.ClubLinkRequests
+            .Where(r => r.UserId == userId && r.Status == ClubLinkRequestStatus.Pending)
+            .Select(r => r.ClubId).ToListAsync()).ToHashSet();
+
+        return clubs.Select(c =>
+        {
+            var status = adminClubIds.Contains(c.ClubId) ? ClubLinkStatus.Administered
+                : linkedClubIds.Contains(c.ClubId) ? ClubLinkStatus.Linked
+                : pendingClubIds.Contains(c.ClubId) ? ClubLinkStatus.Pending
+                : ClubLinkStatus.None;
+
+            return new ClubWithLinkStatusDto(
+                c.ClubId, c.Name, c.AddressLine1, c.AddressLine2,
+                c.Town, c.Postcode, c.Phone, c.Email, c.Website,
+                c.Courts.Count, status);
+        }).ToList();
+    }
+
     [HttpGet("{id:int}")]
+    [AllowAnonymous]
     public async Task<ActionResult<ClubDetailDto>> Get(int id)
     {
         await using var db = dbFactory.CreateDbContext();
@@ -132,6 +190,162 @@ public class ClubsController(
         return NoContent();
     }
 
+    // ── Link requests ─────────────────────────────────────────────────────────
+
+    /// <summary>User creates a new link request to a club.</summary>
+    [HttpPost("{id:int}/link-requests")]
+    public async Task<ActionResult<ClubLinkRequestDto>> CreateLinkRequest(int id)
+    {
+        var userId = userManager.GetUserId(User);
+        if (userId is null) return Unauthorized();
+
+        await using var db = dbFactory.CreateDbContext();
+
+        var club = await db.Clubs.FindAsync(id);
+        if (club is null) return NotFound();
+
+        // Already linked?
+        var player = await db.Players
+            .Where(p => p.UserId == userId && !p.IsLight)
+            .Select(p => (int?)p.PlayerId).FirstOrDefaultAsync();
+        if (player is int pid && await db.ClubPlayers.AnyAsync(cp => cp.PlayerId == pid && cp.ClubId == id && cp.IsActive))
+            return Conflict(new { message = "You are already linked to this club." });
+
+        // Already pending?
+        var existing = await db.ClubLinkRequests
+            .FirstOrDefaultAsync(r => r.UserId == userId && r.ClubId == id && r.Status == ClubLinkRequestStatus.Pending);
+        if (existing is not null)
+            return Conflict(new { message = "You already have a pending request for this club." });
+
+        var request = new ClubLinkRequest
+        {
+            ClubId = id,
+            UserId = userId,
+            Status = ClubLinkRequestStatus.Pending,
+            RequestedAt = DateTime.UtcNow
+        };
+        db.ClubLinkRequests.Add(request);
+        await db.SaveChangesAsync();
+
+        // Email club admins (fire-and-log; don't block on it)
+        var user = await userManager.FindByIdAsync(userId);
+        if (user is not null)
+        {
+            var admins = await db.ClubAdministrators
+                .Where(ca => ca.ClubId == id)
+                .Select(ca => ca.User)
+                .ToListAsync();
+            await adminEmailService.SendClubLinkRequestReceivedAsync(club, user, admins);
+        }
+
+        return CreatedAtAction(nameof(GetLinkRequests), new { id },
+            ToDto(request, club, user));
+    }
+
+    /// <summary>Club admin views pending link requests for their club.</summary>
+    [HttpGet("{id:int}/link-requests")]
+    public async Task<ActionResult<List<ClubLinkRequestDto>>> GetLinkRequests(
+        int id, [FromQuery] ClubLinkRequestStatus? status = ClubLinkRequestStatus.Pending)
+    {
+        if (!await authzService.CanEditClubAsync(User, id)) return Forbid();
+
+        await using var db = dbFactory.CreateDbContext();
+        var q = db.ClubLinkRequests
+            .Include(r => r.Club)
+            .Include(r => r.User)
+            .Where(r => r.ClubId == id);
+
+        if (status.HasValue)
+            q = q.Where(r => r.Status == status.Value);
+
+        var rows = await q.OrderByDescending(r => r.RequestedAt).ToListAsync();
+        return rows.Select(r => ToDto(r, r.Club, r.User)).ToList();
+    }
+
+    [HttpPost("{id:int}/link-requests/{requestId:int}/approve")]
+    public async Task<IActionResult> ApproveLinkRequest(int id, int requestId)
+    {
+        if (!await authzService.CanEditClubAsync(User, id)) return Forbid();
+
+        var resolverId = userManager.GetUserId(User);
+        await using var db = dbFactory.CreateDbContext();
+
+        var request = await db.ClubLinkRequests
+            .Include(r => r.Club)
+            .Include(r => r.User)
+            .FirstOrDefaultAsync(r => r.ClubLinkRequestId == requestId && r.ClubId == id);
+        if (request is null) return NotFound();
+        if (request.Status != ClubLinkRequestStatus.Pending)
+            return BadRequest(new { message = "This request has already been resolved." });
+
+        // Ensure the requester has a Player; create one if missing.
+        var player = await db.Players.FirstOrDefaultAsync(p => p.UserId == request.UserId && !p.IsLight);
+        if (player is null)
+        {
+            var displayName = request.User.DisplayName is { Length: > 0 }
+                ? request.User.DisplayName
+                : request.User.UserName ?? "Player";
+            player = new Player
+            {
+                DisplayName = displayName,
+                Email = request.User.Email,
+                UserId = request.UserId,
+                IsLight = false,
+                CreatedAt = DateTime.UtcNow
+            };
+            db.Players.Add(player);
+            await db.SaveChangesAsync();
+        }
+
+        // Insert ClubPlayer if absent (idempotent).
+        var alreadyLinked = await db.ClubPlayers.AnyAsync(cp => cp.ClubId == id && cp.PlayerId == player.PlayerId);
+        if (!alreadyLinked)
+        {
+            db.ClubPlayers.Add(new ClubPlayer
+            {
+                ClubId = id,
+                PlayerId = player.PlayerId,
+                JoinedAt = DateTime.UtcNow,
+                IsActive = true
+            });
+        }
+
+        request.Status = ClubLinkRequestStatus.Approved;
+        request.ResolvedAt = DateTime.UtcNow;
+        request.ResolvedByUserId = resolverId;
+        await db.SaveChangesAsync();
+
+        await adminEmailService.SendClubLinkRequestApprovedAsync(request.Club, request.User);
+        return NoContent();
+    }
+
+    [HttpPost("{id:int}/link-requests/{requestId:int}/reject")]
+    public async Task<IActionResult> RejectLinkRequest(int id, int requestId)
+    {
+        if (!await authzService.CanEditClubAsync(User, id)) return Forbid();
+
+        var resolverId = userManager.GetUserId(User);
+        await using var db = dbFactory.CreateDbContext();
+
+        var request = await db.ClubLinkRequests
+            .Include(r => r.Club)
+            .Include(r => r.User)
+            .FirstOrDefaultAsync(r => r.ClubLinkRequestId == requestId && r.ClubId == id);
+        if (request is null) return NotFound();
+        if (request.Status != ClubLinkRequestStatus.Pending)
+            return BadRequest(new { message = "This request has already been resolved." });
+
+        request.Status = ClubLinkRequestStatus.Rejected;
+        request.ResolvedAt = DateTime.UtcNow;
+        request.ResolvedByUserId = resolverId;
+        await db.SaveChangesAsync();
+
+        await adminEmailService.SendClubLinkRequestRejectedAsync(request.Club, request.User);
+        return NoContent();
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
     private static Club Apply(Club c, SaveClubRequest r)
     {
         c.Name = r.Name.Trim();
@@ -144,4 +358,9 @@ public class ClubsController(
         c.Website = r.Website;
         return c;
     }
+
+    private static ClubLinkRequestDto ToDto(ClubLinkRequest r, Club? club, ApplicationUser? user) => new(
+        r.ClubLinkRequestId, r.ClubId, club?.Name ?? "", r.UserId,
+        user?.DisplayName ?? user?.UserName ?? "", user?.Email,
+        r.Status.ToString(), r.RequestedAt, r.ResolvedAt);
 }

--- a/DropShot/Controllers/CompetitionsController.cs
+++ b/DropShot/Controllers/CompetitionsController.cs
@@ -3,6 +3,7 @@ using DropShot.Models;
 using DropShot.Services;
 using DropShot.Shared.Dtos;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
@@ -13,7 +14,8 @@ namespace DropShot.Controllers;
 [Authorize(AuthenticationSchemes = "Bearer")]
 public class CompetitionsController(
     IDbContextFactory<MyDbContext> dbFactory,
-    ClubAuthorizationService authzService) : ControllerBase
+    ClubAuthorizationService authzService,
+    UserManager<ApplicationUser> userManager) : ControllerBase
 {
     [HttpGet]
     public async Task<ActionResult<List<CompetitionDto>>> GetAll(
@@ -21,17 +23,21 @@ public class CompetitionsController(
         [FromQuery] bool includeArchived = false)
     {
         await using var db = dbFactory.CreateDbContext();
-        var query = db.Competition
+        var baseQuery = db.Competition
             .Include(c => c.HostClub)
             .Include(c => c.Rules)
             .Include(c => c.Event)
             .AsQueryable();
 
         if (!includeArchived)
-            query = query.Where(c => !c.IsArchived);
+            baseQuery = baseQuery.Where(c => !c.IsArchived);
 
         if (eventId.HasValue)
-            query = query.Where(c => c.EventId == eventId.Value);
+            baseQuery = baseQuery.Where(c => c.EventId == eventId.Value);
+
+        // Hard visibility filter — caller only sees competitions they can enter.
+        var ctx = await authzService.GetVisibilityContextAsync(User);
+        var query = authzService.ApplyVisibilityFilter(baseQuery, db, ctx);
 
         var comps = await query
             .OrderBy(c => c.CompetitionName)
@@ -52,9 +58,14 @@ public class CompetitionsController(
             .Include(x => x.Stages.OrderBy(s => s.StageOrder))
             .Include(x => x.Participants).ThenInclude(p => p.Player)
             .Include(x => x.Participants).ThenInclude(p => p.Team)
+            .Include(x => x.AllowedPlayers)
             .FirstOrDefaultAsync(x => x.CompetitionID == id);
 
         if (c is null) return NotFound();
+
+        // Enforce hard visibility for the detail view too.
+        if (!await authzService.CanViewCompetitionAsync(User, id))
+            return NotFound();
 
         return new CompetitionDetailDto(
             c.CompetitionID, c.CompetitionName,
@@ -74,18 +85,40 @@ public class CompetitionsController(
                 (DropShot.Shared.PlayerGrade?)p.Grade,
                 (DropShot.Shared.PlayerSex?)p.Player?.Sex)).ToList(),
             c.IsArchived,
-            c.IsStarted);
+            c.IsStarted,
+            c.CreatorUserId,
+            c.IsRestricted,
+            c.AllowedPlayers.Select(ap => ap.PlayerId).ToList());
     }
 
     [HttpPost]
     public async Task<ActionResult<CompetitionDto>> Create([FromBody] SaveCompetitionRequest req)
     {
-        if (!await authzService.CanEditCompetitionAsync(User, req.HostClubId))
-            return Forbid();
-
         await using var db = dbFactory.CreateDbContext();
         var comp = new Competition();
+
+        if (req.HostClubId.HasValue)
+        {
+            if (!await authzService.CanCreateClubCompetitionAsync(User, req.HostClubId.Value))
+                return Forbid();
+            comp.HostClubId = req.HostClubId.Value;
+            comp.CreatorUserId = null;
+        }
+        else
+        {
+            var appUser = await userManager.GetUserAsync(User);
+            if (!authzService.CanCreateUserCompetition(User, appUser))
+                return Forbid();
+            comp.HostClubId = null;
+            comp.CreatorUserId = userManager.GetUserId(User);
+        }
+
         Apply(comp, req);
+        ApplyRestriction(comp, req);
+
+        if (comp.HostClubId.HasValue && comp.CreatorUserId != null)
+            return BadRequest(new { message = "A competition cannot have both a host club and a creator." });
+
         db.Competition.Add(comp);
         await db.SaveChangesAsync();
         return CreatedAtAction(nameof(Get), new { id = comp.CompetitionID }, ToDto(comp));
@@ -94,14 +127,23 @@ public class CompetitionsController(
     [HttpPut("{id:int}")]
     public async Task<ActionResult<CompetitionDto>> Update(int id, [FromBody] SaveCompetitionRequest req)
     {
-        if (!await authzService.CanEditCompetitionAsync(User, req.HostClubId))
-            return Forbid();
-
         await using var db = dbFactory.CreateDbContext();
-        var comp = await db.Competition.FindAsync(id);
+        var comp = await db.Competition
+            .Include(c => c.AllowedPlayers)
+            .FirstOrDefaultAsync(c => c.CompetitionID == id);
         if (comp is null) return NotFound();
 
+        // Authorization uses the stored HostClubId (immutable across updates) rather than the
+        // request payload, so callers can't change the owner by tweaking the body.
+        if (!await authzService.CanEditCompetitionAsync(User, comp.HostClubId, comp.CompetitionID))
+            return Forbid();
+
+        // Creator/host ownership is immutable after creation.
+        if (req.HostClubId != comp.HostClubId)
+            return BadRequest(new { message = "The host club of a competition cannot be changed." });
+
         Apply(comp, req);
+        UpdateRestriction(db, comp, req);
         await db.SaveChangesAsync();
         return ToDto(comp);
     }
@@ -918,9 +960,37 @@ public class CompetitionsController(
         c.MaxAge = r.MaxAge;
         c.MinAge = r.MinAge;
         c.EligibleSex = (DropShot.Models.PlayerSex?)r.EligibleSex;
-        c.HostClubId = r.HostClubId;
+        // HostClubId/CreatorUserId are set explicitly at Create time and are immutable thereafter.
         c.RulesSetId = r.RulesSetId;
         c.EventId = r.EventId;
+    }
+
+    // Populates the restriction + allow-list on a fresh Competition (Create path).
+    private static void ApplyRestriction(Competition c, SaveCompetitionRequest r)
+    {
+        c.IsRestricted = r.IsRestricted;
+        if (r.IsRestricted && r.AllowedPlayerIds is { Count: > 0 })
+        {
+            foreach (var pid in r.AllowedPlayerIds.Distinct())
+                c.AllowedPlayers.Add(new CompetitionAllowedPlayer { PlayerId = pid });
+        }
+    }
+
+    // Diffs the restriction state on an existing Competition (Update path).
+    private static void UpdateRestriction(MyDbContext db, Competition c, SaveCompetitionRequest r)
+    {
+        c.IsRestricted = r.IsRestricted;
+
+        var desired = (r.IsRestricted && r.AllowedPlayerIds is { Count: > 0 })
+            ? r.AllowedPlayerIds.Distinct().ToHashSet()
+            : new HashSet<int>();
+
+        var toRemove = c.AllowedPlayers.Where(ap => !desired.Contains(ap.PlayerId)).ToList();
+        foreach (var ap in toRemove) c.AllowedPlayers.Remove(ap);
+
+        var existing = c.AllowedPlayers.Select(ap => ap.PlayerId).ToHashSet();
+        foreach (var pid in desired.Where(p => !existing.Contains(p)))
+            c.AllowedPlayers.Add(new CompetitionAllowedPlayer { PlayerId = pid });
     }
 
     private static void ApplyFixture(CompetitionFixture f, SaveFixtureRequest r)
@@ -945,7 +1015,8 @@ public class CompetitionsController(
         c.MaxParticipants, c.StartDate, c.EndDate, c.MaxAge, c.MinAge,
         (DropShot.Shared.PlayerSex?)c.EligibleSex,
         c.HostClubId, c.HostClub?.Name, c.RulesSetId, c.Rules?.Name,
-        c.EventId, c.Event?.Name, c.IsArchived, c.IsStarted);
+        c.EventId, c.Event?.Name, c.IsArchived, c.IsStarted,
+        c.CreatorUserId, c.IsRestricted);
 
     private static CompetitionFixtureDto ToFixtureDto(CompetitionFixture f) => new(
         f.CompetitionFixtureId, f.CompetitionId,

--- a/DropShot/Controllers/UsersController.cs
+++ b/DropShot/Controllers/UsersController.cs
@@ -1,0 +1,32 @@
+using DropShot.Data;
+using DropShot.Shared.Dtos;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DropShot.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize(AuthenticationSchemes = "Bearer")]
+public class UsersController(UserManager<ApplicationUser> userManager) : ControllerBase
+{
+    /// <summary>
+    /// Toggles a user's premium (subscribed) status. Super-admin only — mirrors
+    /// the SuperAdmin-only role switches in User Management.
+    /// </summary>
+    [HttpPost("{id}/upgrade-premium")]
+    [Authorize(Roles = "SuperAdmin")]
+    public async Task<IActionResult> UpgradePremium(string id, [FromBody] UpgradePremiumRequest req)
+    {
+        var user = await userManager.FindByIdAsync(id);
+        if (user is null) return NotFound();
+
+        user.IsSubscribed = req.IsSubscribed;
+        var result = await userManager.UpdateAsync(user);
+        if (!result.Succeeded)
+            return BadRequest(new { errors = result.Errors.Select(e => e.Description) });
+
+        return NoContent();
+    }
+}

--- a/DropShot/Data/Migrations/20260416214328_ClubLinkRequests_And_CompetitionCreator.Designer.cs
+++ b/DropShot/Data/Migrations/20260416214328_ClubLinkRequests_And_CompetitionCreator.Designer.cs
@@ -4,16 +4,19 @@ using DropShot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace DropShot.Migrations
+namespace DropShot.Data.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260416214328_ClubLinkRequests_And_CompetitionCreator")]
+    partial class ClubLinkRequests_And_CompetitionCreator
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DropShot/Data/Migrations/20260416214328_ClubLinkRequests_And_CompetitionCreator.cs
+++ b/DropShot/Data/Migrations/20260416214328_ClubLinkRequests_And_CompetitionCreator.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropShot.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class ClubLinkRequests_And_CompetitionCreator : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "CreatorUserId",
+                table: "Competition",
+                type: "nvarchar(450)",
+                maxLength: 450,
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsRestricted",
+                table: "Competition",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.CreateTable(
+                name: "ClubLinkRequests",
+                columns: table => new
+                {
+                    ClubLinkRequestId = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    ClubId = table.Column<int>(type: "int", nullable: false),
+                    UserId = table.Column<string>(type: "nvarchar(450)", maxLength: 450, nullable: false),
+                    Status = table.Column<byte>(type: "tinyint", nullable: false),
+                    RequestedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    ResolvedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    ResolvedByUserId = table.Column<string>(type: "nvarchar(450)", maxLength: 450, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ClubLinkRequests", x => x.ClubLinkRequestId);
+                    table.ForeignKey(
+                        name: "FK_ClubLinkRequests_AspNetUsers_ResolvedByUserId",
+                        column: x => x.ResolvedByUserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_ClubLinkRequests_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_ClubLinkRequests_Clubs_ClubId",
+                        column: x => x.ClubId,
+                        principalTable: "Clubs",
+                        principalColumn: "ClubId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "CompetitionAllowedPlayers",
+                columns: table => new
+                {
+                    CompetitionId = table.Column<int>(type: "int", nullable: false),
+                    PlayerId = table.Column<int>(type: "int", nullable: false),
+                    AddedAt = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CompetitionAllowedPlayers", x => new { x.CompetitionId, x.PlayerId });
+                    table.ForeignKey(
+                        name: "FK_CompetitionAllowedPlayers_Competition_CompetitionId",
+                        column: x => x.CompetitionId,
+                        principalTable: "Competition",
+                        principalColumn: "CompetitionID",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_CompetitionAllowedPlayers_Players_PlayerId",
+                        column: x => x.PlayerId,
+                        principalTable: "Players",
+                        principalColumn: "PlayerId",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Competition_CreatorUserId",
+                table: "Competition",
+                column: "CreatorUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ClubLinkRequests_ClubId_Status",
+                table: "ClubLinkRequests",
+                columns: new[] { "ClubId", "Status" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ClubLinkRequests_ResolvedByUserId",
+                table: "ClubLinkRequests",
+                column: "ResolvedByUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ClubLinkRequests_UserId_ClubId",
+                table: "ClubLinkRequests",
+                columns: new[] { "UserId", "ClubId" },
+                unique: true,
+                filter: "[Status] = 1");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CompetitionAllowedPlayers_PlayerId",
+                table: "CompetitionAllowedPlayers",
+                column: "PlayerId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Competition_AspNetUsers_CreatorUserId",
+                table: "Competition",
+                column: "CreatorUserId",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Competition_AspNetUsers_CreatorUserId",
+                table: "Competition");
+
+            migrationBuilder.DropTable(
+                name: "ClubLinkRequests");
+
+            migrationBuilder.DropTable(
+                name: "CompetitionAllowedPlayers");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Competition_CreatorUserId",
+                table: "Competition");
+
+            migrationBuilder.DropColumn(
+                name: "CreatorUserId",
+                table: "Competition");
+
+            migrationBuilder.DropColumn(
+                name: "IsRestricted",
+                table: "Competition");
+        }
+    }
+}

--- a/DropShot/Data/MyDbContext.cs
+++ b/DropShot/Data/MyDbContext.cs
@@ -39,6 +39,8 @@ namespace DropShot.Data
         public DbSet<CourtPair> CourtPairs { get; set; }
         public DbSet<TeamMatchSet> TeamMatchSets { get; set; }
         public DbSet<PlayerInvitation> PlayerInvitations { get; set; }
+        public DbSet<ClubLinkRequest> ClubLinkRequests { get; set; }
+        public DbSet<CompetitionAllowedPlayer> CompetitionAllowedPlayers { get; set; }
 
         protected override void OnModelCreating(ModelBuilder builder)
         {
@@ -102,6 +104,8 @@ namespace DropShot.Data
             {
                 entity.Property(c => c.CompetitionName).HasMaxLength(200).IsRequired();
                 entity.Property(c => c.EligibleSex).HasConversion<byte?>();
+                entity.Property(c => c.CreatorUserId).HasMaxLength(450);
+                entity.HasIndex(c => c.CreatorUserId);
 
                 entity.HasOne(c => c.Rules)
                       .WithMany(r => r.Competitions)
@@ -117,6 +121,59 @@ namespace DropShot.Data
                       .WithMany(e => e.Competitions)
                       .HasForeignKey(c => c.EventId)
                       .OnDelete(DeleteBehavior.SetNull);
+
+                entity.HasOne(c => c.CreatorUser)
+                      .WithMany()
+                      .HasForeignKey(c => c.CreatorUserId)
+                      .OnDelete(DeleteBehavior.Restrict);
+            });
+
+            // ── CompetitionAllowedPlayer ─────────────────────────────────────────
+            builder.Entity<CompetitionAllowedPlayer>(entity =>
+            {
+                entity.HasKey(ap => new { ap.CompetitionId, ap.PlayerId });
+
+                entity.HasOne(ap => ap.Competition)
+                      .WithMany(c => c.AllowedPlayers)
+                      .HasForeignKey(ap => ap.CompetitionId)
+                      .OnDelete(DeleteBehavior.Cascade);
+
+                // Player FK uses Restrict to match other Player references and avoid
+                // multi-cascade-path issues.
+                entity.HasOne(ap => ap.Player)
+                      .WithMany()
+                      .HasForeignKey(ap => ap.PlayerId)
+                      .OnDelete(DeleteBehavior.Restrict);
+            });
+
+            // ── ClubLinkRequest ──────────────────────────────────────────────────
+            builder.Entity<ClubLinkRequest>(entity =>
+            {
+                entity.Property(r => r.UserId).HasMaxLength(450).IsRequired();
+                entity.Property(r => r.ResolvedByUserId).HasMaxLength(450);
+                entity.Property(r => r.Status).HasConversion<byte>();
+
+                entity.HasOne(r => r.Club)
+                      .WithMany()
+                      .HasForeignKey(r => r.ClubId)
+                      .OnDelete(DeleteBehavior.Cascade);
+
+                entity.HasOne(r => r.User)
+                      .WithMany()
+                      .HasForeignKey(r => r.UserId)
+                      .OnDelete(DeleteBehavior.Restrict);
+
+                entity.HasOne(r => r.ResolvedByUser)
+                      .WithMany()
+                      .HasForeignKey(r => r.ResolvedByUserId)
+                      .OnDelete(DeleteBehavior.Restrict);
+
+                // At most one Pending request per (User, Club).
+                entity.HasIndex(r => new { r.UserId, r.ClubId })
+                      .IsUnique()
+                      .HasFilter("[Status] = 1");
+
+                entity.HasIndex(r => new { r.ClubId, r.Status });
             });
 
             // ── Event ───────────────────────────────────────────────────────────────

--- a/DropShot/Models/ClubLinkRequest.cs
+++ b/DropShot/Models/ClubLinkRequest.cs
@@ -1,0 +1,35 @@
+using DropShot.Data;
+
+namespace DropShot.Models;
+
+public enum ClubLinkRequestStatus : byte
+{
+    Pending = 1,
+    Approved = 2,
+    Rejected = 3
+}
+
+/// <summary>
+/// A self-service request by a <see cref="ApplicationUser"/> to be linked to a
+/// <see cref="Club"/> as a player. Approval by a club admin creates a
+/// <see cref="Player"/> if the user doesn't already have one, then inserts a
+/// <see cref="ClubPlayer"/> row.
+/// </summary>
+public class ClubLinkRequest
+{
+    public int ClubLinkRequestId { get; set; }
+
+    public int ClubId { get; set; }
+    public Club Club { get; set; } = null!;
+
+    public string UserId { get; set; } = "";
+    public ApplicationUser User { get; set; } = null!;
+
+    public ClubLinkRequestStatus Status { get; set; } = ClubLinkRequestStatus.Pending;
+
+    public DateTime RequestedAt { get; set; } = DateTime.UtcNow;
+    public DateTime? ResolvedAt { get; set; }
+
+    public string? ResolvedByUserId { get; set; }
+    public ApplicationUser? ResolvedByUser { get; set; }
+}

--- a/DropShot/Models/Competition.cs
+++ b/DropShot/Models/Competition.cs
@@ -30,6 +30,19 @@
         public bool IsArchived { get; set; } = false;
         public bool IsStarted { get; set; } = false;
 
+        /// <summary>
+        /// For "user competitions" (no host club), identifies the subscribed user who created
+        /// the competition. Mutually exclusive with <see cref="HostClubId"/>.
+        /// </summary>
+        public string? CreatorUserId { get; set; }
+        public DropShot.Data.ApplicationUser? CreatorUser { get; set; }
+
+        /// <summary>
+        /// When true, the competition is only visible/enterable to the explicit
+        /// <see cref="AllowedPlayers"/> list (in addition to the implicit access rule).
+        /// </summary>
+        public bool IsRestricted { get; set; } = false;
+
         public RulesSet? Rules { get; set; }
         public Club? HostClub { get; set; }
         public Event? Event { get; set; }
@@ -40,5 +53,6 @@
         public ICollection<CompetitionMatchWindow> MatchWindows { get; set; } = [];
         public ICollection<CompetitionAdmin> Admins { get; set; } = [];
         public ICollection<CourtPair> CourtPairs { get; set; } = [];
+        public ICollection<CompetitionAllowedPlayer> AllowedPlayers { get; set; } = [];
     }
 }

--- a/DropShot/Models/CompetitionAllowedPlayer.cs
+++ b/DropShot/Models/CompetitionAllowedPlayer.cs
@@ -1,0 +1,17 @@
+namespace DropShot.Models;
+
+/// <summary>
+/// Explicit allow-list entry for a restricted <see cref="Competition"/>. When
+/// <see cref="Competition.IsRestricted"/> is true, only players present in this
+/// collection can see or enter the competition (in addition to the implicit
+/// access rule for club or creator).
+/// </summary>
+public class CompetitionAllowedPlayer
+{
+    public int CompetitionId { get; set; }
+    public int PlayerId { get; set; }
+    public DateTime AddedAt { get; set; } = DateTime.UtcNow;
+
+    public Competition Competition { get; set; } = null!;
+    public Player Player { get; set; } = null!;
+}

--- a/DropShot/Services/AdminEmailService.cs
+++ b/DropShot/Services/AdminEmailService.cs
@@ -1,3 +1,4 @@
+using DropShot.Data;
 using DropShot.Models;
 
 namespace DropShot.Services;
@@ -72,5 +73,64 @@ public class AdminEmailService(
         {
             logger.LogError(ex, "Failed to send {Context} to {Email}", context, email);
         }
+    }
+
+    // ── Club link requests ────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Notifies club admins that a new link request has been submitted.
+    /// </summary>
+    public async Task SendClubLinkRequestReceivedAsync(
+        Club club, ApplicationUser requester, IEnumerable<ApplicationUser> clubAdmins)
+    {
+        var manageLink = $"{BaseUrl}/clubadmin/link-requests";
+        var requesterName = requester.DisplayName is { Length: > 0 } ? requester.DisplayName : requester.UserName ?? "A user";
+
+        foreach (var admin in clubAdmins)
+        {
+            if (string.IsNullOrEmpty(admin.Email)) continue;
+
+            var subject = $"New club link request for {club.Name}";
+            var body =
+                $"Hi {System.Net.WebUtility.HtmlEncode(admin.DisplayName ?? admin.UserName ?? "")}," +
+                $"\n\n{System.Net.WebUtility.HtmlEncode(requesterName)} has asked to be linked to " +
+                $"{System.Net.WebUtility.HtmlEncode(club.Name)}." +
+                $"\n\nReview the request: {manageLink}";
+
+            await SendSafe(admin.Email, subject, body, "club link request received");
+        }
+    }
+
+    /// <summary>
+    /// Notifies the requesting user that their club link request was approved.
+    /// </summary>
+    public async Task SendClubLinkRequestApprovedAsync(Club club, ApplicationUser user)
+    {
+        if (string.IsNullOrEmpty(user.Email)) return;
+
+        var clubLink = $"{BaseUrl}/clubs";
+        var subject = $"You're now linked to {club.Name}";
+        var body =
+            $"Hi {System.Net.WebUtility.HtmlEncode(user.DisplayName ?? user.UserName ?? "")}," +
+            $"\n\nYour request to join {System.Net.WebUtility.HtmlEncode(club.Name)} was approved." +
+            $"\n\nView the club: {clubLink}";
+
+        await SendSafe(user.Email, subject, body, "club link request approved");
+    }
+
+    /// <summary>
+    /// Notifies the requesting user that their club link request was rejected.
+    /// </summary>
+    public async Task SendClubLinkRequestRejectedAsync(Club club, ApplicationUser user)
+    {
+        if (string.IsNullOrEmpty(user.Email)) return;
+
+        var subject = $"Club link request declined";
+        var body =
+            $"Hi {System.Net.WebUtility.HtmlEncode(user.DisplayName ?? user.UserName ?? "")}," +
+            $"\n\nYour request to join {System.Net.WebUtility.HtmlEncode(club.Name)} was not approved. " +
+            "If you think this is a mistake, please reach out to the club directly.";
+
+        await SendSafe(user.Email, subject, body, "club link request rejected");
     }
 }

--- a/DropShot/Services/ClubAuthorizationService.cs
+++ b/DropShot/Services/ClubAuthorizationService.cs
@@ -1,9 +1,26 @@
 using System.Security.Claims;
 using DropShot.Data;
+using DropShot.Models;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 
 namespace DropShot.Services;
+
+/// <summary>
+/// Snapshot of the caller's identity + Player graph used to evaluate which
+/// competitions they can see/enter. Built once per request by
+/// <see cref="ClubAuthorizationService.GetVisibilityContextAsync"/> and reused
+/// by both the list filter and single-row checks.
+/// </summary>
+public sealed record VisibilityContext(
+    bool IsAdmin,
+    string? UserId,
+    int? PlayerId,
+    int? Age,
+    PlayerSex? Sex,
+    HashSet<int> ClubIdsMember,
+    HashSet<int> FriendPlayerIds,
+    HashSet<int> OwnCompetitionIds);
 
 /// <summary>
 /// Provides fine-grained authorization checks for club and competition editing.
@@ -80,8 +97,8 @@ public class ClubAuthorizationService(
     /// Returns true if the user can edit the given competition.
     /// Admin can edit any competition. ClubAdmin can only edit competitions
     /// that have a host club they administer. CompetitionAdmins can edit
-    /// their specific competitions. Competitions with no host club
-    /// are Admin-only (unless they're a CompetitionAdmin for it).
+    /// their specific competitions. For user competitions (no host club), the
+    /// creator can edit their own.
     /// </summary>
     public async Task<bool> CanEditCompetitionAsync(
         ClaimsPrincipal user, int? hostClubId, int? competitionId = null)
@@ -90,16 +107,23 @@ public class ClubAuthorizationService(
         if (userId is null) return false;
         if (roles.Contains("Admin") || roles.Contains("SuperAdmin")) return true;
 
-        // Plain User role has no competition admin privileges
-        if (roles.Count == 1 && roles[0] == "User") return false;
-
         if (competitionId.HasValue)
         {
             await using var db = dbFactory.CreateDbContext();
             if (await db.CompetitionAdmins.AnyAsync(ca =>
                     ca.CompetitionId == competitionId.Value && ca.UserId == userId))
                 return true;
+
+            // The creator of a user competition can edit their own.
+            var creatorId = await db.Competition
+                .Where(c => c.CompetitionID == competitionId.Value)
+                .Select(c => c.CreatorUserId)
+                .FirstOrDefaultAsync();
+            if (creatorId == userId) return true;
         }
+
+        // Plain User role has no club admin privileges
+        if (roles.Count == 1 && roles[0] == "User") return false;
 
         if (hostClubId is null) return false;
 
@@ -122,5 +146,139 @@ public class ClubAuthorizationService(
             .Where(ca => ca.UserId == userId)
             .Select(ca => ca.CompetitionId)
             .ToListAsync()).ToHashSet();
+    }
+
+    // ── New premium / visibility gates ─────────────────────────────────────────
+
+    /// <summary>
+    /// Returns true if the caller can create a "user competition" (no host club).
+    /// Requires an active "User" role AND <see cref="ApplicationUser.IsSubscribed"/>=true.
+    /// Admin and SuperAdmin are also allowed as an escape hatch.
+    /// </summary>
+    public bool CanCreateUserCompetition(ClaimsPrincipal user, ApplicationUser? appUser)
+    {
+        var (userId, roles) = GetUserAndRoles(user);
+        if (userId is null || appUser is null) return false;
+
+        if (roles.Contains("SuperAdmin") || roles.Contains("Admin")) return true;
+
+        // Must be acting as a plain User (not ClubAdmin mode) AND be subscribed.
+        var isUserRoleActive = roles.Count == 1 && roles[0] == "User";
+        return isUserRoleActive && appUser.IsSubscribed;
+    }
+
+    /// <summary>
+    /// Returns true if the caller can create a competition hosted by the given club.
+    /// Currently delegates to <see cref="CanEditClubAsync"/>.
+    /// </summary>
+    public Task<bool> CanCreateClubCompetitionAsync(ClaimsPrincipal user, int clubId)
+        => CanEditClubAsync(user, clubId);
+
+    /// <summary>
+    /// Builds a one-shot visibility snapshot for the caller. Cheap enough to be
+    /// called per request; reuses a single DbContext.
+    /// </summary>
+    public async Task<VisibilityContext> GetVisibilityContextAsync(ClaimsPrincipal user)
+    {
+        var (userId, roles) = GetUserAndRoles(user);
+        var isAdmin = userId is not null && (roles.Contains("Admin") || roles.Contains("SuperAdmin"));
+
+        if (userId is null)
+            return new VisibilityContext(false, null, null, null, null, new(), new(), new());
+
+        await using var db = dbFactory.CreateDbContext();
+
+        // Caller's Player (if any).
+        var player = await db.Players
+            .Where(p => p.UserId == userId && !p.IsLight)
+            .Select(p => new { p.PlayerId, p.DateOfBirth, p.Sex })
+            .FirstOrDefaultAsync();
+
+        int? playerId = player?.PlayerId;
+        PlayerSex? sex = player?.Sex;
+        int? age = null;
+        if (player?.DateOfBirth is DateOnly dob)
+        {
+            var today = DateOnly.FromDateTime(DateTime.UtcNow);
+            int a = today.Year - dob.Year;
+            if (dob > today.AddYears(-a)) a--;
+            age = a;
+        }
+
+        HashSet<int> clubIds = new();
+        HashSet<int> friendIds = new();
+
+        if (playerId is int pid)
+        {
+            clubIds = (await db.ClubPlayers
+                .Where(cp => cp.PlayerId == pid && cp.IsActive)
+                .Select(cp => cp.ClubId)
+                .ToListAsync()).ToHashSet();
+
+            friendIds = (await db.PlayerFriends
+                .Where(pf => pf.Status == FriendStatus.Accepted
+                             && (pf.PlayerId == pid || pf.FriendPlayerId == pid))
+                .Select(pf => pf.PlayerId == pid ? pf.FriendPlayerId : pf.PlayerId)
+                .ToListAsync()).ToHashSet();
+        }
+
+        var ownCompIds = (await db.CompetitionAdmins
+            .Where(ca => ca.UserId == userId)
+            .Select(ca => ca.CompetitionId)
+            .ToListAsync()).ToHashSet();
+
+        return new VisibilityContext(isAdmin, userId, playerId, age, sex, clubIds, friendIds, ownCompIds);
+    }
+
+    /// <summary>
+    /// Applies the hard visibility + age/sex filter to a queryable of
+    /// <see cref="Competition"/>. The <paramref name="db"/> context is required
+    /// because the user-competition branch needs a sub-query over
+    /// <c>Players.Friends</c> — passing the same context EF was built against
+    /// keeps this a single SQL statement.
+    /// </summary>
+    public IQueryable<Competition> ApplyVisibilityFilter(
+        IQueryable<Competition> q, MyDbContext db, VisibilityContext ctx, DateTime? now = null)
+    {
+        if (ctx.IsAdmin) return q;
+
+        var playerId = ctx.PlayerId;
+        var userId = ctx.UserId;
+        var clubIds = ctx.ClubIdsMember;
+        var friendIds = ctx.FriendPlayerIds;
+        var ownComps = ctx.OwnCompetitionIds;
+        var age = ctx.Age;
+        var sex = ctx.Sex;
+
+        return q.Where(c =>
+            // Access rule
+            ownComps.Contains(c.CompetitionID) ||
+            (c.HostClubId != null && clubIds.Contains(c.HostClubId.Value)
+                && (!c.IsRestricted || c.AllowedPlayers.Any(ap => playerId != null && ap.PlayerId == playerId)))
+            ||
+            (c.HostClubId == null && c.CreatorUserId != null
+                && (c.CreatorUserId == userId
+                    || (playerId != null && db.Players.Any(p =>
+                        p.UserId == c.CreatorUserId && friendIds.Contains(p.PlayerId))))
+                && (!c.IsRestricted || c.AllowedPlayers.Any(ap => playerId != null && ap.PlayerId == playerId)))
+        )
+        .Where(c =>
+            // Age/sex eligibility: treat as hard filter per product decision.
+            (c.EligibleSex == null || c.EligibleSex == sex) &&
+            (c.MinAge == null || (age != null && age >= c.MinAge)) &&
+            (c.MaxAge == null || (age != null && age <= c.MaxAge))
+        );
+    }
+
+    /// <summary>
+    /// Single-row visibility check. Uses <see cref="ApplyVisibilityFilter"/> to
+    /// avoid drift between list and detail.
+    /// </summary>
+    public async Task<bool> CanViewCompetitionAsync(ClaimsPrincipal user, int competitionId)
+    {
+        var ctx = await GetVisibilityContextAsync(user);
+        await using var db = dbFactory.CreateDbContext();
+        var q = db.Competition.Where(c => c.CompetitionID == competitionId);
+        return await ApplyVisibilityFilter(q, db, ctx).AnyAsync();
     }
 }


### PR DESCRIPTION
## Summary
- Subscribed users can now create their own ("user") competitions (no host club) — gated on `ApplicationUser.IsSubscribed`, which a SuperAdmin can toggle from User Management.
- New **User → Club link request** workflow: users request linking from the clubs page, club admins approve/reject from `/clubadmin/link-requests`, approval auto-creates a `Player` if missing and inserts a `ClubPlayer` row. Emails fire on each state change.
- `GET /api/competitions` applies a **hard visibility filter** — users only see competitions they could enter (club member, creator's accepted friend, explicit allow-list), respecting age/sex on top. Orphan competitions (no host club + no creator) are invisible to non-admins.

## What changed
- `Competition` gains `CreatorUserId` (nullable, mutually exclusive with `HostClubId`), `IsRestricted`, `AllowedPlayers` collection.
- New entities: `ClubLinkRequest` (+ `ClubLinkRequestStatus` enum), `CompetitionAllowedPlayer`.
- Migration `ClubLinkRequests_And_CompetitionCreator` — additive, no data backfill; unique filtered index guarantees one pending request per (user, club).
- `ClubAuthorizationService` gains `CanCreateUserCompetition`, `CanCreateClubCompetitionAsync`, `CanViewCompetitionAsync`, `GetVisibilityContextAsync`, `ApplyVisibilityFilter`.
- New endpoints on `ClubsController`: `/directory`, `/link-requests` (POST/GET), `/link-requests/{id}/approve|reject`. New `UsersController.UpgradePremium` (SuperAdmin-only).
- Blazor UI: Premium column in User Management, link-status chip + request button on Clubs page, new ClubAdmin/Link Requests page, Create-Competition gating for subscribed users, NavMenu entry.
- 8 new tests (authz matrix + page smoke tests). 6 pre-existing failures on main are unrelated.

## Product decisions (as agreed)
- Reuse `IsSubscribed` — no separate `IsPremium` column.
- Link requests are User → Club; approval creates the Player if needed.
- One bundled PR.
- Age/sex ineligibility hides competitions from the list (hard filter).
- A ClubAdmin in ClubAdmin mode cannot create user competitions — must switch to User mode and be subscribed.

## Test plan
- [ ] Apply migration: `dotnet ef database update --project DropShot/DropShot.csproj`
- [ ] As SuperAdmin, toggle Premium for a test user in User Management
- [ ] As that user, click "Request to Link" on a club from `/clubs`
- [ ] As a ClubAdmin of that club, approve from `/clubadmin/link-requests` and verify: Player created, ClubPlayer inserted, approval email logged
- [ ] As the subscribed user, create a user competition (no host club) — confirm `CreatorUserId` persisted
- [ ] As an unsubscribed user, verify the Create button is hidden and the API returns 403
- [ ] Create a club competition with `MinAge=40` and confirm a 30-year-old can't see it in `/api/competitions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)