### PR TITLE
Respect LeagueScoring mode for team league tables

### DIFF
--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -238,6 +238,9 @@
                     </MudRadioGroup>
 
                     <MudText Typo="Typo.subtitle2" Class="mt-3 mb-1">League Scoring</MudText>
+                    <MudText Typo="Typo.caption" Class="mb-2" Style="opacity:0.75">
+                        For TeamMatch competitions, sets and games aggregate across every rubber in the fixture.
+                    </MudText>
                     <MudRadioGroup @bind-Value="Model.LeagueScoring">
                         <MudStack Spacing="1">
                             <MudRadio Value="LeagueScoringMode.WinPoints" Color="Color.Primary">3 points for a win, 1 for a draw</MudRadio>

--- a/DropShot/Components/Pages/ViewCompetition.razor
+++ b/DropShot/Components/Pages/ViewCompetition.razor
@@ -417,12 +417,14 @@ else
             // Team league table for TeamMatch format
             if (_competition.CompetitionFormat == CompetitionFormat.TeamMatch && rrStageIds.Any())
             {
+                var scoringMode = _competition.LeagueScoring;
                 var tPlayed = _teams.ToDictionary(t => t.CompetitionTeamId, _ => 0);
                 var tWon = _teams.ToDictionary(t => t.CompetitionTeamId, _ => 0);
                 var tDrawn = _teams.ToDictionary(t => t.CompetitionTeamId, _ => 0);
                 var tLost = _teams.ToDictionary(t => t.CompetitionTeamId, _ => 0);
                 var tRubbersWon = _teams.ToDictionary(t => t.CompetitionTeamId, _ => 0);
                 var tRubbersAgainst = _teams.ToDictionary(t => t.CompetitionTeamId, _ => 0);
+                var tPoints = _teams.ToDictionary(t => t.CompetitionTeamId, _ => 0);
 
                 foreach (var f in _fixtures.Where(f =>
                     f.CompetitionStageId.HasValue &&
@@ -435,19 +437,35 @@ else
                     if (!tPlayed.ContainsKey(hid) || !tPlayed.ContainsKey(aid)) continue;
 
                     var completed = f.Rubbers.Where(r => r.IsComplete).ToList();
-                    int hw = completed.Count(r => r.WinnerTeamId == hid);
-                    int aw = completed.Count(r => r.WinnerTeamId == aid);
+                    int homeRubbers = completed.Count(r => r.WinnerTeamId == hid);
+                    int awayRubbers = completed.Count(r => r.WinnerTeamId == aid);
+                    int homeSets = completed.Sum(r => r.HomeSetsWon ?? 0);
+                    int awaySets = completed.Sum(r => r.AwaySetsWon ?? 0);
+                    int homeGames = completed.Sum(r => r.HomeGamesTotal ?? 0);
+                    int awayGames = completed.Sum(r => r.AwayGamesTotal ?? 0);
 
                     tPlayed[hid]++;
                     tPlayed[aid]++;
-                    tRubbersWon[hid] += hw;
-                    tRubbersAgainst[hid] += aw;
-                    tRubbersWon[aid] += aw;
-                    tRubbersAgainst[aid] += hw;
+                    tRubbersWon[hid] += homeRubbers;
+                    tRubbersAgainst[hid] += awayRubbers;
+                    tRubbersWon[aid] += awayRubbers;
+                    tRubbersAgainst[aid] += homeRubbers;
 
-                    if (hw > aw) { tWon[hid]++; tLost[aid]++; }
-                    else if (aw > hw) { tWon[aid]++; tLost[hid]++; }
+                    bool homeWin = homeRubbers > awayRubbers;
+                    bool awayWin = awayRubbers > homeRubbers;
+                    if (homeWin) { tWon[hid]++; tLost[aid]++; }
+                    else if (awayWin) { tWon[aid]++; tLost[hid]++; }
                     else { tDrawn[hid]++; tDrawn[aid]++; }
+
+                    (int homePts, int awayPts) = scoringMode switch
+                    {
+                        LeagueScoringMode.SetsWon  => (homeSets, awaySets),
+                        LeagueScoringMode.GamesWon => (homeGames, awayGames),
+                        _ => (homeWin ? 3 : (!awayWin ? 1 : 0),
+                              awayWin ? 3 : (!homeWin ? 1 : 0)),
+                    };
+                    tPoints[hid] += homePts;
+                    tPoints[aid] += awayPts;
                 }
 
                 _teamLeagueTable = _teams
@@ -456,7 +474,7 @@ else
                         tPlayed[t.CompetitionTeamId], tWon[t.CompetitionTeamId],
                         tDrawn[t.CompetitionTeamId], tLost[t.CompetitionTeamId],
                         tRubbersWon[t.CompetitionTeamId], tRubbersAgainst[t.CompetitionTeamId],
-                        tRubbersWon[t.CompetitionTeamId]))
+                        tPoints[t.CompetitionTeamId]))
                     .OrderByDescending(r => r.Points)
                     .ThenByDescending(r => r.RubbersWon - r.RubbersAgainst)
                     .ThenBy(r => r.RubbersAgainst)

