### PR TITLE
Split competition format into category + format pickers

### DIFF
--- a/DropShot.Maui/Components/Pages/CompetitionDialog.razor
+++ b/DropShot.Maui/Components/Pages/CompetitionDialog.razor
@@ -7,11 +7,20 @@
             <MudTextField @bind-Value="Model.CompetitionName" Label="Competition Name"
                           Variant="Variant.Outlined" Required="true" />
 
-            <MudSelect @bind-Value="Model.CompetitionFormat" Label="Format"
-                       Variant="Variant.Outlined" T="CompetitionFormat">
-                @foreach (CompetitionFormat f in Enum.GetValues<CompetitionFormat>())
+            <MudField Label="Category" Variant="Variant.Outlined">
+                <MudRadioGroup T="CompetitionCategoryUi?" Value="Model.Category"
+                               ValueChanged="OnCategoryChanged">
+                    <MudRadio T="CompetitionCategoryUi?" Value="@((CompetitionCategoryUi?)CompetitionCategoryUi.Male)" Color="Color.Primary">Male</MudRadio>
+                    <MudRadio T="CompetitionCategoryUi?" Value="@((CompetitionCategoryUi?)CompetitionCategoryUi.Female)" Color="Color.Primary">Female</MudRadio>
+                    <MudRadio T="CompetitionCategoryUi?" Value="@((CompetitionCategoryUi?)CompetitionCategoryUi.Mixed)" Color="Color.Primary">Mixed</MudRadio>
+                </MudRadioGroup>
+            </MudField>
+
+            <MudSelect T="CompetitionFormatUi?" @bind-Value="Model.Format" Label="Format"
+                       Variant="Variant.Outlined" Disabled="@(Model.Category == null)">
+                @foreach (var f in CompetitionFormModel.AllowedFormats(Model.Category))
                 {
-                    <MudSelectItem Value="f">@f.ToDisplayName()</MudSelectItem>
+                    <MudSelectItem T="CompetitionFormatUi?" Value="@((CompetitionFormatUi?)f)">@f.ToString()</MudSelectItem>
                 }
             </MudSelect>
 
@@ -29,14 +38,6 @@
 
             <MudNumericField @bind-Value="Model.MaxAge" Label="Max Age (leave blank = open)"
                              Variant="Variant.Outlined" Min="1" />
-
-            <MudSelect @bind-Value="Model.EligibleSex" Label="Eligible Sex" Variant="Variant.Outlined"
-                       T="PlayerSex?" Clearable="true">
-                @foreach (PlayerSex s in Enum.GetValues<PlayerSex>())
-                {
-                    <MudSelectItem Value="(PlayerSex?)s">@s</MudSelectItem>
-                }
-            </MudSelect>
 
             <MudSelect @bind-Value="Model.HostClubId" Label="Host Club" Variant="Variant.Outlined"
                        T="int?" Clearable="true">
@@ -66,7 +67,7 @@
     <DialogActions>
         <MudButton OnClick="Cancel">Cancel</MudButton>
         <MudButton Color="Color.Primary" Variant="Variant.Filled"
-                   Disabled="string.IsNullOrWhiteSpace(Model.CompetitionName)"
+                   Disabled="@(string.IsNullOrWhiteSpace(Model.CompetitionName) || Model.Category == null || Model.Format == null)"
                    OnClick="Submit">Save</MudButton>
     </DialogActions>
 </MudDialog>
@@ -92,4 +93,12 @@
 
     private void Cancel() => MudDialog.Cancel();
     private void Submit() => MudDialog.Close(DialogResult.Ok(Model));
+
+    private void OnCategoryChanged(CompetitionCategoryUi? value)
+    {
+        Model.Category = value;
+        // Mixed doesn't allow Singles; clear an incompatible selection so the user re-picks.
+        if (Model.Format.HasValue && !CompetitionFormModel.AllowedFormats(value).Contains(Model.Format.Value))
+            Model.Format = null;
+    }
 }

