### PR TITLE
Per-division match windows + division-aware scheduler

### DIFF
--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -368,7 +368,13 @@
             @* ── Match Windows ───────────────────────────────── *@
             <MudPaper Class="pa-4 mb-4" Elevation="0"
                  Style="background: rgba(255,255,255,0.08); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border: 1px solid rgba(255,255,255,0.12); border-radius: 12px; color: white;">
-                <MudText Typo="Typo.h6" Class="mb-3">Match Windows</MudText>
+                <MudText Typo="Typo.h6" Class="mb-1">@(Model.HasDivisions ? "Shared Match Windows" : "Match Windows")</MudText>
+                @if (Model.HasDivisions)
+                {
+                    <MudText Typo="Typo.caption" Class="mb-3" Style="opacity:0.75">
+                        These windows apply to <b>every</b> division. Use the <b>Divisions</b> tab to add windows that only apply to a single division.
+                    </MudText>
+                }
 
                 <MudGrid Spacing="1" Class="mb-2">
                     <MudItem xs="3">
@@ -402,14 +408,17 @@
                     </MudItem>
                 </MudGrid>
 
-                @if (_matchWindows.Count > 0)
+                @{
+                    var sharedWindows = _matchWindows.Where(w => w.CompetitionDivisionId == null).ToList();
+                }
+                @if (sharedWindows.Count > 0)
                 {
                     <MudSimpleTable Dense="true" Class="mb-2">
                         <thead>
                             <tr><th>Day</th><th>Court</th><th>From</th><th>To</th><th></th></tr>
                         </thead>
                         <tbody>
-                            @foreach (var w in _matchWindows)
+                            @foreach (var w in sharedWindows)
                             {
                                 <tr>
                                     <td>@w.DayOfWeek</td>
@@ -428,7 +437,7 @@
                 else
                 {
                     <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mb-2">
-                        No windows defined — auto-schedule will use default time slots.
+                        No shared windows defined — auto-schedule will use default time slots.
                     </MudText>
                 }
 
@@ -1108,6 +1117,90 @@
             <NoRecordsContent><MudText Typo="Typo.caption">No divisions defined yet.</MudText></NoRecordsContent>
         </MudTable>
     </MudPaper>
+
+    @if (_divisions.Count > 0)
+    {
+        <MudPaper Class="pa-4 mb-4" Elevation="0"
+                     Style="background: rgba(255,255,255,0.08); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border: 1px solid rgba(255,255,255,0.12); border-radius: 12px; color: white;">
+            <MudText Typo="Typo.h6" Class="mb-1">Match Windows by Division</MudText>
+            <MudText Typo="Typo.caption" Class="mb-3" Style="opacity:0.75">
+                Add windows that only apply when auto-scheduling fixtures in this division.
+                Shared windows (configured on the Setup tab) apply to every division in addition to these.
+            </MudText>
+
+            <MudExpansionPanels MultiExpansion="true">
+                @foreach (var d in _divisions)
+                {
+                    var divId = d.CompetitionDivisionId;
+                    var divWindows = _matchWindows.Where(w => w.CompetitionDivisionId == divId).ToList();
+                    var form = GetDivisionWindowForm(divId);
+                    <MudExpansionPanel Text="@($"{d.Name} ({divWindows.Count} window{(divWindows.Count == 1 ? "" : "s")})")">
+                        <MudGrid Spacing="1" Class="mb-2">
+                            <MudItem xs="3">
+                                <MudSelect @bind-Value="form.Day" Label="Day" Variant="Variant.Outlined" Margin="Margin.Dense">
+                                    @foreach (DayOfWeek dow in Enum.GetValues<DayOfWeek>())
+                                    {
+                                        <MudSelectItem Value="@dow">@dow</MudSelectItem>
+                                    }
+                                </MudSelect>
+                            </MudItem>
+                            <MudItem xs="3">
+                                <MudSelect @bind-Value="form.CourtId" Label="Court" Variant="Variant.Outlined"
+                                           Margin="Margin.Dense" Clearable="true">
+                                    @foreach (var c in _courts)
+                                    {
+                                        <MudSelectItem T="int?" Value="@((int?)c.CourtId)">@c.Name</MudSelectItem>
+                                    }
+                                </MudSelect>
+                            </MudItem>
+                            <MudItem xs="2">
+                                <MudTimePicker @bind-Time="form.Start" Label="From" Variant="Variant.Outlined"
+                                               Margin="Margin.Dense" AmPm="false" />
+                            </MudItem>
+                            <MudItem xs="2">
+                                <MudTimePicker @bind-Time="form.End" Label="To" Variant="Variant.Outlined"
+                                               Margin="Margin.Dense" AmPm="false" />
+                            </MudItem>
+                            <MudItem xs="2" Class="d-flex align-center">
+                                <MudButton Variant="Variant.Filled" Color="Color.Primary" Size="Size.Small"
+                                           OnClick="@(() => AddDivisionMatchWindow(divId))">Add</MudButton>
+                            </MudItem>
+                        </MudGrid>
+
+                        @if (divWindows.Count > 0)
+                        {
+                            <MudSimpleTable Dense="true" Class="mb-2">
+                                <thead>
+                                    <tr><th>Day</th><th>Court</th><th>From</th><th>To</th><th></th></tr>
+                                </thead>
+                                <tbody>
+                                    @foreach (var w in divWindows)
+                                    {
+                                        <tr>
+                                            <td>@w.DayOfWeek</td>
+                                            <td>@(w.Court?.Name ?? "All courts")</td>
+                                            <td>@w.StartTime.ToString(@"hh\:mm")</td>
+                                            <td>@w.EndTime.ToString(@"hh\:mm")</td>
+                                            <td>
+                                                <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small"
+                                                               Color="Color.Error" OnClick="@(() => DeleteMatchWindow(w))" />
+                                            </td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </MudSimpleTable>
+                        }
+                        else
+                        {
+                            <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mb-2">
+                                No division-specific windows — this division falls back to the shared windows only.
+                            </MudText>
+                        }
+                    </MudExpansionPanel>
+                }
+            </MudExpansionPanels>
+        </MudPaper>
+    }
 
     @if (_showDivisionDialog)
     {
@@ -2850,12 +2943,17 @@
         var teams = await db.CompetitionTeams
             .Where(t => t.CompetitionDivisionId == d.CompetitionDivisionId).ToListAsync();
         foreach (var t in teams) t.CompetitionDivisionId = null;
+        var divWindows = await db.CompetitionMatchWindows
+            .Where(w => w.CompetitionDivisionId == d.CompetitionDivisionId).ToListAsync();
+        if (divWindows.Count > 0) db.CompetitionMatchWindows.RemoveRange(divWindows);
         var row = await db.CompetitionDivisions.FindAsync(d.CompetitionDivisionId);
         if (row != null) db.CompetitionDivisions.Remove(row);
         await db.SaveChangesAsync();
 
         foreach (var p in _participants.Where(p => p.CompetitionDivisionId == d.CompetitionDivisionId)) p.CompetitionDivisionId = null;
         foreach (var t in _teams.Where(t => t.CompetitionDivisionId == d.CompetitionDivisionId)) t.CompetitionDivisionId = null;
+        _matchWindows.RemoveAll(w => w.CompetitionDivisionId == d.CompetitionDivisionId);
+        _divisionWindowForms.Remove(d.CompetitionDivisionId);
         _divisions.Remove(d);
     }
 
@@ -3754,6 +3852,53 @@
         if (w != null) { db.CompetitionMatchWindows.Remove(w); await db.SaveChangesAsync(); }
         _matchWindows.Remove(window);
         Snackbar.Add("Window removed.", Severity.Warning);
+    }
+
+    // ── Per-division match windows ──────────────────────────────────────────
+    private class DivisionWindowForm
+    {
+        public DayOfWeek Day { get; set; } = DayOfWeek.Monday;
+        public int? CourtId { get; set; }
+        public TimeSpan? Start { get; set; }
+        public TimeSpan? End { get; set; }
+    }
+    private readonly Dictionary<int, DivisionWindowForm> _divisionWindowForms = [];
+
+    private DivisionWindowForm GetDivisionWindowForm(int divisionId)
+    {
+        if (!_divisionWindowForms.TryGetValue(divisionId, out var form))
+        {
+            form = new DivisionWindowForm();
+            _divisionWindowForms[divisionId] = form;
+        }
+        return form;
+    }
+
+    private async Task AddDivisionMatchWindow(int divisionId)
+    {
+        var form = GetDivisionWindowForm(divisionId);
+        if (form.Start == null || form.End == null || form.End <= form.Start) return;
+
+        await using var db = DbFactory.CreateDbContext();
+        var w = new CompetitionMatchWindow
+        {
+            CompetitionId          = Id,
+            CompetitionDivisionId  = divisionId,
+            CourtId                = form.CourtId,
+            DayOfWeek              = form.Day,
+            StartTime              = form.Start.Value,
+            EndTime                = form.End.Value
+        };
+        db.CompetitionMatchWindows.Add(w);
+        await db.SaveChangesAsync();
+        w.Court = _courts.FirstOrDefault(c => c.CourtId == form.CourtId);
+        _matchWindows.Add(w);
+        _matchWindows = [.. _matchWindows.OrderBy(x => x.DayOfWeek).ThenBy(x => x.StartTime)];
+
+        form.CourtId = null;
+        form.Start = null;
+        form.End = null;
+        Snackbar.Add("Division window added.", Severity.Success);
     }
 
     private async Task ImportFromTemplate(int? templateId)

--- a/DropShot/Controllers/CompetitionsController.cs
+++ b/DropShot/Controllers/CompetitionsController.cs
@@ -678,16 +678,16 @@ public class CompetitionsController(
             : new List<DropShot.Models.Court>();
         var occupied = new HashSet<(DateTime, int?)>();
 
-        (DateTime, int?) RandomCourtSlot()
+        (DateTime, int?) RandomCourtSlot(int? divisionId)
         {
-            var result = SchedulingSlotPicker.PickCourtSlot(matchWindows, courts, occupied, startDate, endDate, rng);
+            var result = SchedulingSlotPicker.PickCourtSlot(matchWindows, courts, occupied, startDate, endDate, rng, divisionId);
             occupied.Add(result);
             return result;
         }
 
-        CompetitionFixture NewFixture(int compId, int stageId)
+        CompetitionFixture NewFixture(int compId, int stageId, int? divisionId = null)
         {
-            var (slot, courtId) = RandomCourtSlot();
+            var (slot, courtId) = RandomCourtSlot(divisionId);
             return new CompetitionFixture
             {
                 CompetitionId = compId,
@@ -731,6 +731,7 @@ public class CompetitionsController(
 
                         foreach (var group in teamGroups)
                         {
+                            var groupDivisionId = group.Key;
                             var teamIds = group.Select(t => t.CompetitionTeamId).ToList();
                             if (teamIds.Count < 2) continue;
 
@@ -753,7 +754,7 @@ public class CompetitionsController(
 
                                     if (homeTeamId == -1 || awayTeamId == -1) continue; // BYE
 
-                                    var fixture = NewFixture(id, stage.CompetitionStageId);
+                                    var fixture = NewFixture(id, stage.CompetitionStageId, groupDivisionId);
                                     fixture.HomeTeamId = homeTeamId;
                                     fixture.AwayTeamId = awayTeamId;
 

--- a/DropShot/Data/Migrations/20260422195039_AddDivisionToMatchWindow.Designer.cs
+++ b/DropShot/Data/Migrations/20260422195039_AddDivisionToMatchWindow.Designer.cs
@@ -4,16 +4,19 @@ using DropShot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace DropShot.Migrations
+namespace DropShot.Data.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260422195039_AddDivisionToMatchWindow")]
+    partial class AddDivisionToMatchWindow
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DropShot/Data/Migrations/20260422195039_AddDivisionToMatchWindow.cs
+++ b/DropShot/Data/Migrations/20260422195039_AddDivisionToMatchWindow.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropShot.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDivisionToMatchWindow : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Idempotent — same pattern as ReplaceLeaguesWithCompetitionDivisions.
+            migrationBuilder.Sql(@"
+                IF COL_LENGTH(N'[CompetitionMatchWindows]', N'CompetitionDivisionId') IS NULL
+                    ALTER TABLE [CompetitionMatchWindows] ADD [CompetitionDivisionId] int NULL;
+
+                IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = N'IX_CompetitionMatchWindows_CompetitionDivisionId' AND object_id = OBJECT_ID(N'[CompetitionMatchWindows]'))
+                    CREATE INDEX [IX_CompetitionMatchWindows_CompetitionDivisionId] ON [CompetitionMatchWindows] ([CompetitionDivisionId]);
+
+                IF NOT EXISTS (SELECT 1 FROM sys.foreign_keys WHERE name = N'FK_CompetitionMatchWindows_CompetitionDivisions_CompetitionDivisionId')
+                    ALTER TABLE [CompetitionMatchWindows]
+                        ADD CONSTRAINT [FK_CompetitionMatchWindows_CompetitionDivisions_CompetitionDivisionId]
+                        FOREIGN KEY ([CompetitionDivisionId])
+                        REFERENCES [CompetitionDivisions] ([CompetitionDivisionId])
+                        ON DELETE NO ACTION;
+            ");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_CompetitionMatchWindows_CompetitionDivisions_CompetitionDivisionId",
+                table: "CompetitionMatchWindows");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CompetitionMatchWindows_CompetitionDivisionId",
+                table: "CompetitionMatchWindows");
+
+            migrationBuilder.DropColumn(
+                name: "CompetitionDivisionId",
+                table: "CompetitionMatchWindows");
+        }
+    }
+}

--- a/DropShot/Data/MyDbContext.cs
+++ b/DropShot/Data/MyDbContext.cs
@@ -395,6 +395,13 @@ namespace DropShot.Data
                       .WithMany()
                       .HasForeignKey(w => w.CourtId)
                       .OnDelete(DeleteBehavior.SetNull);
+
+                entity.HasOne(w => w.Division)
+                      .WithMany()
+                      .HasForeignKey(w => w.CompetitionDivisionId)
+                      .OnDelete(DeleteBehavior.NoAction);
+
+                entity.HasIndex(w => w.CompetitionDivisionId);
             });
 
             // ── ClubSchedulingTemplate / ClubSchedulingTemplateWindow ────────────

--- a/DropShot/Models/SchedulingModels.cs
+++ b/DropShot/Models/SchedulingModels.cs
@@ -5,12 +5,21 @@ public class CompetitionMatchWindow
     public int CompetitionMatchWindowId { get; set; }
     public int CompetitionId { get; set; }
     public int? CourtId { get; set; }
+
+    /// <summary>
+    /// When set, this window only applies to the named division. When null,
+    /// the window is "shared" and applies to every division (plus any
+    /// non-divisioned fixtures).
+    /// </summary>
+    public int? CompetitionDivisionId { get; set; }
+
     public DayOfWeek DayOfWeek { get; set; }
     public TimeSpan StartTime { get; set; }
     public TimeSpan EndTime { get; set; }
 
     public Competition Competition { get; set; } = null!;
     public Court? Court { get; set; }
+    public CompetitionDivision? Division { get; set; }
 }
 
 public class ClubSchedulingTemplate

