### PR TITLE
Add player names and score card to result emails

### DIFF
--- a/DropShot/Services/EmailTemplateService.cs
+++ b/DropShot/Services/EmailTemplateService.cs
@@ -186,27 +186,64 @@ public class EmailTemplateService
 
     // ── Match / result emails ────────────────────────────────────────────────
 
-    public string MatchResultEmail(string fixtureTitle, string resultSummary)
+    public string MatchResultEmail(string fixtureTitle, string resultSummary, string side1Name, string side2Name, string? winnerName)
     {
         var body = $@"
 <h2 style=""margin:0 0 16px 0;font-size:22px;color:#1b5e20;"">Match Result</h2>
 <p style=""margin:0 0 12px 0;"">The result for your match has been recorded:</p>
-{InfoBox($@"<strong>{Encode(fixtureTitle)}</strong><br>{Encode(resultSummary)}")}
+{InfoBox($@"<strong>{Encode(fixtureTitle)}</strong>")}
+{ScoreCard(side1Name, side2Name, resultSummary, winnerName)}
 <p style=""margin:16px 0 0 0;font-size:13px;color:#888888;"">This is an automated notification from DropShot.</p>";
 
-        return WrapInBaseLayout($"Match Result: {fixtureTitle}", body, $"Result recorded: {resultSummary}");
+        return WrapInBaseLayout($"Match Result: {fixtureTitle}", body, $"Result recorded: {side1Name} vs {side2Name} — {resultSummary}");
     }
 
-    public string AdminVerificationEmail(string fixtureTitle, string resultSummary, string verifyUrl)
+    public string AdminVerificationEmail(string fixtureTitle, string resultSummary, string verifyUrl, string side1Name, string side2Name, string? winnerName)
     {
         var body = $@"
 <h2 style=""margin:0 0 16px 0;font-size:22px;color:#1b5e20;"">Result Verification Required</h2>
 <p style=""margin:0 0 12px 0;"">A result has been submitted and requires your verification:</p>
-{InfoBox($@"<strong>{Encode(fixtureTitle)}</strong><br>{Encode(resultSummary)}")}
+{InfoBox($@"<strong>{Encode(fixtureTitle)}</strong>")}
+{ScoreCard(side1Name, side2Name, resultSummary, winnerName)}
 {ActionButton("Verify Result", verifyUrl)}
 <p style=""margin:16px 0 0 0;font-size:13px;color:#888888;"">Please review and verify this result at your earliest convenience.</p>";
 
-        return WrapInBaseLayout($"Verify Result: {fixtureTitle}", body, $"Result verification needed: {fixtureTitle}");
+        return WrapInBaseLayout($"Verify Result: {fixtureTitle}", body, $"Result verification needed: {side1Name} vs {side2Name}");
+    }
+
+    private string ScoreCard(string side1Name, string side2Name, string resultSummary, string? winnerName)
+    {
+        var sets = resultSummary.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        var setHeaders = "";
+        var side1Scores = "";
+        var side2Scores = "";
+        for (int i = 0; i < sets.Length; i++)
+        {
+            var parts = sets[i].Split('-');
+            var g1 = parts.Length > 0 ? parts[0] : "";
+            var g2 = parts.Length > 1 ? parts[1] : "";
+            setHeaders += $@"<th style=""padding:6px 12px;text-align:center;font-size:13px;color:#888;"">Set {i + 1}</th>";
+            side1Scores += $@"<td style=""padding:6px 12px;text-align:center;font-size:16px;font-weight:bold;"">{Encode(g1)}</td>";
+            side2Scores += $@"<td style=""padding:6px 12px;text-align:center;font-size:16px;font-weight:bold;"">{Encode(g2)}</td>";
+        }
+
+        var side1Style = winnerName == side1Name ? "color:#1b5e20;font-weight:bold;" : "";
+        var side2Style = winnerName == side2Name ? "color:#1b5e20;font-weight:bold;" : "";
+
+        return $@"<table role=""presentation"" cellpadding=""0"" cellspacing=""0"" border=""0"" width=""100%"" style=""margin:16px 0;border-collapse:collapse;"">
+    <tr style=""border-bottom:2px solid #e0e0e0;"">
+        <th style=""padding:6px 12px;text-align:left;font-size:13px;color:#888;"">Player</th>
+        {setHeaders}
+    </tr>
+    <tr style=""border-bottom:1px solid #f0f0f0;background-color:#fafafa;"">
+        <td style=""padding:8px 12px;font-size:15px;{side1Style}"">{Encode(side1Name)}{(winnerName == side1Name ? " &#9733;" : "")}</td>
+        {side1Scores}
+    </tr>
+    <tr style=""background-color:#ffffff;"">
+        <td style=""padding:8px 12px;font-size:15px;{side2Style}"">{Encode(side2Name)}{(winnerName == side2Name ? " &#9733;" : "")}</td>
+        {side2Scores}
+    </tr>
+</table>";
     }
 
     // ── Club link request emails ─────────────────────────────────────────────

