### PR TITLE
Add loading spinner to account form submit buttons

### DIFF
--- a/DropShot/Components/Account/Shared/AccountLayout.razor
+++ b/DropShot/Components/Account/Shared/AccountLayout.razor
@@ -11,6 +11,47 @@ else
     @Body
 }
 
+<style>
+    .btn-submitting {
+        position: relative;
+        pointer-events: none;
+        opacity: 0.75;
+    }
+    .btn-submitting .btn-spinner {
+        display: inline-block;
+        width: 1rem;
+        height: 1rem;
+        border: 2px solid currentColor;
+        border-right-color: transparent;
+        border-radius: 50%;
+        animation: btn-spin 0.75s linear infinite;
+        vertical-align: middle;
+        margin-right: 0.4rem;
+    }
+    @@keyframes btn-spin {
+        to { transform: rotate(360deg); }
+    }
+</style>
+
+<script>
+    document.addEventListener('submit', function (e) {
+        var form = e.target;
+        if (!form || form.tagName !== 'FORM') return;
+
+        // Only act on forms inside the account layout
+        var btn = form.querySelector('button[type="submit"]');
+        if (!btn || btn.classList.contains('btn-submitting')) return;
+
+        // Let the browser validate first — if invalid, don't show spinner
+        if (!form.checkValidity()) return;
+
+        btn.classList.add('btn-submitting');
+        btn.disabled = true;
+        var original = btn.innerHTML;
+        btn.innerHTML = '<span class="btn-spinner"></span>' + original;
+    });
+</script>
+
 @code {
     [CascadingParameter]
     private HttpContext? HttpContext { get; set; }


### PR DESCRIPTION
## Summary
- Adds inline spinner and disabled state to all submit buttons across account pages (login, register, forgot password, reset password, etc.)
- Implemented in AccountLayout so it covers all 17 submit buttons automatically
- Only triggers after form validation passes, preventing false spinners on invalid submissions

## Test plan
- [ ] Click "Reset password" on forgot password page — button should show spinner and disable
- [ ] Click "Register" on registration page — button should show spinner and disable
- [ ] Click "Log in" on login page — button should show spinner and disable
- [ ] Submit a form with validation errors — button should NOT show spinner

🤖 Generated with [Claude Code](https://claude.com/claude-code)