--- a/DropShot/Services/SchedulingSlotPicker.cs
+++ b/DropShot/Services/SchedulingSlotPicker.cs
@@ -19,8 +19,11 @@ public static class SchedulingSlotPicker
         DateTime windowStart,
         DateTime windowEnd,
         Random rng,
-        int[]? fallbackTimeSlots = null)
+        int[]? fallbackTimeSlots = null,
+        int? divisionId = null)
     {
+        windows = FilterForDivision(windows, divisionId);
+
         if (windows.Count > 0)
         {
             var candidates = new List<(DateTime date, TimeSpan time)>();
@@ -56,8 +59,11 @@ public static class SchedulingSlotPicker
         HashSet<(DateTime, int?)> occupied,
         DateTime windowStart,
         DateTime windowEnd,
-        Random rng)
+        Random rng,
+        int? divisionId = null)
     {
+        windows = FilterForDivision(windows, divisionId);
+
         if (courts.Count == 0)
             return (PickSlot(windows, windowStart, windowEnd, rng), null);
 
@@ -112,6 +118,28 @@ public static class SchedulingSlotPicker
 
         // All court slots exhausted — fall back to time-only
         return (PickSlot(windows, windowStart, windowEnd, rng), null);
+    }
+
+    /// <summary>
+    /// Narrows a window list to those applicable to the given division: a
+    /// shared (DivisionId == null) window applies to every division, and a
+    /// division-tagged window only applies to its own division.
+    /// </summary>
+    private static IReadOnlyList<CompetitionMatchWindow> FilterForDivision(
+        IReadOnlyList<CompetitionMatchWindow> windows, int? divisionId)
+    {
+        if (windows.Count == 0) return windows;
+        if (divisionId is null)
+        {
+            // No division context → only shared windows are eligible. Callers
+            // that pass a division ID of null because the competition is
+            // non-divisional still get all their (null-divisioned) windows.
+            if (windows.All(w => w.CompetitionDivisionId == null)) return windows;
+            return windows.Where(w => w.CompetitionDivisionId == null).ToList();
+        }
+        return windows
+            .Where(w => w.CompetitionDivisionId == null || w.CompetitionDivisionId == divisionId)
+            .ToList();
     }
 
     private static DateTime FallbackSlot(DateTime start, DateTime end, Random rng, int[] timeSlots)


