### PR TITLE
Team context on server-select screen

### DIFF
--- a/DropShot/Components/ServerSelectScreen.razor
+++ b/DropShot/Components/ServerSelectScreen.razor
@@ -10,19 +10,54 @@
         </MudText>
 
         <div class="server-select-options">
-            <MudButton Variant="Variant.Filled" Color="Color.Primary"
-                       Size="Size.Large" Class="server-select-btn"
-                       StartIcon="@Icons.Material.Filled.Person"
-                       OnClick="@(() => OnSelected("player2"))">
-                @OpponentLabel
-            </MudButton>
+            @if (IsTeamContext)
+            {
+                @* Team match: home (user) on top, away (opponent) on bottom, vs between *@
+                <MudButton Variant="Variant.Filled" Color="Color.Success"
+                           Size="Size.Large" Class="server-select-btn"
+                           StartIcon="@Icons.Material.Filled.Person"
+                           OnClick="@(() => OnSelected("player1"))">
+                    <div class="server-option-stack">
+                        @if (!string.IsNullOrEmpty(UserTeamName))
+                        {
+                            <span class="server-option-team">@UserTeamName</span>
+                        }
+                        <span class="server-option-name">@UserLabel</span>
+                    </div>
+                </MudButton>
 
-            <MudButton Variant="Variant.Filled" Color="Color.Success"
-                       Size="Size.Large" Class="server-select-btn"
-                       StartIcon="@Icons.Material.Filled.Person"
-                       OnClick="@(() => OnSelected("player1"))">
-                @UserLabel
-            </MudButton>
+                <div class="server-select-vs">vs</div>
+
+                <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                           Size="Size.Large" Class="server-select-btn"
+                           StartIcon="@Icons.Material.Filled.Person"
+                           OnClick="@(() => OnSelected("player2"))">
+                    <div class="server-option-stack">
+                        @if (!string.IsNullOrEmpty(OpponentTeamName))
+                        {
+                            <span class="server-option-team">@OpponentTeamName</span>
+                        }
+                        <span class="server-option-name">@OpponentLabel</span>
+                    </div>
+                </MudButton>
+            }
+            else
+            {
+                @* Non-team match: preserve existing layout *@
+                <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                           Size="Size.Large" Class="server-select-btn"
+                           StartIcon="@Icons.Material.Filled.Person"
+                           OnClick="@(() => OnSelected("player2"))">
+                    @OpponentLabel
+                </MudButton>
+
+                <MudButton Variant="Variant.Filled" Color="Color.Success"
+                           Size="Size.Large" Class="server-select-btn"
+                           StartIcon="@Icons.Material.Filled.Person"
+                           OnClick="@(() => OnSelected("player1"))">
+                    @UserLabel
+                </MudButton>
+            }
 
             <MudButton Variant="Variant.Outlined" Color="Color.Warning"
                        Size="Size.Large" Class="server-select-btn"
@@ -36,7 +71,7 @@
                    StartIcon="@Icons.Material.Filled.ArrowBack"
                    Style="color: rgba(255,255,255,0.6);"
                    OnClick="@(() => OnBack.InvokeAsync())">
-            Back to setup
+            @BackLabel
         </MudButton>
     </div>
 </div>
@@ -44,8 +79,14 @@
 @code {
     [Parameter] public string UserLabel { get; set; } = "You";
     [Parameter] public string OpponentLabel { get; set; } = "Opponent";
+    [Parameter] public string? UserTeamName { get; set; }
+    [Parameter] public string? OpponentTeamName { get; set; }
+    [Parameter] public string BackLabel { get; set; } = "Back to setup";
     [Parameter] public EventCallback<string> OnServerSelected { get; set; }
     [Parameter] public EventCallback OnBack { get; set; }
+
+    private bool IsTeamContext =>
+        !string.IsNullOrEmpty(UserTeamName) || !string.IsNullOrEmpty(OpponentTeamName);
 
     private async Task OnSelected(string choice)
     {

--- a/DropShot/Components/ServerSelectScreen.razor.css
+++ b/DropShot/Components/ServerSelectScreen.razor.css
@@ -35,3 +35,33 @@
     border-radius: 12px !important;
     text-transform: none !important;
 }
+
+.server-option-stack {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    line-height: 1.2;
+}
+
+.server-option-team {
+    font-size: 13px;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    opacity: 0.75;
+}
+
+.server-option-name {
+    font-size: 18px;
+    font-weight: 700;
+}
+
+.server-select-vs {
+    text-align: center;
+    font-size: 14px;
+    font-weight: 600;
+    color: rgba(255, 255, 255, 0.5);
+    letter-spacing: 2px;
+    text-transform: uppercase;
+    margin: -4px 0;
+}

--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -33,6 +33,9 @@
 {
     <ServerSelectScreen UserLabel="@GetUserDisplayName()"
                         OpponentLabel="@GetOpponentDisplayName()"
+                        UserTeamName="@(_rubber?.Fixture?.HomeTeam?.Name)"
+                        OpponentTeamName="@(_rubber?.Fixture?.AwayTeam?.Name)"
+                        BackLabel="@(_rubber != null ? "Back to team match" : "Back to setup")"
                         OnServerSelected="HandleServerSelected"
                         OnBack="HandleServerSelectBack" />
 }
@@ -561,6 +564,14 @@
 
     private void HandleServerSelectBack()
     {
+        // Auto-started flows (rubber scoring, fixture Play buttons) never showed
+        // a setup wizard, so hiding the server-select screen would leave an empty
+        // state. Instead send the user back to whatever page invoked us.
+        if (!string.IsNullOrEmpty(ReturnUrl))
+        {
+            Navigation.NavigateTo(ReturnUrl);
+            return;
+        }
         _showServerSelect = false;
     }
 


### PR DESCRIPTION
## Summary
When scoring a rubber, the "Who serves first?" screen now shows:

- **Home team name** above the home player pair (top button)
- **"vs"** separator
- **Away team name** above the away player pair (bottom button)

Team names render as a small uppercase caption; player names stay prominent. Non-team matches (singles / doubles) keep their existing layout — opponent on top, user on bottom, no team labels.

The **Back** button now navigates to `ReturnUrl` when one is set (fired by Play / Start from a fixture or rubber). Previously it just hid the server-select overlay, which dropped auto-started flows into an empty match-setup wizard. Label swaps to "Back to team match" for the rubber path.

## Test plan
- [ ] Start a rubber from a team match → server-select shows "HOME TEAM / players" on top, "vs", "AWAY TEAM / players" on bottom
- [ ] Back button says "Back to team match" and returns to `/team-match/{FixtureId}`
- [ ] Start a singles / doubles fixture from the fixtures list → server-select layout unchanged
- [ ] Start a casual match (no ReturnUrl) → Back still hides the screen and shows the setup wizard

🤖 Generated with [Claude Code](https://claude.com/claude-code)