### PR TITLE
Add tennis background to match setup wizard

### DIFF
--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -62,7 +62,8 @@
 
 @if (loaded && CurrentMatch == null && !_showCoinToss && !_showServerSelect)
 {
-    <div style="max-width: 800px; margin: 0 auto; padding: 1.5rem 0 2rem;">
+    <section class="bg-tennis overlay-dark" style="min-height: 100vh; align-items: flex-start;">
+    <div style="max-width: 800px; margin: 0 auto; padding: 1.5rem 1rem 2rem; width: 100%; position: relative; z-index: 1;">
         <MatchSetupWizard OnSetupComplete="HandleSetupComplete"
                           PresetPlayer1="@_value" PresetPlayer2="@_value2"
                           PresetPlayer3="@_value3" PresetPlayer4="@_value4"
@@ -111,6 +112,7 @@
             </MudCard>
         }
     </div>
+    </section>
 }
 
 @if (loaded && @CurrentMatch != null)


### PR DESCRIPTION
## Summary
- Wrap the match setup wizard in the same `bg-tennis overlay-dark` background used by the scoring screen
- Creates visual continuity between setup and live match experience
- MudPaper cards float on top of the dark background with existing elevation

## Test plan
- [ ] Navigate to `/match/0` — verify dark tennis pattern background behind wizard cards
- [ ] Verify all text and controls remain readable on card surfaces
- [ ] Verify upcoming matches table (if present) is also readable
- [ ] Check mobile viewport for no overflow issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)