### PR TITLE
Add fixed sets format and configurable league scoring

### DIFF
--- a/DropShot/Components/MatchSetupWizard.razor
+++ b/DropShot/Components/MatchSetupWizard.razor
@@ -319,7 +319,7 @@
                 </MudStack>
                 <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
                     <MudIcon Icon="@Icons.Material.Filled.EmojiEvents" Size="Size.Small" Color="Color.Secondary" />
-                    <MudText Typo="Typo.body2">Best of @_bestOf @(_bestOf == 1 ? "set" : "sets")</MudText>
+                    <MudText Typo="Typo.body2">@(_isFixedSets ? $"{_fixedSetCount} fixed set(s)" : $"Best of {_bestOf}")</MudText>
                 </MudStack>
                 <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
                     <MudIcon Icon="@Icons.Material.Filled.SportsTennis" Size="Size.Small" Color="Color.Secondary" />
@@ -372,14 +372,30 @@
 
                 <MudDivider Class="my-3" />
 
-                <MudSelect T="int" @bind-Value="_bestOf" Label="Best of (sets)"
-                           Variant="Variant.Outlined"
-                           Style="max-width: 160px;" Class="mb-2">
-                    <MudSelectItem T="int" Value="1">1</MudSelectItem>
-                    <MudSelectItem T="int" Value="3">3</MudSelectItem>
-                    <MudSelectItem T="int" Value="5">5</MudSelectItem>
-                    <MudSelectItem T="int" Value="7">7</MudSelectItem>
-                </MudSelect>
+                <MudText Typo="Typo.subtitle2" Class="mb-1">Match Format</MudText>
+                <MudRadioGroup @bind-Value="_isFixedSets">
+                    <MudStack Row="true" Spacing="2">
+                        <MudRadio Value="false" Color="Color.Primary">Best of</MudRadio>
+                        <MudRadio Value="true" Color="Color.Primary">Fixed sets</MudRadio>
+                    </MudStack>
+                </MudRadioGroup>
+                @if (!_isFixedSets)
+                {
+                    <MudSelect T="int" @bind-Value="_bestOf" Label="Best of (sets)"
+                               Variant="Variant.Outlined"
+                               Style="max-width: 160px;" Class="mb-2">
+                        <MudSelectItem T="int" Value="1">1</MudSelectItem>
+                        <MudSelectItem T="int" Value="3">3</MudSelectItem>
+                        <MudSelectItem T="int" Value="5">5</MudSelectItem>
+                        <MudSelectItem T="int" Value="7">7</MudSelectItem>
+                    </MudSelect>
+                }
+                else
+                {
+                    <MudNumericField @bind-Value="_fixedSetCount" Label="Number of sets"
+                                     Variant="Variant.Outlined" Min="1" Max="20"
+                                     Style="max-width: 160px;" Class="mb-2" />
+                }
 
                 <MudNumericField @bind-Value="_gamesPerSet" Label="Games per set"
                                  Variant="Variant.Outlined" Min="1" Max="12"
@@ -504,6 +520,8 @@
     private bool _unlimitedDeuce = true;
     private int _deuceLimit = 1;
     private int _bestOf = 3;
+    private bool _isFixedSets;
+    private int _fixedSetCount = 3;
     private int _gamesPerSet = 6;
     private SetWinMode _setWinMode = SetWinMode.WinBy2;
 
@@ -1058,6 +1076,8 @@
             UnlimitedDeuce = _unlimitedDeuce,
             DeuceLimit = _unlimitedDeuce ? 0 : _deuceLimit,
             BestOf = _bestOf,
+            IsFixedSets = _isFixedSets,
+            FixedSetCount = _fixedSetCount,
             GamesPerSet = _gamesPerSet,
             SetWinMode = _setWinMode,
             ServerChoice = "random"
@@ -1085,6 +1105,8 @@
         public bool UnlimitedDeuce { get; set; } = true;
         public int DeuceLimit { get; set; }
         public int BestOf { get; set; } = 3;
+        public bool IsFixedSets { get; set; }
+        public int FixedSetCount { get; set; } = 3;
         public int GamesPerSet { get; set; } = 6;
         public SetWinMode SetWinMode { get; set; } = SetWinMode.WinBy2;
         public string ServerChoice { get; set; } = "random";

