### PR TITLE
Add branded HTML email templates

### DIFF
--- a/DropShot/Components/Account/Pages/ExternalLogin.razor
+++ b/DropShot/Components/Account/Pages/ExternalLogin.razor
@@ -15,6 +15,7 @@
 @inject IdentityRedirectManager RedirectManager
 @inject ILogger<ExternalLogin> Logger
 @inject EmailService EmailService
+@inject EmailTemplateService EmailTemplateService
 
 <PageTitle>Register</PageTitle>
 
@@ -150,7 +151,8 @@
                 var callbackUrl = NavigationManager.GetUriWithQueryParameters(
                     NavigationManager.ToAbsoluteUri("Account/ConfirmEmail").AbsoluteUri,
                     new Dictionary<string, object?> { ["userId"] = userId, ["code"] = code });
-                await EmailService.SendEmailAsync(Input.Email, "Confirm Registration", $"Please confirm your account by <a href='{callbackUrl}'>clicking here</a>.");
+                await EmailService.SendEmailAsync(Input.Email, "Confirm Your Email",
+                    EmailTemplateService.ConfirmationEmail(callbackUrl), isHtml: true);
 
 
                 // If account confirmation is required, we need to show the link if we don't have a real email sender

--- a/DropShot/Components/Account/Pages/ForgotPassword.razor
+++ b/DropShot/Components/Account/Pages/ForgotPassword.razor
@@ -11,6 +11,7 @@
 @inject NavigationManager NavigationManager
 @inject IdentityRedirectManager RedirectManager
 @inject EmailService EmailService
+@inject EmailTemplateService EmailTemplateService
 
 <PageTitle>Forgot your password?</PageTitle>
 
@@ -56,7 +57,8 @@
             NavigationManager.ToAbsoluteUri("Account/ResetPassword").AbsoluteUri,
             new Dictionary<string, object?> { ["code"] = code });
 
-        await EmailService.SendEmailAsync(Input.Email, "Reset Password", $"Please reset your password by <a href='{callbackUrl}'>clicking here</a>.");
+        await EmailService.SendEmailAsync(Input.Email, "Reset Your Password",
+            EmailTemplateService.PasswordResetEmail(callbackUrl), isHtml: true);
 
         RedirectManager.RedirectTo("Account/ForgotPasswordConfirmation");
     }

--- a/DropShot/Components/Account/Pages/Manage/Email.razor
+++ b/DropShot/Components/Account/Pages/Manage/Email.razor
@@ -11,6 +11,7 @@
 @inject IdentityUserAccessor UserAccessor
 @inject NavigationManager NavigationManager
 @inject EmailService EmailService
+@inject EmailTemplateService EmailTemplateService
 
 <PageTitle>Manage email</PageTitle>
 
@@ -91,7 +92,8 @@
             NavigationManager.ToAbsoluteUri("Account/ConfirmEmailChange").AbsoluteUri,
             new Dictionary<string, object?> { ["userId"] = userId, ["email"] = Input.NewEmail, ["code"] = code });
 
-        await EmailService.SendEmailAsync(Input.NewEmail, "Confirm Registration", $"Please confirm your account by <a href='{callbackUrl}'>clicking here</a>.");
+        await EmailService.SendEmailAsync(Input.NewEmail, "Confirm Your New Email",
+            EmailTemplateService.EmailChangeEmail(callbackUrl), isHtml: true);
 
         message = "Confirmation link to change email sent. Please check your email.";
     }
@@ -110,7 +112,8 @@
             NavigationManager.ToAbsoluteUri("Account/ConfirmEmail").AbsoluteUri,
             new Dictionary<string, object?> { ["userId"] = userId, ["code"] = code });
 
-        await EmailService.SendEmailAsync(email, "Confirm Registration", $"Please confirm your account by <a href='{callbackUrl}'>clicking here</a>.");
+        await EmailService.SendEmailAsync(email, "Confirm Your Email",
+            EmailTemplateService.ConfirmationEmail(callbackUrl), isHtml: true);
 
         message = "Verification email sent. Please check your email.";
     }

--- a/DropShot/Components/Account/Pages/Register.razor
+++ b/DropShot/Components/Account/Pages/Register.razor
@@ -17,6 +17,7 @@
 @inject NavigationManager NavigationManager
 @inject IdentityRedirectManager RedirectManager
 @inject EmailService EmailService
