### PR TITLE
Add multi-league / multi-division system

### DIFF
--- a/DropShot.Shared/Dtos/LeagueDtos.cs
+++ b/DropShot.Shared/Dtos/LeagueDtos.cs
@@ -1,0 +1,167 @@
+namespace DropShot.Shared.Dtos;
+
+public enum LeagueSeasonStatusDto : byte
+{
+    Planning = 1,
+    Active = 2,
+    Closed = 3,
+}
+
+public record LeagueSummaryDto(
+    int LeagueId,
+    string Name,
+    int HostClubId,
+    string? HostClubName,
+    bool IsArchived,
+    int SeasonCount,
+    int MembershipCount);
+
+public record LeagueDetailDto(
+    int LeagueId,
+    string Name,
+    int HostClubId,
+    string? HostClubName,
+    bool IsArchived,
+    CompetitionFormat CompetitionFormat,
+    int TeamSize,
+    LeagueScoringMode LeagueScoring,
+    string? RubberTemplateKey,
+    MatchFormatType MatchFormat,
+    int NumberOfSets,
+    int GamesPerSet,
+    SetWinMode SetWinMode,
+    int TeamsPerDivisionTarget,
+    int TeamsPerDivisionMin);
+
+public record CreateLeagueRequest(
+    string Name,
+    int HostClubId,
+    CompetitionFormat CompetitionFormat = CompetitionFormat.TeamMatch,
+    int TeamSize = 4,
+    LeagueScoringMode LeagueScoring = LeagueScoringMode.WinPoints,
+    string? RubberTemplateKey = null,
+    MatchFormatType MatchFormat = MatchFormatType.BestOf,
+    int NumberOfSets = 3,
+    int GamesPerSet = 6,
+    SetWinMode SetWinMode = SetWinMode.WinBy2,
+    int TeamsPerDivisionTarget = 8,
+    int TeamsPerDivisionMin = 6);
+
+public record UpdateLeagueRequest(
+    string Name,
+    CompetitionFormat CompetitionFormat,
+    int TeamSize,
+    LeagueScoringMode LeagueScoring,
+    string? RubberTemplateKey,
+    MatchFormatType MatchFormat,
+    int NumberOfSets,
+    int GamesPerSet,
+    SetWinMode SetWinMode,
+    int TeamsPerDivisionTarget,
+    int TeamsPerDivisionMin,
+    bool IsArchived = false);
+
+public record LeagueMembershipDto(
+    int PlayerId,
+    string DisplayName,
+    DateTime JoinedAt,
+    bool IsActive,
+    byte? CurrentDivisionRank);
+
+public record EnrolPlayerRequest(int PlayerId);
+
+public record LeagueSeasonSummaryDto(
+    int LeagueSeasonId,
+    int LeagueId,
+    string Name,
+    DateTime? StartDate,
+    DateTime? EndDate,
+    LeagueSeasonStatusDto Status,
+    DateTime? ClosedAt,
+    int DivisionCount);
+
+public record CreateSeasonRequest(
+    string Name,
+    DateTime? StartDate = null,
+    DateTime? EndDate = null);
+
+public record DivisionBucketDto(
+    byte Rank,
+    string Name,
+    IReadOnlyList<int> PlayerIds);
+
+public record DivisionSuggestionDto(
+    IReadOnlyList<DivisionBucketDto> Buckets,
+    IReadOnlyList<int> UnassignedPlayerIds);
+
+public record DivisionTeamAssignmentDto(
+    string TeamName,
+    IReadOnlyList<PlayerRoleAssignmentDto> Members);
+
+public record PlayerRoleAssignmentDto(int PlayerId, string? Role);
+
+public record MaterialiseDivisionDto(
+    byte Rank,
+    string Name,
+    IReadOnlyList<DivisionTeamAssignmentDto> Teams);
+
+public record CreateDivisionsRequest(
+    IReadOnlyList<MaterialiseDivisionDto> Divisions);
+
+public record LeagueDivisionDto(
+    int LeagueDivisionId,
+    byte Rank,
+    string Name,
+    int CompetitionId,
+    string CompetitionName,
+    int TeamCount,
+    int PlayerCount);
+
+public record LeagueSeasonDetailDto(
+    int LeagueSeasonId,
+    int LeagueId,
+    string Name,
+    DateTime? StartDate,
+    DateTime? EndDate,
+    LeagueSeasonStatusDto Status,
+    DateTime? ClosedAt,
+    IReadOnlyList<LeagueDivisionDto> Divisions);
+
+public record PlayerStatsDto(
+    int PlayerId,
+    string DisplayName,
+    int DivisionRank,
+    string DivisionName,
+    int RubbersPlayed,
+    int RubbersWon,
+    int RubbersLost,
+    int SetsWon,
+    int SetsAgainst,
+    int GamesWon,
+    int GamesAgainst,
+    int LeaguePoints,
+    double WinRate);
+
+public record PromotionCandidateDto(
+    int PlayerId,
+    string DisplayName,
+    byte CurrentRank,
+    int PositionInDivision,
+    int RubbersPlayed,
+    int LeaguePoints,
+    double WinRate);
+
+public record PromotionPreviewDto(
+    int LeagueSeasonId,
+    IReadOnlyList<PromotionDivisionDto> Divisions);
+
+public record PromotionDivisionDto(
+    byte Rank,
+    string Name,
+    IReadOnlyList<PromotionCandidateDto> Players);
+
+public record PromotionDecisionDto(int PlayerId, byte NewRank);
+
+public record CloseSeasonRequest(IReadOnlyList<PromotionDecisionDto> Decisions);
+
+public record CloseSeasonResultDto(int SeasonId, int DecisionsApplied);

--- a/DropShot.Shared/Enums.cs
+++ b/DropShot.Shared/Enums.cs
@@ -56,3 +56,22 @@ public enum FixtureStatus : byte
     Cancelled = 4,
     Walkover = 5
 }
+
+public enum MatchFormatType : byte
+{
+    BestOf = 1,
+    FixedSets = 2
+}
+
+public enum LeagueScoringMode : byte
+{
+    WinPoints = 1,
+    SetsWon = 2,
+    GamesWon = 3
+}
+
+public enum SetWinMode : byte
+{
+    WinBy2 = 0,
+    FirstTo = 1
+}

--- a/DropShot/Components/Layout/NavMenu.razor
+++ b/DropShot/Components/Layout/NavMenu.razor
@@ -65,6 +65,12 @@
                     </div>
 
                     <div class="nav-item">
+                        <NavLink class="nav-link" href="leagues">
+                            <MudIcon Icon="@Icons.Material.Filled.AccountTree" Class="nav-icon" /> <span class="nav-label">Leagues</span>
+                        </NavLink>
+                    </div>
+
+                    <div class="nav-item">
                         @if (_isClubAdminActive)
                         {
                             <NavLink class="nav-link" href="players/club">

--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -28,6 +28,23 @@
     <div style="position: absolute; inset: 0; background-color: rgba(18, 18, 18, 0.85); pointer-events: none;"></div>
     <div style="position: relative; z-index: 1; max-width: 1200px; margin: 0 auto; padding: 1rem 0.5rem 2rem;">
 
+@if (_divisionBreadcrumb is not null)
+{
+    <MudStack Row="true" AlignItems="AlignItems.Center" Class="mb-2" Spacing="1">
+        <MudIcon Icon="@Icons.Material.Filled.AccountTree" Size="Size.Small" Style="opacity:0.6" />
+        <MudLink Href="@($"/leagues/{_divisionBreadcrumb.LeagueId}")" Underline="Underline.Hover">
+            @_divisionBreadcrumb.LeagueName
+        </MudLink>
+        <MudText Typo="Typo.caption" Style="opacity:0.5">/</MudText>
+        <MudLink Href="@($"/leagues/{_divisionBreadcrumb.LeagueId}/seasons/{_divisionBreadcrumb.SeasonId}/dashboard")"
+                 Underline="Underline.Hover">
+            @_divisionBreadcrumb.SeasonName
+        </MudLink>
+        <MudText Typo="Typo.caption" Style="opacity:0.5">/</MudText>
+        <MudText Typo="Typo.caption" Style="font-weight:500">@_divisionBreadcrumb.DivisionName</MudText>
+    </MudStack>
+}
+
 <MudStack Row="true" AlignItems="AlignItems.Center" Class="mb-4" Spacing="2">
     @if (_nameOverride)
     {
@@ -1434,6 +1451,9 @@
     private List<Court> _courts = [];
     private List<CourtPair> _courtPairs = [];
 
+    private record DivisionBreadcrumb(int LeagueId, string LeagueName, int SeasonId, string SeasonName, string DivisionName);
+    private DivisionBreadcrumb? _divisionBreadcrumb;
+
     // Rubber template editor
     private List<string> _availableRoles = [];
     private List<(string Key, string Label)> _rubberPresets = [];
@@ -1783,6 +1803,20 @@
             }
 
             await LoadCompetitionAdmins(db);
+
+            if (comp.LeagueDivisionId.HasValue)
+            {
+                var div = await db.LeagueDivisions
+                    .AsNoTracking()
+                    .Include(d => d.Season).ThenInclude(s => s.League)
+                    .FirstOrDefaultAsync(d => d.LeagueDivisionId == comp.LeagueDivisionId.Value);
+                if (div is not null)
+                    _divisionBreadcrumb = new DivisionBreadcrumb(
+                        div.Season.LeagueId, div.Season.League.Name,
+                        div.LeagueSeasonId, div.Season.Name,
+                        div.Name);
+            }
+
             if (comp.CompetitionFormat == CompetitionFormat.TeamMatch)
                 await LoadRubberTemplateStateAsync(db, comp.CompetitionID, comp.RubberTemplateKey);
         }