--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -192,13 +192,40 @@
                         </MudItem>
                     </MudGrid>
 
-                    <MudSelect @bind-Value="Model.BestOf" Label="Best Of" Variant="Variant.Text">
-                        <MudSelectItem T="int" Value="1">Best of 1</MudSelectItem>
-                        <MudSelectItem T="int" Value="3">Best of 3</MudSelectItem>
-                        <MudSelectItem T="int" Value="5">Best of 5</MudSelectItem>
-                    </MudSelect>
+                    <MudText Typo="Typo.subtitle2" Class="mt-2 mb-1">Match Format</MudText>
+                    <MudRadioGroup @bind-Value="Model.MatchFormat">
+                        <MudStack Row="true" Spacing="2">
+                            <MudRadio Value="MatchFormatType.BestOf" Color="Color.Primary">Best of</MudRadio>
+                            <MudRadio Value="MatchFormatType.FixedSets" Color="Color.Primary">Fixed sets</MudRadio>
+                        </MudStack>
+                    </MudRadioGroup>
+                    @if (Model.MatchFormat == MatchFormatType.BestOf)
+                    {
+                        <MudSelect @bind-Value="Model.BestOf" Label="Best of (sets)" Variant="Variant.Outlined"
+                                   Style="max-width: 160px;" Class="mt-1">
+                            <MudSelectItem T="int" Value="1">1</MudSelectItem>
+                            <MudSelectItem T="int" Value="3">3</MudSelectItem>
+                            <MudSelectItem T="int" Value="5">5</MudSelectItem>
+                            <MudSelectItem T="int" Value="7">7</MudSelectItem>
+                        </MudSelect>
+                    }
+                    else
+                    {
+                        <MudNumericField @bind-Value="Model.NumberOfSets" Label="Number of sets to play"
+                                         Variant="Variant.Outlined" Min="1" Max="20"
+                                         Style="max-width: 160px;" Class="mt-1" />
+                    }
 
-                    <MudCheckBox @bind-Value="Model.RequireVerification" Label="Require admin verification of results" />
+                    <MudText Typo="Typo.subtitle2" Class="mt-3 mb-1">League Scoring</MudText>
+                    <MudRadioGroup @bind-Value="Model.LeagueScoring">
+                        <MudStack Spacing="1">
+                            <MudRadio Value="LeagueScoringMode.WinPoints" Color="Color.Primary">3 points for a win, 1 for a draw</MudRadio>
+                            <MudRadio Value="LeagueScoringMode.SetsWon" Color="Color.Primary">1 point per set won</MudRadio>
+                            <MudRadio Value="LeagueScoringMode.GamesWon" Color="Color.Primary">1 point per game won</MudRadio>
+                        </MudStack>
+                    </MudRadioGroup>
+
+                    <MudCheckBox @bind-Value="Model.RequireVerification" Label="Require admin verification of results" Class="mt-2" />
                 </MudStack>
 
                 @if (!string.IsNullOrWhiteSpace(_serverError))
@@ -1324,6 +1351,9 @@
         public int BestOf { get; set; } = 3;
         public bool RequireVerification { get; set; } = false;
         public int? TeamSize { get; set; }
+        public MatchFormatType MatchFormat { get; set; } = MatchFormatType.BestOf;
+        public int NumberOfSets { get; set; } = 3;
+        public LeagueScoringMode LeagueScoring { get; set; } = LeagueScoringMode.WinPoints;
     }
 
     // UI-only enums that separate category (Male/Female/Mixed) from the format shown in the
@@ -1497,7 +1527,10 @@
                 EventId = comp.EventId,
                 BestOf = comp.BestOf,
                 RequireVerification = comp.RequireVerification,
-                TeamSize = comp.TeamSize
+                TeamSize = comp.TeamSize,
+                MatchFormat = comp.MatchFormat,
+                NumberOfSets = comp.NumberOfSets,
+                LeagueScoring = comp.LeagueScoring
             };
             _stages = comp.Stages.ToList();
             _participants = comp.Participants.ToList();
