### PR TITLE
Switch self-referencing SeededFromCompetition FK to NO ACTION

### DIFF
--- a/DropShot/Data/Migrations/20260422142936_ReplaceLeaguesWithCompetitionDivisions.Designer.cs
+++ b/DropShot/Data/Migrations/20260422142936_ReplaceLeaguesWithCompetitionDivisions.Designer.cs
@@ -1792,8 +1792,7 @@ namespace DropShot.Data.Migrations
 
                     b.HasOne("DropShot.Models.Competition", "SeededFromCompetition")
                         .WithMany()
-                        .HasForeignKey("SeededFromCompetitionId")
-                        .OnDelete(DeleteBehavior.SetNull);
+                        .HasForeignKey("SeededFromCompetitionId");
 
                     b.Navigation("CreatorUser");
 

--- a/DropShot/Data/Migrations/20260422142936_ReplaceLeaguesWithCompetitionDivisions.cs
+++ b/DropShot/Data/Migrations/20260422142936_ReplaceLeaguesWithCompetitionDivisions.cs
@@ -29,96 +29,47 @@ namespace DropShot.Data.Migrations
             ");
 
             // ── New: divisions live inside a Competition ──
-            migrationBuilder.AddColumn<bool>(
-                name: "HasDivisions",
-                table: "Competition",
-                type: "bit",
-                nullable: false,
-                defaultValue: false);
+            // Each step is guarded so a retry after a partial run converges.
+            // Self-referencing FK uses NO ACTION (SQL Server forbids SET NULL
+            // / CASCADE on self-references because of cycle / multi-path rules).
+            migrationBuilder.Sql(@"
+                IF COL_LENGTH(N'[Competition]', N'HasDivisions') IS NULL
+                    ALTER TABLE [Competition] ADD [HasDivisions] bit NOT NULL CONSTRAINT DF_Competition_HasDivisions DEFAULT CAST(0 AS bit);
+                IF COL_LENGTH(N'[Competition]', N'SeededFromCompetitionId') IS NULL
+                    ALTER TABLE [Competition] ADD [SeededFromCompetitionId] int NULL;
+                IF COL_LENGTH(N'[CompetitionParticipants]', N'CompetitionDivisionId') IS NULL
+                    ALTER TABLE [CompetitionParticipants] ADD [CompetitionDivisionId] int NULL;
+                IF COL_LENGTH(N'[CompetitionTeams]', N'CompetitionDivisionId') IS NULL
+                    ALTER TABLE [CompetitionTeams] ADD [CompetitionDivisionId] int NULL;
 
-            migrationBuilder.AddColumn<int>(
-                name: "SeededFromCompetitionId",
-                table: "Competition",
-                type: "int",
-                nullable: true);
+                IF OBJECT_ID(N'[CompetitionDivisions]', N'U') IS NULL
+                BEGIN
+                    CREATE TABLE [CompetitionDivisions] (
+                        [CompetitionDivisionId] int NOT NULL IDENTITY,
+                        [CompetitionId] int NOT NULL,
+                        [Rank] tinyint NOT NULL,
+                        [Name] nvarchar(80) NOT NULL,
+                        CONSTRAINT [PK_CompetitionDivisions] PRIMARY KEY ([CompetitionDivisionId]),
+                        CONSTRAINT [FK_CompetitionDivisions_Competition_CompetitionId] FOREIGN KEY ([CompetitionId]) REFERENCES [Competition] ([CompetitionID]) ON DELETE CASCADE
+                    );
+                END;
 
-            migrationBuilder.AddColumn<int>(
-                name: "CompetitionDivisionId",
-                table: "CompetitionParticipants",
-                type: "int",
-                nullable: true);
+                IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = N'IX_Competition_SeededFromCompetitionId' AND object_id = OBJECT_ID(N'[Competition]'))
+                    CREATE INDEX [IX_Competition_SeededFromCompetitionId] ON [Competition] ([SeededFromCompetitionId]);
+                IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = N'IX_CompetitionDivisions_CompetitionId_Rank' AND object_id = OBJECT_ID(N'[CompetitionDivisions]'))
+                    CREATE UNIQUE INDEX [IX_CompetitionDivisions_CompetitionId_Rank] ON [CompetitionDivisions] ([CompetitionId], [Rank]);
+                IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = N'IX_CompetitionParticipants_CompetitionDivisionId' AND object_id = OBJECT_ID(N'[CompetitionParticipants]'))
+                    CREATE INDEX [IX_CompetitionParticipants_CompetitionDivisionId] ON [CompetitionParticipants] ([CompetitionDivisionId]);
+                IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = N'IX_CompetitionTeams_CompetitionDivisionId' AND object_id = OBJECT_ID(N'[CompetitionTeams]'))
+                    CREATE INDEX [IX_CompetitionTeams_CompetitionDivisionId] ON [CompetitionTeams] ([CompetitionDivisionId]);
 
