### PR TITLE
Preserve rubber context across the post-save URL replace

### DIFF
--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -685,8 +685,18 @@
         await SaveInitialMatchAsync();
 
         // Navigate to /match/{id} so that refreshing the page restores this exact match.
+        // Preserve rubber/return-url query params — without them the component would lose
+        // its rubber context on re-initialisation, so the rubber-completion block at match
+        // end would skip (score lost) and the post-match navigation would fall back to
+        // "/match" instead of returning to the team-match page.
         if (_savedMatchId > 0)
-            Navigation.NavigateTo($"/match/{_savedMatchId}", replace: true);
+        {
+            var preserved = new List<string>();
+            if (RubberId.HasValue && RubberId > 0) preserved.Add($"RubberId={RubberId}");
+            if (!string.IsNullOrEmpty(ReturnUrl)) preserved.Add($"ReturnUrl={Uri.EscapeDataString(ReturnUrl)}");
+            var qs = preserved.Count > 0 ? "?" + string.Join("&", preserved) : "";
+            Navigation.NavigateTo($"/match/{_savedMatchId}{qs}", replace: true);
+        }
 
         // Broadcast initial state so the scoreboard shows player names and serve indicator immediately.
         var initialState = new GameState(


### PR DESCRIPTION
## Summary
Fixes the two user-visible bugs reported for rubber scoring:

- **Rubber result is lost** — after match-end, the rubber row stays incomplete and the sets score never appears on the team-match page.
- **Post-match navigation lands on "new match" screen** instead of the team-match fixtures page.

## Root cause
`SaveInitialMatchAsync` ends with `Navigation.NavigateTo($"/match/{_savedMatchId}", replace: true)` so refreshing the page restores the in-progress match. That replace drops the original query string. `RubberId` and `ReturnUrl` are both `[SupplyParameterFromQuery]`, so Blazor re-reads them from the new URL and they become null — which makes the `_rubber != null` match-end block skip (result lost) and the post-match countdown fall through to the default `/match` navigation.

Fix: rebuild the replacement URL with `RubberId` and `ReturnUrl` preserved as query params.

## Test plan
- [ ] Score a rubber through to completion → row shows sets-won and the result is persisted after a refresh
- [ ] Finish a rubber → after the congrats countdown, you land back on `/team-match/{fixtureId}` rather than `/match`
- [ ] Refreshing the page mid-match still restores the exact scoring state

🤖 Generated with [Claude Code](https://claude.com/claude-code)