### PR TITLE
Flow LeagueScoring mode through team-fixture displays

### DIFF
--- a/DropShot.Shared/Dtos/CompetitionDtos.cs
+++ b/DropShot.Shared/Dtos/CompetitionDtos.cs
@@ -227,7 +227,10 @@ public record TeamLeagueTableEntryDto(
     int Lost,
     int RubbersWon,
     int RubbersAgainst,
-    int Points);
+    int Points,
+    int ScoringFor = 0,
+    int ScoringAgainst = 0,
+    string ScoringUnitLabel = "rubbers");
 
 public record SaveCourtPairRequest(int Court1Id, int Court2Id, string Name);
 

--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -857,9 +857,12 @@
                         <MudTd>@FixturePlayers(context)</MudTd>
                         <MudTd>@FixtureCourtLabel(context)</MudTd>
                         <MudTd>
-                            @if (!string.IsNullOrEmpty(context.ResultSummary))
+                            @{
+                                var fixtureResult = FixtureResultDisplay(context);
+                            }
+                            @if (!string.IsNullOrEmpty(fixtureResult))
                             {
-                                <MudText Typo="Typo.body2">@context.ResultSummary</MudText>
+                                <MudText Typo="Typo.body2">@fixtureResult</MudText>
                                 @if (context.ResultModifiedByAdmin)
                                 {
                                     <MudTooltip Text="@($"Original: {context.OriginalResultSummary}")">
@@ -1695,6 +1698,7 @@
                 .Include(c => c.Fixtures).ThenInclude(f => f.AwayTeam)
                 .Include(c => c.Fixtures).ThenInclude(f => f.CourtPair).ThenInclude(cp => cp!.Court1)
                 .Include(c => c.Fixtures).ThenInclude(f => f.CourtPair).ThenInclude(cp => cp!.Court2)
+                .Include(c => c.Fixtures).ThenInclude(f => f.Rubbers)
                 .Include(c => c.Teams).ThenInclude(t => t.Captain)
                 .Include(c => c.MatchWindows).ThenInclude(w => w.Court)
                 .AsSplitQuery()
@@ -3939,6 +3943,7 @@
             .Include(f => f.AwayTeam)
             .Include(f => f.CourtPair).ThenInclude(cp => cp!.Court1)
             .Include(f => f.CourtPair).ThenInclude(cp => cp!.Court2)
+            .Include(f => f.Rubbers)
             .OrderBy(f => f.RoundNumber)
             .ThenBy(f => f.ScheduledAt)
             .ToListAsync();
@@ -4047,6 +4052,7 @@
             .Include(f => f.AwayTeam)
             .Include(f => f.CourtPair).ThenInclude(cp => cp!.Court1)
             .Include(f => f.CourtPair).ThenInclude(cp => cp!.Court2)
+            .Include(f => f.Rubbers)
             .OrderBy(f => f.RoundNumber)
             .ThenBy(f => f.ScheduledAt)
             .ToListAsync();
@@ -4117,6 +4123,25 @@
         }
         return f.Court?.Name ?? "—";
     }
