### PR TITLE
Add magic link passwordless authentication

### DIFF
--- a/DropShot.Shared/Dtos/AuthDtos.cs
+++ b/DropShot.Shared/Dtos/AuthDtos.cs
@@ -28,3 +28,7 @@ public record SwitchRoleResponse(
     List<string> GrantedRoles);
 
 public record UpgradePremiumRequest(bool IsSubscribed);
+
+public record MagicLinkRequest(string Email);
+
+public record MagicLinkVerifyRequest(string UserId, string Code);

--- a/DropShot/Components/Account/Pages/Login.razor
+++ b/DropShot/Components/Account/Pages/Login.razor
@@ -43,6 +43,9 @@
                 </div>
                 <div>
                     <p>
+                        <a href="@(NavigationManager.GetUriWithQueryParameters("Account/LoginMagicLink", new Dictionary<string, object?> { ["ReturnUrl"] = ReturnUrl }))">Sign in with magic link</a>
+                    </p>
+                    <p>
                         <a href="Account/ForgotPassword">Forgot your password?</a>
                     </p>
                     <p>

--- a/DropShot/Components/Account/Pages/LoginMagicLink.razor
+++ b/DropShot/Components/Account/Pages/LoginMagicLink.razor
@@ -1,0 +1,78 @@
+@page "/Account/LoginMagicLink"
+
+@using System.ComponentModel.DataAnnotations
+@using System.Text
+@using Microsoft.AspNetCore.Identity
+@using Microsoft.AspNetCore.WebUtilities
+@using DropShot.Data
+
+@inject UserManager<ApplicationUser> UserManager
+@inject NavigationManager NavigationManager
+@inject IdentityRedirectManager RedirectManager
+@inject EmailService EmailService
+@inject EmailTemplateService EmailTemplateService
+
+<PageTitle>Sign in with magic link</PageTitle>
+
+<h1>Sign in with magic link</h1>
+<h2>Enter your email to receive a sign-in link.</h2>
+<hr />
+<div class="row">
+    <div class="col-md-4">
+        <EditForm Model="Input" FormName="magic-link" OnValidSubmit="OnValidSubmitAsync" method="post">
+            <DataAnnotationsValidator />
+            <ValidationSummary class="text-danger" role="alert" />
+
+            <div class="form-floating mb-3">
+                <InputText @bind-Value="Input.Email" class="form-control" autocomplete="username" aria-required="true" placeholder="name@example.com" />
+                <label for="email" class="form-label">Email</label>
+                <ValidationMessage For="() => Input.Email" class="text-danger" />
+            </div>
+            <button type="submit" class="w-100 btn btn-lg btn-primary">Send magic link</button>
+        </EditForm>
+    </div>
+</div>
+
+@code {
+    private InputModel _input = new();
+
+    [SupplyParameterFromForm]
+    private InputModel Input { get => _input; set => _input = value ?? _input; }
+
+    [SupplyParameterFromQuery]
+    private string? ReturnUrl { get; set; }
+
+    private async Task OnValidSubmitAsync()
+    {
+        var user = await UserManager.FindByEmailAsync(Input.Email);
+        if (user is null || !(await UserManager.IsEmailConfirmedAsync(user)))
+        {
+            // Don't reveal that the user does not exist or is not confirmed
+            RedirectManager.RedirectTo("Account/LoginMagicLinkConfirmation");
+        }
+
+        var code = await UserManager.GenerateUserTokenAsync(user, "MagicLogin", "magic-link");
+        code = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(code));
+
+        var callbackUrl = NavigationManager.GetUriWithQueryParameters(
+            NavigationManager.ToAbsoluteUri("Account/LoginMagicLinkCallback").AbsoluteUri,
+            new Dictionary<string, object?>
+            {
+                ["userId"] = user.Id,
+                ["code"] = code,
+                ["returnUrl"] = ReturnUrl
+            });
+
+        await EmailService.SendEmailAsync(Input.Email, "Sign In to DropShot",
+            EmailTemplateService.MagicLinkEmail(callbackUrl), isHtml: true);
+
+        RedirectManager.RedirectTo("Account/LoginMagicLinkConfirmation");
+    }
+
+    private sealed class InputModel
+    {
+        [Required]
+        [EmailAddress]
+        public string Email { get; set; } = "";
+    }
+}