-            migrationBuilder.AddColumn<int>(
-                name: "CompetitionDivisionId",
-                table: "CompetitionTeams",
-                type: "int",
-                nullable: true);
-
-            migrationBuilder.CreateTable(
-                name: "CompetitionDivisions",
-                columns: table => new
-                {
-                    CompetitionDivisionId = table.Column<int>(type: "int", nullable: false)
-                        .Annotation("SqlServer:Identity", "1, 1"),
-                    CompetitionId = table.Column<int>(type: "int", nullable: false),
-                    Rank = table.Column<byte>(type: "tinyint", nullable: false),
-                    Name = table.Column<string>(type: "nvarchar(80)", maxLength: 80, nullable: false)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_CompetitionDivisions", x => x.CompetitionDivisionId);
-                    table.ForeignKey(
-                        name: "FK_CompetitionDivisions_Competition_CompetitionId",
-                        column: x => x.CompetitionId,
-                        principalTable: "Competition",
-                        principalColumn: "CompetitionID",
-                        onDelete: ReferentialAction.Cascade);
-                });
-
-            migrationBuilder.CreateIndex(
-                name: "IX_Competition_SeededFromCompetitionId",
-                table: "Competition",
-                column: "SeededFromCompetitionId");
-
-            migrationBuilder.CreateIndex(
-                name: "IX_CompetitionDivisions_CompetitionId_Rank",
-                table: "CompetitionDivisions",
-                columns: new[] { "CompetitionId", "Rank" },
-                unique: true);
-
-            migrationBuilder.CreateIndex(
-                name: "IX_CompetitionParticipants_CompetitionDivisionId",
-                table: "CompetitionParticipants",
-                column: "CompetitionDivisionId");
-
-            migrationBuilder.CreateIndex(
-                name: "IX_CompetitionTeams_CompetitionDivisionId",
-                table: "CompetitionTeams",
-                column: "CompetitionDivisionId");
-
-            migrationBuilder.AddForeignKey(
-                name: "FK_Competition_Competition_SeededFromCompetitionId",
-                table: "Competition",
-                column: "SeededFromCompetitionId",
-                principalTable: "Competition",
-                principalColumn: "CompetitionID",
-                onDelete: ReferentialAction.SetNull);
-
-            migrationBuilder.AddForeignKey(
-                name: "FK_CompetitionParticipants_CompetitionDivisions_CompetitionDivisionId",
-                table: "CompetitionParticipants",
-                column: "CompetitionDivisionId",
-                principalTable: "CompetitionDivisions",
-                principalColumn: "CompetitionDivisionId",
-                onDelete: ReferentialAction.SetNull);
-
-            migrationBuilder.AddForeignKey(
-                name: "FK_CompetitionTeams_CompetitionDivisions_CompetitionDivisionId",
-                table: "CompetitionTeams",
-                column: "CompetitionDivisionId",
-                principalTable: "CompetitionDivisions",
-                principalColumn: "CompetitionDivisionId",
-                onDelete: ReferentialAction.SetNull);
+                IF NOT EXISTS (SELECT 1 FROM sys.foreign_keys WHERE name = N'FK_Competition_Competition_SeededFromCompetitionId')
+                    ALTER TABLE [Competition] ADD CONSTRAINT [FK_Competition_Competition_SeededFromCompetitionId] FOREIGN KEY ([SeededFromCompetitionId]) REFERENCES [Competition] ([CompetitionID]) ON DELETE NO ACTION;
+                IF NOT EXISTS (SELECT 1 FROM sys.foreign_keys WHERE name = N'FK_CompetitionParticipants_CompetitionDivisions_CompetitionDivisionId')
+                    ALTER TABLE [CompetitionParticipants] ADD CONSTRAINT [FK_CompetitionParticipants_CompetitionDivisions_CompetitionDivisionId] FOREIGN KEY ([CompetitionDivisionId]) REFERENCES [CompetitionDivisions] ([CompetitionDivisionId]) ON DELETE SET NULL;
+                IF NOT EXISTS (SELECT 1 FROM sys.foreign_keys WHERE name = N'FK_CompetitionTeams_CompetitionDivisions_CompetitionDivisionId')
+                    ALTER TABLE [CompetitionTeams] ADD CONSTRAINT [FK_CompetitionTeams_CompetitionDivisions_CompetitionDivisionId] FOREIGN KEY ([CompetitionDivisionId]) REFERENCES [CompetitionDivisions] ([CompetitionDivisionId]) ON DELETE SET NULL;
+            ");
         }
 
         /// <inheritdoc />

