### PR TITLE
Four MTT rubbers, each played as a multi-set match

### DIFF
--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -193,7 +193,11 @@
                         </MudItem>
                     </MudGrid>
 
-                    <MudText Typo="Typo.subtitle2" Class="mt-2 mb-1">Match Format</MudText>
+                    <MudText Typo="Typo.subtitle2" Class="mt-2 mb-1">Match / Rubber Format</MudText>
+                    <MudText Typo="Typo.caption" Class="mb-2" Style="opacity:0.75">
+                        For singles or doubles, controls the whole match. For TeamMatch,
+                        controls the format of each individual rubber.
+                    </MudText>
                     <MudRadioGroup @bind-Value="Model.MatchFormat">
                         <MudStack Row="true" Spacing="2">
                             <MudRadio Value="MatchFormatType.BestOf" Color="Color.Primary">Best of</MudRadio>

--- a/DropShot/Components/Pages/TeamMatchScoring.razor
+++ b/DropShot/Components/Pages/TeamMatchScoring.razor
@@ -159,7 +159,7 @@ else
     {
         var returnUrl = $"/team-match/{FixtureId}";
         Navigation.NavigateTo(
-            $"/tennisscore?RubberId={rubber.RubberId}&BestOfOverride=1&ReturnUrl={Uri.EscapeDataString(returnUrl)}&AutoStart=true");
+            $"/tennisscore?RubberId={rubber.RubberId}&ReturnUrl={Uri.EscapeDataString(returnUrl)}&AutoStart=true");
     }
 
     private void ResumeRubber(Rubber rubber)
@@ -188,7 +188,11 @@ else
                         @if (rubber.IsComplete)
                         {
                             <MudChip T="string" Size="Size.Small" Color="Color.Success">
-                                @rubber.HomeGames — @rubber.AwayGames
+                                @* Prefer sets-won; fall back to games-in-last-set for rows *@
+                                @* predating the sets-won column. *@
+                                @(rubber.HomeSetsWon.HasValue && rubber.AwaySetsWon.HasValue
+                                    ? $"{rubber.HomeSetsWon} — {rubber.AwaySetsWon} sets"
+                                    : $"{rubber.HomeGames} — {rubber.AwayGames}")
                             </MudChip>
                         }
                         else if (rubber.SavedMatchId.HasValue)

--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -963,22 +963,37 @@
             }
         }
 
-        // Auto-start: skip wizard and show server selection screen
+        // Auto-start: skip wizard and show server selection screen.
+        // For rubber scoring, pull players + competition config from the rubber's
+        // parent fixture/competition (since _competitionFixture is null in that path).
         if (AutoStart == true && (_competitionFixture != null || _rubber != null)
             && !string.IsNullOrEmpty(_value) && !string.IsNullOrEmpty(_value2))
         {
-            _state.BestOf = BestOfOverride ?? _competitionFixture?.Competition?.BestOf ?? 3;
-            _state.IsFixedSets = _competitionFixture?.Competition?.MatchFormat == MatchFormatType.FixedSets;
-            _state.FixedSetCount = _competitionFixture?.Competition?.NumberOfSets ?? 3;
+            var comp = _competitionFixture?.Competition ?? _rubber?.Fixture?.Competition;
+            _state.BestOf = BestOfOverride ?? comp?.BestOf ?? 3;
+            _state.IsFixedSets = comp?.MatchFormat == MatchFormatType.FixedSets;
+            _state.FixedSetCount = comp?.NumberOfSets ?? 3;
             _state.GameScoring = true;
             _state.UnlimitedDeuce = true;
-            _state.GamesFirstTo = _competitionFixture?.Competition?.GamesPerSet ?? 6;
-            _state.SetWinMode = _competitionFixture?.Competition?.SetWinMode ?? SetWinMode.WinBy2;
-            _selectedCourtId = _competitionFixture?.CourtId;
-            _player1Id = _competitionFixture?.Player1Id;
-            _player2Id = _competitionFixture?.Player2Id;
-            _player3Id = _competitionFixture?.Player3Id;
-            _player4Id = _competitionFixture?.Player4Id;
+            _state.GamesFirstTo = comp?.GamesPerSet ?? 6;
+            _state.SetWinMode = comp?.SetWinMode ?? SetWinMode.WinBy2;
+
+            if (_rubber != null)
+            {
+                _selectedCourtId = null;
+                _player1Id = _rubber.HomePlayer1Id;
+                _player2Id = _rubber.AwayPlayer1Id;
+                _player3Id = _rubber.HomePlayer2Id;
+                _player4Id = _rubber.AwayPlayer2Id;
+            }
+            else
+            {
+                _selectedCourtId = _competitionFixture?.CourtId;
+                _player1Id = _competitionFixture?.Player1Id;
+                _player2Id = _competitionFixture?.Player2Id;
+                _player3Id = _competitionFixture?.Player3Id;
+                _player4Id = _competitionFixture?.Player4Id;
+            }
             _showServerSelect = true;
         }
 
@@ -1153,7 +1168,10 @@
                 rub.IsComplete = true;
                 rub.SavedMatchId = _savedMatchId;
 