@@ -1809,6 +1842,9 @@
         comp.BestOf = Model.BestOf;
         comp.RequireVerification = Model.RequireVerification;
         comp.TeamSize = Model.TeamSize;
+        comp.MatchFormat = Model.MatchFormat;
+        comp.NumberOfSets = Model.NumberOfSets;
+        comp.LeagueScoring = Model.LeagueScoring;
     }
 
     // ── Stages ──────────────────────────────────────────────────────────────
@@ -3284,8 +3320,14 @@
                 foreach (var pid in pids)
                 {
                     bool win = pid == f.WinnerPlayerId;
+                    int points = Model.LeagueScoring switch
+                    {
+                        LeagueScoringMode.SetsWon => ParseSetsWon(f.ResultSummary, pid == f.Player1Id || pid == f.Player3Id),
+                        LeagueScoringMode.GamesWon => ParseGamesWon(f.ResultSummary, pid == f.Player1Id || pid == f.Player3Id),
+                        _ => win ? 3 : (!f.WinnerPlayerId.HasValue ? 1 : 0) // WinPoints: 3 win, 1 draw, 0 loss
+                    };
                     var cur = pts[pid];
-                    pts[pid] = (cur.Points + (win ? 3 : 0), cur.Won + (win ? 1 : 0));
+                    pts[pid] = (cur.Points + points, cur.Won + (win ? 1 : 0));
                 }
             }
             seededPlayers = pts
@@ -3317,6 +3359,37 @@
             .ToListAsync();
 
         Snackbar.Add($"Quarter-final fixtures seeded from standings.", Severity.Success);
+    }
+
+    // ── League scoring helpers ──────────────────────────────────────────────
+
+    /// <summary>Parse result summary like "6-4 3-6 7-5" and return sets won by side1 or side2.</summary>
+    private static int ParseSetsWon(string? resultSummary, bool isSide1)
+    {
+        if (string.IsNullOrWhiteSpace(resultSummary)) return 0;
+        int count = 0;
+        foreach (var set in resultSummary.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var parts = set.Split('-');
+            if (parts.Length != 2 || !int.TryParse(parts[0], out var g1) || !int.TryParse(parts[1], out var g2)) continue;
+            if (isSide1 && g1 > g2) count++;
+            else if (!isSide1 && g2 > g1) count++;
+        }
+        return count;
+    }
+
+    /// <summary>Parse result summary and return total games won by side1 or side2.</summary>
+    private static int ParseGamesWon(string? resultSummary, bool isSide1)
+    {
+        if (string.IsNullOrWhiteSpace(resultSummary)) return 0;
+        int total = 0;
+        foreach (var set in resultSummary.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var parts = set.Split('-');
+            if (parts.Length != 2 || !int.TryParse(parts[0], out var g1) || !int.TryParse(parts[1], out var g2)) continue;
+            total += isSide1 ? g1 : g2;
+        }
+        return total;
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────

--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -533,6 +533,8 @@
 
         _state.GameScoring = result.GameScoring;
         _state.BestOf = result.BestOf;
+        _state.IsFixedSets = result.IsFixedSets;
+        _state.FixedSetCount = result.FixedSetCount;
         _state.GamesFirstTo = result.GamesPerSet;
         _state.UnlimitedDeuce = result.UnlimitedDeuce;
         _state.DeuceLimit = result.DeuceLimit;
@@ -594,6 +596,8 @@
             CourtId = _selectedCourtId,
             GameScoring = _state.GameScoring,
             BestOf = _state.BestOf,
+            IsFixedSets = _state.IsFixedSets,
+            FixedSetCount = _state.FixedSetCount,
             GamesFirstTo = _state.GamesFirstTo,
             UnlimitedDeuce = _state.UnlimitedDeuce,
             DeuceLimit = _state.DeuceLimit,
@@ -879,6 +883,8 @@
                     ScoreService.RestoreFromGameState(_state, history.Peek());
                 _state.GameScoring = CurrentMatch.GameScoring;
                 _state.BestOf = CurrentMatch.BestOf;
+                _state.IsFixedSets = CurrentMatch.IsFixedSets;
+                _state.FixedSetCount = CurrentMatch.FixedSetCount;
                 _state.GamesFirstTo = CurrentMatch.GamesFirstTo;
                 _state.UnlimitedDeuce = CurrentMatch.UnlimitedDeuce;
                 _state.DeuceLimit = CurrentMatch.DeuceLimit;

--- a/DropShot/Data/Migrations/20260418004325_AddMatchFormatAndLeagueScoring.Designer.cs
+++ b/DropShot/Data/Migrations/20260418004325_AddMatchFormatAndLeagueScoring.Designer.cs
@@ -4,16 +4,19 @@ using DropShot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace DropShot.Migrations
+namespace DropShot.Data.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260418004325_AddMatchFormatAndLeagueScoring")]
+    partial class AddMatchFormatAndLeagueScoring
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DropShot/Data/Migrations/20260418004325_AddMatchFormatAndLeagueScoring.cs
+++ b/DropShot/Data/Migrations/20260418004325_AddMatchFormatAndLeagueScoring.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropShot.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMatchFormatAndLeagueScoring : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<byte>(
+                name: "LeagueScoring",
+                table: "Competition",
+                type: "tinyint",
+                nullable: false,
+                defaultValue: (byte)0);
+
+            migrationBuilder.AddColumn<byte>(
+                name: "MatchFormat",
+                table: "Competition",
+                type: "tinyint",
+                nullable: false,
+                defaultValue: (byte)0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "NumberOfSets",
+                table: "Competition",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "LeagueScoring",
+                table: "Competition");
+
+            migrationBuilder.DropColumn(
+                name: "MatchFormat",
+                table: "Competition");
+
+            migrationBuilder.DropColumn(
+                name: "NumberOfSets",
+                table: "Competition");
+        }
+    }
+}

