### PR TITLE
Remove autocomplete 10-item display limit on participant search

### DIFF
--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -349,6 +349,7 @@
                                      @ref="_participantAutocomplete"
                                      ToStringFunc="@(p => p?.DisplayName ?? "")"
                                      ValueChanged="AddParticipant" ResetValueOnEmptyText="true"
+                                     MaxItems="null"
                                      Variant="Variant.Outlined" Dense="true" Style="max-width:260px" />
                     @if (Model.HostClubId.HasValue)
                     {


### PR DESCRIPTION
## Summary
- Set `MaxItems="null"` on the participant autocomplete to override MudBlazor's default limit of 10 displayed items

🤖 Generated with [Claude Code](https://claude.com/claude-code)