--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -1181,13 +1181,17 @@
                 rub.HomeSetsWon = _state.UserSets;
                 rub.AwaySetsWon = _state.OppSets;
 
-                // Last-set games for display; sets-won is the authoritative score.
+                // Last-set games for quick display; sets-won is the authoritative
+                // rubber score. Games-total sums every set and drives league-table
+                // aggregation when the competition uses per-game league scoring.
                 var lastSet = _state.SetScores.LastOrDefault();
                 if (lastSet != null)
                 {
                     rub.HomeGames = lastSet.UserGames;
                     rub.AwayGames = lastSet.OpponentGames;
                 }
+                rub.HomeGamesTotal = _state.SetScores.Sum(s => s.UserGames);
+                rub.AwayGamesTotal = _state.SetScores.Sum(s => s.OpponentGames);
 
                 bool homeSideWon = (_state.UserSets > _state.OppSets);
                 rub.WinnerTeamId = homeSideWon ? rub.Fixture.HomeTeamId : rub.Fixture.AwayTeamId;

--- a/DropShot/Controllers/CompetitionsController.cs
+++ b/DropShot/Controllers/CompetitionsController.cs
@@ -1338,6 +1338,9 @@ public class CompetitionsController(
     {
         await using var db = dbFactory.CreateDbContext();
 
+        var comp = await db.Competition.AsNoTracking().FirstOrDefaultAsync(c => c.CompetitionID == id);
+        var scoringMode = comp?.LeagueScoring ?? DropShot.Models.LeagueScoringMode.WinPoints;
+
         var rrStageIds = await db.CompetitionStages
             .Where(s => s.CompetitionId == id && s.StageType == DropShot.Models.StageType.RoundRobin)
             .Select(s => s.CompetitionStageId)
@@ -1365,6 +1368,7 @@ public class CompetitionsController(
         var lost = teams.ToDictionary(t => t.CompetitionTeamId, _ => 0);
         var rubbersWon = teams.ToDictionary(t => t.CompetitionTeamId, _ => 0);
         var rubbersAgainst = teams.ToDictionary(t => t.CompetitionTeamId, _ => 0);
+        var points = teams.ToDictionary(t => t.CompetitionTeamId, _ => 0);
 
         foreach (var f in fixtures)
         {
@@ -1373,19 +1377,37 @@ public class CompetitionsController(
             if (!played.ContainsKey(homeId) || !played.ContainsKey(awayId)) continue;
 
             var completed = f.Rubbers.Where(r => r.IsComplete).ToList();
-            int homeWon = completed.Count(r => r.WinnerTeamId == homeId);
-            int awayWon = completed.Count(r => r.WinnerTeamId == awayId);
+            int homeRubbers = completed.Count(r => r.WinnerTeamId == homeId);
+            int awayRubbers = completed.Count(r => r.WinnerTeamId == awayId);
+            int homeSets = completed.Sum(r => r.HomeSetsWon ?? 0);
+            int awaySets = completed.Sum(r => r.AwaySetsWon ?? 0);
+            int homeGames = completed.Sum(r => r.HomeGamesTotal ?? 0);
+            int awayGames = completed.Sum(r => r.AwayGamesTotal ?? 0);
 
             played[homeId]++;
             played[awayId]++;
-            rubbersWon[homeId] += homeWon;
-            rubbersAgainst[homeId] += awayWon;
-            rubbersWon[awayId] += awayWon;
-            rubbersAgainst[awayId] += homeWon;
+            rubbersWon[homeId] += homeRubbers;
+            rubbersAgainst[homeId] += awayRubbers;
+            rubbersWon[awayId] += awayRubbers;
+            rubbersAgainst[awayId] += homeRubbers;
 
-            if (homeWon > awayWon) { won[homeId]++; lost[awayId]++; }
-            else if (awayWon > homeWon) { won[awayId]++; lost[homeId]++; }
+            bool homeWin = homeRubbers > awayRubbers;
+            bool awayWin = awayRubbers > homeRubbers;
+            if (homeWin) { won[homeId]++; lost[awayId]++; }
+            else if (awayWin) { won[awayId]++; lost[homeId]++; }
             else { drawn[homeId]++; drawn[awayId]++; }
+
+            (int homePts, int awayPts) = scoringMode switch
+            {
+                DropShot.Models.LeagueScoringMode.SetsWon =>
+                    (homeSets, awaySets),
+                DropShot.Models.LeagueScoringMode.GamesWon =>
+                    (homeGames, awayGames),
+                _ => (homeWin ? 3 : (!awayWin ? 1 : 0),
+                      awayWin ? 3 : (!homeWin ? 1 : 0)),
+            };
+            points[homeId] += homePts;
+            points[awayId] += awayPts;
         }
 
         var entries = teams
@@ -1394,7 +1416,7 @@ public class CompetitionsController(
                 played[t.CompetitionTeamId], won[t.CompetitionTeamId],
                 drawn[t.CompetitionTeamId], lost[t.CompetitionTeamId],
                 rubbersWon[t.CompetitionTeamId], rubbersAgainst[t.CompetitionTeamId],
-                rubbersWon[t.CompetitionTeamId]))
+                points[t.CompetitionTeamId]))
             .OrderByDescending(e => e.Points)
             .ThenByDescending(e => e.RubbersWon - e.RubbersAgainst)
             .ThenBy(e => e.RubbersAgainst)

--- a/DropShot/Data/Migrations/20260422010000_AddRubberGamesTotal.Designer.cs
+++ b/DropShot/Data/Migrations/20260422010000_AddRubberGamesTotal.Designer.cs
@@ -4,16 +4,19 @@ using DropShot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace DropShot.Migrations
+namespace DropShot.Data.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260422010000_AddRubberGamesTotal")]
+    partial class AddRubberGamesTotal
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DropShot/Data/Migrations/20260422010000_AddRubberGamesTotal.cs
+++ b/DropShot/Data/Migrations/20260422010000_AddRubberGamesTotal.cs
@@ -1,0 +1,33 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropShot.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRubberGamesTotal : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "HomeGamesTotal",
+                table: "Rubbers",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "AwayGamesTotal",
+                table: "Rubbers",
+                type: "int",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(name: "HomeGamesTotal", table: "Rubbers");
+            migrationBuilder.DropColumn(name: "AwayGamesTotal", table: "Rubbers");
+        }
+    }
+}