--- a/DropShot/Models/Competition.cs
+++ b/DropShot/Models/Competition.cs
@@ -1,5 +1,18 @@
 ﻿namespace DropShot.Models
 {
+    public enum MatchFormatType : byte
+    {
+        BestOf = 1,
+        FixedSets = 2
+    }
+
+    public enum LeagueScoringMode : byte
+    {
+        WinPoints = 1,
+        SetsWon = 2,
+        GamesWon = 3
+    }
+
     public enum CompetitionFormat
     {
         Singles = 1,
@@ -47,6 +60,10 @@
         /// Number of players per team (or pair). Defaults: 2 for Doubles/MixedDoubles, 4 for MixedTeam.
         /// </summary>
         public int? TeamSize { get; set; }
+
+        public MatchFormatType MatchFormat { get; set; } = MatchFormatType.BestOf;
+        public int NumberOfSets { get; set; } = 3;
+        public LeagueScoringMode LeagueScoring { get; set; } = LeagueScoringMode.WinPoints;
 
         public RulesSet? Rules { get; set; }
         public Club? HostClub { get; set; }

--- a/DropShot/Models/Match.cs
+++ b/DropShot/Models/Match.cs
@@ -18,4 +18,6 @@ public class Match
     public bool UnlimitedDeuce { get; set; } = true;
     public int DeuceLimit { get; set; } = 1;
     public SetWinMode SetWinMode { get; set; } = SetWinMode.WinBy2;
+    public bool IsFixedSets { get; set; }
+    public int FixedSetCount { get; set; } = 3;
 }

--- a/DropShot/Models/TennisMatchState.cs
+++ b/DropShot/Models/TennisMatchState.cs
@@ -30,4 +30,6 @@ public class TennisMatchState
     public int DeuceLimit { get; set; } = 1;
     public SetWinMode SetWinMode { get; set; } = SetWinMode.WinBy2;
     public bool GameScoring { get; set; } = true;
+    public bool IsFixedSets { get; set; }
+    public int FixedSetCount { get; set; } = 3;
 }

--- a/DropShot/Services/CompetitionProgressionService.cs
+++ b/DropShot/Services/CompetitionProgressionService.cs
@@ -104,6 +104,9 @@ public static class CompetitionProgressionService
             .Select(p => p.PlayerId)
             .ToListAsync();
 
