### PR TITLE
Drop unit label from team result cell on ViewCompetition

### DIFF
--- a/DropShot/Components/Pages/ViewCompetition.razor
+++ b/DropShot/Components/Pages/ViewCompetition.razor
@@ -143,7 +143,6 @@ else
                                         @teamResult.awayFor
                                     </MudText>
                                 </MudStack>
-                                <MudText Typo="Typo.caption" Color="Color.Secondary">@teamResult.unitLabel</MudText>
                             </MudStack>
                             @if (context.Status == FixtureStatus.AwaitingVerification)
                             {


### PR DESCRIPTION
## Summary
Removes the small `rubbers` / `sets` / `games` caption from under each team result block on the public view's fixtures list. The team names and counts are enough on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)