### PR TITLE
Fix verify result toggle by adding MudProviders

### DIFF
--- a/DropShot/Components/Pages/VerifyResult.razor
+++ b/DropShot/Components/Pages/VerifyResult.razor
@@ -7,6 +7,7 @@
 
 @inject IDbContextFactory<MyDbContext> DbFactory
 
+<MudProviders />
 <PageTitle>Verify Result</PageTitle>
 
 <MudContainer MaxWidth="MaxWidth.Small" Class="mt-8">


### PR DESCRIPTION
## Summary
- Add missing \`<MudProviders />\` to the VerifyResult page
- Fixes the yellow error banner when toggling the "Modify score" switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)