+
+    private string FixtureResultDisplay(CompetitionFixture f)
+    {
+        // For team fixtures: derive a mode-aware "X — Y unit" string from the
+        // loaded rubbers so the Result column reflects the competition's league
+        // scoring setting (rubbers / sets / games) rather than a bare rubber tally.
+        if (f.HomeTeamId.HasValue && f.AwayTeamId.HasValue && f.Rubbers.Any(r => r.IsComplete))
+        {
+            var mode = EffectivePersistedLeagueScoring() ?? LeagueScoringMode.WinPoints;
+            var (home, away, unit) = RubberResolutionService.ComputeLeagueScore(
+                f.Rubbers, f.HomeTeamId.Value, f.AwayTeamId.Value, mode);
+            return $"{home} — {away} {unit}";
+        }
+
+        // Singles / doubles: fall back to the set-by-set ResultSummary string.
+        return f.ResultSummary ?? "";
+    }
+
+    private LeagueScoringMode? EffectivePersistedLeagueScoring() => Model?.LeagueScoring;
 
     private static Color StatusColor(FixtureStatus s) => s switch
     {

--- a/DropShot/Components/Pages/TeamMatchScoring.razor
+++ b/DropShot/Components/Pages/TeamMatchScoring.razor
@@ -48,7 +48,7 @@ else
                     </MudText>
                 </MudStack>
                 <MudChip T="string" Size="Size.Large" Color="@(_allComplete ? Color.Success : Color.Primary)">
-                    @_homeScore — @_awayScore
+                    @_homeScore — @_awayScore @_scoreUnit
                 </MudChip>
             </MudStack>
         </MudPaper>
@@ -69,7 +69,7 @@ else
         @if (_allComplete)
         {
             <MudAlert Severity="Severity.Success" Class="mt-4">
-                Match complete: @(_fixture.HomeTeam?.Name) @_homeScore — @_awayScore @(_fixture.AwayTeam?.Name)
+                Match complete: @(_fixture.HomeTeam?.Name) @_homeScore — @_awayScore @_scoreUnit @(_fixture.AwayTeam?.Name)
                 @if (_homeScore == _awayScore)
                 {
                     <span> (Draw)</span>
@@ -92,6 +92,7 @@ else
     private bool _loading = true;
     private int _homeScore;
     private int _awayScore;
+    private string _scoreUnit = "rubbers";
     private bool _allComplete;
     private string? _resolutionError;
 
@@ -139,8 +140,9 @@ else
     {
         if (_fixture?.HomeTeamId != null && _fixture?.AwayTeamId != null)
         {
-            (_homeScore, _awayScore) = RubberResolutionService.ComputeScore(
-                _rubbers, _fixture.HomeTeamId.Value, _fixture.AwayTeamId.Value);
+            var mode = _fixture.Competition?.LeagueScoring ?? LeagueScoringMode.WinPoints;
+            (_homeScore, _awayScore, _scoreUnit) = RubberResolutionService.ComputeLeagueScore(
+                _rubbers, _fixture.HomeTeamId.Value, _fixture.AwayTeamId.Value, mode);
         }
         _allComplete = _rubbers.Count > 0 && RubberResolutionService.AllComplete(_rubbers);
     }

--- a/DropShot/Components/Pages/ViewCompetition.razor
+++ b/DropShot/Components/Pages/ViewCompetition.razor
@@ -144,6 +144,21 @@ else
     @* ── League Table (round-robin stages only) ──────────────── *@
     @if (_teamLeagueTable.Any())
     {
+        var forHeader = _scoringUnitLabel switch
+        {
+            "sets"  => "SW",
+            "games" => "GW",
+            _       => "RW",
+        };
+        var againstHeader = _scoringUnitLabel switch
+        {
+            "sets"  => "SA",
+            "games" => "GA",
+            _       => "RA",
+        };
+        var forTooltip = $"{_scoringUnitLabel} won";
+        var againstTooltip = $"{_scoringUnitLabel} against";
+
         <MudDivider Class="my-4" />
         <MudText Typo="Typo.h5" Class="mb-3">Team League Table</MudText>
         <MudTable Items="@_teamLeagueTable" Dense="true" Hover="true" Class="mb-4">
@@ -155,8 +170,8 @@ else
                 <MudTh>W</MudTh>
                 <MudTh>D</MudTh>
                 <MudTh>L</MudTh>
-                <MudTh>RW</MudTh>
-                <MudTh>RA</MudTh>
+                <MudTh><MudTooltip Text="@forTooltip">@forHeader</MudTooltip></MudTh>
+                <MudTh><MudTooltip Text="@againstTooltip">@againstHeader</MudTooltip></MudTh>
                 <MudTh>Pts</MudTh>
             </HeaderContent>
             <RowTemplate>
@@ -167,8 +182,8 @@ else
                 <MudTd>@context.Won</MudTd>
                 <MudTd>@context.Drawn</MudTd>
                 <MudTd>@context.Lost</MudTd>
-                <MudTd>@context.RubbersWon</MudTd>
-                <MudTd>@context.RubbersAgainst</MudTd>
+                <MudTd>@context.ScoringFor</MudTd>
+                <MudTd>@context.ScoringAgainst</MudTd>
                 <MudTd Style="font-weight:bold">@context.Points</MudTd>
             </RowTemplate>
         </MudTable>
@@ -286,8 +301,9 @@ else
     private record LeagueRow(int PlayerId, string PlayerName, int Played, int Won, int Lost, int Points);
     private List<LeagueRow> _leagueTable = [];
 
-    private record TeamLeagueRow(int TeamId, string TeamName, string? CaptainName, int Played, int Won, int Drawn, int Lost, int RubbersWon, int RubbersAgainst, int Points);
+    private record TeamLeagueRow(int TeamId, string TeamName, string? CaptainName, int Played, int Won, int Drawn, int Lost, int ScoringFor, int ScoringAgainst, int Points);
     private List<TeamLeagueRow> _teamLeagueTable = [];
+    private string _scoringUnitLabel = "rubbers";
 
 #pragma warning disable CS8714 // Null keys are intentionally used for unstaged fixtures
     private Dictionary<string?, List<CompetitionFixture>> _fixturesByStage = [];
@@ -418,12 +434,19 @@ else
             if (_competition.CompetitionFormat == CompetitionFormat.TeamMatch && rrStageIds.Any())
             {
                 var scoringMode = _competition.LeagueScoring;
+                _scoringUnitLabel = scoringMode switch
+                {
+                    LeagueScoringMode.SetsWon  => "sets",
+                    LeagueScoringMode.GamesWon => "games",
+                    _                           => "rubbers",
+                };
+
                 var tPlayed = _teams.ToDictionary(t => t.CompetitionTeamId, _ => 0);
                 var tWon = _teams.ToDictionary(t => t.CompetitionTeamId, _ => 0);
                 var tDrawn = _teams.ToDictionary(t => t.CompetitionTeamId, _ => 0);
                 var tLost = _teams.ToDictionary(t => t.CompetitionTeamId, _ => 0);
-                var tRubbersWon = _teams.ToDictionary(t => t.CompetitionTeamId, _ => 0);
-                var tRubbersAgainst = _teams.ToDictionary(t => t.CompetitionTeamId, _ => 0);
+                var tFor = _teams.ToDictionary(t => t.CompetitionTeamId, _ => 0);
+                var tAgainst = _teams.ToDictionary(t => t.CompetitionTeamId, _ => 0);
                 var tPoints = _teams.ToDictionary(t => t.CompetitionTeamId, _ => 0);
 
                 foreach (var f in _fixtures.Where(f =>
@@ -446,10 +469,17 @@ else
 
                     tPlayed[hid]++;
                     tPlayed[aid]++;
-                    tRubbersWon[hid] += homeRubbers;
-                    tRubbersAgainst[hid] += awayRubbers;
-                    tRubbersWon[aid] += awayRubbers;
-                    tRubbersAgainst[aid] += homeRubbers;
+
+                    (int homeFor, int awayFor) = scoringMode switch
+                    {
+                        LeagueScoringMode.SetsWon  => (homeSets, awaySets),
+                        LeagueScoringMode.GamesWon => (homeGames, awayGames),
+                        _                           => (homeRubbers, awayRubbers),
+                    };
+                    tFor[hid] += homeFor;
+                    tAgainst[hid] += awayFor;
+                    tFor[aid] += awayFor;
+                    tAgainst[aid] += homeFor;
 
                     bool homeWin = homeRubbers > awayRubbers;
                     bool awayWin = awayRubbers > homeRubbers;
@@ -473,11 +503,11 @@ else
                         t.CompetitionTeamId, t.Name, t.Captain?.DisplayName,
                         tPlayed[t.CompetitionTeamId], tWon[t.CompetitionTeamId],
                         tDrawn[t.CompetitionTeamId], tLost[t.CompetitionTeamId],
-                        tRubbersWon[t.CompetitionTeamId], tRubbersAgainst[t.CompetitionTeamId],
+                        tFor[t.CompetitionTeamId], tAgainst[t.CompetitionTeamId],
                         tPoints[t.CompetitionTeamId]))
                     .OrderByDescending(r => r.Points)
-                    .ThenByDescending(r => r.RubbersWon - r.RubbersAgainst)
-                    .ThenBy(r => r.RubbersAgainst)
+                    .ThenByDescending(r => r.ScoringFor - r.ScoringAgainst)
+                    .ThenBy(r => r.ScoringAgainst)
                     .ToList();
             }
         }

--- a/DropShot/Controllers/CompetitionsController.cs
+++ b/DropShot/Controllers/CompetitionsController.cs
@@ -1368,7 +1368,16 @@ public class CompetitionsController(
         var lost = teams.ToDictionary(t => t.CompetitionTeamId, _ => 0);
         var rubbersWon = teams.ToDictionary(t => t.CompetitionTeamId, _ => 0);
         var rubbersAgainst = teams.ToDictionary(t => t.CompetitionTeamId, _ => 0);
+        var scoringFor = teams.ToDictionary(t => t.CompetitionTeamId, _ => 0);
+        var scoringAgainst = teams.ToDictionary(t => t.CompetitionTeamId, _ => 0);
         var points = teams.ToDictionary(t => t.CompetitionTeamId, _ => 0);
+
+        string unitLabel = scoringMode switch
+        {
+            DropShot.Models.LeagueScoringMode.SetsWon  => "sets",
+            DropShot.Models.LeagueScoringMode.GamesWon => "games",
+            _                                          => "rubbers",
+        };
 
         foreach (var f in fixtures)
         {
@@ -1391,6 +1400,17 @@ public class CompetitionsController(
             rubbersWon[awayId] += awayRubbers;
             rubbersAgainst[awayId] += homeRubbers;
 
+            (int homeFor, int awayFor) = scoringMode switch
+            {
+                DropShot.Models.LeagueScoringMode.SetsWon  => (homeSets, awaySets),
+                DropShot.Models.LeagueScoringMode.GamesWon => (homeGames, awayGames),
+                _                                          => (homeRubbers, awayRubbers),
+            };
+            scoringFor[homeId] += homeFor;
+            scoringAgainst[homeId] += awayFor;
+            scoringFor[awayId] += awayFor;
+            scoringAgainst[awayId] += homeFor;
+
             bool homeWin = homeRubbers > awayRubbers;
             bool awayWin = awayRubbers > homeRubbers;
             if (homeWin) { won[homeId]++; lost[awayId]++; }
@@ -1399,10 +1419,8 @@ public class CompetitionsController(
 
             (int homePts, int awayPts) = scoringMode switch
             {
-                DropShot.Models.LeagueScoringMode.SetsWon =>
-                    (homeSets, awaySets),
-                DropShot.Models.LeagueScoringMode.GamesWon =>
-                    (homeGames, awayGames),
+                DropShot.Models.LeagueScoringMode.SetsWon  => (homeSets, awaySets),
+                DropShot.Models.LeagueScoringMode.GamesWon => (homeGames, awayGames),
                 _ => (homeWin ? 3 : (!awayWin ? 1 : 0),
                       awayWin ? 3 : (!homeWin ? 1 : 0)),
             };
@@ -1416,10 +1434,12 @@ public class CompetitionsController(
                 played[t.CompetitionTeamId], won[t.CompetitionTeamId],
                 drawn[t.CompetitionTeamId], lost[t.CompetitionTeamId],
                 rubbersWon[t.CompetitionTeamId], rubbersAgainst[t.CompetitionTeamId],
-                points[t.CompetitionTeamId]))
+                points[t.CompetitionTeamId],
+                scoringFor[t.CompetitionTeamId], scoringAgainst[t.CompetitionTeamId],
+                unitLabel))
             .OrderByDescending(e => e.Points)
-            .ThenByDescending(e => e.RubbersWon - e.RubbersAgainst)
-            .ThenBy(e => e.RubbersAgainst)
+            .ThenByDescending(e => e.ScoringFor - e.ScoringAgainst)
+            .ThenBy(e => e.ScoringAgainst)
             .ToList();
 
         return entries;

--- a/DropShot/Services/RubberResolutionService.cs
+++ b/DropShot/Services/RubberResolutionService.cs
@@ -76,6 +76,34 @@ public class RubberResolutionService(ICompetitionRubberTemplateProvider template
         return (home, away);
     }
 
+    /// <summary>
+    /// Returns the for/against metric that matches the competition's LeagueScoring
+    /// mode — rubbers (default / WinPoints), sets, or total games. The label is
+    /// suitable for UI use ("rubbers" / "sets" / "games").
+    /// </summary>
+    public static (int homeFor, int awayFor, string unitLabel) ComputeLeagueScore(
+        IEnumerable<Rubber> rubbers, int homeTeamId, int awayTeamId, LeagueScoringMode mode)
+    {
+        int homeRubbers = 0, awayRubbers = 0;
+        int homeSets = 0, awaySets = 0;
+        int homeGames = 0, awayGames = 0;
+        foreach (var r in rubbers.Where(r => r.IsComplete))
+        {
+            if (r.WinnerTeamId == homeTeamId) homeRubbers++;
+            else if (r.WinnerTeamId == awayTeamId) awayRubbers++;
+            homeSets += r.HomeSetsWon ?? 0;
+            awaySets += r.AwaySetsWon ?? 0;
+            homeGames += r.HomeGamesTotal ?? 0;
+            awayGames += r.AwayGamesTotal ?? 0;
+        }
+        return mode switch
+        {
+            LeagueScoringMode.SetsWon  => (homeSets, awaySets, "sets"),
+            LeagueScoringMode.GamesWon => (homeGames, awayGames, "games"),
+            _                          => (homeRubbers, awayRubbers, "rubbers"),
+        };
+    }
+
     public static bool AllComplete(IEnumerable<Rubber> rubbers)
         => rubbers.All(r => r.IsComplete);
 


### PR DESCRIPTION
## Summary
Three team-fixture displays all showed rubber counts regardless of the competition's **LeagueScoring** choice (WinPoints / SetsWon / GamesWon). This PR plumbs the mode through all three so the numbers on screen match the rule that actually awards points:

1. **Team-match scoring header** — chip and the "Match complete" banner now show e.g. "3 — 1 rubbers", "7 — 5 sets", or "36 — 28 games" depending on the mode.
2. **Fixtures grid Result column** — for team fixtures, the Result cell renders the mode-aware summary computed from the loaded Rubbers. Non-team fixtures still show their set-by-set `ResultSummary` string.
3. **Team League Table** — columns labelled `RW`/`RA` become `SW`/`SA` or `GW`/`GA` based on mode, with tooltips spelling the unit out. The underlying metric switches to match (sets won in SetsWon mode, games won in GamesWon mode), and the tie-break ordering now uses the mode's For/Against difference.

## Note on "TBD"
The TBD you see on scheduled matches comes from the **Players** column's `FixturePlayers` helper (`f.HomeTeam?.Name ?? "TBD"`), not the Result column. It appears on downstream knockout fixtures that haven't yet received a winner from the previous round. It's intentional — it just means "to be decided". If you'd prefer a clearer wording (e.g. "Awaiting previous round"), say the word and I'll change it.

## Test plan
- [ ] Set a TeamMatch competition to Win Points → all three surfaces show rubber counts
- [ ] Switch to Sets Won → chip shows "7 — 5 sets", grid Result cells re-render, table columns become SW/SA
- [ ] Switch to Games Won → chip shows "36 — 28 games", etc.
- [ ] Non-team competitions still show their existing set-by-set result strings unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)