### PR TITLE
Add mobile and gender fields to competition player dialog

### DIFF
--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -369,8 +369,20 @@
                                               Variant="Variant.Outlined" />
                             </MudItem>
                             <MudItem xs="12">
-                                <MudTextField @bind-Value="_newPlayerForm.Email" Label="Email (optional)"
+                                <MudTextField @bind-Value="_newPlayerForm.Email" Label="Email address"
                                               Variant="Variant.Outlined" InputType="InputType.Email" />
+                            </MudItem>
+                            <MudItem xs="12">
+                                <MudTextField @bind-Value="_newPlayerForm.MobileNumber" Label="Mobile number"
+                                              Variant="Variant.Outlined" InputType="InputType.Telephone" />
+                            </MudItem>
+                            <MudItem xs="12">
+                                <MudText Typo="Typo.body2" Class="mb-1">Competition category</MudText>
+                                <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mb-2">Determines which events they're eligible to enter</MudText>
+                                <MudRadioGroup T="PlayerSex?" @bind-Value="_newPlayerForm.CompetitionCategory">
+                                    <MudRadio T="PlayerSex?" Value="@PlayerSex.Male" Color="Color.Primary">Male events</MudRadio>
+                                    <MudRadio T="PlayerSex?" Value="@PlayerSex.Female" Color="Color.Primary">Female events</MudRadio>
+                                </MudRadioGroup>
                             </MudItem>
                         </MudGrid>
                     </DialogContent>
@@ -1886,6 +1898,8 @@
         public string? FirstName { get; set; }
         public string? LastName { get; set; }
         public string? Email { get; set; }
+        public string? MobileNumber { get; set; }
+        public PlayerSex? CompetitionCategory { get; set; }
     }
 
     private void OpenNewPlayerDialog()
@@ -1903,7 +1917,9 @@
             DisplayName = cp.Player?.DisplayName ?? "",
             FirstName = cp.Player?.FirstName,
             LastName = cp.Player?.LastName,
-            Email = cp.Player?.Email
+            Email = cp.Player?.Email,
+            MobileNumber = cp.Player?.MobileNumber,
+            CompetitionCategory = cp.Player?.Sex
         };
         _showNewPlayerDialog = true;
     }
@@ -1920,6 +1936,8 @@
         player.FirstName = string.IsNullOrWhiteSpace(_newPlayerForm.FirstName) ? null : _newPlayerForm.FirstName.Trim();
         player.LastName = string.IsNullOrWhiteSpace(_newPlayerForm.LastName) ? null : _newPlayerForm.LastName.Trim();
         player.Email = string.IsNullOrWhiteSpace(_newPlayerForm.Email) ? null : _newPlayerForm.Email.Trim();
+        player.MobileNumber = string.IsNullOrWhiteSpace(_newPlayerForm.MobileNumber) ? null : _newPlayerForm.MobileNumber.Trim();
+        player.Sex = _newPlayerForm.CompetitionCategory;
         await db.SaveChangesAsync();
 
         // Update local state
@@ -1930,6 +1948,8 @@
             cp.Player.FirstName = player.FirstName;
             cp.Player.LastName = player.LastName;
             cp.Player.Email = player.Email;
+            cp.Player.MobileNumber = player.MobileNumber;
+            cp.Player.Sex = player.Sex;
         }
 
         _showNewPlayerDialog = false;
@@ -1948,6 +1968,8 @@
             FirstName = string.IsNullOrWhiteSpace(_newPlayerForm.FirstName) ? null : _newPlayerForm.FirstName!.Trim(),
             LastName = string.IsNullOrWhiteSpace(_newPlayerForm.LastName) ? null : _newPlayerForm.LastName!.Trim(),
             Email = string.IsNullOrWhiteSpace(_newPlayerForm.Email) ? null : _newPlayerForm.Email!.Trim(),
+            MobileNumber = string.IsNullOrWhiteSpace(_newPlayerForm.MobileNumber) ? null : _newPlayerForm.MobileNumber!.Trim(),
+            Sex = _newPlayerForm.CompetitionCategory,
             IsLight = true,
             CreatedByClubId = clubId
         };


### PR DESCRIPTION
## Summary
- Add mobile number and competition category (Male/Female) fields to the add/edit player dialog on the competition page
- Matches the dialog layout used on the Club Players page
- Fields are saved on both create and edit, and populated when editing existing light players

## Test plan
- [ ] Add a new light player — verify mobile number and competition category fields appear
- [ ] Edit an existing light player — verify fields are pre-filled
- [ ] Save with category set — verify player's Sex is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)