### PR DESCRIPTION
## Summary

- Match windows can now be scoped to a single division. A window with `CompetitionDivisionId = null` applies to **every** division (and is the only mode for non-divisional competitions); a window with a division id applies only when scheduling fixtures for that division.
- When `HasDivisions` is on, the existing top-level block becomes **Shared Match Windows** and a new **Match Windows by Division** block appears on the Divisions tab (one `MudExpansionPanel` per division with its own add-form + list).
- `SchedulingSlotPicker` takes an optional `divisionId` and filters the window list before it builds slot candidates, so each division's round-robin fixtures land in that division's availability (plus the shared windows).

## Schema

- `CompetitionMatchWindow.CompetitionDivisionId INT NULL`, FK to `CompetitionDivisions` with `ON DELETE NO ACTION`. `DeleteDivision` now deletes child windows before deleting the division row. Migration `AddDivisionToMatchWindow` uses the same idempotent IF-NOT-EXISTS raw-SQL pattern as the recent division migrations — safe to re-run on a partially-applied DB.

## Test plan

- [ ] `dotnet ef database update --configuration Release` applies cleanly.
- [ ] On a TeamMatch competition with `HasDivisions = true`, add a window on the Divisions tab for Division A (e.g. Mon 19:00–21:00 on Court 1). Auto-schedule — Division A fixtures only land on Monday evenings.
- [ ] Division B, with no division-specific windows, still uses the shared windows.
- [ ] Add a shared Saturday window on the Setup tab; re-schedule — both divisions pick it up in addition to their own windows.
- [ ] Delete a division whose windows exist — the division-scoped windows disappear from the list and are removed from the DB.
- [ ] Non-division competition is unchanged (no Division tab block, shared label reverts to plain "Match Windows").

🤖 Generated with [Claude Code](https://claude.com/claude-code)