### PR TITLE
Show team names on team match screen and scoring page

### DIFF
--- a/DropShot/Components/Pages/TeamMatchScoring.razor
+++ b/DropShot/Components/Pages/TeamMatchScoring.razor
@@ -190,16 +190,23 @@ else
 
     private RenderFragment RenderRubber(Rubber rubber) => __builder =>
     {
+        var homeTeam = _fixture?.HomeTeam?.Name ?? "Home";
+        var awayTeam = _fixture?.AwayTeam?.Name ?? "Away";
+        var homePair = $"{rubber.HomePlayer1?.DisplayName} & {rubber.HomePlayer2?.DisplayName}";
+        var awayPair = $"{rubber.AwayPlayer1?.DisplayName} & {rubber.AwayPlayer2?.DisplayName}";
         <MudCard Class="mb-2" Outlined="true">
             <MudCardContent>
-                <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
-                    <MudStack Spacing="0">
-                        <MudText Typo="Typo.subtitle2">@rubber.Name (set @rubber.Order)</MudText>
-                        <MudText Typo="Typo.body2">
-                            @(rubber.HomePlayer1?.DisplayName) & @(rubber.HomePlayer2?.DisplayName)
-                            vs
-                            @(rubber.AwayPlayer1?.DisplayName) & @(rubber.AwayPlayer2?.DisplayName)
-                        </MudText>
+                <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Spacing="3">
+                    <MudStack Spacing="1" Style="flex:1; min-width:0">
+                        <MudText Typo="Typo.subtitle2">@rubber.Name (rubber @rubber.Order)</MudText>
+                        <MudStack Row="true" AlignItems="AlignItems.Baseline" Spacing="2">
+                            <MudText Typo="Typo.body2" Style="font-weight:600; min-width:90px">@homeTeam</MudText>
+                            <MudText Typo="Typo.body2" Style="opacity:0.9">@homePair</MudText>
+                        </MudStack>
+                        <MudStack Row="true" AlignItems="AlignItems.Baseline" Spacing="2">
+                            <MudText Typo="Typo.body2" Style="font-weight:600; min-width:90px">@awayTeam</MudText>
+                            <MudText Typo="Typo.body2" Style="opacity:0.9">@awayPair</MudText>
+                        </MudStack>
                     </MudStack>
                     <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
                         @if (rubber.IsComplete)

--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -164,9 +164,24 @@
                         @_headerCourt.Club.Name — @_headerCourt.Name
                     </div>
                 }
-                <div class="match-header-players">
-                    @GetUserDisplayName() <span class="match-header-vs">vs</span> @GetOpponentDisplayName()
-                </div>
+                @if (_rubber?.Fixture != null)
+                {
+                    @* Rubber scoring: show team names in bold above the player pair *@
+                    <div class="match-header-teams">
+                        @(_rubber.Fixture.HomeTeam?.Name ?? "Home")
+                        <span class="match-header-vs">vs</span>
+                        @(_rubber.Fixture.AwayTeam?.Name ?? "Away")
+                    </div>
+                    <div class="match-header-players match-header-players--rubber">
+                        @GetUserDisplayName() <span class="match-header-vs">vs</span> @GetOpponentDisplayName()
+                    </div>
+                }
+                else
+                {
+                    <div class="match-header-players">
+                        @GetUserDisplayName() <span class="match-header-vs">vs</span> @GetOpponentDisplayName()
+                    </div>
+                }
                 @* #7 — Match elapsed timer *@
                 <div class="match-timer">@_elapsedDisplay</div>
             </div>
@@ -957,6 +972,8 @@
         {
             _rubber = await DbContext.Rubbers
                 .Include(r => r.Fixture).ThenInclude(f => f.Competition)
+                .Include(r => r.Fixture).ThenInclude(f => f.HomeTeam)
+                .Include(r => r.Fixture).ThenInclude(f => f.AwayTeam)
                 .Include(r => r.HomePlayer1)
                 .Include(r => r.HomePlayer2)
                 .Include(r => r.AwayPlayer1)

--- a/DropShot/Components/TennisScore.razor.css
+++ b/DropShot/Components/TennisScore.razor.css
@@ -115,6 +115,22 @@
     font-weight: bold;
 }
 
+/* When scoring a rubber, the team names sit above the player pair line.
+   De-emphasise the player names so the team-name row reads as the heading. */
+.match-header-players--rubber {
+    font-size: 1.05rem;
+    font-weight: 500;
+    color: rgba(255, 255, 255, 0.85);
+    margin-top: 2px;
+}
+
+.match-header-teams {
+    font-size: 1.4rem;
+    color: white;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+}
+
 .match-header-vs {
     color: #aaa;
 }
@@ -303,9 +319,11 @@
     flex-shrink: 0;
 }
 
-/* Short player name next to score */
+/* Short player name next to score — sized to fit doubles pair names like
+   "A. Smith & B. Jones" without truncation at typical desktop widths. */
 .score-player-name {
-    flex: 0 0 90px;
+    flex: 0 1 220px;
+    min-width: 120px;
     text-align: left;
     font-size: 18px;
     font-weight: 500;
@@ -313,7 +331,7 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    margin-right: 6px;
+    margin-right: 10px;
 }
 
 /* Completed set scores */
@@ -593,6 +611,20 @@
 
     .match-header-players {
         font-size: 0.85rem;
+    }
+
+    .match-header-teams {
+        font-size: 0.95rem;
+    }
+
+    .match-header-players--rubber {
+        font-size: 0.75rem;
+    }
+
+    .score-player-name {
+        flex: 0 1 140px;
+        min-width: 80px;
+        font-size: 15px;
     }
 
     .player-row {


### PR DESCRIPTION
## Summary
- **Team match rubber cards** now stack home and away on separate rows with the team name in bold before the player pair. Previously both pairs ran together in one `Alice & Bob vs Charlie & Dave` line which was hard to parse.
- **In-match scoring page** shows the team names as the big bold heading when scoring a rubber; the player-pair names sit underneath in a lighter weight. For non-rubber matches (singles / doubles) the header is unchanged.
- **Score rows** get more space for names — the `.score-player-name` flex-basis was 90px which truncated doubles pairs like "A. Smith & B. Jones". Now 220px / min 120px on desktop, 140px / min 80px on the mobile breakpoint.

## Test plan
- [ ] TeamMatchScoring rubber rows show team name bold, players below
- [ ] Scoring a rubber: big header is "Home Team vs Away Team", smaller row below is the player pair
- [ ] Scoring a singles / doubles fixture: header unchanged
- [ ] Score rows show full doubles names without truncation at typical desktop widths
- [ ] Mobile breakpoint still fits

🤖 Generated with [Claude Code](https://claude.com/claude-code)