--- a/DropShot/Services/ResultVerificationService.cs
+++ b/DropShot/Services/ResultVerificationService.cs
@@ -12,8 +12,10 @@ public class ResultVerificationService(EmailService emailService, EmailTemplateS
     {
         var title = FixtureTitle(fixture);
         var resultSummary = fixture.ResultSummary ?? "";
-        var subject = $"Match result: {title}";
-        var html = emailTemplateService.MatchResultEmail(title, resultSummary);
+        var (side1, side2) = SideNames(fixture);
+        var winnerName = WinnerName(fixture);
+        var subject = $"Match result: {side1} vs {side2}";
+        var html = emailTemplateService.MatchResultEmail(title, resultSummary, side1, side2, winnerName);
 
         var emails = new[] { fixture.Player1, fixture.Player2, fixture.Player3, fixture.Player4 }
             .Where(p => p?.Email != null)
@@ -29,9 +31,11 @@ public class ResultVerificationService(EmailService emailService, EmailTemplateS
         if (fixture.VerificationToken == null) return;
 
         var title = FixtureTitle(fixture);
+        var (side1, side2) = SideNames(fixture);
+        var winnerName = WinnerName(fixture);
         var verifyUrl = $"{BaseUrl}/verify-result/{fixture.VerificationToken}";
-        var subject = $"Result verification required: {title}";
-        var html = emailTemplateService.AdminVerificationEmail(title, fixture.ResultSummary ?? "", verifyUrl);
+        var subject = $"Result verification required: {side1} vs {side2}";
+        var html = emailTemplateService.AdminVerificationEmail(title, fixture.ResultSummary ?? "", verifyUrl, side1, side2, winnerName);
 
         await Task.WhenAll(adminEmails.Select(email => SendSafe(email, subject, html, "admin verification", isHtml: true)));
     }
@@ -50,6 +54,37 @@ public class ResultVerificationService(EmailService emailService, EmailTemplateS
     {
         var name = fixture.Competition?.CompetitionName ?? "Competition";
         return fixture.FixtureLabel != null ? $"{name} — {fixture.FixtureLabel}" : name;
+    }
+
+    private static (string side1, string side2) SideNames(CompetitionFixture f)
+    {
+        if (f.HomeTeam != null || f.AwayTeam != null)
+            return (f.HomeTeam?.Name ?? "TBD", f.AwayTeam?.Name ?? "TBD");
+
+        var s1 = new[] { f.Player1?.DisplayName, f.Player3?.DisplayName }
+            .Where(n => n != null);
+        var s2 = new[] { f.Player2?.DisplayName, f.Player4?.DisplayName }
+            .Where(n => n != null);
+        return (
+            s1.Any() ? string.Join(" & ", s1) : "TBD",
+            s2.Any() ? string.Join(" & ", s2) : "TBD"
+        );
+    }
+
+    private static string? WinnerName(CompetitionFixture f)
+    {
+        if (f.WinnerTeamId.HasValue)
+        {
+            if (f.HomeTeam != null && f.WinnerTeamId == f.HomeTeamId) return f.HomeTeam.Name;
+            if (f.AwayTeam != null && f.WinnerTeamId == f.AwayTeamId) return f.AwayTeam.Name;
+        }
+        if (f.WinnerPlayerId.HasValue)
+        {
+            var (side1, side2) = SideNames(f);
+            if (f.WinnerPlayerId == f.Player1Id) return side1;
+            if (f.WinnerPlayerId == f.Player2Id) return side2;
+        }
+        return null;
     }
 
     private async Task SendSafe(string email, string subject, string body, string context, bool isHtml = false)


### PR DESCRIPTION
## Summary
- Add player/team names to result notification and admin verification emails
- Subject lines now show "Player A vs Player B" instead of just the competition name
- Replace plain text result summary with a formatted score card table:
  - Player names with winner indicated by a star
  - Per-set scores in columns
  - Winner row highlighted in green
- Supports singles (Player1 vs Player2), doubles (P1 & P3 vs P2 & P4), and team fixtures

## Test plan
- [ ] Submit a score for a singles match — verify email shows both player names and score card
- [ ] Submit a score for a doubles match — verify paired names appear
- [ ] Check admin verification email — verify score card and verify button both appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)