### PR TITLE
Load AdSense script in site-wide head

### DIFF
--- a/DropShot/Components/App.razor
+++ b/DropShot/Components/App.razor
@@ -25,6 +25,8 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="DropShot" />
     <link rel="apple-touch-icon" href="Images/Logo.png" />
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6819827391362636"
+            crossorigin="anonymous"></script>
     <HeadOutlet />
 </head>
 


### PR DESCRIPTION
## Summary
- Adds the Google AdSense loader script to the `<head>` in `App.razor` so it's included on every page.

## Notes
- The loader `<script>` added to `Home.razor` in #301 is now redundant but left in place; safe to remove in a follow-up if desired.

## Test plan
- [ ] Load any page and confirm `pagead2.googlesyndication.com/pagead/js/adsbygoogle.js` is requested from `<head>`.
- [ ] Home page ad unit still renders correctly above the footer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)