### PR TITLE
Add back button to server selection screen

### DIFF
--- a/DropShot/Components/ServerSelectScreen.razor
+++ b/DropShot/Components/ServerSelectScreen.razor
@@ -31,6 +31,13 @@
                 Spin
             </MudButton>
         </div>
+
+        <MudButton Variant="Variant.Text" Class="mt-4"
+                   StartIcon="@Icons.Material.Filled.ArrowBack"
+                   Style="color: rgba(255,255,255,0.6);"
+                   OnClick="@(() => OnBack.InvokeAsync())">
+            Back to setup
+        </MudButton>
     </div>
 </div>
 
@@ -38,6 +45,7 @@
     [Parameter] public string UserLabel { get; set; } = "You";
     [Parameter] public string OpponentLabel { get; set; } = "Opponent";
     [Parameter] public EventCallback<string> OnServerSelected { get; set; }
+    [Parameter] public EventCallback OnBack { get; set; }
 
     private async Task OnSelected(string choice)
     {

--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -33,7 +33,8 @@
 {
     <ServerSelectScreen UserLabel="@GetUserDisplayName()"
                         OpponentLabel="@GetOpponentDisplayName()"
-                        OnServerSelected="HandleServerSelected" />
+                        OnServerSelected="HandleServerSelected"
+                        OnBack="HandleServerSelectBack" />
 }
 
 @if (_showCoinToss)
@@ -539,6 +540,11 @@
 
         _showServerSelect = true;
         return Task.CompletedTask;
+    }
+
+    private void HandleServerSelectBack()
+    {
+        _showServerSelect = false;
     }
 
     private async Task HandleServerSelected(string choice)


### PR DESCRIPTION
## Summary
- Add "Back to setup" button on the server selection screen
- Returns user to the match setup wizard at the last step (settings)

## Test plan
- [ ] Start a match, reach server selection, tap "Back to setup" — verify you return to setup wizard
- [ ] Verify you can then proceed forward again to server selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)