+@inject EmailTemplateService EmailTemplateService
 @inject IDbContextFactory<MyDbContext> DbFactory
 
 <PageTitle>Register</PageTitle>
@@ -223,7 +224,8 @@
             NavigationManager.ToAbsoluteUri("Account/ConfirmEmail").AbsoluteUri,
             new Dictionary<string, object?> { ["userId"] = userId, ["code"] = code, ["returnUrl"] = ReturnUrl });
 
-        await EmailService.SendEmailAsync(Input.Email, "Confirm Registration", $"Please confirm your account by <a href='{callbackUrl}'>clicking here</a>.");
+        await EmailService.SendEmailAsync(Input.Email, "Confirm Your Email",
+            EmailTemplateService.ConfirmationEmail(callbackUrl), isHtml: true);
 
         if (UserManager.Options.SignIn.RequireConfirmedAccount)
         {

--- a/DropShot/Components/Account/Pages/ResendEmailConfirmation.razor
+++ b/DropShot/Components/Account/Pages/ResendEmailConfirmation.razor
@@ -11,6 +11,7 @@
 @inject NavigationManager NavigationManager
 @inject IdentityRedirectManager RedirectManager
 @inject EmailService EmailService
+@inject EmailTemplateService EmailTemplateService
 
 <PageTitle>Resend email confirmation</PageTitle>
 
@@ -56,7 +57,8 @@
         var callbackUrl = NavigationManager.GetUriWithQueryParameters(
             NavigationManager.ToAbsoluteUri("Account/ConfirmEmail").AbsoluteUri,
             new Dictionary<string, object?> { ["userId"] = userId, ["code"] = code });
-        await EmailService.SendEmailAsync(Input.Email, "Confirm Registration", $"Please confirm your account by <a href='{callbackUrl}'>clicking here</a>.");
+        await EmailService.SendEmailAsync(Input.Email, "Confirm Your Email",
+            EmailTemplateService.ConfirmationEmail(callbackUrl), isHtml: true);
 
         message = "Verification email sent. Please check your email.";
     }

--- a/DropShot/Components/Pages/MyPlayers.razor
+++ b/DropShot/Components/Pages/MyPlayers.razor
@@ -16,6 +16,7 @@
 @inject NavigationManager NavigationManager
 @inject IJSRuntime JS
 @inject EmailService EmailService
+@inject EmailTemplateService EmailTemplateService
 
 <MudProviders />
 
@@ -707,14 +708,9 @@
             }
 
             var subject = $"You've been invited to join DropShot as \"{_invitingPlayer.DisplayName}\"";
-            var body =
-                $"Hi,\n\nYou've been invited to join DropShot as \"{_invitingPlayer.DisplayName}\". " +
-                $"Click the link below to register. Your new account will be linked to the existing " +
-                $"player record and any match history will be transferred automatically.\n\n" +
-                $"{_inviteLink}\n\n" +
-                $"If you weren't expecting this, you can safely ignore it.";
+            var html = EmailTemplateService.PlayerInvitationEmail(_invitingPlayer.DisplayName, _inviteLink);
 
-            await EmailService.SendEmailAsync(_inviteEmail.Trim(), subject, body);
+            await EmailService.SendEmailAsync(_inviteEmail.Trim(), subject, html, isHtml: true);
             Snackbar.Add($"Invite sent to {_inviteEmail.Trim()}.", Severity.Success);
             _showInviteDialog = false;
         }

--- a/DropShot/Components/_Imports.razor
+++ b/DropShot/Components/_Imports.razor
@@ -9,5 +9,6 @@
 @using Microsoft.JSInterop
 @using DropShot
 @using DropShot.Components
+@using DropShot.Services
 @using DropShot.Components.Scoreboards
 @using MudBlazor

--- a/DropShot/Models/EmailService.cs
+++ b/DropShot/Models/EmailService.cs
@@ -1,4 +1,5 @@
-﻿using Azure.Communication.Email;
+﻿using System.Text.RegularExpressions;
+using Azure.Communication.Email;
 
 public class EmailService
 {
@@ -18,7 +19,7 @@ public class EmailService
         _emailClient = new EmailClient(connectionString);
     }
 