+        var comp = await db.Competition.AsNoTracking().FirstOrDefaultAsync(c => c.CompetitionID == competitionId);
+        var scoringMode = comp?.LeagueScoring ?? LeagueScoringMode.WinPoints;
+
         var pts = activePids.ToDictionary(pid => pid, _ => (Points: 0, Won: 0));
         foreach (var f in rrFixtures.Where(f => f.Status == FixtureStatus.Completed && f.WinnerPlayerId.HasValue))
         {
@@ -113,8 +116,15 @@ public static class CompetitionProgressionService
             foreach (var pid in pids)
             {
                 bool win = pid == f.WinnerPlayerId;
+                bool isSide1 = pid == f.Player1Id || pid == f.Player3Id;
+                int points = scoringMode switch
+                {
+                    LeagueScoringMode.SetsWon => ParseSetsWon(f.ResultSummary, isSide1),
+                    LeagueScoringMode.GamesWon => ParseGamesWon(f.ResultSummary, isSide1),
+                    _ => win ? 3 : (!f.WinnerPlayerId.HasValue ? 1 : 0)
+                };
                 var cur = pts[pid];
-                pts[pid] = (cur.Points + (win ? 3 : 0), cur.Won + (win ? 1 : 0));
+                pts[pid] = (cur.Points + points, cur.Won + (win ? 1 : 0));
             }
         }
 
@@ -448,5 +458,32 @@ public static class CompetitionProgressionService
             targets[i].Player1Id = i     < winners.Count ? winners[i]     : null;
             targets[i].Player2Id = p2Idx < winners.Count ? winners[p2Idx] : null;
         }
+    }
+
+    private static int ParseSetsWon(string? resultSummary, bool isSide1)
+    {
+        if (string.IsNullOrWhiteSpace(resultSummary)) return 0;
+        int count = 0;
+        foreach (var set in resultSummary.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var parts = set.Split('-');
+            if (parts.Length != 2 || !int.TryParse(parts[0], out var g1) || !int.TryParse(parts[1], out var g2)) continue;
+            if (isSide1 && g1 > g2) count++;
+            else if (!isSide1 && g2 > g1) count++;
+        }
+        return count;
+    }
+
+    private static int ParseGamesWon(string? resultSummary, bool isSide1)
+    {
+        if (string.IsNullOrWhiteSpace(resultSummary)) return 0;
+        int total = 0;
+        foreach (var set in resultSummary.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var parts = set.Split('-');
+            if (parts.Length != 2 || !int.TryParse(parts[0], out var g1) || !int.TryParse(parts[1], out var g2)) continue;
+            total += isSide1 ? g1 : g2;
+        }
+        return total;
     }
 }

--- a/DropShot/Services/TennisScoreService.cs
+++ b/DropShot/Services/TennisScoreService.cs
@@ -114,8 +114,15 @@ public class TennisScoreService
         s.UserPoints = s.OppPoints = 0;
         s.IsTieBreak = false;
 
-        if (s.UserSets == GetMaxSetsToWin(s.BestOf) || s.OppSets == GetMaxSetsToWin(s.BestOf))
+        if (s.IsFixedSets)
+        {
+            if (s.UserSets + s.OppSets >= s.FixedSetCount)
+                s.IsMatchEnded = true;
+        }
+        else if (s.UserSets == GetMaxSetsToWin(s.BestOf) || s.OppSets == GetMaxSetsToWin(s.BestOf))
+        {
             s.IsMatchEnded = true;
+        }
     }
 
     public string? EndMatch(TennisMatchState s, Match match, bool isDoubles)


### PR DESCRIPTION
## Summary
- **Fixed Sets format**: Play all N sets (winner = most sets won), as alternative to Best-of (ends when majority reached)
- **League Scoring modes**: 3 options — win points (3W/1D), sets won, games won
- Updated scoring engine, competition page, match setup wizard, and standings calculations
- New DB migration for MatchFormat, NumberOfSets, LeagueScoring columns

## Test plan
- [ ] Create competition with Fixed Sets = 4 — verify all 4 sets are played in a match
- [ ] Create competition with Best of 3 — verify existing behaviour unchanged
- [ ] Set scoring to "Sets Won", complete matches — verify standings reflect total sets
- [ ] Set scoring to "Games Won" — verify standings reflect total games
- [ ] Verify seeding from standings respects the scoring mode
- [ ] In match setup wizard, select Fixed Sets — verify numeric field appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)