--- a/DropShot.Maui/Components/Pages/CompetitionFormModel.cs
+++ b/DropShot.Maui/Components/Pages/CompetitionFormModel.cs
@@ -6,29 +6,80 @@ namespace DropShot.Maui.Components.Pages;
 public class CompetitionFormModel
 {
     public string CompetitionName { get; set; } = "";
-    public CompetitionFormat CompetitionFormat { get; set; } = CompetitionFormat.Singles;
+    public CompetitionCategoryUi? Category { get; set; }
+    public CompetitionFormatUi? Format { get; set; }
     public int? MaxParticipants { get; set; }
     public DateTime? StartDate { get; set; }
     public DateTime? EndDate { get; set; }
     public int? MaxAge { get; set; }
     public int? MinAge { get; set; }
-    public PlayerSex? EligibleSex { get; set; }
     public int? HostClubId { get; set; }
     public int? RulesSetId { get; set; }
     public int? EventId { get; set; }
 
-    public static CompetitionFormModel From(CompetitionDto dto) => new()
+    /// <summary>Persisted format derived from (Category, Format). Null until both are picked.</summary>
+    public CompetitionFormat? CompetitionFormat => (Category, Format) switch
     {
-        CompetitionName = dto.CompetitionName,
-        CompetitionFormat = dto.CompetitionFormat,
-        MaxParticipants = dto.MaxParticipants,
-        StartDate = dto.StartDate,
-        EndDate = dto.EndDate,
-        MaxAge = dto.MaxAge,
-        MinAge = dto.MinAge,
-        EligibleSex = dto.EligibleSex,
-        HostClubId = dto.HostClubId,
-        RulesSetId = dto.RulesSetId,
-        EventId = dto.EventId
+        (CompetitionCategoryUi.Mixed, CompetitionFormatUi.Doubles) => Shared.CompetitionFormat.MixedDoubles,
+        (CompetitionCategoryUi.Mixed, CompetitionFormatUi.Team)    => Shared.CompetitionFormat.MixedTeam,
+        (_, CompetitionFormatUi.Singles) => Shared.CompetitionFormat.Singles,
+        (_, CompetitionFormatUi.Doubles) => Shared.CompetitionFormat.Doubles,
+        (_, CompetitionFormatUi.Team)    => Shared.CompetitionFormat.Team,
+        _ => (CompetitionFormat?)null
     };
+
+    /// <summary>Persisted EligibleSex derived from Category. Mixed → null (open).</summary>
+    public PlayerSex? EligibleSex => Category switch
+    {
+        CompetitionCategoryUi.Male   => PlayerSex.Male,
+        CompetitionCategoryUi.Female => PlayerSex.Female,
+        CompetitionCategoryUi.Mixed  => null,
+        _ => null
+    };
+
+    public static CompetitionFormModel From(CompetitionDto dto)
+    {
+        var (category, format) = SplitPersistedFormat(dto.CompetitionFormat, dto.EligibleSex);
+        return new CompetitionFormModel
+        {
+            CompetitionName = dto.CompetitionName,
+            Category = category,
+            Format = format,
+            MaxParticipants = dto.MaxParticipants,
+            StartDate = dto.StartDate,
+            EndDate = dto.EndDate,
+            MaxAge = dto.MaxAge,
+            MinAge = dto.MinAge,
+            HostClubId = dto.HostClubId,
+            RulesSetId = dto.RulesSetId,
+            EventId = dto.EventId
+        };
+    }
+
+    public static (CompetitionCategoryUi Category, CompetitionFormatUi Format) SplitPersistedFormat(
+        CompetitionFormat persisted, PlayerSex? eligibleSex) => persisted switch
+    {
+        Shared.CompetitionFormat.MixedDoubles => (CompetitionCategoryUi.Mixed, CompetitionFormatUi.Doubles),
+        Shared.CompetitionFormat.MixedTeam    => (CompetitionCategoryUi.Mixed, CompetitionFormatUi.Team),
+        _ => (
+            eligibleSex switch
+            {
+                PlayerSex.Female => CompetitionCategoryUi.Female,
+                _                => CompetitionCategoryUi.Male
+            },
+            persisted switch
+            {
+                Shared.CompetitionFormat.Doubles => CompetitionFormatUi.Doubles,
+                Shared.CompetitionFormat.Team    => CompetitionFormatUi.Team,
+                _                                => CompetitionFormatUi.Singles
+            })
+    };
+
+    public static IEnumerable<CompetitionFormatUi> AllowedFormats(CompetitionCategoryUi? category) =>
+        category == CompetitionCategoryUi.Mixed
+            ? new[] { CompetitionFormatUi.Doubles, CompetitionFormatUi.Team }
+            : new[] { CompetitionFormatUi.Singles, CompetitionFormatUi.Doubles, CompetitionFormatUi.Team };
 }
+
+public enum CompetitionCategoryUi { Male, Female, Mixed }
+public enum CompetitionFormatUi { Singles, Doubles, Team }

--- a/DropShot.Maui/Components/Pages/Competitions.razor
+++ b/DropShot.Maui/Components/Pages/Competitions.razor
@@ -229,8 +229,10 @@ else
     {
         try
         {
+            // Dialog's Save button is disabled until Category and Format are both picked,
+            // so CompetitionFormat should never be null here — fall back to Singles for safety.
             var req = new SaveCompetitionRequest(
-                model.CompetitionName, model.CompetitionFormat,
+                model.CompetitionName, model.CompetitionFormat ?? CompetitionFormat.Singles,
                 model.MaxParticipants, model.StartDate, model.EndDate,
                 model.MaxAge, model.MinAge, model.EligibleSex,
                 model.HostClubId, model.RulesSetId, model.EventId);

--- a/DropShot/Components/Account/Pages/Manage/Index.razor
+++ b/DropShot/Components/Account/Pages/Manage/Index.razor
@@ -58,6 +58,21 @@
                     <label for="display-name" class="form-label">Display name</label>
                     <ValidationMessage For="() => Input.DisplayName" class="text-danger" />
                 </div>
+                <fieldset class="mb-3">
+                    <legend class="form-label mb-1" style="font-size: 1rem;">Competition category</legend>
+                    <small class="form-text text-muted d-block mb-2">Determines which events you're eligible to enter</small>
+                    <InputRadioGroup @bind-Value="Input.CompetitionCategory">
+                        <div class="form-check">
+                            <InputRadio class="form-check-input" id="manage-category-male" Value="@PlayerSex.Male" />
+                            <label class="form-check-label" for="manage-category-male">Male events</label>
+                        </div>
+                        <div class="form-check">
+                            <InputRadio class="form-check-input" id="manage-category-female" Value="@PlayerSex.Female" />
+                            <label class="form-check-label" for="manage-category-female">Female events</label>
+                        </div>
+                    </InputRadioGroup>
+                    <ValidationMessage For="() => Input.CompetitionCategory" class="text-danger" />
+                </fieldset>
             }
             <div class="form-floating mb-3">
                 <InputText @bind-Value="Input.PhoneNumber" class="form-control" placeholder="Please enter your phone number." />
@@ -101,6 +116,7 @@
     private string? username;
     private string? phoneNumber;
     private string? displayName;
+    private PlayerSex? competitionCategory;
     private bool hasLinkedPlayer;
     private int? linkedPlayerId;
     private string? avatarError;
@@ -126,7 +142,10 @@
             hasLinkedPlayer = true;
             linkedPlayerId = player.PlayerId;
             displayName = player.DisplayName;
+            // Only Male/Female are offered in the category picker; Other/null → unset.
+            competitionCategory = player.Sex is PlayerSex.Male or PlayerSex.Female ? player.Sex : null;
             Input.DisplayName ??= displayName;
+            Input.CompetitionCategory ??= competitionCategory;
         }
 
         Input.PhoneNumber ??= phoneNumber;
