### PR TITLE
Use alphabetical team/pair names in generate wizard

### DIFF
--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -2210,7 +2210,7 @@
                 var members = new List<CompetitionParticipant>();
                 members.AddRange(males.Skip(i * perGender).Take(perGender));
                 members.AddRange(females.Skip(i * perGender).Take(perGender));
-                _generatedPreview.Add(new GeneratedTeamPreview($"{itemLabel} {i + 1}", members));
+                _generatedPreview.Add(new GeneratedTeamPreview($"{itemLabel} {(char)('A' + i)}", members));
             }
         }
         else
@@ -2232,7 +2232,7 @@
             for (int i = 0; i < teamCount; i++)
             {
                 var members = shuffled.Skip(i * teamSize).Take(teamSize).ToList();
-                _generatedPreview.Add(new GeneratedTeamPreview($"{itemLabel} {i + 1}", members));
+                _generatedPreview.Add(new GeneratedTeamPreview($"{itemLabel} {(char)('A' + i)}", members));
             }
         }
     }


### PR DESCRIPTION
## Summary
- Change auto-generated team names from "Team 1, Team 2" to "Team A, Team B" (alphabetical)
- Same for pairings: "Pair A, Pair B" etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)