--- a/DropShot/Components/Pages/Leagues/LeagueDetail.razor
+++ b/DropShot/Components/Pages/Leagues/LeagueDetail.razor
@@ -1,0 +1,313 @@
+@page "/leagues/{LeagueId:int}"
+@rendermode InteractiveServer
+@attribute [Authorize]
+
+@using Microsoft.AspNetCore.Authorization
+@using DropShot.Data
+@using DropShot.Models
+@using DropShot.Services
+@using Microsoft.EntityFrameworkCore
+
+@inject NavigationManager Nav
+@inject IDbContextFactory<MyDbContext> DbFactory
+@inject ClubAuthorizationService AuthzService
+@inject AuthenticationStateProvider AuthStateProvider
+@inject ISnackbar Snackbar
+@inject IDialogService DialogService
+
+<MudProviders />
+
+<MudContainer MaxWidth="MaxWidth.Large" Class="py-4">
+    @if (_league == null)
+    {
+        <MudProgressLinear Indeterminate="true" Color="Color.Primary" />
+    }
+    else
+    {
+        <MudStack Row="true" AlignItems="AlignItems.Center" Class="mb-3" Spacing="2">
+            <MudIconButton Icon="@Icons.Material.Filled.ArrowBack" Size="Size.Small"
+                           Href="/leagues" />
+            <MudText Typo="Typo.h4" Style="flex:1">@_league.Name</MudText>
+            <MudChip T="string" Size="Size.Small" Color="Color.Default">@(_league.HostClub?.Name ?? "—")</MudChip>
+        </MudStack>
+
+        <MudTabs Elevation="0" Rounded="true" ApplyEffectsToContainer="true" PanelClass="pa-4">
+            <MudTabPanel Text="Format defaults" Icon="@Icons.Material.Filled.Settings">
+                <MudStack Spacing="2" Style="max-width:480px">
+                    <MudTextField T="string" Label="Name" @bind-Value="_league.Name" Disabled="@(!_canEdit)" />
+                    <MudNumericField T="int" Label="Team size" @bind-Value="_league.TeamSize" Min="2" Max="12" Disabled="@(!_canEdit)" />
+                    <MudSelect T="LeagueScoringMode" Label="League scoring" @bind-Value="_league.LeagueScoring" Disabled="@(!_canEdit)">
+                        <MudSelectItem T="LeagueScoringMode" Value="LeagueScoringMode.WinPoints">3 pts for a win, 1 for draw</MudSelectItem>
+                        <MudSelectItem T="LeagueScoringMode" Value="LeagueScoringMode.SetsWon">1 point per set won</MudSelectItem>
+                        <MudSelectItem T="LeagueScoringMode" Value="LeagueScoringMode.GamesWon">1 point per game won</MudSelectItem>
+                    </MudSelect>
+                    <MudSelect T="MatchFormatType" Label="Rubber format" @bind-Value="_league.MatchFormat" Disabled="@(!_canEdit)">
+                        <MudSelectItem T="MatchFormatType" Value="MatchFormatType.BestOf">Best of</MudSelectItem>
+                        <MudSelectItem T="MatchFormatType" Value="MatchFormatType.FixedSets">Fixed sets</MudSelectItem>
+                    </MudSelect>
+                    <MudNumericField T="int" Label="Sets per rubber" @bind-Value="_league.NumberOfSets" Min="1" Max="9" Disabled="@(!_canEdit)" />
+                    <MudNumericField T="int" Label="Games per set" @bind-Value="_league.GamesPerSet" Min="1" Max="12" Disabled="@(!_canEdit)" />
+                    <MudNumericField T="int" Label="Teams per division (target)" @bind-Value="_league.TeamsPerDivisionTarget" Min="2" Max="16" Disabled="@(!_canEdit)" />
+                    <MudNumericField T="int" Label="Teams per division (minimum)" @bind-Value="_league.TeamsPerDivisionMin" Min="2" Max="16" Disabled="@(!_canEdit)" />
+                    <MudTextField T="string" Label="Rubber template key (optional)" @bind-Value="_league.RubberTemplateKey" HelperText="Leave blank for the format default." Disabled="@(!_canEdit)" />
+                    @if (_canEdit)
+                    {
+                        <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="SaveDefaults">Save defaults</MudButton>
+                    }
+                </MudStack>
+            </MudTabPanel>
+
+            <MudTabPanel Text="Members" Icon="@Icons.Material.Filled.Group">
+                <MudStack Row="true" AlignItems="AlignItems.End" Class="mb-3" Spacing="2">
+                    <MudAutocomplete T="Player" Label="Enrol player" SearchFunc="SearchPlayers"
+                                     ToStringFunc="@(p => p?.DisplayName ?? "")"
+                                     CoerceText="true" Clearable="true"
+                                     Disabled="@(!_canEdit)"
+                                     Value="_playerToEnrol" ValueChanged="EnrolPlayerAsync" />
+                </MudStack>
+                <MudTable Items="@_memberships" Dense="true" Hover="true">
+                    <HeaderContent>
+                        <MudTh>Player</MudTh>
+                        <MudTh>Joined</MudTh>
+                        <MudTh>Current rank</MudTh>
+                        <MudTh></MudTh>
+                    </HeaderContent>
+                    <RowTemplate>
+                        <MudTd>@(context.Player?.DisplayName ?? "—")</MudTd>
+                        <MudTd>@context.JoinedAt.ToString("dd MMM yyyy")</MudTd>
+                        <MudTd>@(context.CurrentDivisionRank?.ToString() ?? "—")</MudTd>
+                        <MudTd>
+                            @if (_canEdit)
+                            {
+                                <MudIconButton Icon="@Icons.Material.Filled.PersonRemove" Size="Size.Small" Color="Color.Error"
+                                               OnClick="@(() => UnenrolPlayerAsync(context.PlayerId))" />
+                            }
+                        </MudTd>
+                    </RowTemplate>
+                    <NoRecordsContent><MudText Typo="Typo.caption">No members yet.</MudText></NoRecordsContent>
+                </MudTable>
+            </MudTabPanel>
+
+            <MudTabPanel Text="Seasons" Icon="@Icons.Material.Filled.CalendarMonth">
+                <MudStack Row="true" Class="mb-3">
+                    @if (_canEdit)
+                    {
+                        <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                                   StartIcon="@Icons.Material.Filled.Add"
+                                   OnClick="OpenCreateSeasonDialog"
+                                   Disabled="@_hasOpenSeason">
+                            New season
+                        </MudButton>
+                    }
+                </MudStack>
+                <MudTable Items="@_seasons" Dense="true" Hover="true">
+                    <HeaderContent>
+                        <MudTh>Name</MudTh>
+                        <MudTh>Dates</MudTh>
+                        <MudTh>Status</MudTh>
+                        <MudTh>Divisions</MudTh>
+                        <MudTh></MudTh>
+                    </HeaderContent>
+                    <RowTemplate>
+                        <MudTd>@context.Name</MudTd>
+                        <MudTd>@FormatDates(context.StartDate, context.EndDate)</MudTd>
+                        <MudTd>
+                            <MudChip T="string" Size="Size.Small" Color="@StatusColor(context.Status)">@context.Status</MudChip>
+                        </MudTd>
+                        <MudTd>@context.Divisions.Count</MudTd>
+                        <MudTd>
+                            @{
+                                var routeName = context.Divisions.Count == 0 ? "setup" : "dashboard";
+                            }
+                            <MudButton Size="Size.Small" Color="Color.Primary" Variant="Variant.Text"
+                                       OnClick="@(() => Nav.NavigateTo($"/leagues/{LeagueId}/seasons/{context.LeagueSeasonId}/{routeName}"))">
+                                Open
+                            </MudButton>
+                        </MudTd>
+                    </RowTemplate>
+                    <NoRecordsContent><MudText Typo="Typo.caption">No seasons yet.</MudText></NoRecordsContent>
+                </MudTable>
+            </MudTabPanel>
+        </MudTabs>
+
+        @if (_showCreateSeasonDialog)
+        {
+            <MudDialog @bind-Visible="_showCreateSeasonDialog" Options="@(new DialogOptions { FullWidth = true, MaxWidth = MaxWidth.Small })">
+                <TitleContent>Create season</TitleContent>
+                <DialogContent>
+                    <MudStack Spacing="2">
+                        <MudTextField T="string" Label="Name" @bind-Value="_newSeasonName" Required="true" HelperText="e.g. Spring 2026" />
+                        <MudDatePicker Label="Start date" @bind-Date="_newSeasonStart" />
+                        <MudDatePicker Label="End date" @bind-Date="_newSeasonEnd" />
+                    </MudStack>
+                </DialogContent>
+                <DialogActions>
+                    <MudButton OnClick="@(() => _showCreateSeasonDialog = false)">Cancel</MudButton>
+                    <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="CreateSeason">Create</MudButton>
+                </DialogActions>
+            </MudDialog>
+        }
+    }
+</MudContainer>
+
+@code {
+    [Parameter] public int LeagueId { get; set; }
+
+    private League? _league;
+    private bool _canEdit;
+    private List<LeagueMembership> _memberships = [];
+    private List<LeagueSeason> _seasons = [];
+    private bool _hasOpenSeason;
+
+    private Player? _playerToEnrol;
+
+    private bool _showCreateSeasonDialog;
+    private string _newSeasonName = "";
+    private DateTime? _newSeasonStart;
+    private DateTime? _newSeasonEnd;
+
+    protected override async Task OnParametersSetAsync()
+    {
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        await using var db = DbFactory.CreateDbContext();
+        _league = await db.Leagues
+            .Include(l => l.HostClub)
+            .FirstOrDefaultAsync(l => l.LeagueId == LeagueId);
+        if (_league == null) return;
+
+        var authState = await AuthStateProvider.GetAuthenticationStateAsync();
+        _canEdit = await AuthzService.CanEditCompetitionAsync(authState.User, _league.HostClubId);
+
+        _memberships = await db.LeagueMemberships
+            .Include(m => m.Player)
+            .Where(m => m.LeagueId == LeagueId && m.IsActive)
+            .OrderBy(m => m.Player.DisplayName)
+            .ToListAsync();
+
+        _seasons = await db.LeagueSeasons
+            .Include(s => s.Divisions)
+            .Where(s => s.LeagueId == LeagueId)
+            .OrderByDescending(s => s.StartDate)
+            .ToListAsync();
+
+        _hasOpenSeason = _seasons.Any(s => s.Status != LeagueSeasonStatus.Closed);
+    }
+
+    private async Task SaveDefaults()
+    {
+        if (_league == null) return;
+        await using var db = DbFactory.CreateDbContext();
+        var l = await db.Leagues.FindAsync(LeagueId);
+        if (l == null) return;
+        l.Name = _league.Name;
+        l.TeamSize = _league.TeamSize;
+        l.LeagueScoring = _league.LeagueScoring;
+        l.MatchFormat = _league.MatchFormat;
+        l.NumberOfSets = _league.NumberOfSets;
+        l.GamesPerSet = _league.GamesPerSet;
+        l.TeamsPerDivisionTarget = _league.TeamsPerDivisionTarget;
+        l.TeamsPerDivisionMin = _league.TeamsPerDivisionMin;
+        l.RubberTemplateKey = string.IsNullOrWhiteSpace(_league.RubberTemplateKey) ? null : _league.RubberTemplateKey;
+        await db.SaveChangesAsync();
+        Snackbar.Add("League defaults saved.", Severity.Success);
+    }
+
+    private async Task<IEnumerable<Player>> SearchPlayers(string value, CancellationToken _)
+    {
+        await using var db = DbFactory.CreateDbContext();
+        var q = db.Players.AsNoTracking().AsQueryable();
+        if (!string.IsNullOrWhiteSpace(value))
+            q = q.Where(p => p.DisplayName.Contains(value));
+        var alreadyEnrolled = _memberships.Select(m => m.PlayerId).ToHashSet();
+        return await q
+            .Where(p => !alreadyEnrolled.Contains(p.PlayerId))
+            .OrderBy(p => p.DisplayName)
+            .Take(20)
+            .ToListAsync();
+    }
+
+    private async Task EnrolPlayerAsync(Player? player)
+    {
+        _playerToEnrol = null;
+        if (player == null || _league == null) return;
+        await using var db = DbFactory.CreateDbContext();
+        var existing = await db.LeagueMemberships.FindAsync(LeagueId, player.PlayerId);
+        if (existing == null)
+        {
+            db.LeagueMemberships.Add(new LeagueMembership { LeagueId = LeagueId, PlayerId = player.PlayerId });
+        }
+        else
+        {
+            existing.IsActive = true;
+        }
+        await db.SaveChangesAsync();
+        Snackbar.Add($"{player.DisplayName} enrolled.", Severity.Success);
+        await LoadAsync();
+    }
+
+    private async Task UnenrolPlayerAsync(int playerId)
+    {
+        await using var db = DbFactory.CreateDbContext();
+        var m = await db.LeagueMemberships.FindAsync(LeagueId, playerId);
+        if (m != null)
+        {
+            m.IsActive = false;
+            await db.SaveChangesAsync();
+        }
+        await LoadAsync();
+    }
+
+    private void OpenCreateSeasonDialog()
+    {
+        _newSeasonName = "";
+        _newSeasonStart = DateTime.Today;
+        _newSeasonEnd = DateTime.Today.AddMonths(3);
+        _showCreateSeasonDialog = true;
+    }
+
+    private async Task CreateSeason()
+    {
+        if (string.IsNullOrWhiteSpace(_newSeasonName)) return;
+        await using var db = DbFactory.CreateDbContext();
+        bool openSeason = await db.LeagueSeasons.AnyAsync(s => s.LeagueId == LeagueId && s.Status != LeagueSeasonStatus.Closed);
+        if (openSeason)
+        {
+            Snackbar.Add("Close the open season first.", Severity.Warning);
+            return;
+        }
+        var season = new LeagueSeason
+        {
+            LeagueId = LeagueId,
+            Name = _newSeasonName.Trim(),
+            StartDate = _newSeasonStart,
+            EndDate = _newSeasonEnd,
+            Status = LeagueSeasonStatus.Planning,
+        };
+        db.LeagueSeasons.Add(season);
+        await db.SaveChangesAsync();
+        _showCreateSeasonDialog = false;
+        Snackbar.Add($"Season '{season.Name}' created.", Severity.Success);
+        Nav.NavigateTo($"/leagues/{LeagueId}/seasons/{season.LeagueSeasonId}/setup");
+    }
+
+    private static string FormatDates(DateTime? start, DateTime? end) =>
+        (start, end) switch
+        {
+            (null, null) => "—",
+            (var s, null) => s!.Value.ToString("dd MMM yyyy"),
+            (null, var e) => $"→ {e!.Value:dd MMM yyyy}",
+            (var s, var e) => $"{s!.Value:dd MMM} – {e!.Value:dd MMM yyyy}",
+        };
+
+    private static Color StatusColor(LeagueSeasonStatus s) => s switch
+    {
+        LeagueSeasonStatus.Planning => Color.Default,
+        LeagueSeasonStatus.Active => Color.Success,
+        LeagueSeasonStatus.Closed => Color.Secondary,
+        _ => Color.Default,
+    };
+}