-                // Get the final set score
+                rub.HomeSetsWon = _state.UserSets;
+                rub.AwaySetsWon = _state.OppSets;
+
+                // Last-set games for display; sets-won is the authoritative score.
                 var lastSet = _state.SetScores.LastOrDefault();
                 if (lastSet != null)
                 {

--- a/DropShot/Data/Migrations/20260422000000_AddRubberSetsWon.Designer.cs
+++ b/DropShot/Data/Migrations/20260422000000_AddRubberSetsWon.Designer.cs
@@ -4,16 +4,19 @@ using DropShot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace DropShot.Migrations
+namespace DropShot.Data.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260422000000_AddRubberSetsWon")]
+    partial class AddRubberSetsWon
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DropShot/Data/Migrations/20260422000000_AddRubberSetsWon.cs
+++ b/DropShot/Data/Migrations/20260422000000_AddRubberSetsWon.cs
@@ -1,0 +1,33 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropShot.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRubberSetsWon : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "HomeSetsWon",
+                table: "Rubbers",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "AwaySetsWon",
+                table: "Rubbers",
+                type: "int",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(name: "HomeSetsWon", table: "Rubbers");
+            migrationBuilder.DropColumn(name: "AwaySetsWon", table: "Rubbers");
+        }
+    }
+}

--- a/DropShot/Models/Rubber.cs
+++ b/DropShot/Models/Rubber.cs
@@ -29,6 +29,8 @@ public class Rubber
 
     public int? HomeGames { get; set; }
     public int? AwayGames { get; set; }
+    public int? HomeSetsWon { get; set; }
+    public int? AwaySetsWon { get; set; }
     public int? WinnerTeamId { get; set; }
     public bool IsComplete { get; set; }
     public int? SavedMatchId { get; set; }

--- a/DropShot/Services/RubberTemplateRegistry.cs
+++ b/DropShot/Services/RubberTemplateRegistry.cs
@@ -27,16 +27,15 @@ public static class RubberTemplateRegistry
     public const string MttKey = "mtt";
     public const string CountyDoublesKey = "county-doubles";
 
+    // One rubber per matchup, played as the competition's configured
+    // best-of-sets × games-per-set format. Two rubbers run simultaneously
+    // (court 1: Men's Doubles then Mixed A; court 2: Women's Doubles then Mixed B).
     private static readonly IReadOnlyList<RubberDef> MttTemplate =
     [
         new(1, "Men's Doubles",   1, [Roles.MA, Roles.MB], [Roles.MA, Roles.MB]),
-        new(2, "Men's Doubles",   1, [Roles.MA, Roles.MB], [Roles.MA, Roles.MB]),
-        new(3, "Women's Doubles", 2, [Roles.FA, Roles.FB], [Roles.FA, Roles.FB]),
-        new(4, "Women's Doubles", 2, [Roles.FA, Roles.FB], [Roles.FA, Roles.FB]),
-        new(5, "Mixed A",         1, [Roles.MA, Roles.FA], [Roles.MA, Roles.FA]),
-        new(6, "Mixed A",         1, [Roles.MA, Roles.FA], [Roles.MA, Roles.FA]),
-        new(7, "Mixed B",         2, [Roles.MB, Roles.FB], [Roles.MB, Roles.FB]),
-        new(8, "Mixed B",         2, [Roles.MB, Roles.FB], [Roles.MB, Roles.FB]),
+        new(2, "Women's Doubles", 2, [Roles.FA, Roles.FB], [Roles.FA, Roles.FB]),
+        new(3, "Mixed A",         1, [Roles.MA, Roles.FA], [Roles.MA, Roles.FA]),
+        new(4, "Mixed B",         2, [Roles.MB, Roles.FB], [Roles.MB, Roles.FB]),
     ];
 
     // County Doubles: 4 players per team split into two pairs (D1A+D1B, D2A+D2B).


### PR DESCRIPTION
## Summary
- Reduced Mixed Team Tennis template from 8 single-set rubbers to 4 multi-set rubbers (Men's Doubles, Women's Doubles, Mixed A, Mixed B)
- Each rubber is now played as the competition's configured Match / Rubber Format (best-of-N sets, games-per-set, set-win mode)
- Fixes the scoring bug where clicking Start on the first rubber didn't save and the next rubber stayed locked — the auto-start path was reading from `_competitionFixture` which is null for rubbers, so the state machine had no players and no config
- Added `HomeSetsWon` / `AwaySetsWon` columns to `Rubber` so the team match grid can show "2 — 1 sets" for multi-set rubbers

## Why the old flow broke
Starting a rubber navigated to `/tennisscore?RubberId=X&BestOfOverride=1&AutoStart=true`. The auto-start block read `_competitionFixture?.Competition?.BestOf` and `_competitionFixture?.Player1Id` etc. — all null for the rubber path — so BestOf defaulted to 3 and the players were never loaded. The state machine started with no players, never detected a match end, and the rubber-completion handler never ran. Removing `BestOfOverride=1` wasn't enough on its own; the real fix is reading the config and player IDs from `_rubber.Fixture.Competition` and the rubber itself.

## Schema
Single migration `AddRubberSetsWon` adds two nullable int columns on `Rubbers` — no existing data touched.

## Test plan
- [ ] `dotnet ef database update` applies the new migration cleanly
- [ ] Open a TeamMatch fixture → see 4 rubber rows (one per matchup), not 8
- [ ] Click Start on the first rubber → player names / court / format come through correctly, scoring works end-to-end
- [ ] Set a competition to Best of 3, 6 games per set → each rubber plays to best of 3 sets of 6 games
- [ ] Finish the first rubber → back on the team-match page, the next rubber on that court unlocks and the row shows "2 — 1 sets"
- [ ] Finish all 4 rubbers → fixture completes, ResultSummary reflects the rubber count

🤖 Generated with [Claude Code](https://claude.com/claude-code)