### PR TITLE
Fix ViewCompetition SQL timeout

### DIFF
--- a/DropShot/Components/Pages/ViewCompetition.razor
+++ b/DropShot/Components/Pages/ViewCompetition.razor
@@ -313,6 +313,7 @@ else
             .Include(c => c.Fixtures).ThenInclude(f => f.AwayTeam)
             .Include(c => c.Fixtures).ThenInclude(f => f.TeamMatchSets)
             .Include(c => c.Teams).ThenInclude(t => t.Captain)
+            .AsSplitQuery()
             .AsNoTracking()
             .FirstOrDefaultAsync(c => c.CompetitionID == Id);
 


### PR DESCRIPTION
## Summary
- Add `.AsSplitQuery()` to the ViewCompetition query (same fix as CompetitionPage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)