### PR TITLE
Change theme primary colour from purple to teal

### DIFF
--- a/DropShot/Components/Layout/MainLayout.razor
+++ b/DropShot/Components/Layout/MainLayout.razor
@@ -27,5 +27,14 @@
 </div>
 
 @code {
-    private MudTheme _theme = new();
+    private MudTheme _theme = new()
+    {
+        PaletteDark = new PaletteDark
+        {
+            Primary = "#00897b",
+            PrimaryDarken = "#00695c",
+            PrimaryLighten = "#4db6ac",
+            Secondary = "#26a69a",
+        }
+    };
 }


### PR DESCRIPTION
## Summary
- Customise MudBlazor dark theme palette to use teal instead of default purple
- Primary: #00897b, Secondary: #26a69a with darken/lighten variants

## Test plan
- [ ] Navigate around the app — verify buttons, links, switches, and highlights are teal not purple
- [ ] Check match setup wizard, nav menu, and scoring screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)