--- a/DropShot/Components/Account/Pages/LoginMagicLinkConfirmation.razor
+++ b/DropShot/Components/Account/Pages/LoginMagicLinkConfirmation.razor
@@ -1,0 +1,6 @@
+@page "/Account/LoginMagicLinkConfirmation"
+
+<PageTitle>Magic link sent</PageTitle>
+
+<h1>Check your email</h1>
+<p>If an account exists for that email address, we've sent a sign-in link. Please check your inbox and click the link to sign in.</p>

--- a/DropShot/Controllers/AuthController.cs
+++ b/DropShot/Controllers/AuthController.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using DropShot.Data;
 using DropShot.Models;
 using DropShot.Services;
@@ -5,6 +6,7 @@ using DropShot.Shared.Dtos;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.EntityFrameworkCore;
 
 namespace DropShot.Controllers;
@@ -101,5 +103,56 @@ public class AuthController(
         var token = jwtTokenService.GenerateTokenWithActiveRole(user, grantedRoles, request.Role);
 
         return Ok(new SwitchRoleResponse(token, request.Role, grantedRoles));
+    }
+
+    [HttpPost("magic-link/request")]
+    public async Task<IActionResult> RequestMagicLink(
+        [FromBody] MagicLinkRequest request,
+        [FromServices] EmailService emailService,
+        [FromServices] EmailTemplateService emailTemplateService,
+        [FromServices] IConfiguration config)
+    {
+        var user = await userManager.FindByEmailAsync(request.Email);
+        if (user is null || !(await userManager.IsEmailConfirmedAsync(user)))
+        {
+            // Don't reveal that the user does not exist
+            return Ok(new { message = "If that email exists, a sign-in link has been sent." });
+        }
+
+        var code = await userManager.GenerateUserTokenAsync(user, "MagicLogin", "magic-link");
+        code = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(code));
+
+        var baseUrl = config["App:BaseUrl"]?.TrimEnd('/') ?? "";
+        var callbackUrl = $"{baseUrl}/Account/LoginMagicLinkCallback?userId={user.Id}&code={code}";
+
+        await emailService.SendEmailAsync(request.Email, "Sign In to DropShot",
+            emailTemplateService.MagicLinkEmail(callbackUrl), isHtml: true);
+
+        return Ok(new { message = "If that email exists, a sign-in link has been sent." });
+    }
+
+    [HttpPost("magic-link/verify")]
+    public async Task<ActionResult<LoginResponse>> VerifyMagicLink([FromBody] MagicLinkVerifyRequest request)
+    {
+        var user = await userManager.FindByIdAsync(request.UserId);
+        if (user is null)
+            return Unauthorized(new { message = "Invalid or expired magic link." });
+
+        var decodedCode = Encoding.UTF8.GetString(WebEncoders.Base64UrlDecode(request.Code));
+        var isValid = await userManager.VerifyUserTokenAsync(user, "MagicLogin", "magic-link", decodedCode);
+        if (!isValid)
+            return Unauthorized(new { message = "Invalid or expired magic link." });
+
+        var roles = (await userManager.GetRolesAsync(user)).ToList();
+        var activeRole = roles.FirstOrDefault() ?? "";
+        var token = jwtTokenService.GenerateTokenWithActiveRole(user, roles, activeRole);
+
+        await using var db = dbFactory.CreateDbContext();
+        var adminClubIds = await db.ClubAdministrators
+            .Where(ca => ca.UserId == user.Id)
+            .Select(ca => ca.ClubId)
+            .ToListAsync();
+
+        return Ok(new LoginResponse(token, user.UserName!, user.Email!, roles, adminClubIds, activeRole, roles));
     }
 }

