### PR TITLE
Add AdSense unit to home page above footer

### DIFF
--- a/DropShot/Components/Pages/Home.razor
+++ b/DropShot/Components/Pages/Home.razor
@@ -260,6 +260,19 @@
     </MudGrid>
 }
 
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6819827391362636"
+     crossorigin="anonymous"></script>
+<!-- Home page Ad -->
+<ins class="adsbygoogle"
+     style="display:block"
+     data-ad-client="ca-pub-6819827391362636"
+     data-ad-slot="5137127862"
+     data-ad-format="auto"
+     data-full-width-responsive="true"></ins>
+<script>
+     (adsbygoogle = window.adsbygoogle || []).push({});
+</script>
+
 @code {
     private bool arrows = true;
     private bool bullets = true;


### PR DESCRIPTION
## Summary
- Adds Google AdSense ad unit (pub-6819827391362636, slot 5137127862) at the bottom of the home page, rendering above the global footer.

## Test plan
- [ ] Load `/` on a fresh session and confirm the ad slot renders below the fixtures/recent results grid and above the footer.
- [ ] Verify AdSense console shows no policy errors for the publisher/slot IDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)