### PR TITLE
Remove redundant Back button from competition page

### DIFF
--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -223,10 +223,13 @@
                             Save & Exit
                         </MudButton>
                     }
-                    <MudButton Color="Color.Default" Variant="Variant.Outlined"
-                               Disabled="@_isSaving" OnClick="@(() => Nav.NavigateTo("/Competitions"))">
-                        @(IsEdit ? "Back" : "Cancel")
-                    </MudButton>
+                    @if (!IsEdit)
+                    {
+                        <MudButton Color="Color.Default" Variant="Variant.Outlined"
+                                   Disabled="@_isSaving" OnClick="@(() => Nav.NavigateTo("/Competitions"))">
+                            Cancel
+                        </MudButton>
+                    }
                 </MudStack>
             </MudForm>
         </MudPaper>


### PR DESCRIPTION
## Summary
- Remove the Back button when editing a competition (Save & Exit serves the same purpose)
- Keep Cancel button visible only when creating a new competition

🤖 Generated with [Claude Code](https://claude.com/claude-code)