### PR TITLE
Fix pending model changes warning blocking database update

### DIFF
--- a/DropShot/Data/MyDbContext.cs
+++ b/DropShot/Data/MyDbContext.cs
@@ -107,6 +107,7 @@ namespace DropShot.Data
                 entity.Property(c => c.CompetitionName).HasMaxLength(200).IsRequired();
                 entity.Property(c => c.EligibleSex).HasConversion<byte?>();
                 entity.Property(c => c.CreatorUserId).HasMaxLength(450);
+                entity.Property(c => c.RubberTemplateKey).HasMaxLength(32);
                 entity.HasIndex(c => c.CreatorUserId);
 
                 entity.HasOne(c => c.Rules)


### PR DESCRIPTION
## Summary
The merged rubbers PR declared `nvarchar(32)` for `Competition.RubberTemplateKey` in the migration and snapshot, but never added `HasMaxLength(32)` to `OnModelCreating`. That left the live model reporting the column as unconstrained, which tripped `PendingModelChangesWarning` in `dotnet ef database update` before any migration could run.

Adding a one-line property configuration in `MyDbContext` makes the model and snapshot agree. Verified locally with `dotnet ef migrations has-pending-model-changes` → "No changes have been made to the model since the last migration."

## Test plan
- [ ] `dotnet ef database update --project DropShot/DropShot.csproj --configuration Release` now runs both pending migrations to completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)