### PR TITLE
Add SetWinMode to competition and validate submitted scores

### DIFF
--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -220,6 +220,18 @@
                                      Variant="Variant.Outlined" Min="1" Max="12"
                                      Style="max-width: 160px;" Class="mt-1" />
 
+                    <MudText Typo="Typo.subtitle2" Class="mt-2 mb-1">Set wins on</MudText>
+                    <MudRadioGroup @bind-Value="Model.SetWinMode">
+                        <MudStack Row="true" Spacing="2">
+                            <MudTooltip Text="Must win by 2 clear games; tie-break at games-all.">
+                                <MudRadio Value="SetWinMode.WinBy2" Color="Color.Primary">Win by 2</MudRadio>
+                            </MudTooltip>
+                            <MudTooltip Text="First player to reach the games-per-set target wins the set.">
+                                <MudRadio Value="SetWinMode.FirstTo" Color="Color.Primary">First to</MudRadio>
+                            </MudTooltip>
+                        </MudStack>
+                    </MudRadioGroup>
+
                     <MudText Typo="Typo.subtitle2" Class="mt-3 mb-1">League Scoring</MudText>
                     <MudRadioGroup @bind-Value="Model.LeagueScoring">
                         <MudStack Spacing="1">
@@ -1358,6 +1370,7 @@
         public MatchFormatType MatchFormat { get; set; } = MatchFormatType.BestOf;
         public int NumberOfSets { get; set; } = 3;
         public int GamesPerSet { get; set; } = 6;
+        public SetWinMode SetWinMode { get; set; } = SetWinMode.WinBy2;
         public LeagueScoringMode LeagueScoring { get; set; } = LeagueScoringMode.WinPoints;
     }
 
@@ -1536,6 +1549,7 @@
                 MatchFormat = comp.MatchFormat,
                 NumberOfSets = comp.NumberOfSets,
                 GamesPerSet = comp.GamesPerSet,
+                SetWinMode = comp.SetWinMode,
                 LeagueScoring = comp.LeagueScoring
             };
             _stages = comp.Stages.ToList();
@@ -1851,6 +1865,7 @@
         comp.MatchFormat = Model.MatchFormat;
         comp.NumberOfSets = Model.NumberOfSets;
         comp.GamesPerSet = Model.GamesPerSet;
+        comp.SetWinMode = Model.SetWinMode;
         comp.LeagueScoring = Model.LeagueScoring;
     }
 

--- a/DropShot/Components/SubmitScoreDialog.razor
+++ b/DropShot/Components/SubmitScoreDialog.razor
@@ -20,7 +20,9 @@
             {
                 <MudText Typo="Typo.caption" Color="Color.Secondary">
                     @Fixture.Competition.CompetitionName@(Fixture.FixtureLabel != null ? $" — {Fixture.FixtureLabel}" : "")
-                    &nbsp;·&nbsp;Best of @_bestOf
+                    &nbsp;·&nbsp;@(Fixture.Competition?.MatchFormat == MatchFormatType.FixedSets ? $"{_bestOf} sets" : $"Best of {_bestOf}")
+                    &nbsp;·&nbsp;@_gamesPerSet games/set
+                    &nbsp;·&nbsp;@(_setWinMode == SetWinMode.WinBy2 ? "Win by 2" : "First to")
                 </MudText>
             }
 
@@ -99,6 +101,8 @@
     private static readonly Dictionary<string, object> _numericAttrs = new() { { "pattern", "[0-9]*" } };
 
     private int _bestOf = 3;
+    private int _gamesPerSet = 6;
+    private SetWinMode _setWinMode = SetWinMode.WinBy2;
     private int?[] _score1 = new int?[3];
     private int?[] _score2 = new int?[3];
     private MudTextField<int?>[] _f1 = new MudTextField<int?>[3];
@@ -111,7 +115,12 @@
 
     protected override void OnParametersSet()
     {
-        int newBestOf = Math.Max(1, Fixture.Competition?.BestOf ?? 3);
+        var comp = Fixture.Competition;
+        int newBestOf = comp?.MatchFormat == MatchFormatType.FixedSets
+            ? Math.Max(1, comp.NumberOfSets)
+            : Math.Max(1, comp?.BestOf ?? 3);
+        _gamesPerSet = comp?.GamesPerSet ?? 6;
+        _setWinMode = comp?.SetWinMode ?? SetWinMode.WinBy2;
 
         var s1Parts = new[] { Fixture.Player1?.DisplayName, Fixture.Player3?.DisplayName }
             .Where(n => n != null).ToList();
@@ -185,13 +194,56 @@
             return;
         }
 
