### PR TITLE
Register MagicLogin token provider and improve magic link UI

### DIFF
--- a/DropShot/Components/Account/Pages/Login.razor
+++ b/DropShot/Components/Account/Pages/Login.razor
@@ -42,9 +42,11 @@
                     <button type="submit" class="w-100 btn btn-lg btn-primary">Log in</button>
                 </div>
                 <div>
-                    <p>
-                        <a href="@(NavigationManager.GetUriWithQueryParameters("Account/LoginMagicLink", new Dictionary<string, object?> { ["ReturnUrl"] = ReturnUrl }))">Sign in with magic link</a>
-                    </p>
+                    <div class="mb-3">
+                        <a href="@(NavigationManager.GetUriWithQueryParameters("Account/LoginMagicLink", new Dictionary<string, object?> { ["ReturnUrl"] = ReturnUrl }))" class="w-100 btn btn-outline-primary">
+                            <MudIcon Icon="@Icons.Material.Filled.AutoFixHigh" Size="Size.Small" Class="me-1" /> Sign in with magic link
+                        </a>
+                    </div>
                     <p>
                         <a href="Account/ForgotPassword">Forgot your password?</a>
                     </p>

--- a/DropShot/Components/Pages/Home.razor
+++ b/DropShot/Components/Pages/Home.razor
@@ -132,6 +132,11 @@
                     <MudText Typo="Typo.body1" Class="mt-2 d-md-none">
                         <MudLink Href="/Account/Login">Log in with email and password</MudLink> to get started.
                     </MudText>
+                    <MudButton Variant="Variant.Outlined" Color="Color.Primary" Class="mt-3"
+                               StartIcon="@Icons.Material.Filled.AutoFixHigh"
+                               Href="/Account/LoginMagicLink">
+                        Sign in with magic link
+                    </MudButton>
                 </MudItem>
                 <MudItem xs="12" md="6" Class="d-none d-md-block">
                     <QrLoginPanel />

--- a/DropShot/Program.cs
+++ b/DropShot/Program.cs
@@ -104,7 +104,8 @@ builder.Services.AddIdentityCore<ApplicationUser>(options => options.SignIn.Requ
     .AddRoles<IdentityRole>()
     .AddEntityFrameworkStores<MyDbContext>()
     .AddSignInManager()
-    .AddDefaultTokenProviders();
+    .AddDefaultTokenProviders()
+    .AddTokenProvider<DataProtectorTokenProvider<ApplicationUser>>("MagicLogin");
 
 // ── App services ─────────────────────────────────────────────────────────────
 builder.Services.AddHttpContextAccessor();


### PR DESCRIPTION
## Summary
- Fix `NotSupportedException` by registering the `MagicLogin` token provider in Identity config
- Replace plain text magic link with a styled button + magic wand icon on the login page
- Add magic link button to the homepage for unauthenticated users

## Test plan
- [ ] Navigate to `/Account/LoginMagicLink`, enter an email — should no longer throw
- [ ] Verify magic wand button appears on login page and homepage
- [ ] Click through and confirm sign-in flow works end to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)