### PR TITLE
Add games per set to competition config

### DIFF
--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -216,6 +216,10 @@
                                          Style="max-width: 160px;" Class="mt-1" />
                     }
 
+                    <MudNumericField @bind-Value="Model.GamesPerSet" Label="Games per set"
+                                     Variant="Variant.Outlined" Min="1" Max="12"
+                                     Style="max-width: 160px;" Class="mt-1" />
+
                     <MudText Typo="Typo.subtitle2" Class="mt-3 mb-1">League Scoring</MudText>
                     <MudRadioGroup @bind-Value="Model.LeagueScoring">
                         <MudStack Spacing="1">
@@ -1353,6 +1357,7 @@
         public int? TeamSize { get; set; }
         public MatchFormatType MatchFormat { get; set; } = MatchFormatType.BestOf;
         public int NumberOfSets { get; set; } = 3;
+        public int GamesPerSet { get; set; } = 6;
         public LeagueScoringMode LeagueScoring { get; set; } = LeagueScoringMode.WinPoints;
     }
 
@@ -1530,6 +1535,7 @@
                 TeamSize = comp.TeamSize,
                 MatchFormat = comp.MatchFormat,
                 NumberOfSets = comp.NumberOfSets,
+                GamesPerSet = comp.GamesPerSet,
                 LeagueScoring = comp.LeagueScoring
             };
             _stages = comp.Stages.ToList();
@@ -1844,6 +1850,7 @@
         comp.TeamSize = Model.TeamSize;
         comp.MatchFormat = Model.MatchFormat;
         comp.NumberOfSets = Model.NumberOfSets;
+        comp.GamesPerSet = Model.GamesPerSet;
         comp.LeagueScoring = Model.LeagueScoring;
     }
 

--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -968,9 +968,11 @@
             && !string.IsNullOrEmpty(_value) && !string.IsNullOrEmpty(_value2))
         {
             _state.BestOf = BestOfOverride ?? _competitionFixture?.Competition?.BestOf ?? 3;
+            _state.IsFixedSets = _competitionFixture?.Competition?.MatchFormat == MatchFormatType.FixedSets;
+            _state.FixedSetCount = _competitionFixture?.Competition?.NumberOfSets ?? 3;
             _state.GameScoring = true;
             _state.UnlimitedDeuce = true;
-            _state.GamesFirstTo = 6;
+            _state.GamesFirstTo = _competitionFixture?.Competition?.GamesPerSet ?? 6;
             _selectedCourtId = _competitionFixture?.CourtId;
             _player1Id = _competitionFixture?.Player1Id;
             _player2Id = _competitionFixture?.Player2Id;

--- a/DropShot/Data/Migrations/20260418013447_AddCompetitionGamesPerSet.Designer.cs
+++ b/DropShot/Data/Migrations/20260418013447_AddCompetitionGamesPerSet.Designer.cs
@@ -4,16 +4,19 @@ using DropShot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace DropShot.Migrations
+namespace DropShot.Data.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260418013447_AddCompetitionGamesPerSet")]
+    partial class AddCompetitionGamesPerSet
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DropShot/Data/Migrations/20260418013447_AddCompetitionGamesPerSet.cs
+++ b/DropShot/Data/Migrations/20260418013447_AddCompetitionGamesPerSet.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropShot.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCompetitionGamesPerSet : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "GamesPerSet",
+                table: "Competition",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "GamesPerSet",
+                table: "Competition");
+        }
+    }
+}

--- a/DropShot/Models/Competition.cs
+++ b/DropShot/Models/Competition.cs
@@ -63,6 +63,7 @@
 
         public MatchFormatType MatchFormat { get; set; } = MatchFormatType.BestOf;
         public int NumberOfSets { get; set; } = 3;
+        public int GamesPerSet { get; set; } = 6;
         public LeagueScoringMode LeagueScoring { get; set; } = LeagueScoringMode.WinPoints;
 
         public RulesSet? Rules { get; set; }


### PR DESCRIPTION
## Summary
- Add \`GamesPerSet\` field to Competition model (default 6, range 1-12)
- Show numeric field on competition page next to Best of / Fixed sets
- Use the competition's GamesPerSet when starting a match from a fixture (was hardcoded to 6)
- Also wire MatchFormat and NumberOfSets through to the scoring engine for competition fixtures

## Test plan
- [ ] Set games per set to 4 on a competition, play a fixture — verify sets end at 4 games
- [ ] Verify default of 6 for existing competitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)