--- a/DropShot/Program.cs
+++ b/DropShot/Program.cs
@@ -11,6 +11,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using MudBlazor.Services;
 using System.Text;
+using Microsoft.AspNetCore.WebUtilities;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -200,6 +201,32 @@ app.MapGet("/Account/QrLogin", async (
 
     if (session.CourtId.HasValue)
         return Results.Redirect($"/score?courtId={session.CourtId.Value}");
+
+    return Results.Redirect("/");
+});
+
+// ── Magic link login callback (validates token, sets identity cookie, redirects) ──
+app.MapGet("/Account/LoginMagicLinkCallback", async (
+    string userId,
+    string code,
+    string? returnUrl,
+    UserManager<ApplicationUser> userManager,
+    SignInManager<ApplicationUser> signInManager) =>
+{
+    var user = await userManager.FindByIdAsync(userId);
+    if (user is null)
+        return Results.Redirect("/Account/Login");
+
+    var decodedCode = Encoding.UTF8.GetString(WebEncoders.Base64UrlDecode(code));
+    var isValid = await userManager.VerifyUserTokenAsync(user, "MagicLogin", "magic-link", decodedCode);
+    if (!isValid)
+        return Results.Redirect("/Account/Login");
+
+    await signInManager.SignInAsync(user, isPersistent: false);
+
+    // Prevent open redirects
+    if (!string.IsNullOrEmpty(returnUrl) && Uri.IsWellFormedUriString(returnUrl, UriKind.Relative))
+        return Results.LocalRedirect(returnUrl);
 
     return Results.Redirect("/");
 });

--- a/DropShot/Services/EmailTemplateService.cs
+++ b/DropShot/Services/EmailTemplateService.cs
@@ -157,6 +157,19 @@ public class EmailTemplateService
         return WrapInBaseLayout("Reset Your Password", body, "Reset your DropShot password.");
     }
 
+    // ── Magic link login ──────────────────────────────────────────────────────
+
+    public string MagicLinkEmail(string callbackUrl)
+    {
+        var body = $@"
+<h2 style=""margin:0 0 16px 0;font-size:22px;color:#1b5e20;"">Sign In to DropShot</h2>
+<p style=""margin:0 0 8px 0;"">Click the button below to sign in to your account. No password needed!</p>
+{ActionButton("Sign In", callbackUrl)}
+<p style=""margin:16px 0 0 0;font-size:13px;color:#888888;"">This link is single-use and will expire shortly. If you didn't request this, you can safely ignore this email.</p>";
+
+        return WrapInBaseLayout("Sign In to DropShot", body, "Click to sign in to your DropShot account.");
+    }
+
     // ── Player invitation ────────────────────────────────────────────────────
 
     public string PlayerInvitationEmail(string playerName, string inviteLink)


### PR DESCRIPTION
## Summary
- Allow users to sign in via a one-time email link instead of a password
- Blazor SSR flow: request page (`/Account/LoginMagicLink`), confirmation page, and callback endpoint
- API flow for MAUI: `POST /api/auth/magic-link/request` and `POST /api/auth/magic-link/verify`
- Uses ASP.NET Identity's built-in token provider — no new DB tables needed
- Branded email template matching existing style

## Test plan
- [ ] Navigate to `/Account/Login` and verify "Sign in with magic link" link appears
- [ ] Click through to `/Account/LoginMagicLink`, enter an email, and verify email is sent (console in dev)
- [ ] Click the callback URL and verify user is signed in and redirected
- [ ] Test with invalid/expired token — should redirect to login
- [ ] Test API endpoints via Postman/MAUI client

🤖 Generated with [Claude Code](https://claude.com/claude-code)