--- a/DropShot/Components/Pages/Leagues/LeaguesIndex.razor
+++ b/DropShot/Components/Pages/Leagues/LeaguesIndex.razor
@@ -1,0 +1,164 @@
+@page "/leagues"
+@rendermode InteractiveServer
+@attribute [Authorize]
+
+@using Microsoft.AspNetCore.Authorization
+@using DropShot.Data
+@using DropShot.Models
+@using DropShot.Services
+@using Microsoft.EntityFrameworkCore
+
+@inject NavigationManager Nav
+@inject IDbContextFactory<MyDbContext> DbFactory
+@inject ClubAuthorizationService AuthzService
+@inject AuthenticationStateProvider AuthStateProvider
+@inject ISnackbar Snackbar
+
+<MudProviders />
+
+<MudContainer MaxWidth="MaxWidth.Large" Class="py-4">
+    <MudStack Row="true" AlignItems="AlignItems.Center" Class="mb-4">
+        <MudText Typo="Typo.h4" Style="flex:1">Leagues</MudText>
+        @if (_canCreate)
+        {
+            <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                       StartIcon="@Icons.Material.Filled.Add"
+                       OnClick="OpenCreateDialog">
+                New league
+            </MudButton>
+        }
+    </MudStack>
+
+    @if (_loading)
+    {
+        <MudProgressLinear Indeterminate="true" Color="Color.Primary" />
+    }
+    else if (!_leagues.Any())
+    {
+        <MudAlert Severity="Severity.Info">No leagues yet. Create one to get started.</MudAlert>
+    }
+    else
+    {
+        <MudTable Items="@_leagues" Dense="true" Hover="true">
+            <HeaderContent>
+                <MudTh>Name</MudTh>
+                <MudTh>Club</MudTh>
+                <MudTh>Seasons</MudTh>
+                <MudTh>Members</MudTh>
+                <MudTh></MudTh>
+            </HeaderContent>
+            <RowTemplate>
+                <MudTd>@context.Name</MudTd>
+                <MudTd>@(context.HostClub?.Name ?? "—")</MudTd>
+                <MudTd>@context.Seasons.Count</MudTd>
+                <MudTd>@context.Memberships.Count(m => m.IsActive)</MudTd>
+                <MudTd>
+                    <MudButton Size="Size.Small" Variant="Variant.Text" Color="Color.Primary"
+                               OnClick="@(() => Nav.NavigateTo($"/leagues/{context.LeagueId}"))">
+                        Open
+                    </MudButton>
+                </MudTd>
+            </RowTemplate>
+        </MudTable>
+    }
+
+    @if (_showCreateDialog)
+    {
+        <MudDialog @bind-Visible="_showCreateDialog" Options="@(new DialogOptions { FullWidth = true, MaxWidth = MaxWidth.Small })">
+            <TitleContent>Create league</TitleContent>
+            <DialogContent>
+                <MudStack Spacing="2">
+                    <MudTextField T="string" Label="Name" @bind-Value="_newLeagueName" Required="true" />
+                    <MudSelect T="int?" Label="Host club" @bind-Value="_newLeagueHostClubId" Required="true">
+                        @foreach (var c in _clubs)
+                        {
+                            <MudSelectItem T="int?" Value="@((int?)c.ClubId)">@c.Name</MudSelectItem>
+                        }
+                    </MudSelect>
+                    <MudNumericField T="int" Label="Teams per division (target)" @bind-Value="_newTeamsPerDivision" Min="2" Max="16" />
+                    <MudNumericField T="int" Label="Team size" @bind-Value="_newTeamSize" Min="2" Max="12" />
+                </MudStack>
+            </DialogContent>
+            <DialogActions>
+                <MudButton OnClick="@(() => _showCreateDialog = false)">Cancel</MudButton>
+                <MudButton Color="Color.Primary" Variant="Variant.Filled"
+                           OnClick="CreateLeague" Disabled="_creating">Create</MudButton>
+            </DialogActions>
+        </MudDialog>
+    }
+</MudContainer>
+
+@code {
+    private bool _loading = true;
+    private bool _canCreate;
+    private List<League> _leagues = [];
+    private List<Club> _clubs = [];
+
+    private bool _showCreateDialog;
+    private bool _creating;
+    private string _newLeagueName = "";
+    private int? _newLeagueHostClubId;
+    private int _newTeamsPerDivision = 8;
+    private int _newTeamSize = 4;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await using var db = DbFactory.CreateDbContext();
+        _leagues = await db.Leagues.AsNoTracking()
+            .Include(l => l.HostClub)
+            .Include(l => l.Seasons)
+            .Include(l => l.Memberships)
+            .Where(l => !l.IsArchived)
+            .OrderBy(l => l.Name)
+            .ToListAsync();
+
+        var authState = await AuthStateProvider.GetAuthenticationStateAsync();
+        var adminClubIds = await AuthzService.GetAdminClubIdsAsync(authState.User);
+        bool isAdmin = await AuthzService.IsAdminAsync(authState.User);
+        _canCreate = isAdmin || adminClubIds.Count > 0;
+
+        if (_canCreate)
+        {
+            _clubs = await db.Clubs
+                .Where(c => isAdmin || adminClubIds.Contains(c.ClubId))
+                .OrderBy(c => c.Name)
+                .ToListAsync();
+            _newLeagueHostClubId = _clubs.FirstOrDefault()?.ClubId;
+        }
+        _loading = false;
+    }
+
+    private void OpenCreateDialog()
+    {
+        _newLeagueName = "";
+        _newTeamsPerDivision = 8;
+        _newTeamSize = 4;
+        _showCreateDialog = true;
+    }
+
+    private async Task CreateLeague()
+    {
+        if (string.IsNullOrWhiteSpace(_newLeagueName) || !_newLeagueHostClubId.HasValue) return;
+        _creating = true;
+        try
+        {
+            await using var db = DbFactory.CreateDbContext();
+            var league = new League
+            {
+                Name = _newLeagueName.Trim(),
+                HostClubId = _newLeagueHostClubId.Value,
+                TeamsPerDivisionTarget = _newTeamsPerDivision,
+                TeamSize = _newTeamSize,
+            };
+            db.Leagues.Add(league);
+            await db.SaveChangesAsync();
+            _showCreateDialog = false;
+            Snackbar.Add($"League '{league.Name}' created.", Severity.Success);
+            Nav.NavigateTo($"/leagues/{league.LeagueId}");
+        }
+        finally
+        {
+            _creating = false;
+        }
+    }
+}