-    public async Task SendEmailAsync(string recipient, string subject, string body)
+    public async Task SendEmailAsync(string recipient, string subject, string body, bool isHtml = false)
     {
         if (_emailClient is null || _sender is null)
         {
@@ -26,17 +27,39 @@ public class EmailService
             return;
         }
 
-        var emailContent = new EmailContent(subject)
+        EmailContent emailContent;
+
+        if (isHtml)
         {
-            PlainText = body,
-            Html = $"<html><body><p>{System.Net.WebUtility.HtmlEncode(body)}</p></body></html>"
-        };
+            emailContent = new EmailContent(subject)
+            {
+                Html = body,
+                PlainText = StripHtmlForPlainText(body)
+            };
+        }
+        else
+        {
+            emailContent = new EmailContent(subject)
+            {
+                PlainText = body,
+                Html = $"<html><body><p>{System.Net.WebUtility.HtmlEncode(body)}</p></body></html>"
+            };
+        }
 
         var recipients = new EmailRecipients(new List<EmailAddress> { new EmailAddress(recipient) });
 
         var message = new EmailMessage(_sender, recipients, emailContent);
 
-        // Fix: Specify WaitUntil.Completed as required by the method signature
         await _emailClient.SendAsync(Azure.WaitUntil.Completed, message);
+    }
+
+    private static string StripHtmlForPlainText(string html)
+    {
+        var text = Regex.Replace(html, @"<br\s*/?>", "\n", RegexOptions.IgnoreCase);
+        text = Regex.Replace(text, @"</p>", "\n\n", RegexOptions.IgnoreCase);
+        text = Regex.Replace(text, @"<[^>]+>", "");
+        text = System.Net.WebUtility.HtmlDecode(text);
+        text = Regex.Replace(text, @"\n{3,}", "\n\n");
+        return text.Trim();
     }
 }

--- a/DropShot/Program.cs
+++ b/DropShot/Program.cs
@@ -112,6 +112,7 @@ builder.Services.AddScoped<TennisScoreService>();
 builder.Services.AddScoped<ClubAuthorizationService>();
 builder.Services.AddScoped<JwtTokenService>();
 builder.Services.AddSingleton<EmailService>();
+builder.Services.AddSingleton<EmailTemplateService>();
 builder.Services.AddScoped<ResultVerificationService>();
 builder.Services.AddScoped<AdminEmailService>();
 builder.Services.AddScoped<FuzzySearchService>();

--- a/DropShot/Services/AdminEmailService.cs
+++ b/DropShot/Services/AdminEmailService.cs
@@ -5,6 +5,7 @@ namespace DropShot.Services;
 
 public class AdminEmailService(
     EmailService emailService,
+    EmailTemplateService emailTemplateService,
     IConfiguration config,
     ILogger<AdminEmailService> logger)
 {
@@ -31,7 +32,8 @@ public class AdminEmailService(
         {
             var resolvedSubject = SubstituteVariables(subject, player!.DisplayName, competitionName, matchLink);
             var resolvedBody = SubstituteVariables(body, player.DisplayName, competitionName, matchLink);
-            return SendSafe(player.Email!, resolvedSubject, resolvedBody, "match-specific admin email");
+            var html = emailTemplateService.AdminCustomEmail(resolvedBody);
+            return SendSafe(player.Email!, resolvedSubject, html, "match-specific admin email", isHtml: true);
         }));
     }
 
@@ -53,7 +55,8 @@ public class AdminEmailService(
             {
                 var resolvedSubject = SubstituteVariables(subject, player.DisplayName, competitionName, link);
                 var resolvedBody = SubstituteVariables(body, player.DisplayName, competitionName, link);
-                return SendSafe(player.Email!, resolvedSubject, resolvedBody, "competition-wide admin email");
+                var html = emailTemplateService.AdminCustomEmail(resolvedBody);
+                return SendSafe(player.Email!, resolvedSubject, html, "competition-wide admin email", isHtml: true);
             }));
     }
 
