### PR TITLE
Reduce side padding on match setup wizard

### DIFF
--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -63,7 +63,7 @@
 @if (loaded && CurrentMatch == null && !_showCoinToss && !_showServerSelect)
 {
     <section class="bg-tennis overlay-dark" style="min-height: 100vh; align-items: flex-start;">
-    <div style="max-width: 800px; margin: 0 auto; padding: 1.5rem 1rem 2rem; width: 100%; position: relative; z-index: 1;">
+    <div style="max-width: 800px; margin: 0 auto; padding: 1rem 0.5rem 2rem; width: 100%; position: relative; z-index: 1;">
         <MatchSetupWizard OnSetupComplete="HandleSetupComplete"
                           PresetPlayer1="@_value" PresetPlayer2="@_value2"
                           PresetPlayer3="@_value3" PresetPlayer4="@_value4"


### PR DESCRIPTION
## Summary
- Reduce horizontal padding from 1rem to 0.5rem and top padding from 1.5rem to 1rem on the setup wizard container

🤖 Generated with [Claude Code](https://claude.com/claude-code)