### PR TITLE
Show paired courts and drop redundant fixture label column

### DIFF
--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -836,8 +836,7 @@
 
                 <MudTable Items="@_fixtures" Dense="true" Hover="true">
                     <HeaderContent>
-                        <MudTh>Stage</MudTh>
-                        <MudTh>Label</MudTh>
+                        <MudTh>Match</MudTh>
                         <MudTh>Date / Time</MudTh>
                         <MudTh>Players</MudTh>
                         <MudTh>Court</MudTh>
@@ -846,11 +845,10 @@
                         <MudTh></MudTh>
                     </HeaderContent>
                     <RowTemplate>
-                        <MudTd>@(context.Stage?.Name ?? "—")</MudTd>
-                        <MudTd>@(context.FixtureLabel ?? "—")</MudTd>
+                        <MudTd>@(!string.IsNullOrEmpty(context.FixtureLabel) ? context.FixtureLabel : context.Stage?.Name ?? "—")</MudTd>
                         <MudTd>@(context.ScheduledAt?.ToString("dd MMM yyyy HH:mm") ?? "—")</MudTd>
                         <MudTd>@FixturePlayers(context)</MudTd>
-                        <MudTd>@(context.Court?.Name ?? "—")</MudTd>
+                        <MudTd>@FixtureCourtLabel(context)</MudTd>
                         <MudTd>
                             @if (!string.IsNullOrEmpty(context.ResultSummary))
                             {
@@ -1665,7 +1663,8 @@
                 .Include(c => c.Fixtures).ThenInclude(f => f.Player4)
                 .Include(c => c.Fixtures).ThenInclude(f => f.HomeTeam)
                 .Include(c => c.Fixtures).ThenInclude(f => f.AwayTeam)
-                .Include(c => c.Fixtures).ThenInclude(f => f.CourtPair)
+                .Include(c => c.Fixtures).ThenInclude(f => f.CourtPair).ThenInclude(cp => cp!.Court1)
+                .Include(c => c.Fixtures).ThenInclude(f => f.CourtPair).ThenInclude(cp => cp!.Court2)
                 .Include(c => c.Teams).ThenInclude(t => t.Captain)
                 .Include(c => c.MatchWindows).ThenInclude(w => w.Court)
                 .AsSplitQuery()
@@ -3922,6 +3921,20 @@
         var side2 = new[] { f.Player2?.DisplayName, f.Player4?.DisplayName }
             .Where(n => n != null).DefaultIfEmpty("TBD").Aggregate((a, b) => $"{a} & {b}");
         return $"{side1} vs {side2}";
+    }
+
+    private static string FixtureCourtLabel(CompetitionFixture f)
+    {
+        if (f.CourtPair != null)
+        {
+            var c1 = f.CourtPair.Court1?.Name;
+            var c2 = f.CourtPair.Court2?.Name;
+            if (!string.IsNullOrEmpty(c1) && !string.IsNullOrEmpty(c2))
+                return $"{c1} & {c2}";
+            if (!string.IsNullOrEmpty(f.CourtPair.Name))
+                return f.CourtPair.Name;
+        }
+        return f.Court?.Name ?? "—";
     }
 
     private static Color StatusColor(FixtureStatus s) => s switch

--- a/DropShot/Components/Pages/ViewCompetition.razor
+++ b/DropShot/Components/Pages/ViewCompetition.razor
@@ -105,7 +105,7 @@ else
                     <MudTd DataLabel="Date / Time">@(((context.Status == FixtureStatus.Completed || context.Status == FixtureStatus.AwaitingVerification) ? (context.CompletedAt ?? context.ScheduledAt) : context.ScheduledAt)?.ToString("dd MMM yyyy HH:mm") ?? "—")</MudTd>
                     <MudTd DataLabel="Match">@(context.FixtureLabel ?? "—")</MudTd>
                     <MudTd DataLabel="Players">@FixturePlayers(context)</MudTd>
-                    <MudTd DataLabel="Court">@(context.Court?.Name ?? "—")</MudTd>
+                    <MudTd DataLabel="Court">@FixtureCourtLabel(context)</MudTd>
                     <MudTd DataLabel="Status">
                         <MudChip T="string" Size="Size.Small" Color="@StatusColor(context.Status)">@context.Status</MudChip>
                     </MudTd>
@@ -305,6 +305,8 @@ else
             .Include(c => c.Participants).ThenInclude(p => p.Player)
             .Include(c => c.Fixtures).ThenInclude(f => f.Stage)
             .Include(c => c.Fixtures).ThenInclude(f => f.Court)
+            .Include(c => c.Fixtures).ThenInclude(f => f.CourtPair).ThenInclude(cp => cp!.Court1)
+            .Include(c => c.Fixtures).ThenInclude(f => f.CourtPair).ThenInclude(cp => cp!.Court2)
             .Include(c => c.Fixtures).ThenInclude(f => f.Player1)
             .Include(c => c.Fixtures).ThenInclude(f => f.Player2)
             .Include(c => c.Fixtures).ThenInclude(f => f.Player3)
@@ -479,6 +481,20 @@ else
         var side2 = new[] { f.Player2?.DisplayName, f.Player4?.DisplayName }
             .Where(n => n != null).DefaultIfEmpty("TBD").Aggregate((a, b) => $"{a} & {b}");
         return $"{side1} vs {side2}";
+    }
+
+    private static string FixtureCourtLabel(CompetitionFixture f)
+    {
+        if (f.CourtPair != null)
+        {
+            var c1 = f.CourtPair.Court1?.Name;
+            var c2 = f.CourtPair.Court2?.Name;
+            if (!string.IsNullOrEmpty(c1) && !string.IsNullOrEmpty(c2))
+                return $"{c1} & {c2}";
+            if (!string.IsNullOrEmpty(f.CourtPair.Name))
+                return f.CourtPair.Name;
+        }
+        return f.Court?.Name ?? "—";
     }
 
     private string? WinnerName(CompetitionFixture f)


### PR DESCRIPTION
## Summary
- Fixture grid on CompetitionPage: merged Stage and Label into a single Match column. Falls back to `Stage.Name` when `FixtureLabel` is empty, so round-robin rows stop repeating the stage name while knockout labels like "Quarter-Final 1" still show.
- Court column now renders `Court1 & Court2` for fixtures that use a court pair (TeamMatch with multi-court templates). Falls back to the single `Court.Name` otherwise.
- Same court-label helper added to ViewCompetition so the public view shows both paired courts.

## Test plan
- [ ] Open a TeamMatch competition with fixtures scheduled on a court pair → Court column shows both court names
- [ ] Non-team fixtures still show the single court name
- [ ] Round-robin fixtures show the stage name in Match; knockout fixtures show the disambiguating label (e.g. "Semi-Final 1")

🤖 Generated with [Claude Code](https://claude.com/claude-code)