@@ -63,11 +66,11 @@ public class AdminEmailService(
             .Replace("{CompetitionName}", System.Net.WebUtility.HtmlEncode(competitionName))
             .Replace("{MatchLink}", System.Net.WebUtility.HtmlEncode(matchLink));
 
-    private async Task SendSafe(string email, string subject, string body, string context)
+    private async Task SendSafe(string email, string subject, string body, string context, bool isHtml = false)
     {
         try
         {
-            await emailService.SendEmailAsync(email, subject, body);
+            await emailService.SendEmailAsync(email, subject, body, isHtml);
         }
         catch (Exception ex)
         {
@@ -90,14 +93,10 @@ public class AdminEmailService(
         {
             if (string.IsNullOrEmpty(admin.Email)) continue;
 
+            var adminName = admin.DisplayName ?? admin.UserName ?? "";
             var subject = $"New club link request for {club.Name}";
-            var body =
-                $"Hi {System.Net.WebUtility.HtmlEncode(admin.DisplayName ?? admin.UserName ?? "")}," +
-                $"\n\n{System.Net.WebUtility.HtmlEncode(requesterName)} has asked to be linked to " +
-                $"{System.Net.WebUtility.HtmlEncode(club.Name)}." +
-                $"\n\nReview the request: {manageLink}";
-
-            await SendSafe(admin.Email, subject, body, "club link request received");
+            var html = emailTemplateService.ClubLinkRequestReceivedEmail(adminName, requesterName, club.Name, manageLink);
+            await SendSafe(admin.Email, subject, html, "club link request received", isHtml: true);
         }
     }
 
@@ -109,13 +108,10 @@ public class AdminEmailService(
         if (string.IsNullOrEmpty(user.Email)) return;
 
         var clubLink = $"{BaseUrl}/clubs";
+        var userName = user.DisplayName ?? user.UserName ?? "";
         var subject = $"You're now linked to {club.Name}";
-        var body =
-            $"Hi {System.Net.WebUtility.HtmlEncode(user.DisplayName ?? user.UserName ?? "")}," +
-            $"\n\nYour request to join {System.Net.WebUtility.HtmlEncode(club.Name)} was approved." +
-            $"\n\nView the club: {clubLink}";
-
-        await SendSafe(user.Email, subject, body, "club link request approved");
+        var html = emailTemplateService.ClubLinkRequestApprovedEmail(userName, club.Name, clubLink);
+        await SendSafe(user.Email, subject, html, "club link request approved", isHtml: true);
     }
 
     /// <summary>
@@ -125,12 +121,9 @@ public class AdminEmailService(
     {
         if (string.IsNullOrEmpty(user.Email)) return;
 
-        var subject = $"Club link request declined";
-        var body =
-            $"Hi {System.Net.WebUtility.HtmlEncode(user.DisplayName ?? user.UserName ?? "")}," +
-            $"\n\nYour request to join {System.Net.WebUtility.HtmlEncode(club.Name)} was not approved. " +
-            "If you think this is a mistake, please reach out to the club directly.";
-
-        await SendSafe(user.Email, subject, body, "club link request rejected");
+        var userName = user.DisplayName ?? user.UserName ?? "";
+        var subject = "Club link request declined";
+        var html = emailTemplateService.ClubLinkRequestRejectedEmail(userName, club.Name);
+        await SendSafe(user.Email, subject, html, "club link request rejected", isHtml: true);
     }
 }

--- a/DropShot/Services/EmailTemplateService.cs
+++ b/DropShot/Services/EmailTemplateService.cs
@@ -1,0 +1,256 @@
+namespace DropShot.Services;
+
+public class EmailTemplateService
+{
+    private readonly string _baseUrl;
+    private readonly string _logoUrl;
+
+    public EmailTemplateService(IConfiguration config)
+    {
+        _baseUrl = config["App:BaseUrl"]?.TrimEnd('/') ?? "";
+        _logoUrl = $"{_baseUrl}/Images/Logo.png";
+    }
+
+    // ── Base layout ──────────────────────────────────────────────────────────
+
+    private string WrapInBaseLayout(string title, string bodyContentHtml, string? preheaderText = null)
+    {
+        var preheader = preheaderText != null
+            ? $@"<span style=""display:none;font-size:1px;color:#f4f4f4;line-height:1px;max-height:0;max-width:0;opacity:0;overflow:hidden;"">{Encode(preheaderText)}</span>"
+            : "";
+
+        return $@"<!DOCTYPE html>
+<html lang=""en"" xmlns=""http://www.w3.org/1999/xhtml"" xmlns:v=""urn:schemas-microsoft-com:vml"" xmlns:o=""urn:schemas-microsoft-com:office:office"">
+<head>
+    <meta charset=""utf-8"">
+    <meta name=""viewport"" content=""width=device-width, initial-scale=1.0"">
+    <meta http-equiv=""X-UA-Compatible"" content=""IE=edge"">
+    <meta name=""color-scheme"" content=""light"">
+    <meta name=""supported-color-schemes"" content=""light"">
+    <title>{Encode(title)}</title>
+    <!--[if mso]>
+    <noscript>
+        <xml>
+            <o:OfficeDocumentSettings>
+                <o:PixelsPerInch>96</o:PixelsPerInch>
+            </o:OfficeDocumentSettings>
+        </xml>
+    </noscript>
+    <![endif]-->
+</head>
+<body style=""margin:0;padding:0;background-color:#f4f4f4;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;"">
+    {preheader}
+    <table role=""presentation"" cellpadding=""0"" cellspacing=""0"" border=""0"" width=""100%"" style=""background-color:#f4f4f4;"">
+        <tr>
+            <td align=""center"" style=""padding:24px 16px;"">
+                <!--[if mso]><table role=""presentation"" cellpadding=""0"" cellspacing=""0"" border=""0"" width=""600""><tr><td><![endif]-->
+                <table role=""presentation"" cellpadding=""0"" cellspacing=""0"" border=""0"" width=""100%"" style=""max-width:600px;background-color:#ffffff;border-radius:8px;overflow:hidden;box-shadow:0 2px 8px rgba(0,0,0,0.08);"">
+                    {HeaderRow()}
+                    <tr>
+                        <td style=""padding:32px 32px 24px 32px;color:#333333;font-size:16px;line-height:1.6;"">
+                            {bodyContentHtml}
+                        </td>
+                    </tr>
+                    {FooterRow()}
+                </table>
+                <!--[if mso]></td></tr></table><![endif]-->
+            </td>
+        </tr>
+    </table>
+</body>
+</html>";
+    }
+
+    private string HeaderRow()
+    {
+        return $@"<tr>
+    <td align=""center"" style=""background-color:#1b5e20;padding:24px 32px;"">
+        <img src=""{_logoUrl}"" alt=""DropShot"" width=""140"" style=""display:block;border:0;outline:none;max-width:140px;height:auto;"">
+    </td>
+</tr>";
+    }
+
+    private static string FooterRow()
+    {
+        return $@"<tr>
+    <td style=""background-color:#f9f9f9;padding:20px 32px;border-top:1px solid #eeeeee;"">
+        <table role=""presentation"" cellpadding=""0"" cellspacing=""0"" border=""0"" width=""100%"">
+            <tr>
+                <td align=""center"" style=""color:#999999;font-size:12px;line-height:1.5;"">
+                    DropShot &mdash; Tennis Club Management<br>
+                    &copy; {DateTime.UtcNow.Year} DropShot. All rights reserved.
+                </td>
+            </tr>
+        </table>
+    </td>
+</tr>";
+    }
+
+    // ── Bulletproof CTA button ───────────────────────────────────────────────
+
+    private static string ActionButton(string text, string url)
+    {
+        return $@"<table role=""presentation"" cellpadding=""0"" cellspacing=""0"" border=""0"" style=""margin:24px auto;"">
+    <tr>
+        <td align=""center"" style=""border-radius:6px;background-color:#1565c0;"">
+            <!--[if mso]>
+            <v:roundrect xmlns:v=""urn:schemas-microsoft-com:vml"" xmlns:w=""urn:schemas-microsoft-com:office:word"" href=""{url}"" style=""height:48px;v-text-anchor:middle;width:240px;"" arcsize=""13%"" strokecolor=""#1565c0"" fillcolor=""#1565c0"">
+            <w:anchorlock/>
+            <center style=""color:#ffffff;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:16px;font-weight:bold;"">
+                {Encode(text)}
+            </center>
+            </v:roundrect>
+            <![endif]-->
+            <!--[if !mso]><!-->
+            <a href=""{url}"" target=""_blank"" style=""display:inline-block;padding:14px 32px;color:#ffffff;background-color:#1565c0;border-radius:6px;font-size:16px;font-weight:bold;text-decoration:none;text-align:center;line-height:1;"">
+                {Encode(text)}
+            </a>
+            <!--<![endif]-->
+        </td>
+    </tr>
+</table>";
+    }
+
+    private static string InfoBox(string contentHtml)
+    {
+        return $@"<table role=""presentation"" cellpadding=""0"" cellspacing=""0"" border=""0"" width=""100%"" style=""margin:16px 0;"">
+    <tr>
+        <td style=""background-color:#f5f5f5;border-left:4px solid #1b5e20;padding:16px 20px;border-radius:0 4px 4px 0;font-size:15px;line-height:1.6;color:#333333;"">
+            {contentHtml}
+        </td>
+    </tr>
+</table>";
+    }
+
+    // ── Account emails ───────────────────────────────────────────────────────
+
+    public string ConfirmationEmail(string callbackUrl)
+    {
+        var body = $@"
+<h2 style=""margin:0 0 16px 0;font-size:22px;color:#1b5e20;"">Welcome to DropShot!</h2>
+<p style=""margin:0 0 8px 0;"">Thanks for signing up. Please confirm your email address to get started.</p>
+{ActionButton("Confirm Email Address", callbackUrl)}
+<p style=""margin:16px 0 0 0;font-size:13px;color:#888888;"">If you didn't create a DropShot account, you can safely ignore this email.</p>";
+
+        return WrapInBaseLayout("Confirm Your Email", body, "Please confirm your email address to activate your DropShot account.");
+    }
+
+    public string EmailChangeEmail(string callbackUrl)
+    {
+        var body = $@"
+<h2 style=""margin:0 0 16px 0;font-size:22px;color:#1b5e20;"">Confirm Your New Email</h2>
+<p style=""margin:0 0 8px 0;"">You've requested to change the email address on your DropShot account. Please confirm your new address by clicking the button below.</p>
+{ActionButton("Confirm New Email", callbackUrl)}
+<p style=""margin:16px 0 0 0;font-size:13px;color:#888888;"">If you didn't request this change, please ignore this email. Your account email will remain unchanged.</p>";
+
+        return WrapInBaseLayout("Confirm Email Change", body, "Confirm your new email address for your DropShot account.");
+    }
+
+    public string PasswordResetEmail(string callbackUrl)
+    {
+        var body = $@"
+<h2 style=""margin:0 0 16px 0;font-size:22px;color:#1b5e20;"">Reset Your Password</h2>
+<p style=""margin:0 0 8px 0;"">We received a request to reset your DropShot password. Click the button below to choose a new one.</p>
+{ActionButton("Reset Password", callbackUrl)}
+<p style=""margin:16px 0 0 0;font-size:13px;color:#888888;"">If you didn't request a password reset, you can safely ignore this email. Your password will remain unchanged.</p>";
+
+        return WrapInBaseLayout("Reset Your Password", body, "Reset your DropShot password.");
+    }
+
+    // ── Player invitation ────────────────────────────────────────────────────
+
+    public string PlayerInvitationEmail(string playerName, string inviteLink)
+    {
+        var body = $@"
+<h2 style=""margin:0 0 16px 0;font-size:22px;color:#1b5e20;"">You're Invited!</h2>
+<p style=""margin:0 0 8px 0;"">You've been invited to join DropShot as <strong>{Encode(playerName)}</strong>.</p>
+<p style=""margin:0 0 8px 0;"">Click the button below to register. Your new account will be linked to the existing player record and any match history will be transferred automatically.</p>
+{ActionButton("Accept Invitation", inviteLink)}
+<p style=""margin:16px 0 0 0;font-size:13px;color:#888888;"">If you weren't expecting this invitation, you can safely ignore it.</p>";
+
+        return WrapInBaseLayout("DropShot Invitation", body, $"You've been invited to join DropShot as {playerName}.");
+    }
+
+    // ── Match / result emails ────────────────────────────────────────────────
+
+    public string MatchResultEmail(string fixtureTitle, string resultSummary)
+    {
+        var body = $@"
+<h2 style=""margin:0 0 16px 0;font-size:22px;color:#1b5e20;"">Match Result</h2>
+<p style=""margin:0 0 12px 0;"">The result for your match has been recorded:</p>
+{InfoBox($@"<strong>{Encode(fixtureTitle)}</strong><br>{Encode(resultSummary)}")}
+<p style=""margin:16px 0 0 0;font-size:13px;color:#888888;"">This is an automated notification from DropShot.</p>";
+
+        return WrapInBaseLayout($"Match Result: {fixtureTitle}", body, $"Result recorded: {resultSummary}");
+    }
+
+    public string AdminVerificationEmail(string fixtureTitle, string resultSummary, string verifyUrl)
+    {
+        var body = $@"
+<h2 style=""margin:0 0 16px 0;font-size:22px;color:#1b5e20;"">Result Verification Required</h2>
+<p style=""margin:0 0 12px 0;"">A result has been submitted and requires your verification:</p>
+{InfoBox($@"<strong>{Encode(fixtureTitle)}</strong><br>{Encode(resultSummary)}")}
+{ActionButton("Verify Result", verifyUrl)}
+<p style=""margin:16px 0 0 0;font-size:13px;color:#888888;"">Please review and verify this result at your earliest convenience.</p>";
+
+        return WrapInBaseLayout($"Verify Result: {fixtureTitle}", body, $"Result verification needed: {fixtureTitle}");
+    }
+
+    // ── Club link request emails ─────────────────────────────────────────────
+
+    public string ClubLinkRequestReceivedEmail(string adminName, string requesterName, string clubName, string manageLink)
+    {
+        var body = $@"
+<h2 style=""margin:0 0 16px 0;font-size:22px;color:#1b5e20;"">New Club Link Request</h2>
+<p style=""margin:0 0 8px 0;"">Hi {Encode(adminName)},</p>
+<p style=""margin:0 0 8px 0;""><strong>{Encode(requesterName)}</strong> has asked to be linked to <strong>{Encode(clubName)}</strong>.</p>
+{ActionButton("Review Request", manageLink)}";
+
+        return WrapInBaseLayout($"New club link request for {clubName}", body, $"{requesterName} wants to join {clubName}.");
+    }
+
+    public string ClubLinkRequestApprovedEmail(string userName, string clubName, string clubLink)
+    {
+        var body = $@"
+<h2 style=""margin:0 0 16px 0;font-size:22px;color:#1b5e20;"">Request Approved</h2>
+<p style=""margin:0 0 8px 0;"">Hi {Encode(userName)},</p>
+<p style=""margin:0 0 8px 0;"">Your request to join <strong>{Encode(clubName)}</strong> has been approved. You're now linked to the club.</p>
+{ActionButton("View Club", clubLink)}";
+
+        return WrapInBaseLayout($"You're now linked to {clubName}", body, $"Your request to join {clubName} was approved.");
+    }
+
+    public string ClubLinkRequestRejectedEmail(string userName, string clubName)
+    {
+        var body = $@"
+<h2 style=""margin:0 0 16px 0;font-size:22px;color:#1b5e20;"">Request Declined</h2>
+<p style=""margin:0 0 8px 0;"">Hi {Encode(userName)},</p>
+<p style=""margin:0 0 8px 0;"">Unfortunately, your request to join <strong>{Encode(clubName)}</strong> was not approved.</p>
+<p style=""margin:0 0 8px 0;"">If you think this is a mistake, please reach out to the club directly.</p>";
+
+        return WrapInBaseLayout("Club link request declined", body, $"Your request to join {clubName} was declined.");
+    }
+
+    // ── Admin custom email (wraps admin-authored text in branded layout) ──
+
+    /// <summary>
+    /// Wraps admin-authored text in the branded layout.
+    /// The bodyText should already have variable values HTML-encoded (via SubstituteVariables).
+    /// Line breaks in the text are converted to &lt;br&gt; tags.
+    /// </summary>
+    public string AdminCustomEmail(string bodyText)
+    {
+        var htmlBody = bodyText.Replace("\n", "<br>");
+
+        var body = $@"
+<div style=""font-size:16px;line-height:1.6;color:#333333;"">
+    {htmlBody}
+</div>";
+
+        return WrapInBaseLayout("DropShot", body);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static string Encode(string text) => System.Net.WebUtility.HtmlEncode(text);
+}

--- a/DropShot/Services/ResultVerificationService.cs
+++ b/DropShot/Services/ResultVerificationService.cs
@@ -4,19 +4,22 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DropShot.Services;
 
-public class ResultVerificationService(EmailService emailService, IConfiguration config, ILogger<ResultVerificationService> logger)
+public class ResultVerificationService(EmailService emailService, EmailTemplateService emailTemplateService, IConfiguration config, ILogger<ResultVerificationService> logger)
 {
     private string BaseUrl => config["App:BaseUrl"]?.TrimEnd('/') ?? "";
 
     public async Task SendResultNotificationAsync(CompetitionFixture fixture)
     {
-        var (subject, body) = ResultEmailContent(fixture);
+        var title = FixtureTitle(fixture);
+        var resultSummary = fixture.ResultSummary ?? "";
+        var subject = $"Match result: {title}";
+        var html = emailTemplateService.MatchResultEmail(title, resultSummary);
 
         var emails = new[] { fixture.Player1, fixture.Player2, fixture.Player3, fixture.Player4 }
             .Where(p => p?.Email != null)
             .Select(p => p!.Email!)
             .Distinct()
-            .Select(email => SendSafe(email, subject, body, "result notification"));
+            .Select(email => SendSafe(email, subject, html, "result notification", isHtml: true));
 
         await Task.WhenAll(emails);
     }
@@ -28,9 +31,9 @@ public class ResultVerificationService(EmailService emailService, IConfiguration
         var title = FixtureTitle(fixture);
         var verifyUrl = $"{BaseUrl}/verify-result/{fixture.VerificationToken}";
         var subject = $"Result verification required: {title}";
-        var body = $"A result has been submitted for {title}.\n\nResult: {fixture.ResultSummary}\n\nClick the link below to verify this result:\n{verifyUrl}";
+        var html = emailTemplateService.AdminVerificationEmail(title, fixture.ResultSummary ?? "", verifyUrl);
 
-        await Task.WhenAll(adminEmails.Select(email => SendSafe(email, subject, body, "admin verification")));
+        await Task.WhenAll(adminEmails.Select(email => SendSafe(email, subject, html, "admin verification", isHtml: true)));
     }
 
     public async Task<List<string>> GetAdminEmailsForCompetitionAsync(int competitionId, MyDbContext db)
@@ -49,20 +52,11 @@ public class ResultVerificationService(EmailService emailService, IConfiguration
         return fixture.FixtureLabel != null ? $"{name} — {fixture.FixtureLabel}" : name;
     }
 
-    private static (string subject, string body) ResultEmailContent(CompetitionFixture fixture)
-    {
-        var title = FixtureTitle(fixture);
-        return (
-            $"Match result: {title}",
-            $"The result for your match in {title} has been recorded: {fixture.ResultSummary}."
-        );
-    }
-
-    private async Task SendSafe(string email, string subject, string body, string context)
+    private async Task SendSafe(string email, string subject, string body, string context, bool isHtml = false)
     {
         try
         {
-            await emailService.SendEmailAsync(email, subject, body);
+            await emailService.SendEmailAsync(email, subject, body, isHtml);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary
- Created `EmailTemplateService` with a reusable branded HTML email layout (600px table-based, inline CSS, Outlook VML fallbacks)
- Added `isHtml` parameter to `EmailService.SendEmailAsync` for backward compatibility
- Updated all 12 email send sites across account pages, result verification, admin emails, and player invitations

## Email types covered
- Account confirmation (registration, re-verify, external login)
- Password reset
- Email change confirmation
- Player invitation
- Match result notification
- Admin result verification request
- Club link request received/approved/rejected
- Admin custom match/competition emails

## Test plan
- [ ] Build passes (`dotnet build`)
- [ ] Register a new account and verify the confirmation email renders with branded layout
- [ ] Trigger a password reset and verify the email layout
- [ ] Send a player invitation and verify it uses the new template
- [ ] Submit a match result and verify notification emails are branded
- [ ] Test club link request flow (received/approved/rejected emails)
- [ ] Verify plain-text fallback is generated for email clients that prefer it

🤖 Generated with [Claude Code](https://claude.com/claude-code)