@@ -139,16 +158,21 @@
 
     private async Task OnValidSubmitAsync()
     {
-        if (hasLinkedPlayer && linkedPlayerId.HasValue
-            && !string.IsNullOrWhiteSpace(Input.DisplayName)
-            && Input.DisplayName.Trim() != displayName)
+        if (hasLinkedPlayer && linkedPlayerId.HasValue)
         {
-            await using var db = DbFactory.CreateDbContext();
-            var player = await db.Players.FindAsync(linkedPlayerId.Value);
-            if (player is not null)
+            var nameChanged = !string.IsNullOrWhiteSpace(Input.DisplayName)
+                && Input.DisplayName.Trim() != displayName;
+            var categoryChanged = Input.CompetitionCategory != competitionCategory;
+            if (nameChanged || categoryChanged)
             {
-                player.DisplayName = Input.DisplayName.Trim();
-                await db.SaveChangesAsync();
+                await using var db = DbFactory.CreateDbContext();
+                var player = await db.Players.FindAsync(linkedPlayerId.Value);
+                if (player is not null)
+                {
+                    if (nameChanged) player.DisplayName = Input.DisplayName!.Trim();
+                    if (categoryChanged) player.Sex = Input.CompetitionCategory;
+                    await db.SaveChangesAsync();
+                }
             }
         }
 
@@ -174,5 +198,8 @@
         [Phone]
         [Display(Name = "Phone number")]
         public string? PhoneNumber { get; set; }
+
+        [Display(Name = "Competition category")]
+        public PlayerSex? CompetitionCategory { get; set; }
     }
 }

--- a/DropShot/Components/Account/Pages/Register.razor
+++ b/DropShot/Components/Account/Pages/Register.razor
@@ -7,6 +7,7 @@
 @using Microsoft.AspNetCore.WebUtilities
 @using Microsoft.AspNetCore.Authentication
 @using DropShot.Data
+@using DropShot.Models
 @using Microsoft.EntityFrameworkCore
 
 @inject UserManager<ApplicationUser> UserManager
@@ -50,6 +51,21 @@
                 <label for="confirm-password">Confirm Password</label>
                 <ValidationMessage For="() => Input.ConfirmPassword" class="text-danger" />
             </div>
+            <fieldset class="mb-3">
+                <legend class="form-label mb-1" style="font-size: 1rem;">Competition category</legend>
+                <small class="form-text text-muted d-block mb-2">Determines which events you're eligible to enter</small>
+                <InputRadioGroup @bind-Value="Input.CompetitionCategory">
+                    <div class="form-check">
+                        <InputRadio class="form-check-input" id="category-male" Value="@PlayerSex.Male" />
+                        <label class="form-check-label" for="category-male">Male events</label>
+                    </div>
+                    <div class="form-check">
+                        <InputRadio class="form-check-input" id="category-female" Value="@PlayerSex.Female" />
+                        <label class="form-check-label" for="category-female">Female events</label>
+                    </div>
+                </InputRadioGroup>
+                <ValidationMessage For="() => Input.CompetitionCategory" class="text-danger" />
+            </fieldset>
             <button type="submit" class="w-100 btn btn-lg btn-primary">Register</button>
         </EditForm>
     </div>
@@ -128,6 +144,7 @@
                         invited.IsLight = false;
                         invited.UserId = userIdStr;
                         invited.Email = Input.Email;
+                        invited.Sex = Input.CompetitionCategory;
                         if (string.IsNullOrWhiteSpace(invited.DisplayName))
                             invited.DisplayName = Input.DisplayName;
                         invite.AcceptedAt = DateTime.UtcNow;
@@ -159,6 +176,7 @@
             if (player is not null)
             {
                 player.UserId = userIdStr;
+                player.Sex = Input.CompetitionCategory;
                 await db.SaveChangesAsync();
                 linkedPlayer = true;
                 Logger.LogInformation("Linked new user {Email} to existing player record.", Input.Email);
@@ -175,6 +193,7 @@
                     lightMatch.IsLight = false;
                     lightMatch.UserId = userIdStr;
                     lightMatch.Email = Input.Email;
+                    lightMatch.Sex = Input.CompetitionCategory;
                     await db.SaveChangesAsync();
                     linkedPlayer = true;
                     Logger.LogInformation("Claimed light player record for {DisplayName}.", Input.DisplayName);
@@ -188,6 +207,7 @@
                     DisplayName = Input.DisplayName,
                     Email = Input.Email,
                     UserId = userIdStr,
+                    Sex = Input.CompetitionCategory,
                     CreatedAt = DateTime.UtcNow
                 };
                 db.Players.Add(newPlayer);
