### PR TITLE
Add Auto-assign captains button for TeamMatch teams

### DIFF
--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -844,6 +844,12 @@
                         <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary"
                                    StartIcon="@Icons.Material.Filled.AutoFixHigh"
                                    OnClick="OpenGenerateDialog">Generate @sectionLabel</MudButton>
+                        @if (isTeamMatch && _teams.Any(t => !t.CaptainPlayerId.HasValue))
+                        {
+                            <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Secondary"
+                                       StartIcon="@Icons.Material.Filled.Casino"
+                                       OnClick="AutoAssignCaptains">Auto-assign captains</MudButton>
+                        }
                         @if (_teams.Count > 0)
                         {
                             <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Error"
@@ -2882,6 +2888,40 @@
         await using var db = DbFactory.CreateDbContext();
         var row = await db.CompetitionTeams.FindAsync(team.CompetitionTeamId);
         if (row != null) { row.CaptainPlayerId = captainPlayerId; await db.SaveChangesAsync(); team.CaptainPlayerId = captainPlayerId; }
+    }
+
+    private async Task AutoAssignCaptains()
+    {
+        var teamsNeedingCaptain = _teams.Where(t => !t.CaptainPlayerId.HasValue).ToList();
+        if (teamsNeedingCaptain.Count == 0) return;
+
+        await using var db = DbFactory.CreateDbContext();
+        var rng = new Random();
+        int assigned = 0;
+        int skipped = 0;
+
+        foreach (var team in teamsNeedingCaptain)
+        {
+            var candidates = _participants
+                .Where(p => p.TeamId == team.CompetitionTeamId
+                         && (p.Status == ParticipantStatus.Registered || p.Status == ParticipantStatus.Confirmed))
+                .ToList();
+            if (candidates.Count == 0) { skipped++; continue; }
+
+            var pick = candidates[rng.Next(candidates.Count)];
+            var row = await db.CompetitionTeams.FindAsync(team.CompetitionTeamId);
+            if (row == null) { skipped++; continue; }
+            row.CaptainPlayerId = pick.PlayerId;
+            team.CaptainPlayerId = pick.PlayerId;
+            assigned++;
+        }
+
+        if (assigned > 0) await db.SaveChangesAsync();
+
+        if (skipped > 0)
+            Snackbar.Add($"Assigned {assigned} captain(s). {skipped} team(s) skipped — no eligible members.", Severity.Warning);
+        else
+            Snackbar.Add($"Assigned {assigned} captain(s).", Severity.Success);
     }
 
     private async Task AssignParticipantDivision(CompetitionParticipant cp, int? divisionId)


### PR DESCRIPTION
## Summary

Adds an **Auto-assign captains** button to the Teams section header on `CompetitionPage`. Only shows for TeamMatch competitions and only when at least one team is still captain-less — it self-hides once every team is covered.

For each team without a captain, picks a random `Registered` / `Confirmed` participant on that team and stamps it as `CaptainPlayerId`. Teams that already have a captain are left alone. Teams with no eligible members get reported in a warning snackbar so admins know which ones still need a manual pick.

## Test plan

- [ ] TeamMatch competition with several teams, some captains set, some not: click the button — only the captain-less teams get populated, existing captains untouched.
- [ ] Re-click — nothing to do, button has disappeared.
- [ ] Team with no Registered/Confirmed members: warning snackbar reports the skip count.
- [ ] Non-TeamMatch competition: button doesn't render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)