### PR TITLE
Update email sender to show DropShot display name

### DIFF
--- a/DropShot/Models/EmailService.cs
+++ b/DropShot/Models/EmailService.cs
@@ -5,6 +5,7 @@ public class EmailService
 {
     private readonly EmailClient? _emailClient;
     private readonly string? _sender;
+    private readonly string? _senderDisplayName;
 
     public EmailService(IConfiguration config)
     {
@@ -16,6 +17,7 @@ public class EmailService
         }
 
         _sender = config["ACS:SenderAddress"] ?? throw new InvalidOperationException("ACS:SenderAddress not configured");
+        _senderDisplayName = config["ACS:SenderDisplayName"] ?? "DropShot";
         _emailClient = new EmailClient(connectionString);
     }
 
@@ -48,7 +50,10 @@ public class EmailService
 
         var recipients = new EmailRecipients(new List<EmailAddress> { new EmailAddress(recipient) });
 
-        var message = new EmailMessage(_sender, recipients, emailContent);
+        var senderFormatted = !string.IsNullOrEmpty(_senderDisplayName)
+            ? $"{_senderDisplayName} <{_sender}>"
+            : _sender;
+        var message = new EmailMessage(senderFormatted, recipients, emailContent);
 
         await _emailClient.SendAsync(Azure.WaitUntil.Completed, message);
     }


### PR DESCRIPTION
## Summary
- Adds configurable sender display name (`ACS:SenderDisplayName`, defaults to "DropShot")
- Formats sender as `"DropShot <address>"` so recipients see a branded name instead of "DoNotReply"

## Test plan
- [ ] Verify emails show "DropShot" as sender name
- [ ] Verify `ACS:SenderDisplayName` config override works

🤖 Generated with [Claude Code](https://claude.com/claude-code)