### PR TITLE
Fix competition page SQL timeout

### DIFF
--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -1436,6 +1436,7 @@
                 .Include(c => c.Fixtures).ThenInclude(f => f.CourtPair)
                 .Include(c => c.Teams).ThenInclude(t => t.Captain)
                 .Include(c => c.MatchWindows).ThenInclude(w => w.Court)
+                .AsSplitQuery()
                 .AsNoTracking()
                 .FirstOrDefaultAsync(c => c.CompetitionID == Id);
 


### PR DESCRIPTION
## Summary
- Add `.AsSplitQuery()` to the competition loading query which has 11 Include chains
- EF was generating a massive cartesian product JOIN that timed out on Azure SQL
- Split query executes separate SQL queries per Include, avoiding the exponential row explosion

## Test plan
- [ ] Open a competition with many fixtures — verify it loads without timeout
- [ ] Verify all data (stages, participants, fixtures, teams) still loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)