@@ -260,5 +280,9 @@
         [Display(Name = "Confirm password")]
         [Compare("Password", ErrorMessage = "The password and confirmation password do not match.")]
         public string ConfirmPassword { get; set; } = "";
+
+        [Required(ErrorMessage = "Please select a competition category.")]
+        [Display(Name = "Competition category")]
+        public PlayerSex? CompetitionCategory { get; set; }
     }
 }

--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -79,13 +79,24 @@
 
             <MudForm @ref="_form" @bind-IsValid="_isValid" @bind-Errors="_errors">
                 <MudStack Spacing="3">
-                    <MudSelect T="CompetitionFormat?" Label="Format" Variant="Variant.Text"
+                    <MudField Label="Category" Variant="Variant.Text"
+                              Error="@(_categoryError != null)" ErrorText="@_categoryError">
+                        <MudRadioGroup T="CompetitionCategoryUi?" Value="Model.Category"
+                                       ValueChanged="OnCategoryChanged">
+                            <MudRadio T="CompetitionCategoryUi?" Value="@((CompetitionCategoryUi?)CompetitionCategoryUi.Male)" Color="Color.Primary">Male</MudRadio>
+                            <MudRadio T="CompetitionCategoryUi?" Value="@((CompetitionCategoryUi?)CompetitionCategoryUi.Female)" Color="Color.Primary">Female</MudRadio>
+                            <MudRadio T="CompetitionCategoryUi?" Value="@((CompetitionCategoryUi?)CompetitionCategoryUi.Mixed)" Color="Color.Primary">Mixed</MudRadio>
+                        </MudRadioGroup>
+                    </MudField>
+
+                    <MudSelect T="CompetitionFormatUi?" Label="Format" Variant="Variant.Text"
                                Required="true" RequiredError="Please select a competition format."
-                               Value="Model.CompetitionFormat"
-                               ValueChanged="@(v => { Model.CompetitionFormat = v; AutoDetermineEligibleSex(); AutoGenerateName(); })">
-                        @foreach (CompetitionFormat f in Enum.GetValues<CompetitionFormat>())
+                               Disabled="@(Model.Category == null)"
+                               Value="Model.Format"
+                               ValueChanged="@(v => { Model.Format = v; AutoGenerateName(); })">
+                        @foreach (var f in AllowedFormats(Model.Category))
                         {
-                            <MudSelectItem T="CompetitionFormat?" Value="@((CompetitionFormat?)f)">@f.ToDisplayName()</MudSelectItem>
+                            <MudSelectItem T="CompetitionFormatUi?" Value="@((CompetitionFormatUi?)f)">@f.ToString()</MudSelectItem>
                         }
                     </MudSelect>
 
@@ -367,11 +378,11 @@
                         <MudTh>Player</MudTh>
                         <MudTh>Status</MudTh>
                         <MudTh>Registered</MudTh>
-                        @if (Model.CompetitionFormat is CompetitionFormat.Team or CompetitionFormat.MixedTeam)
+                        @if (EffectivePersistedFormat() is CompetitionFormat.Team or CompetitionFormat.MixedTeam)
                         {
                             <MudTh>Team</MudTh>
                         }
