### PR TITLE
Replace opaque cards with glass effect on match setup

### DIFF
--- a/DropShot/Components/MatchSetupWizard.razor
+++ b/DropShot/Components/MatchSetupWizard.razor
@@ -46,7 +46,7 @@
     }
     else if (_currentStep == 0)
     {
-        <MudPaper Class="pa-4" Elevation="2">
+        <MudPaper Class="pa-4 setup-card" Elevation="0">
             <MudText Typo="Typo.h6" Class="mb-3">Start a Match</MudText>
 
             @* ── Colourful match type toggle ─────────────── *@
@@ -236,7 +236,7 @@
     }
     else if (_currentStep == 1)
     {
-        <MudPaper Class="pa-4" Elevation="2">
+        <MudPaper Class="pa-4 setup-card" Elevation="0">
             <MudText Typo="Typo.h6" Class="mb-3">Court Selection</MudText>
 
             <MudAutocomplete T="Club" Label="Search for a club"
@@ -280,7 +280,7 @@
     @* ── Match Settings ──────────────────────────────────── *@
     @if (_currentStep == 2)
     {
-        <MudPaper Class="pa-4" Elevation="2">
+        <MudPaper Class="pa-4 setup-card" Elevation="0">
             <div class="d-flex justify-space-between align-center mb-3">
                 <MudText Typo="Typo.h6">Match Settings</MudText>
                 <MudTooltip Text="Customise rules">

--- a/DropShot/Components/MatchSetupWizard.razor.css
+++ b/DropShot/Components/MatchSetupWizard.razor.css
@@ -1,3 +1,44 @@
+/* ── Glass card style for dark background ────────────── */
+
+.setup-card {
+    background: rgba(255, 255, 255, 0.08) !important;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 12px;
+    color: white;
+}
+
+::deep .setup-card .mud-typography {
+    color: rgba(255, 255, 255, 0.95);
+}
+
+::deep .setup-card .mud-input-label,
+::deep .setup-card .mud-input,
+::deep .setup-card .mud-select-input {
+    color: rgba(255, 255, 255, 0.9) !important;
+}
+
+::deep .setup-card .mud-input-outlined .mud-input-outlined-border {
+    border-color: rgba(255, 255, 255, 0.3) !important;
+}
+
+::deep .setup-card .mud-table th {
+    color: rgba(255, 255, 255, 0.6);
+}
+
+::deep .setup-card .mud-table td {
+    border-bottom-color: rgba(255, 255, 255, 0.08);
+}
+
+::deep .setup-card .mud-radio .mud-typography {
+    color: rgba(255, 255, 255, 0.9);
+}
+
+::deep .setup-card .mud-divider {
+    border-color: rgba(255, 255, 255, 0.12);
+}
+
 /* ── Singles / Doubles toggle ────────────────────────── */
 
 .match-type-toggle {

--- a/DropShot/Components/StepSummary.razor.css
+++ b/DropShot/Components/StepSummary.razor.css
@@ -4,12 +4,17 @@
     cursor: pointer;
     border-radius: 12px;
     transition: box-shadow 0.2s ease, transform 0.15s ease;
-    background: var(--mud-palette-surface);
+    background: rgba(255, 255, 255, 0.08);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    color: white;
 }
 
 .step-summary:hover {
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
     transform: translateY(-1px);
+    background: rgba(255, 255, 255, 0.12);
 }
 
 .step-summary-accent {


### PR DESCRIPTION
## Summary
- Replace solid MudPaper backgrounds with semi-transparent glassmorphism (blur + border)
- Style all text, inputs, labels, dividers, and table elements for white-on-dark readability
- Update StepSummary cards with matching frosted glass treatment

## Test plan
- [ ] Navigate to `/match/0` — verify tennis background is visible through cards
- [ ] Check all text is readable (headings, labels, player names, settings)
- [ ] Verify input fields (autocomplete, selects, numeric) are visible and usable
- [ ] Check StepSummary cards after advancing steps
- [ ] Test on mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)