### PR TITLE
Add spacing between login and magic link buttons

### DIFF
--- a/DropShot/Components/Account/Pages/Login.razor
+++ b/DropShot/Components/Account/Pages/Login.razor
@@ -41,7 +41,7 @@
                 <div>
                     <button type="submit" class="w-100 btn btn-lg btn-primary">Log in</button>
                 </div>
-                <div>
+                <div class="mt-3">
                     <div class="mb-3">
                         <a href="@(NavigationManager.GetUriWithQueryParameters("Account/LoginMagicLink", new Dictionary<string, object?> { ["ReturnUrl"] = ReturnUrl }))" class="w-100 btn btn-outline-primary">
                             <MudIcon Icon="@Icons.Material.Filled.AutoFixHigh" Size="Size.Small" Class="me-1" /> Sign in with magic link


### PR DESCRIPTION
## Summary
- Add `mt-3` margin between the Log in button and the Sign in with magic link button

🤖 Generated with [Claude Code](https://claude.com/claude-code)