### PR TITLE
Inline role dropdown next to Browsing as label

### DIFF
--- a/DropShot/Components/Shared/RoleBanner.razor
+++ b/DropShot/Components/Shared/RoleBanner.razor
@@ -12,20 +12,17 @@
 @if (_grantedRoles.Count > 1 && !_isMatchPage)
 {
     <div class="role-banner">
-        <span>Browsing as: <strong>@_activeRole</strong></span>
-        @if (_grantedRoles.Count > 1)
-        {
-            <form action="Account/SwitchRole" method="post" data-enhance-nav="false" style="display: inline;">
-                <AntiforgeryToken />
-                <input type="hidden" name="returnUrl" value="@_currentUrl" />
-                <select name="role" class="role-banner-select" onchange="this.form.submit()">
-                    @foreach (var role in _grantedRoles)
-                    {
-                        <option value="@role" selected="@(role == _activeRole)">@role</option>
-                    }
-                </select>
-            </form>
-        }
+        <form action="Account/SwitchRole" method="post" data-enhance-nav="false" style="display: inline;">
+            <AntiforgeryToken />
+            <input type="hidden" name="returnUrl" value="@_currentUrl" />
+            <span>Browsing as</span>
+            <select name="role" class="role-banner-select" onchange="this.form.submit()">
+                @foreach (var role in _grantedRoles)
+                {
+                    <option value="@role" selected="@(role == _activeRole)">@role</option>
+                }
+            </select>
+        </form>
         @if (_activeRole.Equals("ClubAdmin", StringComparison.OrdinalIgnoreCase) && _adminClubs.Count > 1)
         {
             <form action="Account/SwitchClub" method="post" data-enhance-nav="false" style="display: inline; margin-left: 0.5rem;">


### PR DESCRIPTION
## Summary
- Replace the separate \"Browsing as: **Role**\" text + dropdown with a single inline \"Browsing as\" label immediately followed by the role dropdown
- Remove the redundant inner `@if (_grantedRoles.Count > 1)` since the parent conditional already guarantees it

## Test plan
- [ ] Verify banner renders with \"Browsing as\" label directly next to the role dropdown
- [ ] Confirm switching roles via the dropdown still submits correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)