--- a/DropShot/Components/Pages/Leagues/PlayerSeasonStats.razor
+++ b/DropShot/Components/Pages/Leagues/PlayerSeasonStats.razor
@@ -1,0 +1,145 @@
+@page "/leagues/{LeagueId:int}/seasons/{SeasonId:int}/stats"
+@rendermode InteractiveServer
+@attribute [Authorize]
+
+@using Microsoft.AspNetCore.Authorization
+@using DropShot.Data
+@using DropShot.Models
+@using DropShot.Services
+@using Microsoft.EntityFrameworkCore
+
+@inject NavigationManager Nav
+@inject IDbContextFactory<MyDbContext> DbFactory
+
+<MudProviders />
+
+<MudContainer MaxWidth="MaxWidth.Large" Class="py-4">
+    @if (_loading)
+    {
+        <MudProgressLinear Indeterminate="true" Color="Color.Primary" />
+    }
+    else if (_season == null || _league == null)
+    {
+        <MudAlert Severity="Severity.Error">Season not found.</MudAlert>
+    }
+    else
+    {
+        <MudStack Row="true" AlignItems="AlignItems.Center" Class="mb-3" Spacing="2">
+            <MudIconButton Icon="@Icons.Material.Filled.ArrowBack" Size="Size.Small"
+                           Href="@($"/leagues/{LeagueId}/seasons/{SeasonId}/dashboard")" />
+            <MudText Typo="Typo.h4" Style="flex:1">@_league.Name — @_season.Name — player stats</MudText>
+        </MudStack>
+
+        @if (_rows.Count == 0)
+        {
+            <MudAlert Severity="Severity.Info">No rubbers played yet.</MudAlert>
+        }
+        else
+        {
+            <MudTable Items="@_rows" Dense="true" Hover="true" Filter="new Func<StatRow, bool>(FilterFunc)">
+                <ToolBarContent>
+                    <MudTextField T="string" @bind-Value="_search" Placeholder="Search players..." Clearable="true"
+                                  Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search"
+                                  Style="max-width:300px" />
+                </ToolBarContent>
+                <HeaderContent>
+                    <MudTh>Player</MudTh>
+                    <MudTh>Division</MudTh>
+                    <MudTh>Rubbers</MudTh>
+                    <MudTh>W-L</MudTh>
+                    <MudTh>Sets W-L</MudTh>
+                    <MudTh>Games W-L</MudTh>
+                    <MudTh>Win %</MudTh>
+                    <MudTh>Points</MudTh>
+                </HeaderContent>
+                <RowTemplate>
+                    <MudTd Style="font-weight:500">@context.DisplayName</MudTd>
+                    <MudTd>@context.DivisionName</MudTd>
+                    <MudTd>@context.Played</MudTd>
+                    <MudTd>@context.Won – @context.Lost</MudTd>
+                    <MudTd>@context.SetsWon – @context.SetsAgainst</MudTd>
+                    <MudTd>@context.GamesWon – @context.GamesAgainst</MudTd>
+                    <MudTd>@($"{context.WinRate * 100:0}%")</MudTd>
+                    <MudTd Style="font-weight:bold">@context.Points</MudTd>
+                </RowTemplate>
+            </MudTable>
+        }
+    }
+</MudContainer>
+
+@code {
+    [Parameter] public int LeagueId { get; set; }
+    [Parameter] public int SeasonId { get; set; }
+
+    private bool _loading = true;
+    private LeagueSeason? _season;
+    private League? _league;
+    private List<StatRow> _rows = [];
+    private string? _search;
+
+    private record StatRow(
+        int PlayerId,
+        string DisplayName,
+        string DivisionName,
+        int Played,
+        int Won,
+        int Lost,
+        int SetsWon,
+        int SetsAgainst,
+        int GamesWon,
+        int GamesAgainst,
+        int Points,
+        double WinRate);
+
+    protected override async Task OnParametersSetAsync()
+    {
+        await using var db = DbFactory.CreateDbContext();
+        _league = await db.Leagues.FindAsync(LeagueId);
+        _season = await db.LeagueSeasons
+            .Include(s => s.Divisions).ThenInclude(d => d.Competition).ThenInclude(c => c.Participants).ThenInclude(p => p.Player)
+            .FirstOrDefaultAsync(s => s.LeagueSeasonId == SeasonId);
+        if (_league == null || _season == null) { _loading = false; return; }
+
+        _rows = [];
+        foreach (var d in _season.Divisions.OrderBy(d => d.Rank))
+        {
+            var stats = await PlayerStatsService.ComputeAsync(
+                db, [d.CompetitionId], _league.LeagueScoring);
+
+            foreach (var p in d.Competition.Participants.Where(p => p.Player != null))
+            {
+                stats.TryGetValue(p.PlayerId, out var s);
+                int played = s?.RubbersPlayed ?? 0;
+                double wr = played > 0 ? (s!.RubbersWon / (double)played) : 0.0;
+                _rows.Add(new StatRow(
+                    p.PlayerId,
+                    p.Player!.DisplayName,
+                    d.Name,
+                    played,
+                    s?.RubbersWon ?? 0,
+                    s?.RubbersLost ?? 0,
+                    s?.SetsWon ?? 0,
+                    s?.SetsAgainst ?? 0,
+                    s?.GamesWon ?? 0,
+                    s?.GamesAgainst ?? 0,
+                    s?.LeaguePoints ?? 0,
+                    wr));
+            }
+        }
+
+        _rows = _rows
+            .OrderByDescending(r => r.Points)
+            .ThenByDescending(r => r.Won)
+            .ThenByDescending(r => r.WinRate)
+            .ToList();
+
+        _loading = false;
+    }
+
+    private bool FilterFunc(StatRow row)
+    {
+        if (string.IsNullOrWhiteSpace(_search)) return true;
+        return row.DisplayName.Contains(_search, StringComparison.OrdinalIgnoreCase)
+            || row.DivisionName.Contains(_search, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/DropShot/Components/Pages/Leagues/SeasonClose.razor
+++ b/DropShot/Components/Pages/Leagues/SeasonClose.razor
@@ -1,0 +1,204 @@
+@page "/leagues/{LeagueId:int}/seasons/{SeasonId:int}/close"
+@rendermode InteractiveServer
+@attribute [Authorize]
+
+@using Microsoft.AspNetCore.Authorization
+@using DropShot.Data
+@using DropShot.Models
+@using DropShot.Services
+@using Microsoft.EntityFrameworkCore
+
+@inject NavigationManager Nav
+@inject IDbContextFactory<MyDbContext> DbFactory
+@inject ClubAuthorizationService AuthzService
+@inject AuthenticationStateProvider AuthStateProvider
+@inject ISnackbar Snackbar
+
+<MudProviders />
+
+<MudContainer MaxWidth="MaxWidth.Large" Class="py-4">
+    @if (_loading)
+    {
+        <MudProgressLinear Indeterminate="true" Color="Color.Primary" />
+    }
+    else if (_season == null || _league == null)
+    {
+        <MudAlert Severity="Severity.Error">Season not found.</MudAlert>
+    }
+    else
+    {
+        <MudStack Row="true" AlignItems="AlignItems.Center" Class="mb-3" Spacing="2">
+            <MudIconButton Icon="@Icons.Material.Filled.ArrowBack" Size="Size.Small"
+                           Href="@($"/leagues/{LeagueId}/seasons/{SeasonId}/dashboard")" />
+            <MudText Typo="Typo.h4" Style="flex:1">Close @_season.Name</MudText>
+        </MudStack>
+
+        <MudText Typo="Typo.body2" Class="mb-3" Style="opacity:0.8">
+            Players are ranked within each division by their league points. Use the arrows to promote (↑) or demote (↓) a player into an adjacent division. When ready, click "Execute close" — each player's division assignment is saved to their league membership and drives the next season's bucketing.
+        </MudText>
+
+        @foreach (var div in _rankedDivisions.OrderBy(d => d.Rank))
+        {
+            <MudPaper Class="pa-4 mb-4" Elevation="1">
+                <MudText Typo="Typo.h6" Class="mb-2">@div.Name (rank @div.Rank)</MudText>
+                <MudTable Items="@div.Players" Dense="true" Hover="true">
+                    <HeaderContent>
+                        <MudTh>#</MudTh>
+                        <MudTh>Player</MudTh>
+                        <MudTh>Played</MudTh>
+                        <MudTh>Won</MudTh>
+                        <MudTh>Points</MudTh>
+                        <MudTh>Win %</MudTh>
+                        <MudTh>Next div</MudTh>
+                        <MudTh></MudTh>
+                    </HeaderContent>
+                    <RowTemplate>
+                        <MudTd>@(div.Players.IndexOf(context) + 1)</MudTd>
+                        <MudTd Style="font-weight:500">@context.DisplayName</MudTd>
+                        <MudTd>@context.Played</MudTd>
+                        <MudTd>@context.Won</MudTd>
+                        <MudTd>@context.Points</MudTd>
+                        <MudTd>@($"{context.WinRate * 100:0}%")</MudTd>
+                        <MudTd>@_decisions[context.PlayerId]</MudTd>
+                        <MudTd>
+                            <MudIconButton Icon="@Icons.Material.Filled.ArrowUpward" Size="Size.Small"
+                                           Disabled="@(_decisions[context.PlayerId] <= 1)"
+                                           OnClick="@(() => Move(context.PlayerId, -1))" />
+                            <MudIconButton Icon="@Icons.Material.Filled.ArrowDownward" Size="Size.Small"
+                                           Disabled="@(_decisions[context.PlayerId] >= _divCount)"
+                                           OnClick="@(() => Move(context.PlayerId, +1))" />
+                        </MudTd>
+                    </RowTemplate>
+                </MudTable>
+            </MudPaper>
+        }
+
+        @if (!string.IsNullOrEmpty(_error))
+        {
+            <MudAlert Severity="Severity.Error" Class="mb-3">@_error</MudAlert>
+        }
+
+        <MudStack Row="true" Spacing="2">
+            <MudSpacer />
+            <MudButton Variant="Variant.Filled" Color="Color.Warning"
+                       StartIcon="@Icons.Material.Filled.FlagCircle"
+                       OnClick="ExecuteClose" Disabled="_saving">
+                @(_saving ? "Closing..." : "Execute close")
+            </MudButton>
+        </MudStack>
+    }
+</MudContainer>
+
+@code {
+    [Parameter] public int LeagueId { get; set; }
+    [Parameter] public int SeasonId { get; set; }
+
+    private bool _loading = true;
+    private bool _saving;
+    private string? _error;
+    private League? _league;
+    private LeagueSeason? _season;
+    private List<RankedDivision> _rankedDivisions = [];
+    private Dictionary<int, byte> _decisions = [];
+    private int _divCount = 1;
+
+    private record RankedPlayer(int PlayerId, string DisplayName, int Played, int Won, int Points, double WinRate);
+    private record RankedDivision(byte Rank, string Name, List<RankedPlayer> Players);
+
+    protected override async Task OnParametersSetAsync()
+    {
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        _loading = true;
+        await using var db = DbFactory.CreateDbContext();
+        _league = await db.Leagues.FindAsync(LeagueId);
+        _season = await db.LeagueSeasons
+            .Include(s => s.Divisions).ThenInclude(d => d.Competition).ThenInclude(c => c.Participants).ThenInclude(p => p.Player)
+            .FirstOrDefaultAsync(s => s.LeagueSeasonId == SeasonId);
+        if (_season == null || _league == null) { _loading = false; return; }
+
+        _divCount = _season.Divisions.Count;
+        _rankedDivisions = [];
+        _decisions = [];
+
+        foreach (var d in _season.Divisions.OrderBy(d => d.Rank))
+        {
+            var stats = await PlayerStatsService.ComputeAsync(
+                db, [d.CompetitionId], _league.LeagueScoring);
+
+            var players = d.Competition.Participants
+                .Where(p => p.Player != null)
+                .Select(p =>
+                {
+                    stats.TryGetValue(p.PlayerId, out var s);
+                    int played = s?.RubbersPlayed ?? 0;
+                    double wr = played > 0 ? (s!.RubbersWon / (double)played) : 0.0;
+                    return new RankedPlayer(
+                        p.PlayerId,
+                        p.Player!.DisplayName,
+                        played,
+                        s?.RubbersWon ?? 0,
+                        s?.LeaguePoints ?? 0,
+                        wr);
+                })
+                .OrderByDescending(r => r.Points)
+                .ThenByDescending(r => r.Won)
+                .ThenByDescending(r => r.WinRate)
+                .ToList();
+
+            _rankedDivisions.Add(new RankedDivision(d.Rank, d.Name, players));
+            foreach (var p in players)
+                _decisions[p.PlayerId] = d.Rank;
+        }
+
+        _loading = false;
+    }
+
+    private void Move(int playerId, int delta)
+    {
+        if (!_decisions.TryGetValue(playerId, out var current)) return;
+        byte next = (byte)Math.Clamp(current + delta, 1, _divCount);
+        _decisions[playerId] = next;
+    }
+
+    private async Task ExecuteClose()
+    {
+        _error = null;
+        _saving = true;
+        try
+        {
+            await using var db = DbFactory.CreateDbContext();
+            var league = await db.Leagues
+                .Include(l => l.Memberships)
+                .FirstOrDefaultAsync(l => l.LeagueId == LeagueId);
+            var season = await db.LeagueSeasons.FindAsync(SeasonId);
+            if (league == null || season == null) { _error = "Season not found."; return; }
+            if (season.Status == LeagueSeasonStatus.Closed) { _error = "Already closed."; return; }
+
+            foreach (var (playerId, newRank) in _decisions)
+            {
+                var membership = league.Memberships.FirstOrDefault(m => m.PlayerId == playerId);
+                if (membership == null) continue;
+                membership.CurrentDivisionRank = newRank;
+            }
+
+            season.Status = LeagueSeasonStatus.Closed;
+            season.ClosedAt = DateTime.UtcNow;
+            await db.SaveChangesAsync();
+
+            Snackbar.Add("Season closed — promotions / demotions saved.", Severity.Success);
+            Nav.NavigateTo($"/leagues/{LeagueId}");
+        }
+        catch (Exception ex)
+        {
+            _error = $"Close failed: {ex.Message}";
+        }
+        finally
+        {
+            _saving = false;
+        }
+    }
+}

--- a/DropShot/Components/Pages/Leagues/SeasonDashboard.razor
+++ b/DropShot/Components/Pages/Leagues/SeasonDashboard.razor
@@ -1,0 +1,204 @@
+@page "/leagues/{LeagueId:int}/seasons/{SeasonId:int}/dashboard"
+@rendermode InteractiveServer
+@attribute [Authorize]
+
+@using Microsoft.AspNetCore.Authorization
+@using DropShot.Data
+@using DropShot.Models
+@using DropShot.Services
+@using Microsoft.EntityFrameworkCore
+
+@inject NavigationManager Nav
+@inject IDbContextFactory<MyDbContext> DbFactory
+@inject ClubAuthorizationService AuthzService
+@inject AuthenticationStateProvider AuthStateProvider
+
+<MudProviders />
+
+<MudContainer MaxWidth="MaxWidth.Large" Class="py-4">
+    @if (_loading)
+    {
+        <MudProgressLinear Indeterminate="true" Color="Color.Primary" />
+    }
+    else if (_season == null)
+    {
+        <MudAlert Severity="Severity.Error">Season not found.</MudAlert>
+    }
+    else
+    {
+        <MudStack Row="true" AlignItems="AlignItems.Center" Class="mb-4" Spacing="2">
+            <MudIconButton Icon="@Icons.Material.Filled.ArrowBack" Size="Size.Small"
+                           Href="@($"/leagues/{LeagueId}")" />
+            <MudText Typo="Typo.h4" Style="flex:1">@(_league?.Name) — @_season.Name</MudText>
+            <MudChip T="string" Size="Size.Small" Color="@StatusColor(_season.Status)">@_season.Status</MudChip>
+            @if (_season.Status == LeagueSeasonStatus.Active && _canEdit)
+            {
+                <MudButton Variant="Variant.Outlined" Color="Color.Warning"
+                           StartIcon="@Icons.Material.Filled.FlagCircle"
+                           Href="@($"/leagues/{LeagueId}/seasons/{SeasonId}/close")">
+                    Close season
+                </MudButton>
+            }
+            <MudButton Variant="Variant.Text" Color="Color.Primary"
+                       StartIcon="@Icons.Material.Filled.QueryStats"
+                       Href="@($"/leagues/{LeagueId}/seasons/{SeasonId}/stats")">
+                Stats
+            </MudButton>
+        </MudStack>
+
+        @foreach (var division in _season.Divisions.OrderBy(d => d.Rank))
+        {
+            <MudPaper Class="pa-4 mb-4" Elevation="1">
+                <MudStack Row="true" AlignItems="AlignItems.Center" Class="mb-2" Spacing="2">
+                    <MudText Typo="Typo.h6" Style="flex:1">@division.Name</MudText>
+                    <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Primary"
+                               StartIcon="@Icons.Material.Filled.Edit"
+                               Href="@($"/competition/{division.CompetitionId}")">
+                        Manage division
+                    </MudButton>
+                    <MudButton Size="Size.Small" Variant="Variant.Text"
+                               StartIcon="@Icons.Material.Filled.Visibility"
+                               Href="@($"/competition/{division.CompetitionId}/view")">
+                        View
+                    </MudButton>
+                </MudStack>
+                @{
+                    var table = _tables.GetValueOrDefault(division.LeagueDivisionId);
+                }
+                @if (table == null || table.Count == 0)
+                {
+                    <MudText Typo="Typo.caption" Color="Color.Secondary">No completed fixtures yet.</MudText>
+                }
+                else
+                {
+                    <MudTable Items="@table" Dense="true" Hover="true">
+                        <HeaderContent>
+                            <MudTh>Pos</MudTh>
+                            <MudTh>Team</MudTh>
+                            <MudTh>P</MudTh>
+                            <MudTh>W</MudTh>
+                            <MudTh>D</MudTh>
+                            <MudTh>L</MudTh>
+                            <MudTh>Pts</MudTh>
+                        </HeaderContent>
+                        <RowTemplate>
+                            <MudTd>@(table.IndexOf(context) + 1)</MudTd>
+                            <MudTd Style="font-weight:500">@context.TeamName</MudTd>
+                            <MudTd>@context.Played</MudTd>
+                            <MudTd>@context.Won</MudTd>
+                            <MudTd>@context.Drawn</MudTd>
+                            <MudTd>@context.Lost</MudTd>
+                            <MudTd Style="font-weight:bold">@context.Points</MudTd>
+                        </RowTemplate>
+                    </MudTable>
+                }
+            </MudPaper>
+        }
+    }
+</MudContainer>
+
+@code {
+    [Parameter] public int LeagueId { get; set; }
+    [Parameter] public int SeasonId { get; set; }
+
+    private bool _loading = true;
+    private bool _canEdit;
+    private League? _league;
+    private LeagueSeason? _season;
+    private Dictionary<int, List<TableRow>> _tables = [];
+
+    private record TableRow(string TeamName, int Played, int Won, int Drawn, int Lost, int Points);
+
+    protected override async Task OnParametersSetAsync()
+    {
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        _loading = true;
+        await using var db = DbFactory.CreateDbContext();
+        _league = await db.Leagues.FindAsync(LeagueId);
+        _season = await db.LeagueSeasons
+            .Include(s => s.Divisions)
+                .ThenInclude(d => d.Competition)
+                    .ThenInclude(c => c.Teams)
+            .Include(s => s.Divisions)
+                .ThenInclude(d => d.Competition)
+                    .ThenInclude(c => c.Fixtures)
+                        .ThenInclude(f => f.Rubbers)
+            .FirstOrDefaultAsync(s => s.LeagueSeasonId == SeasonId);
+        if (_season == null || _league == null) { _loading = false; return; }
+
+        var authState = await AuthStateProvider.GetAuthenticationStateAsync();
+        _canEdit = await AuthzService.CanEditCompetitionAsync(authState.User, _league.HostClubId);
+
+        foreach (var division in _season.Divisions)
+            _tables[division.LeagueDivisionId] = BuildTable(division, _league.LeagueScoring);
+
+        _loading = false;
+    }
+
+    private static List<TableRow> BuildTable(LeagueDivision division, LeagueScoringMode mode)
+    {
+        var teams = division.Competition.Teams.ToList();
+        var fixtures = division.Competition.Fixtures
+            .Where(f => f.Status == FixtureStatus.Completed && f.HomeTeamId.HasValue && f.AwayTeamId.HasValue)
+            .ToList();
+        if (teams.Count == 0) return [];
+
+        var played = teams.ToDictionary(t => t.CompetitionTeamId, _ => 0);
+        var won = teams.ToDictionary(t => t.CompetitionTeamId, _ => 0);
+        var drawn = teams.ToDictionary(t => t.CompetitionTeamId, _ => 0);
+        var lost = teams.ToDictionary(t => t.CompetitionTeamId, _ => 0);
+        var points = teams.ToDictionary(t => t.CompetitionTeamId, _ => 0);
+
+        foreach (var f in fixtures)
+        {
+            int hid = f.HomeTeamId!.Value;
+            int aid = f.AwayTeamId!.Value;
+            if (!played.ContainsKey(hid) || !played.ContainsKey(aid)) continue;
+
+            var (homeFor, awayFor, _) = RubberResolutionService.ComputeLeagueScore(
+                f.Rubbers, hid, aid, mode);
+            int homeRubbers = f.Rubbers.Count(r => r.IsComplete && r.WinnerTeamId == hid);
+            int awayRubbers = f.Rubbers.Count(r => r.IsComplete && r.WinnerTeamId == aid);
+            bool homeWin = homeRubbers > awayRubbers;
+            bool awayWin = awayRubbers > homeRubbers;
+
+            played[hid]++; played[aid]++;
+            if (homeWin) { won[hid]++; lost[aid]++; }
+            else if (awayWin) { won[aid]++; lost[hid]++; }
+            else { drawn[hid]++; drawn[aid]++; }
+
+            (int homePts, int awayPts) = mode switch
+            {
+                LeagueScoringMode.SetsWon => (homeFor, awayFor),
+                LeagueScoringMode.GamesWon => (homeFor, awayFor),
+                _ => (homeWin ? 3 : (!awayWin ? 1 : 0), awayWin ? 3 : (!homeWin ? 1 : 0)),
+            };
+            points[hid] += homePts; points[aid] += awayPts;
+        }
+
+        return teams
+            .Select(t => new TableRow(
+                t.Name,
+                played[t.CompetitionTeamId],
+                won[t.CompetitionTeamId],
+                drawn[t.CompetitionTeamId],
+                lost[t.CompetitionTeamId],
+                points[t.CompetitionTeamId]))
+            .OrderByDescending(r => r.Points)
+            .ThenByDescending(r => r.Won)
+            .ThenBy(r => r.Lost)
+            .ToList();
+    }
+
+    private static Color StatusColor(LeagueSeasonStatus s) => s switch
+    {
+        LeagueSeasonStatus.Planning => Color.Default,
+        LeagueSeasonStatus.Active => Color.Success,
+        LeagueSeasonStatus.Closed => Color.Secondary,
+        _ => Color.Default,
+    };
+}

--- a/DropShot/Components/Pages/Leagues/SeasonSetup.razor
+++ b/DropShot/Components/Pages/Leagues/SeasonSetup.razor
@@ -1,0 +1,312 @@
+@page "/leagues/{LeagueId:int}/seasons/{SeasonId:int}/setup"
+@rendermode InteractiveServer
+@attribute [Authorize]
+
+@using Microsoft.AspNetCore.Authorization
+@using DropShot.Data
+@using DropShot.Models
+@using DropShot.Services
+@using Microsoft.EntityFrameworkCore
+
+@inject NavigationManager Nav
+@inject IDbContextFactory<MyDbContext> DbFactory
+@inject ClubAuthorizationService AuthzService
+@inject AuthenticationStateProvider AuthStateProvider
+@inject ISnackbar Snackbar
+@inject ICompetitionRubberTemplateProvider TemplateProvider
+
+<MudProviders />
+
+<MudContainer MaxWidth="MaxWidth.Large" Class="py-4">
+    @if (_loading)
+    {
+        <MudProgressLinear Indeterminate="true" Color="Color.Primary" />
+    }
+    else if (_season == null || _league == null)
+    {
+        <MudAlert Severity="Severity.Error">Season not found.</MudAlert>
+    }
+    else
+    {
+        <MudStack Row="true" AlignItems="AlignItems.Center" Class="mb-4" Spacing="2">
+            <MudIconButton Icon="@Icons.Material.Filled.ArrowBack" Size="Size.Small"
+                           Href="@($"/leagues/{LeagueId}")" />
+            <MudText Typo="Typo.h4" Style="flex:1">@_league.Name — @_season.Name — setup</MudText>
+            <MudChip T="string" Size="Size.Small" Color="Color.Default">@_season.Status</MudChip>
+        </MudStack>
+
+        @if (_season.Status != LeagueSeasonStatus.Planning)
+        {
+            <MudAlert Severity="Severity.Info">Season already materialised — use the dashboard to manage divisions.</MudAlert>
+            <MudButton Class="mt-3" Variant="Variant.Outlined" Color="Color.Primary"
+                       Href="@($"/leagues/{LeagueId}/seasons/{SeasonId}/dashboard")">
+                Open dashboard
+            </MudButton>
+        }
+        else
+        {
+            <MudText Typo="Typo.body2" Class="mb-3" Style="opacity:0.75">
+                @_activeMembers.Count active members. Suggested @_buckets.Count division(s) at @(_league.TeamsPerDivisionTarget * _league.TeamSize) players each. Drag players between divisions by changing their division dropdown, then confirm team assignments and materialise.
+            </MudText>
+
+            <MudTable Items="@_activeMembers" Dense="true" Hover="true">
+                <HeaderContent>
+                    <MudTh>Player</MudTh>
+                    <MudTh>Last rank</MudTh>
+                    <MudTh>Division (this season)</MudTh>
+                    <MudTh>Team</MudTh>
+                </HeaderContent>
+                <RowTemplate>
+                    <MudTd>@context.DisplayName</MudTd>
+                    <MudTd>@(context.LastRank?.ToString() ?? "—")</MudTd>
+                    <MudTd>
+                        <MudSelect T="byte" Value="context.DivisionRank" Dense="true"
+                                   ValueChanged="@((byte r) => SetDivision(context, r))">
+                            @foreach (var b in _buckets)
+                            {
+                                <MudSelectItem T="byte" Value="@b.Rank">@b.Name</MudSelectItem>
+                            }
+                        </MudSelect>
+                    </MudTd>
+                    <MudTd>
+                        <MudTextField T="string" Value="context.TeamName" Dense="true"
+                                      ValueChanged="@((string n) => context.TeamName = n)"
+                                      Placeholder="Team name" />
+                    </MudTd>
+                </RowTemplate>
+            </MudTable>
+
+            <MudStack Row="true" Spacing="2" Class="mt-4">
+                <MudButton Variant="Variant.Outlined" OnClick="AddDivisionBucket">Add division</MudButton>
+                <MudButton Variant="Variant.Outlined" OnClick="RemoveDivisionBucket"
+                           Disabled="@(_buckets.Count <= 1)">Remove last</MudButton>
+                <MudSpacer />
+                <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                           OnClick="Materialise" Disabled="_saving">
+                    @(_saving ? "Creating..." : "Materialise divisions")
+                </MudButton>
+            </MudStack>
+
+            @if (_error is not null)
+            {
+                <MudAlert Severity="Severity.Error" Class="mt-3">@_error</MudAlert>
+            }
+        }
+    }
+</MudContainer>
+
+@code {
+    [Parameter] public int LeagueId { get; set; }
+    [Parameter] public int SeasonId { get; set; }
+
+    private bool _loading = true;
+    private bool _saving;
+    private League? _league;
+    private LeagueSeason? _season;
+    private List<MemberRow> _activeMembers = [];
+    private List<DivisionBucket> _buckets = [];
+    private string? _error;
+
+    private class MemberRow
+    {
+        public int PlayerId;
+        public string DisplayName = "";
+        public byte? LastRank;
+        public byte DivisionRank = 1;
+        public string TeamName = "";
+    }
+
+    private class DivisionBucket
+    {
+        public byte Rank;
+        public string Name = "";
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        _loading = true;
+        await using var db = DbFactory.CreateDbContext();
+        _league = await db.Leagues.FindAsync(LeagueId);
+        _season = await db.LeagueSeasons.FindAsync(SeasonId);
+        if (_league == null || _season == null) { _loading = false; return; }
+
+        var members = await db.LeagueMemberships
+            .Include(m => m.Player)
+            .Where(m => m.LeagueId == LeagueId && m.IsActive)
+            .OrderBy(m => m.CurrentDivisionRank ?? byte.MaxValue)
+            .ThenBy(m => m.Player.DisplayName)
+            .ToListAsync();
+
+        int playersPerDivision = Math.Max(1, _league.TeamsPerDivisionTarget * _league.TeamSize);
+        int divisionCount = Math.Max(1, (int)Math.Ceiling(members.Count / (double)playersPerDivision));
+
+        _buckets = Enumerable.Range(1, divisionCount)
+            .Select(i => new DivisionBucket { Rank = (byte)i, Name = $"Division {i}" })
+            .ToList();
+
+        // Allocate: if ranks exist use them, otherwise split evenly by index.
+        bool hasRanks = members.Any(m => m.CurrentDivisionRank.HasValue);
+        _activeMembers = [];
+        for (int i = 0; i < members.Count; i++)
+        {
+            var m = members[i];
+            byte rank;
+            if (hasRanks)
+            {
+                rank = m.CurrentDivisionRank ?? (byte)divisionCount;
+                if (rank < 1) rank = 1;
+                if (rank > divisionCount) rank = (byte)divisionCount;
+            }
+            else
+            {
+                rank = (byte)Math.Min(divisionCount, (i / playersPerDivision) + 1);
+            }
+            _activeMembers.Add(new MemberRow
+            {
+                PlayerId = m.PlayerId,
+                DisplayName = m.Player.DisplayName,
+                LastRank = m.CurrentDivisionRank,
+                DivisionRank = rank,
+                TeamName = "",
+            });
+        }
+
+        _loading = false;
+    }
+
+    private void SetDivision(MemberRow row, byte rank)
+    {
+        row.DivisionRank = rank;
+    }
+
+    private void AddDivisionBucket()
+    {
+        var next = (byte)(_buckets.Count + 1);
+        _buckets.Add(new DivisionBucket { Rank = next, Name = $"Division {next}" });
+    }
+
+    private void RemoveDivisionBucket()
+    {
+        if (_buckets.Count <= 1) return;
+        var top = _buckets[^1].Rank;
+        _buckets.RemoveAt(_buckets.Count - 1);
+        foreach (var m in _activeMembers.Where(m => m.DivisionRank == top))
+            m.DivisionRank = (byte)_buckets.Count;
+    }
+
+    private async Task Materialise()
+    {
+        _error = null;
+        if (_league == null || _season == null) return;
+
+        // Group players by division, then by team name.
+        var divisionGroups = _activeMembers
+            .GroupBy(m => m.DivisionRank)
+            .OrderBy(g => g.Key)
+            .ToList();
+
+        foreach (var div in divisionGroups)
+        {
+            var noTeam = div.Where(m => string.IsNullOrWhiteSpace(m.TeamName)).ToList();
+            if (noTeam.Any())
+            {
+                _error = $"Every player must be assigned to a team (division {div.Key} has {noTeam.Count} without a team).";
+                return;
+            }
+        }
+
+        _saving = true;
+        try
+        {
+            await using var db = DbFactory.CreateDbContext();
+            var season = await db.LeagueSeasons
+                .Include(s => s.Divisions)
+                .Include(s => s.League)
+                .FirstOrDefaultAsync(s => s.LeagueSeasonId == SeasonId);
+            if (season == null) { _error = "Season gone."; return; }
+            if (season.Status != LeagueSeasonStatus.Planning || season.Divisions.Any())
+            {
+                _error = "Season already materialised.";
+                return;
+            }
+
+            var league = season.League;
+            foreach (var divGroup in divisionGroups)
+            {
+                var bucket = _buckets.FirstOrDefault(b => b.Rank == divGroup.Key);
+                var divisionName = bucket?.Name ?? $"Division {divGroup.Key}";
+                var comp = new Competition
+                {
+                    CompetitionName = $"{league.Name} — {season.Name} — {divisionName}",
+                    CompetitionFormat = league.CompetitionFormat,
+                    TeamSize = league.TeamSize,
+                    LeagueScoring = league.LeagueScoring,
+                    RubberTemplateKey = league.RubberTemplateKey,
+                    MatchFormat = league.MatchFormat,
+                    NumberOfSets = league.NumberOfSets,
+                    GamesPerSet = league.GamesPerSet,
+                    SetWinMode = league.SetWinMode,
+                    HostClubId = league.HostClubId,
+                    StartDate = season.StartDate,
+                    EndDate = season.EndDate,
+                };
+                db.Competition.Add(comp);
+                await db.SaveChangesAsync();
+
+                // Group into teams by TeamName within this division
+                var teamGroups = divGroup.GroupBy(m => m.TeamName.Trim()).ToList();
+                foreach (var tg in teamGroups)
+                {
+                    var team = new CompetitionTeam { CompetitionId = comp.CompetitionID, Name = tg.Key };
+                    db.CompetitionTeams.Add(team);
+                    await db.SaveChangesAsync();
+
+                    foreach (var m in tg)
+                    {
+                        db.CompetitionParticipants.Add(new CompetitionParticipant
+                        {
+                            CompetitionId = comp.CompetitionID,
+                            PlayerId = m.PlayerId,
+                            TeamId = team.CompetitionTeamId,
+                            Status = Models.ParticipantStatus.Confirmed,
+                        });
+                    }
+                }
+                await db.SaveChangesAsync();
+
+                var division = new LeagueDivision
+                {
+                    LeagueSeasonId = season.LeagueSeasonId,
+                    Rank = divGroup.Key,
+                    Name = divisionName,
+                    CompetitionId = comp.CompetitionID,
+                };
+                db.LeagueDivisions.Add(division);
+                await db.SaveChangesAsync();
+
+                comp.LeagueDivisionId = division.LeagueDivisionId;
+                await db.SaveChangesAsync();
+            }
+
+            season.Status = LeagueSeasonStatus.Active;
+            foreach (var d in season.Divisions) { /* navigation won't be loaded in this ctx — skip */ }
+            await db.SaveChangesAsync();
+
+            Snackbar.Add($"{divisionGroups.Count} division(s) created.", Severity.Success);
+            Nav.NavigateTo($"/leagues/{LeagueId}/seasons/{SeasonId}/dashboard");
+        }
+        catch (Exception ex)
+        {
+            _error = $"Failed to materialise divisions: {ex.Message}";
+        }
+        finally
+        {
+            _saving = false;
+        }
+    }
+}

--- a/DropShot/Controllers/LeaguesController.cs
+++ b/DropShot/Controllers/LeaguesController.cs
@@ -1,0 +1,530 @@
+using DropShot.Data;
+using DropShot.Models;
+using DropShot.Services;
+using DropShot.Shared.Dtos;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace DropShot.Controllers;
+
+[ApiController]
+[Route("api")]
+[Authorize(AuthenticationSchemes = "Bearer")]
+public class LeaguesController(
+    IDbContextFactory<MyDbContext> dbFactory,
+    ClubAuthorizationService authzService) : ControllerBase
+{
+    // ── Leagues ───────────────────────────────────────────────────────────
+
+    [HttpGet("leagues")]
+    public async Task<ActionResult<List<LeagueSummaryDto>>> List([FromQuery] int? clubId = null, [FromQuery] bool includeArchived = false)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var query = db.Leagues.AsNoTracking().Include(l => l.HostClub).AsQueryable();
+        if (clubId.HasValue) query = query.Where(l => l.HostClubId == clubId.Value);
+        if (!includeArchived) query = query.Where(l => !l.IsArchived);
+
+        return await query
+            .OrderBy(l => l.Name)
+            .Select(l => new LeagueSummaryDto(
+                l.LeagueId,
+                l.Name,
+                l.HostClubId,
+                l.HostClub.Name,
+                l.IsArchived,
+                l.Seasons.Count,
+                l.Memberships.Count(m => m.IsActive)))
+            .ToListAsync();
+    }
+
+    [HttpGet("leagues/{id:int}")]
+    public async Task<ActionResult<LeagueDetailDto>> Get(int id)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var l = await db.Leagues.AsNoTracking().Include(x => x.HostClub)
+            .FirstOrDefaultAsync(x => x.LeagueId == id);
+        if (l is null) return NotFound();
+        return ToDetailDto(l);
+    }
+
+    [HttpPost("leagues")]
+    public async Task<ActionResult<LeagueDetailDto>> Create([FromBody] CreateLeagueRequest req)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        if (!await authzService.CanCreateClubCompetitionAsync(User, req.HostClubId)) return Forbid();
+
+        if (string.IsNullOrWhiteSpace(req.Name))
+            return BadRequest(new { message = "Name is required." });
+
+        var league = new League
+        {
+            Name = req.Name.Trim(),
+            HostClubId = req.HostClubId,
+            CompetitionFormat = (Models.CompetitionFormat)req.CompetitionFormat,
+            TeamSize = req.TeamSize,
+            LeagueScoring = (Models.LeagueScoringMode)req.LeagueScoring,
+            RubberTemplateKey = req.RubberTemplateKey,
+            MatchFormat = (Models.MatchFormatType)req.MatchFormat,
+            NumberOfSets = req.NumberOfSets,
+            GamesPerSet = req.GamesPerSet,
+            SetWinMode = (Models.SetWinMode)req.SetWinMode,
+            TeamsPerDivisionTarget = req.TeamsPerDivisionTarget,
+            TeamsPerDivisionMin = req.TeamsPerDivisionMin,
+        };
+        db.Leagues.Add(league);
+        await db.SaveChangesAsync();
+
+        await db.Entry(league).Reference(l => l.HostClub).LoadAsync();
+        return CreatedAtAction(nameof(Get), new { id = league.LeagueId }, ToDetailDto(league));
+    }
+
+    [HttpPut("leagues/{id:int}")]
+    public async Task<IActionResult> Update(int id, [FromBody] UpdateLeagueRequest req)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var l = await db.Leagues.FindAsync(id);
+        if (l is null) return NotFound();
+        if (!await authzService.CanEditCompetitionAsync(User, l.HostClubId)) return Forbid();
+
+        l.Name = req.Name.Trim();
+        l.CompetitionFormat = (Models.CompetitionFormat)req.CompetitionFormat;
+        l.TeamSize = req.TeamSize;
+        l.LeagueScoring = (Models.LeagueScoringMode)req.LeagueScoring;
+        l.RubberTemplateKey = req.RubberTemplateKey;
+        l.MatchFormat = (Models.MatchFormatType)req.MatchFormat;
+        l.NumberOfSets = req.NumberOfSets;
+        l.GamesPerSet = req.GamesPerSet;
+        l.SetWinMode = (Models.SetWinMode)req.SetWinMode;
+        l.TeamsPerDivisionTarget = req.TeamsPerDivisionTarget;
+        l.TeamsPerDivisionMin = req.TeamsPerDivisionMin;
+        l.IsArchived = req.IsArchived;
+        await db.SaveChangesAsync();
+        return NoContent();
+    }
+
+    // ── Memberships ───────────────────────────────────────────────────────
+
+    [HttpGet("leagues/{id:int}/memberships")]
+    public async Task<ActionResult<List<LeagueMembershipDto>>> GetMemberships(int id, [FromQuery] bool includeInactive = false)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var q = db.LeagueMemberships.AsNoTracking().Include(m => m.Player)
+            .Where(m => m.LeagueId == id);
+        if (!includeInactive) q = q.Where(m => m.IsActive);
+
+        return await q
+            .OrderBy(m => m.Player.DisplayName)
+            .Select(m => new LeagueMembershipDto(
+                m.PlayerId, m.Player.DisplayName, m.JoinedAt, m.IsActive, m.CurrentDivisionRank))
+            .ToListAsync();
+    }
+
+    [HttpPost("leagues/{id:int}/memberships")]
+    public async Task<IActionResult> EnrolPlayer(int id, [FromBody] EnrolPlayerRequest req)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var league = await db.Leagues.FindAsync(id);
+        if (league is null) return NotFound();
+        if (!await authzService.CanEditCompetitionAsync(User, league.HostClubId)) return Forbid();
+
+        var existing = await db.LeagueMemberships.FindAsync(id, req.PlayerId);
+        if (existing is null)
+        {
+            db.LeagueMemberships.Add(new LeagueMembership { LeagueId = id, PlayerId = req.PlayerId });
+        }
+        else if (!existing.IsActive)
+        {
+            existing.IsActive = true;
+        }
+        else
+        {
+            return Ok(); // already enrolled
+        }
+        await db.SaveChangesAsync();
+        return Ok();
+    }
+
+    [HttpDelete("leagues/{id:int}/memberships/{playerId:int}")]
+    public async Task<IActionResult> UnenrolPlayer(int id, int playerId)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var league = await db.Leagues.FindAsync(id);
+        if (league is null) return NotFound();
+        if (!await authzService.CanEditCompetitionAsync(User, league.HostClubId)) return Forbid();
+
+        var m = await db.LeagueMemberships.FindAsync(id, playerId);
+        if (m is null) return NotFound();
+        m.IsActive = false;
+        await db.SaveChangesAsync();
+        return NoContent();
+    }
+
+    // ── Seasons ───────────────────────────────────────────────────────────
+
+    [HttpGet("leagues/{id:int}/seasons")]
+    public async Task<ActionResult<List<LeagueSeasonSummaryDto>>> GetSeasons(int id)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        return await db.LeagueSeasons.AsNoTracking()
+            .Where(s => s.LeagueId == id)
+            .OrderByDescending(s => s.StartDate)
+            .Select(s => new LeagueSeasonSummaryDto(
+                s.LeagueSeasonId, s.LeagueId, s.Name, s.StartDate, s.EndDate,
+                (LeagueSeasonStatusDto)s.Status, s.ClosedAt, s.Divisions.Count))
+            .ToListAsync();
+    }
+
+    [HttpPost("leagues/{id:int}/seasons")]
+    public async Task<ActionResult<LeagueSeasonSummaryDto>> CreateSeason(int id, [FromBody] CreateSeasonRequest req)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var league = await db.Leagues.FindAsync(id);
+        if (league is null) return NotFound();
+        if (!await authzService.CanEditCompetitionAsync(User, league.HostClubId)) return Forbid();
+
+        bool openSeasonExists = await db.LeagueSeasons
+            .AnyAsync(s => s.LeagueId == id && s.Status != LeagueSeasonStatus.Closed);
+        if (openSeasonExists)
+            return BadRequest(new { message = "Close the existing open season before starting a new one." });
+
+        if (string.IsNullOrWhiteSpace(req.Name))
+            return BadRequest(new { message = "Season name is required." });
+
+        var season = new LeagueSeason
+        {
+            LeagueId = id,
+            Name = req.Name.Trim(),
+            StartDate = req.StartDate,
+            EndDate = req.EndDate,
+            Status = LeagueSeasonStatus.Planning,
+        };
+        db.LeagueSeasons.Add(season);
+        await db.SaveChangesAsync();
+        return new LeagueSeasonSummaryDto(
+            season.LeagueSeasonId, season.LeagueId, season.Name, season.StartDate, season.EndDate,
+            (LeagueSeasonStatusDto)season.Status, null, 0);
+    }
+
+    [HttpGet("seasons/{id:int}")]
+    public async Task<ActionResult<LeagueSeasonDetailDto>> GetSeason(int id)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var season = await db.LeagueSeasons.AsNoTracking()
+            .Include(s => s.Divisions).ThenInclude(d => d.Competition).ThenInclude(c => c.Teams)
+            .Include(s => s.Divisions).ThenInclude(d => d.Competition).ThenInclude(c => c.Participants)
+            .FirstOrDefaultAsync(s => s.LeagueSeasonId == id);
+        if (season is null) return NotFound();
+
+        var divisions = season.Divisions
+            .OrderBy(d => d.Rank)
+            .Select(d => new LeagueDivisionDto(
+                d.LeagueDivisionId, d.Rank, d.Name, d.CompetitionId,
+                d.Competition.CompetitionName,
+                d.Competition.Teams.Count,
+                d.Competition.Participants.Count(p => p.Status == Models.ParticipantStatus.Registered
+                                                   || p.Status == Models.ParticipantStatus.Confirmed)))
+            .ToList();
+
+        return new LeagueSeasonDetailDto(
+            season.LeagueSeasonId, season.LeagueId, season.Name, season.StartDate, season.EndDate,
+            (LeagueSeasonStatusDto)season.Status, season.ClosedAt, divisions);
+    }
+
+    [HttpPost("seasons/{id:int}/suggest-divisions")]
+    public async Task<ActionResult<DivisionSuggestionDto>> SuggestDivisions(int id)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var season = await db.LeagueSeasons
+            .Include(s => s.League).ThenInclude(l => l.Memberships).ThenInclude(m => m.Player)
+            .FirstOrDefaultAsync(s => s.LeagueSeasonId == id);
+        if (season is null) return NotFound();
+        if (!await authzService.CanEditCompetitionAsync(User, season.League.HostClubId)) return Forbid();
+
+        var activeMembers = season.League.Memberships
+            .Where(m => m.IsActive)
+            .OrderBy(m => m.CurrentDivisionRank ?? byte.MaxValue)
+            .ThenBy(m => m.Player.DisplayName)
+            .ToList();
+
+        int playersPerDivision = season.League.TeamsPerDivisionTarget * season.League.TeamSize;
+        if (playersPerDivision <= 0) playersPerDivision = 32;
+        int divisionCount = Math.Max(1, (int)Math.Ceiling(activeMembers.Count / (double)playersPerDivision));
+
+        // Bucket: if any members have CurrentDivisionRank set (returning season), group by rank.
+        // Otherwise split by target size in order.
+        List<DivisionBucketDto> buckets;
+        var unassigned = new List<int>();
+
+        bool hasRanks = activeMembers.Any(m => m.CurrentDivisionRank.HasValue);
+        if (hasRanks)
+        {
+            buckets = [];
+            for (byte rank = 1; rank <= divisionCount; rank++)
+            {
+                var inRank = activeMembers
+                    .Where(m => (m.CurrentDivisionRank ?? (byte)divisionCount) == rank)
+                    .Select(m => m.PlayerId)
+                    .ToList();
+                buckets.Add(new DivisionBucketDto(rank, $"Division {rank}", inRank));
+            }
+            // Members with no rank (new joiners): append to bottom division
+            var newbies = activeMembers
+                .Where(m => !m.CurrentDivisionRank.HasValue)
+                .Select(m => m.PlayerId)
+                .ToList();
+            if (newbies.Count > 0 && buckets.Count > 0)
+            {
+                var bottom = buckets[^1];
+                buckets[^1] = bottom with { PlayerIds = bottom.PlayerIds.Concat(newbies).ToList() };
+            }
+        }
+        else
+        {
+            buckets = [];
+            int index = 0;
+            for (byte rank = 1; rank <= divisionCount; rank++)
+            {
+                var slice = activeMembers.Skip(index).Take(playersPerDivision).Select(m => m.PlayerId).ToList();
+                buckets.Add(new DivisionBucketDto(rank, $"Division {rank}", slice));
+                index += playersPerDivision;
+            }
+        }
+
+        return new DivisionSuggestionDto(buckets, unassigned);
+    }
+
+    [HttpPost("seasons/{id:int}/divisions")]
+    public async Task<IActionResult> CreateDivisions(int id, [FromBody] CreateDivisionsRequest req)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var season = await db.LeagueSeasons
+            .Include(s => s.League)
+            .Include(s => s.Divisions)
+            .FirstOrDefaultAsync(s => s.LeagueSeasonId == id);
+        if (season is null) return NotFound();
+        if (!await authzService.CanEditCompetitionAsync(User, season.League.HostClubId)) return Forbid();
+        if (season.Status != LeagueSeasonStatus.Planning)
+            return BadRequest(new { message = "Divisions can only be created while the season is in Planning." });
+
+        if (season.Divisions.Any())
+            return BadRequest(new { message = "Divisions already exist for this season." });
+
+        var league = season.League;
+        foreach (var d in req.Divisions.OrderBy(x => x.Rank))
+        {
+            var comp = new Competition
+            {
+                CompetitionName = $"{league.Name} — {season.Name} — {d.Name}",
+                CompetitionFormat = league.CompetitionFormat,
+                TeamSize = league.TeamSize,
+                LeagueScoring = league.LeagueScoring,
+                RubberTemplateKey = league.RubberTemplateKey,
+                MatchFormat = league.MatchFormat,
+                NumberOfSets = league.NumberOfSets,
+                GamesPerSet = league.GamesPerSet,
+                SetWinMode = league.SetWinMode,
+                HostClubId = league.HostClubId,
+                StartDate = season.StartDate,
+                EndDate = season.EndDate,
+                IsStarted = false,
+            };
+            db.Competition.Add(comp);
+            await db.SaveChangesAsync();
+
+            // Teams + participants
+            foreach (var t in d.Teams)
+            {
+                var team = new CompetitionTeam { CompetitionId = comp.CompetitionID, Name = t.TeamName };
+                db.CompetitionTeams.Add(team);
+                await db.SaveChangesAsync();
+
+                foreach (var m in t.Members)
+                {
+                    db.CompetitionParticipants.Add(new CompetitionParticipant
+                    {
+                        CompetitionId = comp.CompetitionID,
+                        PlayerId = m.PlayerId,
+                        TeamId = team.CompetitionTeamId,
+                        Role = m.Role,
+                        Status = Models.ParticipantStatus.Confirmed,
+                    });
+                }
+            }
+            await db.SaveChangesAsync();
+
+            var division = new LeagueDivision
+            {
+                LeagueSeasonId = season.LeagueSeasonId,
+                Rank = d.Rank,
+                Name = d.Name,
+                CompetitionId = comp.CompetitionID,
+            };
+            db.LeagueDivisions.Add(division);
+            await db.SaveChangesAsync();
+
+            comp.LeagueDivisionId = division.LeagueDivisionId;
+            await db.SaveChangesAsync();
+        }
+
+        return NoContent();
+    }
+
+    [HttpPost("seasons/{id:int}/activate")]
+    public async Task<IActionResult> ActivateSeason(int id)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var season = await db.LeagueSeasons
+            .Include(s => s.League)
+            .Include(s => s.Divisions).ThenInclude(d => d.Competition)
+            .FirstOrDefaultAsync(s => s.LeagueSeasonId == id);
+        if (season is null) return NotFound();
+        if (!await authzService.CanEditCompetitionAsync(User, season.League.HostClubId)) return Forbid();
+        if (season.Status == LeagueSeasonStatus.Closed)
+            return BadRequest(new { message = "Season is already closed." });
+
+        season.Status = LeagueSeasonStatus.Active;
+        foreach (var d in season.Divisions)
+            d.Competition.IsStarted = true;
+        await db.SaveChangesAsync();
+        return NoContent();
+    }
+
+    // ── Stats ─────────────────────────────────────────────────────────────
+
+    [HttpGet("seasons/{id:int}/stats")]
+    public async Task<ActionResult<List<PlayerStatsDto>>> GetSeasonStats(int id)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var season = await db.LeagueSeasons
+            .Include(s => s.League)
+            .Include(s => s.Divisions).ThenInclude(d => d.Competition).ThenInclude(c => c.Participants).ThenInclude(p => p.Player)
+            .FirstOrDefaultAsync(s => s.LeagueSeasonId == id);
+        if (season is null) return NotFound();
+
+        var rows = new List<PlayerStatsDto>();
+        foreach (var d in season.Divisions.OrderBy(d => d.Rank))
+        {
+            rows.AddRange(await BuildStatsForDivision(db, d, season.League.LeagueScoring));
+        }
+        return rows;
+    }
+
+    [HttpGet("divisions/{id:int}/stats")]
+    public async Task<ActionResult<List<PlayerStatsDto>>> GetDivisionStats(int id)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var division = await db.LeagueDivisions
+            .Include(d => d.Season).ThenInclude(s => s.League)
+            .Include(d => d.Competition).ThenInclude(c => c.Participants).ThenInclude(p => p.Player)
+            .FirstOrDefaultAsync(d => d.LeagueDivisionId == id);
+        if (division is null) return NotFound();
+
+        return (await BuildStatsForDivision(db, division, division.Season.League.LeagueScoring)).ToList();
+    }
+
+    private static async Task<IEnumerable<PlayerStatsDto>> BuildStatsForDivision(
+        MyDbContext db, LeagueDivision division, Models.LeagueScoringMode scoring)
+    {
+        var stats = await PlayerStatsService.ComputeAsync(
+            db, [division.CompetitionId], scoring);
+
+        return division.Competition.Participants
+            .Where(p => p.Player != null)
+            .Select(p =>
+            {
+                stats.TryGetValue(p.PlayerId, out var s);
+                int played = s?.RubbersPlayed ?? 0;
+                double winRate = played > 0 ? (s!.RubbersWon / (double)played) : 0.0;
+                return new PlayerStatsDto(
+                    p.PlayerId,
+                    p.Player!.DisplayName,
+                    division.Rank,
+                    division.Name,
+                    played,
+                    s?.RubbersWon ?? 0,
+                    s?.RubbersLost ?? 0,
+                    s?.SetsWon ?? 0,
+                    s?.SetsAgainst ?? 0,
+                    s?.GamesWon ?? 0,
+                    s?.GamesAgainst ?? 0,
+                    s?.LeaguePoints ?? 0,
+                    winRate);
+            })
+            .OrderByDescending(r => r.LeaguePoints)
+            .ThenByDescending(r => r.RubbersWon)
+            .ThenByDescending(r => r.SetsWon - r.SetsAgainst)
+            .ThenByDescending(r => r.GamesWon - r.GamesAgainst)
+            .ToList();
+    }
+
+    // ── Promotion / close ─────────────────────────────────────────────────
+
+    [HttpGet("seasons/{id:int}/promotion-preview")]
+    public async Task<ActionResult<PromotionPreviewDto>> PromotionPreview(int id)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var season = await db.LeagueSeasons
+            .Include(s => s.League)
+            .Include(s => s.Divisions).ThenInclude(d => d.Competition).ThenInclude(c => c.Participants).ThenInclude(p => p.Player)
+            .FirstOrDefaultAsync(s => s.LeagueSeasonId == id);
+        if (season is null) return NotFound();
+
+        var divs = new List<PromotionDivisionDto>();
+        foreach (var d in season.Divisions.OrderBy(d => d.Rank))
+        {
+            var stats = await BuildStatsForDivision(db, d, season.League.LeagueScoring);
+            var ranked = stats.Select((s, i) => new PromotionCandidateDto(
+                s.PlayerId, s.DisplayName, d.Rank, i + 1, s.RubbersPlayed, s.LeaguePoints, s.WinRate))
+                .ToList();
+            divs.Add(new PromotionDivisionDto(d.Rank, d.Name, ranked));
+        }
+        return new PromotionPreviewDto(id, divs);
+    }
+
+    [HttpPost("seasons/{id:int}/close")]
+    public async Task<ActionResult<CloseSeasonResultDto>> CloseSeason(int id, [FromBody] CloseSeasonRequest req)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var season = await db.LeagueSeasons
+            .Include(s => s.League).ThenInclude(l => l.Memberships)
+            .FirstOrDefaultAsync(s => s.LeagueSeasonId == id);
+        if (season is null) return NotFound();
+        if (!await authzService.CanEditCompetitionAsync(User, season.League.HostClubId)) return Forbid();
+        if (season.Status == LeagueSeasonStatus.Closed)
+            return BadRequest(new { message = "Season is already closed." });
+
+        int applied = 0;
+        foreach (var decision in req.Decisions)
+        {
+            var membership = season.League.Memberships.FirstOrDefault(m => m.PlayerId == decision.PlayerId);
+            if (membership is null) continue;
+            membership.CurrentDivisionRank = decision.NewRank;
+            applied++;
+        }
+
+        season.Status = LeagueSeasonStatus.Closed;
+        season.ClosedAt = DateTime.UtcNow;
+        await db.SaveChangesAsync();
+        return new CloseSeasonResultDto(id, applied);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────
+
+    private static LeagueDetailDto ToDetailDto(League l) => new(
+        l.LeagueId,
+        l.Name,
+        l.HostClubId,
+        l.HostClub?.Name,
+        l.IsArchived,
+        (Shared.CompetitionFormat)l.CompetitionFormat,
+        l.TeamSize,
+        (Shared.LeagueScoringMode)l.LeagueScoring,
+        l.RubberTemplateKey,
+        (Shared.MatchFormatType)l.MatchFormat,
+        l.NumberOfSets,
+        l.GamesPerSet,
+        (Shared.SetWinMode)l.SetWinMode,
+        l.TeamsPerDivisionTarget,
+        l.TeamsPerDivisionMin);
+}