--- a/DropShot/Data/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/DropShot/Data/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -1789,8 +1789,7 @@ namespace DropShot.Migrations
 
                     b.HasOne("DropShot.Models.Competition", "SeededFromCompetition")
                         .WithMany()
-                        .HasForeignKey("SeededFromCompetitionId")
-                        .OnDelete(DeleteBehavior.SetNull);
+                        .HasForeignKey("SeededFromCompetitionId");
 
                     b.Navigation("CreatorUser");
 

--- a/DropShot/Data/MyDbContext.cs
+++ b/DropShot/Data/MyDbContext.cs
@@ -134,7 +134,7 @@ namespace DropShot.Data
                 entity.HasOne(c => c.SeededFromCompetition)
                       .WithMany()
                       .HasForeignKey(c => c.SeededFromCompetitionId)
-                      .OnDelete(DeleteBehavior.SetNull);
+                      .OnDelete(DeleteBehavior.NoAction);
             });
 
             // ── CompetitionAllowedPlayer ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Fix-forward for the next deploy failure after [#378](https://github.com/kingbeazer/DropShot/pull/378): the teardown now works, but the self-referencing `FK_Competition_Competition_SeededFromCompetitionId` creation threw with `SqlException 1785` (cycles / multiple cascade paths) because SQL Server disallows `ON DELETE SET NULL` / `CASCADE` on a self-reference.
- Switch the FK delete behaviour to `NO ACTION` in both the migration and `MyDbContext` (deleting a seed source is a rare admin-only operation — `NoAction` forces the admin to clear `SeededFromCompetitionId` on dependents first, which is safer than silent blanking).
- Convert the whole `Up` body into a single idempotent raw-SQL block (`IF NOT EXISTS` / `COL_LENGTH IS NULL` / `OBJECT_ID IS NULL` guards) so the migration converges cleanly on a re-run even if the previous failed attempt didn't fully roll back.
- Regenerate designer + snapshot (NoAction is the default, so the explicit `OnDelete` line drops out).

## Test plan

- [ ] `dotnet ef database update --configuration Release` applies cleanly against the partially-applied staging DB.
- [ ] Verify `sys.foreign_keys` shows the three new FKs with the expected `delete_referential_action`: `0` (NO ACTION) for `Competition → Competition`, `2` (SET NULL) for the two `CompetitionDivisions` FKs.
- [ ] Re-running the migration against a database that is already fully migrated is a no-op (no errors, no double-indexes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)