### PR TITLE
Remove 10-result limit on participant player search

### DIFF
--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -1881,8 +1881,7 @@
         var source = Model.HostClubId.HasValue ? _clubPlayers : _allPlayers;
         var results = source
             .Where(p => !alreadyIn.Contains(p.PlayerId) &&
-                        (string.IsNullOrWhiteSpace(text) || p.DisplayName.Contains(text, StringComparison.OrdinalIgnoreCase)))
-            .Take(10);
+                        (string.IsNullOrWhiteSpace(text) || p.DisplayName.Contains(text, StringComparison.OrdinalIgnoreCase)));
         return Task.FromResult(results);
     }
 


### PR DESCRIPTION
## Summary
- Remove `.Take(10)` limit on the participant autocomplete search so all matching club players are shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)