-                        @if (Model.CompetitionFormat == CompetitionFormat.MixedTeam)
+                        @if (EffectivePersistedFormat() == CompetitionFormat.MixedTeam)
                         {
                             <MudTh>Sex</MudTh>
                             <MudTh>Grade</MudTh>
@@ -391,7 +402,7 @@
                             </MudSelect>
                         </MudTd>
                         <MudTd>@context.RegisteredAt.ToString("dd MMM yyyy")</MudTd>
-                        @if (Model.CompetitionFormat is CompetitionFormat.Team or CompetitionFormat.MixedTeam)
+                        @if (EffectivePersistedFormat() is CompetitionFormat.Team or CompetitionFormat.MixedTeam)
                         {
                             <MudTd>
                                 <MudSelect T="int?" Value="context.TeamId" Dense="true" Variant="Variant.Text"
@@ -404,7 +415,7 @@
                                 </MudSelect>
                             </MudTd>
                         }
-                        @if (Model.CompetitionFormat == CompetitionFormat.MixedTeam)
+                        @if (EffectivePersistedFormat() == CompetitionFormat.MixedTeam)
                         {
                             <MudTd>@(context.Player?.Sex?.ToString() ?? "—")</MudTd>
                             <MudTd>
@@ -486,7 +497,7 @@
             }
 
             @* ── Teams (for Team and MixedTeam competitions) ──────────── *@
-            @if (Model.CompetitionFormat is CompetitionFormat.Team or CompetitionFormat.MixedTeam)
+            @if (EffectivePersistedFormat() is CompetitionFormat.Team or CompetitionFormat.MixedTeam)
             {
                 <MudPaper Class="pa-4 mb-4">
                     <MudStack Row="true" AlignItems="AlignItems.Center" Class="mb-3">
@@ -498,7 +509,7 @@
                     <MudTable Items="@_teams" Dense="true" Hover="true">
                         <HeaderContent>
                             <MudTh>Team Name</MudTh>
-                            @if (Model.CompetitionFormat == CompetitionFormat.MixedTeam)
+                            @if (EffectivePersistedFormat() == CompetitionFormat.MixedTeam)
                             {
                                 <MudTh>Captain</MudTh>
                             }
@@ -507,7 +518,7 @@
                         </HeaderContent>
                         <RowTemplate>
                             <MudTd>@context.Name</MudTd>
-                            @if (Model.CompetitionFormat == CompetitionFormat.MixedTeam)
+                            @if (EffectivePersistedFormat() == CompetitionFormat.MixedTeam)
                             {
                                 <MudTd>
                                     <MudSelect T="int?" Value="context.CaptainPlayerId" Dense="true" Variant="Variant.Text"
@@ -521,7 +532,7 @@
                                 </MudTd>
                             }
                             <MudTd>
-                                @if (Model.CompetitionFormat == CompetitionFormat.MixedTeam)
+                                @if (EffectivePersistedFormat() == CompetitionFormat.MixedTeam)
                                 {
                                     @foreach (var p in _participants.Where(p => p.TeamId == context.CompetitionTeamId))
                                     {
@@ -537,7 +548,7 @@
                                 }
                             </MudTd>
                             <MudTd>
-                                @if (Model.CompetitionFormat == CompetitionFormat.MixedTeam)
+                                @if (EffectivePersistedFormat() == CompetitionFormat.MixedTeam)
                                 {
                                     <MudIconButton Icon="@Icons.Material.Filled.CheckCircle" Size="Size.Small"
                                                    Color="Color.Info" aria-label="Validate"
@@ -855,7 +866,7 @@
                     }
                 </MudSelect>
             </MudItem>
-            @if (Model.CompetitionFormat == CompetitionFormat.Doubles || Model.CompetitionFormat == CompetitionFormat.MixedDoubles)
+            @if (EffectivePersistedFormat() is CompetitionFormat.Doubles or CompetitionFormat.MixedDoubles)
             {
                 <MudItem xs="12" sm="6">
                     <MudSelect @bind-Value="_fixtureForm.Player3Id" Label="Player 3 (optional)"
@@ -1107,19 +1118,61 @@
         [Required(ErrorMessage = "Competition name is required!")]
         [StringLength(200, ErrorMessage = "Name must be 200 characters or fewer.")]
         public string CompetitionName { get; set; } = "";
-        public CompetitionFormat? CompetitionFormat { get; set; }
+        public CompetitionCategoryUi? Category { get; set; }
+        public CompetitionFormatUi? Format { get; set; }
         public int? MaxParticipants { get; set; }
         public DateTime? StartDateDt { get; set; }
         public DateTime? EndDateDt { get; set; }
         public DateTime? RegisterByDateDt { get; set; }
         public int? MaxAge { get; set; }
         public int? MinAge { get; set; }
-        public PlayerSex? EligibleSex { get; set; }
         public int? HostClubId { get; set; }
         public int? RulesSetId { get; set; }
         public int? EventId { get; set; }
         public int BestOf { get; set; } = 3;
         public bool RequireVerification { get; set; } = false;
+    }
+
+    // UI-only enums that separate category (Male/Female/Mixed) from the format shown in the
+    // dropdown (Singles/Doubles/Team). The persisted CompetitionFormat + EligibleSex pair is
+    // derived from these two on save; see EffectivePersistedFormat / EffectiveEligibleSex.
+    private enum CompetitionCategoryUi { Male, Female, Mixed }
+    private enum CompetitionFormatUi { Singles, Doubles, Team }
+
+    private static IEnumerable<CompetitionFormatUi> AllowedFormats(CompetitionCategoryUi? category) =>
+        category == CompetitionCategoryUi.Mixed
+            ? new[] { CompetitionFormatUi.Doubles, CompetitionFormatUi.Team }
+            : new[] { CompetitionFormatUi.Singles, CompetitionFormatUi.Doubles, CompetitionFormatUi.Team };
+
+    private CompetitionFormat? EffectivePersistedFormat() =>
+        (Model.Category, Model.Format) switch
+        {
+            (CompetitionCategoryUi.Mixed, CompetitionFormatUi.Doubles) => CompetitionFormat.MixedDoubles,
+            (CompetitionCategoryUi.Mixed, CompetitionFormatUi.Team)    => CompetitionFormat.MixedTeam,
+            (_, CompetitionFormatUi.Singles) => CompetitionFormat.Singles,
+            (_, CompetitionFormatUi.Doubles) => CompetitionFormat.Doubles,
+            (_, CompetitionFormatUi.Team)    => CompetitionFormat.Team,
+            _ => (CompetitionFormat?)null
+        };
+
+    private PlayerSex? EffectiveEligibleSex() => Model.Category switch
+    {
+        CompetitionCategoryUi.Male   => PlayerSex.Male,
+        CompetitionCategoryUi.Female => PlayerSex.Female,
+        CompetitionCategoryUi.Mixed  => null,
+        _ => null
+    };
+
+    private string? _categoryError;
+
+    private void OnCategoryChanged(CompetitionCategoryUi? value)
+    {
+        Model.Category = value;
+        _categoryError = value == null ? "Please select a category." : null;
+        // Mixed doesn't allow Singles; clear an incompatible selection so the user re-picks.
+        if (Model.Format.HasValue && !AllowedFormats(value).Contains(Model.Format.Value))
+            Model.Format = null;
+        AutoGenerateName();
     }
 
     private sealed class StageForm
@@ -1231,17 +1284,18 @@
             _isStarted = comp.IsStarted;
             _nameOverride = true; // Existing competition — preserve its name
 
+            var (loadedCategory, loadedFormat) = SplitPersistedFormat(comp.CompetitionFormat, comp.EligibleSex);
             Model = new CompetitionFormModel
             {
                 CompetitionName = comp.CompetitionName,
-                CompetitionFormat = comp.CompetitionFormat,
+                Category = loadedCategory,
+                Format = loadedFormat,
                 MaxParticipants = comp.MaxParticipants,
                 StartDateDt = comp.StartDate,
                 EndDateDt = comp.EndDate,
                 RegisterByDateDt = comp.RegisterByDate,
                 MaxAge = comp.MaxAge,
                 MinAge = comp.MinAge,
-                EligibleSex = comp.EligibleSex,
                 HostClubId = comp.HostClubId,
                 RulesSetId = comp.RulesSetId,
                 EventId = comp.EventId,
@@ -1326,7 +1380,8 @@
     {
         _serverError = null;
         if (_form is not null) await _form.Validate();
-        if (!_isValid) return;
+        _categoryError = Model.Category == null ? "Please select a category." : null;
+        if (!_isValid || _categoryError != null) return;
 
         _isSaving = true;
         try
@@ -1477,55 +1532,69 @@
         Snackbar.Add($"Event '{ev.Name}' created.", Severity.Success);
     }
 
-    private void AutoDetermineEligibleSex()
-    {
-        Model.EligibleSex = Model.CompetitionFormat switch
-        {
-            CompetitionFormat.MixedDoubles or CompetitionFormat.MixedTeam => null,
-            _ => null  // null = open to all; eligibility enforced at participant level if needed
-        };
-    }
-
     private void AutoGenerateName()
     {
         if (_nameOverride) return;
-        if (Model.CompetitionFormat == null) { Model.CompetitionName = ""; return; }
+        if (Model.Category == null || Model.Format == null) { Model.CompetitionName = ""; return; }
 
         var parts = new List<string>();
-
-        if (Model.EligibleSex == PlayerSex.Male) parts.Add("Men's");
-        else if (Model.EligibleSex == PlayerSex.Female) parts.Add("Women's");
 
         if (Model.MinAge is > 0) parts.Add($"Over {Model.MinAge}");
         if (Model.MaxAge is > 0) parts.Add($"U{Model.MaxAge}");
 
-        parts.Add(Model.CompetitionFormat switch
+        var formatLabel = Model.Format.Value.ToString();
+
+        if (Model.Category == CompetitionCategoryUi.Mixed)
         {
-            CompetitionFormat.Singles => "Singles",
-            CompetitionFormat.Doubles => "Doubles",
-            CompetitionFormat.MixedDoubles => "Mixed Doubles",
-            CompetitionFormat.Team => "Team",
-            CompetitionFormat.MixedTeam => "Mixed Team Tennis",
-            _ => Model.CompetitionFormat.Value.ToString()
-        });
+            parts.Add($"Mixed {formatLabel}");
+        }
+        else
+        {
+            var isJunior = Model.MaxAge is > 0 and < 18;
+            var prefix = Model.Category switch
+            {
+                CompetitionCategoryUi.Male   => isJunior ? "Boys" : "Men's",
+                CompetitionCategoryUi.Female => isJunior ? "Girls" : "Women's",
+                _ => ""
+            };
+            parts.Add($"{prefix} {formatLabel}");
+        }
 
         Model.CompetitionName = string.Join(" ", parts);
     }
 
+    private static (CompetitionCategoryUi Category, CompetitionFormatUi Format) SplitPersistedFormat(
+        CompetitionFormat persisted, PlayerSex? eligibleSex) => persisted switch
+    {
+        CompetitionFormat.MixedDoubles => (CompetitionCategoryUi.Mixed, CompetitionFormatUi.Doubles),
+        CompetitionFormat.MixedTeam    => (CompetitionCategoryUi.Mixed, CompetitionFormatUi.Team),
+        _ => (
+            eligibleSex switch
+            {
+                PlayerSex.Female => CompetitionCategoryUi.Female,
+                // Legacy EligibleSex=null Singles/Doubles/Team → default to Male category
+                // (per migration decision). User can change it on edit.
+                _ => CompetitionCategoryUi.Male
+            },
+            persisted switch
+            {
+                CompetitionFormat.Doubles => CompetitionFormatUi.Doubles,
+                CompetitionFormat.Team    => CompetitionFormatUi.Team,
+                _ => CompetitionFormatUi.Singles
+            })
+    };
+
     private void ApplyModel(Competition comp, string name)
     {
         comp.CompetitionName = name;
-        var format = Model.CompetitionFormat ?? CompetitionFormat.Singles;
-        comp.CompetitionFormat = format;
+        comp.CompetitionFormat = EffectivePersistedFormat() ?? CompetitionFormat.Singles;
+        comp.EligibleSex = EffectiveEligibleSex();
         comp.MaxParticipants = Model.MaxParticipants;
         comp.StartDate = Model.StartDateDt;
         comp.EndDate = Model.EndDateDt;
         comp.RegisterByDate = Model.RegisterByDateDt;
         comp.MaxAge = Model.MaxAge;
         comp.MinAge = Model.MinAge;
-        comp.EligibleSex = format is CompetitionFormat.MixedDoubles or CompetitionFormat.MixedTeam
-            ? null
-            : Model.EligibleSex;
         comp.HostClubId = Model.HostClubId;
         comp.RulesSetId = Model.RulesSetId;
         comp.EventId = Model.EventId;
@@ -2240,8 +2309,9 @@
 
         if (t.Format.HasValue)
         {
-            Model.CompetitionFormat = t.Format.Value;
-            AutoDetermineEligibleSex();
+            var (cat, fmt) = SplitPersistedFormat(t.Format.Value, t.EligibleSex);
+            Model.Category = cat;
+            Model.Format = fmt;
         }
         if (t.RulesSetId.HasValue) Model.RulesSetId = t.RulesSetId;
         if (t.BestOf.HasValue) Model.BestOf = t.BestOf.Value;

--- a/DropShot/Components/Pages/CreateEventDialog.razor
+++ b/DropShot/Components/Pages/CreateEventDialog.razor
@@ -44,18 +44,20 @@
             @* ── Builder Row ─────────────────────── *@
             <MudGrid Spacing="1" Class="mb-2">
                 <MudItem xs="12" sm="3">
-                    <MudSelect @bind-Value="_buildFormat" Label="Format" Variant="Variant.Outlined" Margin="Margin.Dense">
-                        <MudSelectItem Value="CompetitionFormat.Singles">Singles</MudSelectItem>
-                        <MudSelectItem Value="CompetitionFormat.Doubles">Doubles</MudSelectItem>
-                        <MudSelectItem Value="CompetitionFormat.MixedDoubles">Mixed Doubles</MudSelectItem>
-                        <MudSelectItem Value="CompetitionFormat.Team">Team</MudSelectItem>
+                    <MudSelect T="CategoryUi" @bind-Value="_buildCategory" Label="Category"
+                               Variant="Variant.Outlined" Margin="Margin.Dense">
+                        <MudSelectItem Value="CategoryUi.Male">Male</MudSelectItem>
+                        <MudSelectItem Value="CategoryUi.Female">Female</MudSelectItem>
+                        <MudSelectItem Value="CategoryUi.Mixed">Mixed</MudSelectItem>
                     </MudSelect>
                 </MudItem>
                 <MudItem xs="12" sm="3">
-                    <MudSelect @bind-Value="_buildSex" Label="Sex" Variant="Variant.Outlined" Margin="Margin.Dense"
-                               Clearable="true">
-                        <MudSelectItem T="PlayerSex?" Value="@((PlayerSex?)PlayerSex.Male)">Men's</MudSelectItem>
-                        <MudSelectItem T="PlayerSex?" Value="@((PlayerSex?)PlayerSex.Female)">Women's</MudSelectItem>
+                    <MudSelect T="FormatUi" @bind-Value="_buildFormatUi" Label="Format"
+                               Variant="Variant.Outlined" Margin="Margin.Dense">
+                        @foreach (var f in AllowedFormats(_buildCategory))
+                        {
+                            <MudSelectItem Value="@f">@f.ToString()</MudSelectItem>
+                        }
                     </MudSelect>
                 </MudItem>
                 <MudItem xs="12" sm="3">
@@ -82,15 +84,15 @@
             {
                 <MudSimpleTable Dense="true">
                     <thead>
-                        <tr><th>Name</th><th>Format</th><th>Sex</th><th>Age</th><th></th></tr>
+                        <tr><th>Name</th><th>Category</th><th>Format</th><th>Age</th><th></th></tr>
                     </thead>
                     <tbody>
                         @foreach (var comp in Competitions)
                         {
                             <tr>
                                 <td>@comp.Name</td>
-                                <td>@comp.Format</td>
-                                <td>@(comp.EligibleSex?.ToString() ?? "Open")</td>
+                                <td>@CategoryLabel(comp.Format, comp.EligibleSex)</td>
+                                <td>@FormatLabel(comp.Format)</td>
                                 <td>@FormatAge(comp.MinAge, comp.MaxAge)</td>
                                 <td>
                                     <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small"
@@ -132,9 +134,35 @@
     public List<CompetitionEntry> Competitions { get; set; } = [];
 
     // Builder state
-    private CompetitionFormat _buildFormat = CompetitionFormat.Singles;
-    private PlayerSex? _buildSex;
+    private CategoryUi _buildCategory = CategoryUi.Male;
+    private FormatUi _buildFormatUi = FormatUi.Singles;
     private AgeBracket _buildAgeBracket = _ageBrackets[0];
+
+    public enum CategoryUi { Male, Female, Mixed }
+    public enum FormatUi { Singles, Doubles, Team }
+
+    private static IEnumerable<FormatUi> AllowedFormats(CategoryUi category) =>
+        category == CategoryUi.Mixed
+            ? new[] { FormatUi.Doubles, FormatUi.Team }
+            : new[] { FormatUi.Singles, FormatUi.Doubles, FormatUi.Team };
+
+    private static (CompetitionFormat Format, PlayerSex? EligibleSex) MapToPersisted(
+        CategoryUi category, FormatUi format) => (category, format) switch
+    {
+        (CategoryUi.Mixed, FormatUi.Doubles) => (CompetitionFormat.MixedDoubles, (PlayerSex?)null),
+        (CategoryUi.Mixed, FormatUi.Team)    => (CompetitionFormat.MixedTeam,    (PlayerSex?)null),
+        (CategoryUi.Male,   _) => (ToPersistedFormat(format), PlayerSex.Male),
+        (CategoryUi.Female, _) => (ToPersistedFormat(format), PlayerSex.Female),
+        _ => (CompetitionFormat.Singles, (PlayerSex?)null)
+    };
+
+    private static CompetitionFormat ToPersistedFormat(FormatUi f) => f switch
+    {
+        FormatUi.Singles => CompetitionFormat.Singles,
+        FormatUi.Doubles => CompetitionFormat.Doubles,
+        FormatUi.Team    => CompetitionFormat.Team,
+        _                => CompetitionFormat.Singles
+    };
 
     public record CompetitionEntry(string Name, CompetitionFormat Format, PlayerSex? EligibleSex, int? MinAge, int? MaxAge);
 
@@ -157,22 +185,29 @@
 
     private string BuildAutoName()
     {
+        // Clamp an incompatible Format (e.g. user picked Mixed then Singles is no longer listed).
+        if (!AllowedFormats(_buildCategory).Contains(_buildFormatUi))
+            _buildFormatUi = AllowedFormats(_buildCategory).First();
+
         var parts = new List<string>();
+        if (_buildAgeBracket.Label != "Open") parts.Add(_buildAgeBracket.Label);
 
-        if (_buildSex == PlayerSex.Male) parts.Add("Men's");
-        else if (_buildSex == PlayerSex.Female) parts.Add("Women's");
-
-        if (_buildAgeBracket.Label != "Open")
-            parts.Add(_buildAgeBracket.Label);
-
-        parts.Add(_buildFormat switch
+        var formatLabel = _buildFormatUi.ToString();
+        if (_buildCategory == CategoryUi.Mixed)
         {
-            CompetitionFormat.Singles => "Singles",
-            CompetitionFormat.Doubles => "Doubles",
-            CompetitionFormat.MixedDoubles => "Mixed Doubles",
-            CompetitionFormat.Team => "Team",
-            _ => _buildFormat.ToString()
-        });
+            parts.Add($"Mixed {formatLabel}");
+        }
+        else
+        {
+            var isJunior = _buildAgeBracket.MaxAge is > 0 and < 18;
+            var prefix = _buildCategory switch
+            {
+                CategoryUi.Male   => isJunior ? "Boys" : "Men's",
+                CategoryUi.Female => isJunior ? "Girls" : "Women's",
+                _ => ""
+            };
+            parts.Add($"{prefix} {formatLabel}");
+        }
 
         return string.Join(" ", parts);
     }
@@ -181,7 +216,9 @@
     {
         var name = BuildAutoName();
         if (Competitions.Any(c => c.Name == name)) return;
-        Competitions.Add(new CompetitionEntry(name, _buildFormat, _buildSex, _buildAgeBracket.MinAge, _buildAgeBracket.MaxAge));
+        var (format, eligibleSex) = MapToPersisted(_buildCategory, _buildFormatUi);
+        Competitions.Add(new CompetitionEntry(name, format, eligibleSex,
+            _buildAgeBracket.MinAge, _buildAgeBracket.MaxAge));
     }
 
     private void AddStandard5()
@@ -207,6 +244,24 @@
         if (maxAge.HasValue) return $"U{maxAge}";
         return "Open";
     }
+
+    private static string CategoryLabel(CompetitionFormat format, PlayerSex? eligibleSex)
+    {
+        if (format is CompetitionFormat.MixedDoubles or CompetitionFormat.MixedTeam) return "Mixed";
+        return eligibleSex switch
+        {
+            PlayerSex.Male   => "Male",
+            PlayerSex.Female => "Female",
+            _                => "Open"
+        };
+    }
+
+    private static string FormatLabel(CompetitionFormat format) => format switch
+    {
+        CompetitionFormat.MixedDoubles => "Doubles",
+        CompetitionFormat.MixedTeam    => "Team",
+        _                              => format.ToString()
+    };
 
     private void Cancel() => MudDialog.Cancel();
 


### PR DESCRIPTION
## Summary
- Registration and profile edit now collect a required **Competition category** (Male events / Female events) and write it to the linked `Player.Sex` so the existing eligibility filter applies to both registered users and light players.
- Competition creation (both `CompetitionPage` and the `CreateEventDialog` builder) now uses a **Category** radio (Male/Female/Mixed) plus a **Format** dropdown filtered by category — Mixed omits Singles per spec.
- Title preview generator updated: Mixed → `Mixed {Format}`, MaxAge<18 → Boys/Girls, else Men's/Women's.
- MAUI's `CompetitionDialog` mirrors the new UX.
- **No DB schema change and no data migration**: `(CompetitionFormat, EligibleSex)` is derived on save and split back on load, so existing Mixed* rows round-trip cleanly and the `EligibleSex` vs `Player.Sex` filter at `Competitions.razor:593` already implements "Male users see Male + Mixed, Female users see Female + Mixed" (Mixed has `EligibleSex=null` = open).

## Test plan
- [ ] `dotnet build DropShot.sln` succeeds
- [ ] Register a new user picking "Male events" → linked Players row has `Sex=1`
- [ ] Profile edit updates `Player.Sex` when category changes
- [ ] Create each shape via CompetitionPage: Men's Singles, Women's Team, Mixed Doubles, Mixed Team — persisted values match expected (CompetitionFormat, EligibleSex)
- [ ] With Category=Mixed, Singles is not offered in the Format dropdown
- [ ] MaxAge=16 + Category=Female + Format=Singles → title contains "Girls Singles"
- [ ] Editing a pre-existing MixedTeam competition loads with Category=Mixed, Format=Team
- [ ] Two users with different categories see the correct Male/Female + Mixed competitions on `/competitions`
- [ ] MAUI CompetitionDialog can create a new competition end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)