-        // Validate no tied sets
+        // Validate each set score against competition rules
         for (int i = 0; i < _bestOf; i++)
         {
-            if (_score1[i].HasValue && _score2[i].HasValue && _score1[i] == _score2[i])
+            if (!_score1[i].HasValue || !_score2[i].HasValue) continue;
+            int s1 = _score1[i]!.Value, s2 = _score2[i]!.Value;
+
+            if (s1 == s2)
             {
-                _error = $"Set {i + 1} is a tie — one player must win each set.";
+                _error = $"Set {i + 1}: scores are tied — one player must win each set.";
                 return;
+            }
+
+            int winner = Math.Max(s1, s2);
+            int loser = Math.Min(s1, s2);
+
+            if (_setWinMode == SetWinMode.FirstTo)
+            {
+                // First to: winner must have exactly GamesPerSet, loser must have fewer
+                if (winner != _gamesPerSet)
+                {
+                    _error = $"Set {i + 1}: winner must reach exactly {_gamesPerSet} games (First to mode).";
+                    return;
+                }
+                if (loser >= _gamesPerSet)
+                {
+                    _error = $"Set {i + 1}: loser cannot have {loser} games when target is {_gamesPerSet}.";
+                    return;
+                }
+            }
+            else
+            {
+                // Win by 2: winner needs at least GamesPerSet games
+                if (winner < _gamesPerSet)
+                {
+                    _error = $"Set {i + 1}: winner must have at least {_gamesPerSet} games.";
+                    return;
+                }
+                // Normal win: exactly GamesPerSet with loser having at most GamesPerSet-2
+                // Or tie-break: GamesPerSet+1 vs GamesPerSet (e.g. 7-6)
+                // Or extended: both above GamesPerSet with exactly 2 game difference
+                if (winner == _gamesPerSet && loser > _gamesPerSet - 2)
+                {
+                    _error = $"Set {i + 1}: at {_gamesPerSet} games, opponent can have at most {_gamesPerSet - 2} (Win by 2 mode). Use {_gamesPerSet + 1}-{_gamesPerSet} for a tie-break.";
+                    return;
+                }
+                if (winner > _gamesPerSet && Math.Abs(s1 - s2) != 1 && Math.Abs(s1 - s2) != 2)
+                {
+                    _error = $"Set {i + 1}: above {_gamesPerSet}-all, the margin must be 1 (tie-break) or 2 (extended).";
+                    return;
+                }
             }
         }
 

--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -973,6 +973,7 @@
             _state.GameScoring = true;
             _state.UnlimitedDeuce = true;
             _state.GamesFirstTo = _competitionFixture?.Competition?.GamesPerSet ?? 6;
+            _state.SetWinMode = _competitionFixture?.Competition?.SetWinMode ?? SetWinMode.WinBy2;
             _selectedCourtId = _competitionFixture?.CourtId;
             _player1Id = _competitionFixture?.Player1Id;
             _player2Id = _competitionFixture?.Player2Id;

--- a/DropShot/Data/Migrations/20260418014946_AddCompetitionSetWinMode.Designer.cs
+++ b/DropShot/Data/Migrations/20260418014946_AddCompetitionSetWinMode.Designer.cs
@@ -4,16 +4,19 @@ using DropShot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace DropShot.Migrations
+namespace DropShot.Data.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260418014946_AddCompetitionSetWinMode")]
+    partial class AddCompetitionSetWinMode
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DropShot/Data/Migrations/20260418014946_AddCompetitionSetWinMode.cs
+++ b/DropShot/Data/Migrations/20260418014946_AddCompetitionSetWinMode.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropShot.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCompetitionSetWinMode : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<byte>(
+                name: "SetWinMode",
+                table: "Competition",
+                type: "tinyint",
+                nullable: false,
+                defaultValue: (byte)0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SetWinMode",
+                table: "Competition");
+        }
+    }
+}

--- a/DropShot/Models/Competition.cs
+++ b/DropShot/Models/Competition.cs
@@ -64,6 +64,7 @@
         public MatchFormatType MatchFormat { get; set; } = MatchFormatType.BestOf;
         public int NumberOfSets { get; set; } = 3;
         public int GamesPerSet { get; set; } = 6;
+        public SetWinMode SetWinMode { get; set; } = SetWinMode.WinBy2;
         public LeagueScoringMode LeagueScoring { get; set; } = LeagueScoringMode.WinPoints;
 
         public RulesSet? Rules { get; set; }


### PR DESCRIPTION
## Summary
- **SetWinMode on Competition**: Win by 2 or First to, with DB migration and UI
- **Scoring engine**: Competition fixtures now use the configured SetWinMode
- **Score validation**: SubmitScoreDialog validates each set score against GamesPerSet and SetWinMode:
  - FirstTo: winner must hit exactly the target, loser must be below
  - WinBy2: validates normal wins, tie-breaks (7-6), and extended play margins
  - Shows error messages for invalid scores
- **Dialog header**: Shows full match format info (sets, games/set, win mode)
- **FixedSets**: SubmitScoreDialog now uses NumberOfSets for FixedSets format

## Test plan
- [ ] Set competition to 4 games/set, Win by 2 — submit 4-2 (valid), 4-3 (invalid), 5-4 (valid tie-break)
- [ ] Set to First to 6 — submit 6-4 (valid), 5-4 (invalid), 7-5 (invalid)
- [ ] Play a match from competition fixture — verify SetWinMode is honoured in live scoring
- [ ] Verify dialog header shows correct format info

🤖 Generated with [Claude Code](https://claude.com/claude-code)