### PR TITLE
Use NoAction delete on Division FKs to avoid cascade-path error

### DIFF
--- a/DropShot/Data/Migrations/20260422142936_ReplaceLeaguesWithCompetitionDivisions.Designer.cs
+++ b/DropShot/Data/Migrations/20260422142936_ReplaceLeaguesWithCompetitionDivisions.Designer.cs
@@ -1964,8 +1964,7 @@ namespace DropShot.Data.Migrations
                 {
                     b.HasOne("DropShot.Models.CompetitionDivision", "Division")
                         .WithMany("Participants")
-                        .HasForeignKey("CompetitionDivisionId")
-                        .OnDelete(DeleteBehavior.SetNull);
+                        .HasForeignKey("CompetitionDivisionId");
 
                     b.HasOne("DropShot.Models.Competition", "Competition")
                         .WithMany("Participants")
@@ -2024,8 +2023,7 @@ namespace DropShot.Data.Migrations
 
                     b.HasOne("DropShot.Models.CompetitionDivision", "Division")
                         .WithMany("Teams")
-                        .HasForeignKey("CompetitionDivisionId")
-                        .OnDelete(DeleteBehavior.SetNull);
+                        .HasForeignKey("CompetitionDivisionId");
 
                     b.HasOne("DropShot.Models.Competition", "Competition")
                         .WithMany("Teams")

--- a/DropShot/Data/Migrations/20260422142936_ReplaceLeaguesWithCompetitionDivisions.cs
+++ b/DropShot/Data/Migrations/20260422142936_ReplaceLeaguesWithCompetitionDivisions.cs
@@ -66,9 +66,9 @@ namespace DropShot.Data.Migrations
                 IF NOT EXISTS (SELECT 1 FROM sys.foreign_keys WHERE name = N'FK_Competition_Competition_SeededFromCompetitionId')
                     ALTER TABLE [Competition] ADD CONSTRAINT [FK_Competition_Competition_SeededFromCompetitionId] FOREIGN KEY ([SeededFromCompetitionId]) REFERENCES [Competition] ([CompetitionID]) ON DELETE NO ACTION;
                 IF NOT EXISTS (SELECT 1 FROM sys.foreign_keys WHERE name = N'FK_CompetitionParticipants_CompetitionDivisions_CompetitionDivisionId')
-                    ALTER TABLE [CompetitionParticipants] ADD CONSTRAINT [FK_CompetitionParticipants_CompetitionDivisions_CompetitionDivisionId] FOREIGN KEY ([CompetitionDivisionId]) REFERENCES [CompetitionDivisions] ([CompetitionDivisionId]) ON DELETE SET NULL;
+                    ALTER TABLE [CompetitionParticipants] ADD CONSTRAINT [FK_CompetitionParticipants_CompetitionDivisions_CompetitionDivisionId] FOREIGN KEY ([CompetitionDivisionId]) REFERENCES [CompetitionDivisions] ([CompetitionDivisionId]) ON DELETE NO ACTION;
                 IF NOT EXISTS (SELECT 1 FROM sys.foreign_keys WHERE name = N'FK_CompetitionTeams_CompetitionDivisions_CompetitionDivisionId')
-                    ALTER TABLE [CompetitionTeams] ADD CONSTRAINT [FK_CompetitionTeams_CompetitionDivisions_CompetitionDivisionId] FOREIGN KEY ([CompetitionDivisionId]) REFERENCES [CompetitionDivisions] ([CompetitionDivisionId]) ON DELETE SET NULL;
+                    ALTER TABLE [CompetitionTeams] ADD CONSTRAINT [FK_CompetitionTeams_CompetitionDivisions_CompetitionDivisionId] FOREIGN KEY ([CompetitionDivisionId]) REFERENCES [CompetitionDivisions] ([CompetitionDivisionId]) ON DELETE NO ACTION;
             ");
         }
 

--- a/DropShot/Data/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/DropShot/Data/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -1961,8 +1961,7 @@ namespace DropShot.Migrations
                 {
                     b.HasOne("DropShot.Models.CompetitionDivision", "Division")
                         .WithMany("Participants")
-                        .HasForeignKey("CompetitionDivisionId")
-                        .OnDelete(DeleteBehavior.SetNull);
+                        .HasForeignKey("CompetitionDivisionId");
 
                     b.HasOne("DropShot.Models.Competition", "Competition")
                         .WithMany("Participants")
@@ -2021,8 +2020,7 @@ namespace DropShot.Migrations
 
                     b.HasOne("DropShot.Models.CompetitionDivision", "Division")
                         .WithMany("Teams")
-                        .HasForeignKey("CompetitionDivisionId")
-                        .OnDelete(DeleteBehavior.SetNull);
+                        .HasForeignKey("CompetitionDivisionId");
 
                     b.HasOne("DropShot.Models.Competition", "Competition")
                         .WithMany("Teams")

--- a/DropShot/Data/MyDbContext.cs
+++ b/DropShot/Data/MyDbContext.cs
@@ -293,7 +293,7 @@ namespace DropShot.Data
                 entity.HasOne(t => t.Division)
                       .WithMany(d => d.Teams)
                       .HasForeignKey(t => t.CompetitionDivisionId)
-                      .OnDelete(DeleteBehavior.SetNull);
+                      .OnDelete(DeleteBehavior.NoAction);
             });
 
             // ── CompetitionParticipant ───────────────────────────────────────────
@@ -321,7 +321,7 @@ namespace DropShot.Data
                 entity.HasOne(cp => cp.Division)
                       .WithMany(d => d.Participants)
                       .HasForeignKey(cp => cp.CompetitionDivisionId)
-                      .OnDelete(DeleteBehavior.SetNull);
+                      .OnDelete(DeleteBehavior.NoAction);
             });
 
             // ── CompetitionStage ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Third fix-forward in the migration chain. After #379 landed NoAction on the self-ref Competition FK, the next run tripped on SqlException 1785 again — this time for `FK_CompetitionParticipants_CompetitionDivisions_CompetitionDivisionId` (and the equivalent Teams FK).
- Root cause: `CompetitionDivisions → Competition` is `ON DELETE CASCADE`, and `CompetitionParticipants → CompetitionDivisions` was `ON DELETE SET NULL`. Deleting a Competition then had two cascade paths to `CompetitionParticipants` — the direct CASCADE and the SET NULL via the division — which SQL Server forbids.
- Switched both Division FKs (participants + teams) to `NO ACTION`. The app already clears `CompetitionDivisionId` on dependents before deleting a division (see `CompetitionsController.DeleteDivision` and `CompetitionPage.DeleteDivision`), so DB-side NoAction is safe.

## Test plan

- [ ] `dotnet ef database update --configuration Release` applies cleanly end-to-end.
- [ ] Deleting a Competition still cleanly removes its participants/teams/divisions (via the existing CASCADEs on `CompetitionId`).
- [ ] Deleting a Division in the UI still succeeds — the controller clears `CompetitionDivisionId` on participants/teams first, then deletes the division row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)