### PR TITLE
Fix rubber-count label and auto-schedule tracking error

### DIFF
--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -3455,6 +3455,9 @@
         // when the admin hasn't defined pairs explicitly.
         if (isTeamMatchScheduling && _courtPairs.Count == 0 && _courts.Count >= 2)
         {
+            // Insert pairs using only FK ids — the Court navigation entities are
+            // tracked by a different (disposed) DbContext, so attaching them here
+            // produces tracking conflicts and a DbUpdateException.
             var autoCreated = new List<CourtPair>();
             for (int i = 0; i + 1 < _courts.Count; i += 2)
             {
@@ -3464,15 +3467,22 @@
                     Court1Id = _courts[i].CourtId,
                     Court2Id = _courts[i + 1].CourtId,
                     Name = $"{_courts[i].Name} & {_courts[i + 1].Name}",
-                    Court1 = _courts[i],
-                    Court2 = _courts[i + 1],
                 });
             }
             if (autoCreated.Count > 0)
             {
                 db.CourtPairs.AddRange(autoCreated);
                 await db.SaveChangesAsync();
-                _courtPairs = autoCreated;
+
+                // Re-read with Court navs populated so the rest of the page keeps
+                // working after ScheduleFixtures completes.
+                _courtPairs = await db.CourtPairs
+                    .AsNoTracking()
+                    .Where(cp => cp.CompetitionId == Id)
+                    .Include(cp => cp.Court1)
+                    .Include(cp => cp.Court2)
+                    .OrderBy(cp => cp.Name)
+                    .ToListAsync();
             }
         }
 

--- a/DropShot/Services/RubberTemplateRegistry.cs
+++ b/DropShot/Services/RubberTemplateRegistry.cs
@@ -50,7 +50,7 @@ public static class RubberTemplateRegistry
 
     private static readonly Dictionary<string, (string Label, IReadOnlyList<RubberDef> Template)> Presets = new()
     {
-        [MttKey]           = ("Mixed Team Tennis (8 rubbers)", MttTemplate),
+        [MttKey]           = ("Mixed Team Tennis (4 rubbers)", MttTemplate),
         [CountyDoublesKey] = ("County Doubles (4 rubbers)",    CountyDoublesTemplate),
     };
 


### PR DESCRIPTION
## Summary
Two regressions from the 4-rubber/multi-set change:

1. **Preset label wrong** — the dropdown still read "Mixed Team Tennis (8 rubbers)" after the template was reduced to 4. Updated to "(4 rubbers)".
2. **Auto-schedule Blazor error banner** — for TeamMatch competitions with no pre-configured court pairs, the auto-pair path assigned `Court1`/`Court2` navs from the page-level `_courts` list onto new `CourtPair` rows. Those nav entities were tracked by the long-disposed `OnParametersSetAsync` DbContext, so attaching them to the fresh scheduler DbContext produced a `DbUpdateException` and surfaced the Blazor unhandled-exception banner. Switched to FK-only inserts and re-read the pairs with navs populated after `SaveChangesAsync`.

## Test plan
- [ ] Rubber Template panel lists "Mixed Team Tennis (4 rubbers)" in the Load preset dropdown
- [ ] Auto-schedule a TeamMatch competition with no pre-configured court pairs → fixtures get scheduled against auto-created pairs; no error banner
- [ ] Auto-schedule a TeamMatch competition with existing court pairs still works (unchanged path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)