--- a/DropShot/Models/Rubber.cs
+++ b/DropShot/Models/Rubber.cs
@@ -31,6 +31,8 @@ public class Rubber
     public int? AwayGames { get; set; }
     public int? HomeSetsWon { get; set; }
     public int? AwaySetsWon { get; set; }
+    public int? HomeGamesTotal { get; set; }
+    public int? AwayGamesTotal { get; set; }
     public int? WinnerTeamId { get; set; }
     public bool IsComplete { get; set; }
     public int? SavedMatchId { get; set; }


### PR DESCRIPTION
## Summary
Team league tables were hard-coding points to "rubbers won", ignoring the competition's League Scoring setting. Now the mode drives the points calculation:

- **Win points (3-1-0)**: fixture-level win/draw/loss on rubbers-won comparison → 3 / 1 / 0 points.
- **Sets won**: sum of `HomeSetsWon` / `AwaySetsWon` across every completed rubber in the fixture.
- **Games won**: sum of `HomeGamesTotal` / `AwayGamesTotal` across every completed rubber — i.e. total games across all sets of all rubbers.

`HomeGamesTotal` / `AwayGamesTotal` are new nullable `int` columns on `Rubber`, populated at match-end from `_state.SetScores.Sum(...)`. Single migration `AddRubberGamesTotal`.

Covers both the API endpoint (`/teamleaguetable`) and the `ViewCompetition` page that builds its own table client-side.

## Label decision
Keeping "League Scoring" as-is rather than renaming to "League / Rubber Scoring". The term is widely recognised for league-table rules, and the ambiguity the user flagged is about *aggregation* rather than *naming* — addressed with a caption under the heading: "For TeamMatch competitions, sets and games aggregate across every rubber in the fixture."

## Test plan
- [ ] `dotnet ef database update` applies cleanly
- [ ] Existing finished rubbers show 0 points under SetsWon / GamesWon until replayed (new columns are null). New completions populate totals and points tick up correctly.
- [ ] With mode = WinPoints, fixture with home 3 rubbers vs away 1: home team gets 3 league points, away 0
- [ ] With mode = SetsWon, same fixture with (2-0, 2-1, 2-0, 0-2) sets: home gets 6, away gets 3
- [ ] With mode = GamesWon, games sum correctly across all sets

🤖 Generated with [Claude Code](https://claude.com/claude-code)