### PR TITLE
Add start match CTA on home page

### DIFF
--- a/DropShot/Components/Pages/Home.razor
+++ b/DropShot/Components/Pages/Home.razor
@@ -153,6 +153,26 @@
     </MudCardContent>
 </MudCard>
 
+@if (_isAuthenticated)
+{
+    <MudPaper Class="mt-4 pa-5" Elevation="0"
+              Style="background: linear-gradient(135deg, #004d40 0%, #00897b 60%, #4db6ac 100%); border-radius: 16px; text-align: center;">
+        <MudIcon Icon="@Icons.Material.Filled.SportsTennis" Style="font-size: 48px; color: rgba(255,255,255,0.85);" />
+        <MudText Typo="Typo.h5" Style="color: white; font-weight: 700; margin-top: 8px;">
+            Ready to play?
+        </MudText>
+        <MudText Typo="Typo.body1" Style="color: rgba(255,255,255,0.85); margin-top: 4px;">
+            Start a casual match and track your score live.
+        </MudText>
+        <MudButton Variant="Variant.Filled" Color="Color.Dark" Size="Size.Large"
+                   StartIcon="@Icons.Material.Filled.PlayArrow"
+                   Href="/match" Class="mt-3"
+                   Style="font-weight: 600; border-radius: 24px; padding: 10px 32px;">
+            Start a Match
+        </MudButton>
+    </MudPaper>
+}
+
 @if (_upcomingFixtures.Any() || _recentItems.Any())
 {
     <MudGrid Class="mt-4">


### PR DESCRIPTION
## Summary
- Add a teal gradient "Ready to play?" banner with a "Start a Match" button on the home page
- Shown only to authenticated users, positioned between the welcome block and recent results

## Test plan
- [ ] Log in and visit home page — verify banner appears with button
- [ ] Click "Start a Match" — verify navigation to `/match`
- [ ] Log out — verify banner is not shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)