--- a/DropShot/Data/Migrations/20260422132558_AddLeagueStructures.Designer.cs
+++ b/DropShot/Data/Migrations/20260422132558_AddLeagueStructures.Designer.cs
@@ -4,16 +4,19 @@ using DropShot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace DropShot.Migrations
+namespace DropShot.Data.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260422132558_AddLeagueStructures")]
+    partial class AddLeagueStructures
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DropShot/Data/Migrations/20260422132558_AddLeagueStructures.cs
+++ b/DropShot/Data/Migrations/20260422132558_AddLeagueStructures.cs
@@ -1,0 +1,180 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropShot.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLeagueStructures : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "LeagueDivisionId",
+                table: "Competition",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "Leagues",
+                columns: table => new
+                {
+                    LeagueId = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Name = table.Column<string>(type: "nvarchar(120)", maxLength: 120, nullable: false),
+                    HostClubId = table.Column<int>(type: "int", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    IsArchived = table.Column<bool>(type: "bit", nullable: false),
+                    CompetitionFormat = table.Column<int>(type: "int", nullable: false),
+                    TeamSize = table.Column<int>(type: "int", nullable: false),
+                    LeagueScoring = table.Column<byte>(type: "tinyint", nullable: false),
+                    RubberTemplateKey = table.Column<string>(type: "nvarchar(32)", maxLength: 32, nullable: true),
+                    MatchFormat = table.Column<byte>(type: "tinyint", nullable: false),
+                    NumberOfSets = table.Column<int>(type: "int", nullable: false),
+                    GamesPerSet = table.Column<int>(type: "int", nullable: false),
+                    SetWinMode = table.Column<byte>(type: "tinyint", nullable: false),
+                    TeamsPerDivisionTarget = table.Column<int>(type: "int", nullable: false),
+                    TeamsPerDivisionMin = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Leagues", x => x.LeagueId);
+                    table.ForeignKey(
+                        name: "FK_Leagues_Clubs_HostClubId",
+                        column: x => x.HostClubId,
+                        principalTable: "Clubs",
+                        principalColumn: "ClubId",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "LeagueMemberships",
+                columns: table => new
+                {
+                    LeagueId = table.Column<int>(type: "int", nullable: false),
+                    PlayerId = table.Column<int>(type: "int", nullable: false),
+                    JoinedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    IsActive = table.Column<bool>(type: "bit", nullable: false),
+                    CurrentDivisionRank = table.Column<byte>(type: "tinyint", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LeagueMemberships", x => new { x.LeagueId, x.PlayerId });
+                    table.ForeignKey(
+                        name: "FK_LeagueMemberships_Leagues_LeagueId",
+                        column: x => x.LeagueId,
+                        principalTable: "Leagues",
+                        principalColumn: "LeagueId",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_LeagueMemberships_Players_PlayerId",
+                        column: x => x.PlayerId,
+                        principalTable: "Players",
+                        principalColumn: "PlayerId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "LeagueSeasons",
+                columns: table => new
+                {
+                    LeagueSeasonId = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    LeagueId = table.Column<int>(type: "int", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(80)", maxLength: 80, nullable: false),
+                    StartDate = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    EndDate = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    Status = table.Column<byte>(type: "tinyint", nullable: false),
+                    ClosedAt = table.Column<DateTime>(type: "datetime2", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LeagueSeasons", x => x.LeagueSeasonId);
+                    table.ForeignKey(
+                        name: "FK_LeagueSeasons_Leagues_LeagueId",
+                        column: x => x.LeagueId,
+                        principalTable: "Leagues",
+                        principalColumn: "LeagueId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "LeagueDivisions",
+                columns: table => new
+                {
+                    LeagueDivisionId = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    LeagueSeasonId = table.Column<int>(type: "int", nullable: false),
+                    Rank = table.Column<byte>(type: "tinyint", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(80)", maxLength: 80, nullable: false),
+                    CompetitionId = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LeagueDivisions", x => x.LeagueDivisionId);
+                    table.ForeignKey(
+                        name: "FK_LeagueDivisions_Competition_CompetitionId",
+                        column: x => x.CompetitionId,
+                        principalTable: "Competition",
+                        principalColumn: "CompetitionID",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_LeagueDivisions_LeagueSeasons_LeagueSeasonId",
+                        column: x => x.LeagueSeasonId,
+                        principalTable: "LeagueSeasons",
+                        principalColumn: "LeagueSeasonId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LeagueDivisions_CompetitionId",
+                table: "LeagueDivisions",
+                column: "CompetitionId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LeagueDivisions_LeagueSeasonId_Rank",
+                table: "LeagueDivisions",
+                columns: new[] { "LeagueSeasonId", "Rank" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LeagueMemberships_PlayerId",
+                table: "LeagueMemberships",
+                column: "PlayerId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Leagues_HostClubId",
+                table: "Leagues",
+                column: "HostClubId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LeagueSeasons_LeagueId_Name",
+                table: "LeagueSeasons",
+                columns: new[] { "LeagueId", "Name" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "LeagueDivisions");
+
+            migrationBuilder.DropTable(
+                name: "LeagueMemberships");
+
+            migrationBuilder.DropTable(
+                name: "LeagueSeasons");
+
+            migrationBuilder.DropTable(
+                name: "Leagues");
+
+            migrationBuilder.DropColumn(
+                name: "LeagueDivisionId",
+                table: "Competition");
+        }
+    }
+}

--- a/DropShot/Data/MyDbContext.cs
+++ b/DropShot/Data/MyDbContext.cs
@@ -40,6 +40,10 @@ namespace DropShot.Data
         public DbSet<Rubber> Rubbers { get; set; }
         public DbSet<CompetitionRubberTemplate> CompetitionRubberTemplates { get; set; }
         public DbSet<RubberTemplateRubber> RubberTemplateRubbers { get; set; }
+        public DbSet<League> Leagues { get; set; }
+        public DbSet<LeagueSeason> LeagueSeasons { get; set; }
+        public DbSet<LeagueDivision> LeagueDivisions { get; set; }
+        public DbSet<LeagueMembership> LeagueMemberships { get; set; }
         public DbSet<PlayerInvitation> PlayerInvitations { get; set; }
         public DbSet<ClubLinkRequest> ClubLinkRequests { get; set; }
         public DbSet<CompetitionAllowedPlayer> CompetitionAllowedPlayers { get; set; }
@@ -597,6 +601,61 @@ namespace DropShot.Data
                       .WithMany()
                       .HasForeignKey(r => r.SavedMatchId)
                       .OnDelete(DeleteBehavior.SetNull);
+            });
+
+            // ── League / LeagueSeason / LeagueDivision / LeagueMembership ─────
+            builder.Entity<League>(entity =>
+            {
+                entity.Property(l => l.Name).HasMaxLength(120).IsRequired();
+                entity.Property(l => l.RubberTemplateKey).HasMaxLength(32);
+                entity.Property(l => l.CompetitionFormat).HasConversion<int>();
+                entity.Property(l => l.LeagueScoring).HasConversion<byte>();
+                entity.Property(l => l.MatchFormat).HasConversion<byte>();
+                entity.Property(l => l.SetWinMode).HasConversion<byte>();
+                entity.HasIndex(l => l.HostClubId);
+                entity.HasOne(l => l.HostClub)
+                      .WithMany()
+                      .HasForeignKey(l => l.HostClubId)
+                      .OnDelete(DeleteBehavior.Restrict);
+            });
+
+            builder.Entity<LeagueSeason>(entity =>
+            {
+                entity.Property(s => s.Name).HasMaxLength(80).IsRequired();
+                entity.Property(s => s.Status).HasConversion<byte>();
+                entity.HasIndex(s => new { s.LeagueId, s.Name }).IsUnique();
+                entity.HasOne(s => s.League)
+                      .WithMany(l => l.Seasons)
+                      .HasForeignKey(s => s.LeagueId)
+                      .OnDelete(DeleteBehavior.Cascade);
+            });
+
+            builder.Entity<LeagueDivision>(entity =>
+            {
+                entity.Property(d => d.Name).HasMaxLength(80).IsRequired();
+                entity.HasIndex(d => new { d.LeagueSeasonId, d.Rank }).IsUnique();
+                entity.HasIndex(d => d.CompetitionId).IsUnique();
+                entity.HasOne(d => d.Season)
+                      .WithMany(s => s.Divisions)
+                      .HasForeignKey(d => d.LeagueSeasonId)
+                      .OnDelete(DeleteBehavior.Cascade);
+                entity.HasOne(d => d.Competition)
+                      .WithOne(c => c.LeagueDivision!)
+                      .HasForeignKey<LeagueDivision>(d => d.CompetitionId)
+                      .OnDelete(DeleteBehavior.Restrict);
+            });
+
+            builder.Entity<LeagueMembership>(entity =>
+            {
+                entity.HasKey(m => new { m.LeagueId, m.PlayerId });
+                entity.HasOne(m => m.League)
+                      .WithMany(l => l.Memberships)
+                      .HasForeignKey(m => m.LeagueId)
+                      .OnDelete(DeleteBehavior.Cascade);
+                entity.HasOne(m => m.Player)
+                      .WithMany()
+                      .HasForeignKey(m => m.PlayerId)
+                      .OnDelete(DeleteBehavior.Cascade);
             });
 
             // ── CompetitionRubberTemplate ──────────────────────────────────────

--- a/DropShot/Models/Competition.cs
+++ b/DropShot/Models/Competition.cs
@@ -73,9 +73,16 @@
         public SetWinMode SetWinMode { get; set; } = SetWinMode.WinBy2;
         public LeagueScoringMode LeagueScoring { get; set; } = LeagueScoringMode.WinPoints;
 
+        /// <summary>
+        /// When this competition is one division of a league season, points at the
+        /// owning <see cref="LeagueDivision"/> row. Null for standalone competitions.
+        /// </summary>
+        public int? LeagueDivisionId { get; set; }
+
         public RulesSet? Rules { get; set; }
         public Club? HostClub { get; set; }
         public Event? Event { get; set; }
+        public LeagueDivision? LeagueDivision { get; set; }
         public ICollection<CompetitionParticipant> Participants { get; set; } = [];
         public ICollection<CompetitionFixture> Fixtures { get; set; } = [];
         public ICollection<CompetitionStage> Stages { get; set; } = [];

--- a/DropShot/Models/League.cs
+++ b/DropShot/Models/League.cs
@@ -1,0 +1,28 @@
+namespace DropShot.Models;
+
+public class League
+{
+    public int LeagueId { get; set; }
+    public string Name { get; set; } = "";
+    public int HostClubId { get; set; }
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public bool IsArchived { get; set; }
+
+    // Format defaults copied to each season's underlying competitions
+    public CompetitionFormat CompetitionFormat { get; set; } = CompetitionFormat.TeamMatch;
+    public int TeamSize { get; set; } = 4;
+    public LeagueScoringMode LeagueScoring { get; set; } = LeagueScoringMode.WinPoints;
+    public string? RubberTemplateKey { get; set; }
+    public MatchFormatType MatchFormat { get; set; } = MatchFormatType.BestOf;
+    public int NumberOfSets { get; set; } = 3;
+    public int GamesPerSet { get; set; } = 6;
+    public SetWinMode SetWinMode { get; set; } = SetWinMode.WinBy2;
+
+    // Division sizing
+    public int TeamsPerDivisionTarget { get; set; } = 8;
+    public int TeamsPerDivisionMin { get; set; } = 6;
+
+    public Club HostClub { get; set; } = null!;
+    public ICollection<LeagueSeason> Seasons { get; set; } = [];
+    public ICollection<LeagueMembership> Memberships { get; set; } = [];
+}

--- a/DropShot/Models/LeagueDivision.cs
+++ b/DropShot/Models/LeagueDivision.cs
@@ -1,0 +1,13 @@
+namespace DropShot.Models;
+
+public class LeagueDivision
+{
+    public int LeagueDivisionId { get; set; }
+    public int LeagueSeasonId { get; set; }
+    public byte Rank { get; set; } // 1 = top division
+    public string Name { get; set; } = "";
+    public int CompetitionId { get; set; }
+
+    public LeagueSeason Season { get; set; } = null!;
+    public Competition Competition { get; set; } = null!;
+}

--- a/DropShot/Models/LeagueMembership.cs
+++ b/DropShot/Models/LeagueMembership.cs
@@ -1,0 +1,16 @@
+namespace DropShot.Models;
+
+public class LeagueMembership
+{
+    public int LeagueId { get; set; }
+    public int PlayerId { get; set; }
+    public DateTime JoinedAt { get; set; } = DateTime.UtcNow;
+    public bool IsActive { get; set; } = true;
+
+    // Last rank the player finished at (1 = top division). Used to seed the next
+    // season's division buckets; null for a player who hasn't yet completed a season.
+    public byte? CurrentDivisionRank { get; set; }
+
+    public League League { get; set; } = null!;
+    public Player Player { get; set; } = null!;
+}

--- a/DropShot/Models/LeagueSeason.cs
+++ b/DropShot/Models/LeagueSeason.cs
@@ -1,0 +1,22 @@
+namespace DropShot.Models;
+
+public enum LeagueSeasonStatus : byte
+{
+    Planning = 1,
+    Active = 2,
+    Closed = 3,
+}
+
+public class LeagueSeason
+{
+    public int LeagueSeasonId { get; set; }
+    public int LeagueId { get; set; }
+    public string Name { get; set; } = "";
+    public DateTime? StartDate { get; set; }
+    public DateTime? EndDate { get; set; }
+    public LeagueSeasonStatus Status { get; set; } = LeagueSeasonStatus.Planning;
+    public DateTime? ClosedAt { get; set; }
+
+    public League League { get; set; } = null!;
+    public ICollection<LeagueDivision> Divisions { get; set; } = [];
+}

--- a/DropShot/Services/PlayerStatsService.cs
+++ b/DropShot/Services/PlayerStatsService.cs
@@ -1,0 +1,122 @@
+using DropShot.Data;
+using DropShot.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace DropShot.Services;
+
+/// <summary>
+/// Computes per-player rubber / set / game aggregates on demand. No stored
+/// aggregates — everything reads from <see cref="Rubber"/> joined to the
+/// owning fixture / competition. Scoped by the caller to a single division
+/// (one competition) or an entire league season (multiple competitions).
+/// </summary>
+public static class PlayerStatsService
+{
+    public record PlayerStats(
+        int PlayerId,
+        int RubbersPlayed,
+        int RubbersWon,
+        int RubbersLost,
+        int SetsWon,
+        int SetsAgainst,
+        int GamesWon,
+        int GamesAgainst,
+        int LeaguePoints);
+
+    /// <summary>
+    /// Compute per-player stats across every completed rubber in the given set
+    /// of competitions, using the league's scoring mode for LeaguePoints.
+    /// </summary>
+    public static async Task<Dictionary<int, PlayerStats>> ComputeAsync(
+        MyDbContext db, IReadOnlyCollection<int> competitionIds, LeagueScoringMode mode)
+    {
+        if (competitionIds.Count == 0) return new Dictionary<int, PlayerStats>();
+
+        var rubbers = await db.Rubbers
+            .AsNoTracking()
+            .Include(r => r.Fixture)
+            .Where(r => r.IsComplete
+                     && r.Fixture.HomeTeamId.HasValue
+                     && r.Fixture.AwayTeamId.HasValue
+                     && competitionIds.Contains(r.Fixture.CompetitionId))
+            .ToListAsync();
+
+        var accum = new Dictionary<int, Mutable>();
+
+        foreach (var r in rubbers)
+        {
+            int homeTeamId = r.Fixture.HomeTeamId!.Value;
+            int awayTeamId = r.Fixture.AwayTeamId!.Value;
+            bool homeWon = r.WinnerTeamId == homeTeamId;
+            bool awayWon = r.WinnerTeamId == awayTeamId;
+
+            int homeSets = r.HomeSetsWon ?? 0;
+            int awaySets = r.AwaySetsWon ?? 0;
+            int homeGames = r.HomeGamesTotal ?? 0;
+            int awayGames = r.AwayGamesTotal ?? 0;
+
+            int homePoints = mode switch
+            {
+                LeagueScoringMode.SetsWon  => homeSets,
+                LeagueScoringMode.GamesWon => homeGames,
+                _ => homeWon ? 3 : (!awayWon ? 1 : 0),
+            };
+            int awayPoints = mode switch
+            {
+                LeagueScoringMode.SetsWon  => awaySets,
+                LeagueScoringMode.GamesWon => awayGames,
+                _ => awayWon ? 3 : (!homeWon ? 1 : 0),
+            };
+
+            var homeIds = new[] { r.HomePlayer1Id, r.HomePlayer2Id }.Where(id => id.HasValue).Select(id => id!.Value);
+            var awayIds = new[] { r.AwayPlayer1Id, r.AwayPlayer2Id }.Where(id => id.HasValue).Select(id => id!.Value);
+
+            foreach (var pid in homeIds)
+                Credit(accum, pid, homeWon, awayWon, homeSets, awaySets, homeGames, awayGames, homePoints);
+            foreach (var pid in awayIds)
+                Credit(accum, pid, awayWon, homeWon, awaySets, homeSets, awayGames, homeGames, awayPoints);
+        }
+
+        return accum.ToDictionary(
+            kv => kv.Key,
+            kv => new PlayerStats(
+                kv.Key,
+                kv.Value.RubbersPlayed,
+                kv.Value.RubbersWon,
+                kv.Value.RubbersLost,
+                kv.Value.SetsWon,
+                kv.Value.SetsAgainst,
+                kv.Value.GamesWon,
+                kv.Value.GamesAgainst,
+                kv.Value.LeaguePoints));
+    }
+
+    private static void Credit(
+        Dictionary<int, Mutable> accum, int playerId,
+        bool wonRubber, bool opponentWonRubber,
+        int setsFor, int setsAgainst, int gamesFor, int gamesAgainst, int points)
+    {
+        if (!accum.TryGetValue(playerId, out var m))
+            accum[playerId] = m = new Mutable();
+        m.RubbersPlayed++;
+        if (wonRubber) m.RubbersWon++;
+        else if (opponentWonRubber) m.RubbersLost++;
+        m.SetsWon += setsFor;
+        m.SetsAgainst += setsAgainst;
+        m.GamesWon += gamesFor;
+        m.GamesAgainst += gamesAgainst;
+        m.LeaguePoints += points;
+    }
+
+    private class Mutable
+    {
+        public int RubbersPlayed;
+        public int RubbersWon;
+        public int RubbersLost;
+        public int SetsWon;
+        public int SetsAgainst;
+        public int GamesWon;
+        public int GamesAgainst;
+        public int LeaguePoints;
+    }
+}


### PR DESCRIPTION
## Summary
Layers a league / season / division model on top of the existing TeamMatch competition machinery. A **league** persists across **seasons**, and each season is split into **divisions** (1 per tier, up to 7–8 teams each). Each division is backed by an existing `Competition`, so all of the fixture / rubber / scoring / team-league-table code is reused without change.

Players enrol once in the league (`LeagueMembership`), get placed into a division each season, and promote / demote **individually** at season close — the admin chooses who moves where, and the decisions seed the next season's bucketing.

## Model

- `League` (persistent, club-hosted) — carries format defaults: `CompetitionFormat`, `TeamSize`, `LeagueScoring`, `RubberTemplateKey`, `MatchFormat`, `NumberOfSets`, `GamesPerSet`, `SetWinMode`, `TeamsPerDivisionTarget`, `TeamsPerDivisionMin`.
- `LeagueSeason` — named block with `Status` (Planning / Active / Closed).
- `LeagueDivision` — `(LeagueSeasonId, Rank, Name, CompetitionId)`.
- `LeagueMembership` — `(LeagueId, PlayerId)` composite key + `CurrentDivisionRank` that the close wizard writes and the next season's setup reads.
- `Competition` gains nullable `LeagueDivisionId` + nav. Zero impact on existing standalone competitions.

Single migration `AddLeagueStructures`.

## API (`LeaguesController`, `/api`)

- Leagues: list (filtered by club), create, read, update.
- Memberships: list / enrol / soft-unenrol.
- Seasons: list, create (refuses if another open season exists), read (with divisions + competitions), `suggest-divisions`, `divisions` (materialise), `activate`, `close`, `promotion-preview`.
- Stats: `/seasons/{id}/stats`, `/divisions/{id}/stats` (per-player rubbers / sets / games / points / win %).

## Service

`PlayerStatsService` (static) — computes aggregates on demand from `Rubber` joined to `CompetitionFixture`, scoped by a set of competition ids. Reuses `RubberResolutionService.ComputeLeagueScore` semantics for points per mode. Nothing stored.

## UI (under `/leagues/*`)

- `LeaguesIndex.razor` — list + create dialog.
- `LeagueDetail.razor` — tabs for format defaults / members / seasons.
- `SeasonSetup.razor` — wizard that buckets active members into divisions (first season: even split; subsequent: seeded by last rank), lets the admin reassign, names teams, materialises.
- `SeasonDashboard.razor` — one card per division with live team league table (computed from rubbers with the league's scoring mode) and links to the underlying Competition admin / view pages.
- `SeasonClose.razor` — ranked-player table per division, up / down arrows to move players between divisions, writes chosen ranks to `LeagueMembership.CurrentDivisionRank`, closes the season.
- `PlayerSeasonStats.razor` — sortable / searchable per-player stats with search.
- `CompetitionPage.razor` — breadcrumb back to the parent season dashboard when a competition has `LeagueDivisionId` set.
- `NavMenu.razor` — new Leagues entry.

## Decisions (confirmed during planning)

- Promotion granularity: **individual players** — teams re-form each season.
- Ranking metric: **league points** using the competition's `LeagueScoring` mode, summed per player.
- Promotion count: **admin-chosen per season** via the close wizard (no fixed top-N/bottom-N rule).

## Test plan

- [ ] `dotnet ef database update` applies `AddLeagueStructures` cleanly
- [ ] Create a league, enrol ≈16 players, create a season → `SeasonSetup` suggests one division
- [ ] Enrol ≈40 players → suggests two divisions; reassign some via the division dropdown, materialise
- [ ] `SeasonDashboard` shows a live league table per division, links to each underlying `CompetitionPage`
- [ ] Score some rubbers in the competition admin → dashboard tables update, `PlayerSeasonStats` totals match
- [ ] `SeasonClose` shows ranked players, up/down arrows work, "Execute close" updates `LeagueMembership.CurrentDivisionRank` and flips the season to `Closed`
- [ ] Create the next season → `SeasonSetup` seeds buckets from the updated ranks (promoted players in higher division)
- [ ] Breadcrumb appears on a `CompetitionPage` whose competition is under a division and links back to the season dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)