### PR TITLE
Floating section nav on competition Setup tab

### DIFF
--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -72,7 +72,7 @@
 <MudTabPanel Text="Setup" Icon="@Icons.Material.Filled.Settings">
 
     @* ── Details form ───────────────────────────────────────── *@
-    <MudPaper Class="pa-4 mb-4" Elevation="0"
+    <MudPaper id="section-details" Class="pa-4 mb-4 setup-section" Elevation="0"
                  Style="background: rgba(255,255,255,0.08); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border: 1px solid rgba(255,255,255,0.12); border-radius: 12px; color: white;">
         <MudText Typo="Typo.h6" Class="mb-3">Details</MudText>
 
@@ -297,10 +297,40 @@
             </MudForm>
         </MudPaper>
 
+        @* ── Floating section navigation (sticks to top after scrolling past Details) ─ *@
+        @{
+            var _navShowAdmins = IsEdit && _canEdit;
+            var _navShowMatchWindows = IsEdit && !Model.HasDivisions;
+            var _navShowRubber = IsEdit && EffectivePersistedFormat() == CompetitionFormat.TeamMatch;
+            var _navShowTemplates = IsEdit && _competitionTemplates.Count > 0;
+            var _navShowDivisions = IsEdit && Model.HasDivisions;
+            var _navShowTeams = IsEdit && !Model.HasDivisions
+                && EffectivePersistedFormat() is CompetitionFormat.Team or CompetitionFormat.TeamMatch or CompetitionFormat.Doubles or CompetitionFormat.MixedDoubles;
+            var _navTeamsLabel = EffectivePersistedFormat() is CompetitionFormat.Doubles or CompetitionFormat.MixedDoubles ? "Pairings" : "Teams";
+            var _navShowFixtures = IsEdit && !Model.HasDivisions;
+        }
+        <nav class="setup-nav" aria-label="Competition setup sections">
+            <div class="setup-nav-inner">
+                <a href="#section-details">Details</a>
+                @if (_navShowAdmins) { <a href="#section-admins">Admins</a> }
+                @if (IsEdit)
+                {
+                    <a href="#section-stages">Stages</a>
+                    @if (_navShowMatchWindows) { <a href="#section-match-windows">Match Windows</a> }
+                    @if (_navShowRubber) { <a href="#section-rubber-template">Rubber</a> }
+                    <a href="#section-participants">Participants</a>
+                    @if (_navShowTemplates) { <a href="#section-templates">Template</a> }
+                    @if (_navShowDivisions) { <a href="#section-divisions">Divisions</a> }
+                    @if (_navShowTeams) { <a href="#section-teams">@_navTeamsLabel</a> }
+                    @if (_navShowFixtures) { <a href="#section-fixtures">Fixtures</a> }
+                }
+            </div>
+        </nav>
+
         @* ── Competition Admins ───────────────────────────── *@
         @if (IsEdit && _canEdit)
         {
-            <MudPaper Class="pa-4 mb-4" Elevation="0"
+            <MudPaper id="section-admins" Class="pa-4 mb-4 setup-section" Elevation="0"
                  Style="background: rgba(255,255,255,0.08); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border: 1px solid rgba(255,255,255,0.12); border-radius: 12px; color: white;">
                 <MudText Typo="Typo.h6" Class="mb-3">Competition Admins</MudText>
                 <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Class="mb-3">
@@ -340,7 +370,7 @@
         @* ── Stages ─────────────────────────────────────────── *@
         @if (IsEdit)
         {
-            <MudPaper Class="pa-4 mb-4" Elevation="0"
+            <MudPaper id="section-stages" Class="pa-4 mb-4 setup-section" Elevation="0"
                  Style="background: rgba(255,255,255,0.08); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border: 1px solid rgba(255,255,255,0.12); border-radius: 12px; color: white;">
                 <MudStack Row="true" AlignItems="AlignItems.Center" Class="mb-3">
                     <MudText Typo="Typo.h6" Style="flex:1">Stages</MudText>
@@ -369,7 +399,7 @@
             @* ── Match Windows (hidden when HasDivisions — per-division UI lives in the Divisions section below) *@
             @if (!Model.HasDivisions)
             {
-            <MudPaper Class="pa-4 mb-4" Elevation="0"
+            <MudPaper id="section-match-windows" Class="pa-4 mb-4 setup-section" Elevation="0"
                  Style="background: rgba(255,255,255,0.08); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border: 1px solid rgba(255,255,255,0.12); border-radius: 12px; color: white;">
                 <MudText Typo="Typo.h6" Class="mb-1">Match Windows</MudText>
 
@@ -477,7 +507,7 @@
                 var statusLabel = isCustom ? "Custom"
                                 : _rubberTemplateSource == "preset" ? "Preset"
                                 : "Default";
-                <MudPaper Class="pa-4 mb-4" Elevation="0"
+                <MudPaper id="section-rubber-template" Class="pa-4 mb-4 setup-section" Elevation="0"
                      Style="background: rgba(255,255,255,0.08); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border: 1px solid rgba(255,255,255,0.12); border-radius: 12px; color: white;">
                     <MudStack Row="true" AlignItems="AlignItems.Center" Class="mb-3">
                         <MudText Typo="Typo.h6" Style="flex:1">Rubber Template</MudText>
@@ -587,7 +617,7 @@
             }
 
             @* ── Participants ────────────────────────────────── *@
-            <MudPaper Class="pa-4 mb-4" Elevation="0"
+            <MudPaper id="section-participants" Class="pa-4 mb-4 setup-section" Elevation="0"
                  Style="background: rgba(255,255,255,0.08); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border: 1px solid rgba(255,255,255,0.12); border-radius: 12px; color: white;">
                 <MudStack Row="true" AlignItems="AlignItems.Center" Class="mb-3">
                     <MudText Typo="Typo.h6" Style="flex:1">Participants</MudText>
@@ -807,7 +837,7 @@
             @* ── Apply Competition Template ───────────────────── *@
             @if (_competitionTemplates.Count > 0)
             {
-                <MudPaper Class="pa-4 mb-4" Elevation="0"
+                <MudPaper id="section-templates" Class="pa-4 mb-4 setup-section" Elevation="0"
                  Style="background: rgba(255,255,255,0.08); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border: 1px solid rgba(255,255,255,0.12); border-radius: 12px; color: white;">
                     <MudText Typo="Typo.h6" Class="mb-3">Apply Competition Template</MudText>
                     <MudSelect T="int?" Label="Choose a template to apply" Variant="Variant.Outlined"
@@ -827,7 +857,7 @@
             @* -- Divisions -- *@
             @if (Model.HasDivisions)
             {
-                <MudPaper Class="pa-4 mb-4" Elevation="0"
+                <MudPaper id="section-divisions" Class="pa-4 mb-4 setup-section" Elevation="0"
                          Style="background: rgba(255,255,255,0.08); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border: 1px solid rgba(255,255,255,0.12); border-radius: 12px; color: white;">
                     <MudStack Row="true" AlignItems="AlignItems.Center" Class="mb-2" Wrap="Wrap.Wrap">
                         <MudText Typo="Typo.h6" Style="flex:1">Divisions</MudText>
@@ -1198,7 +1228,7 @@
                 var itemLabel = isDoubles ? "Pair" : "Team";
                 var isTeamMatch = EffectivePersistedFormat() == CompetitionFormat.TeamMatch;
 
-                <MudPaper Class="pa-4 mb-4" Elevation="0"
+                <MudPaper id="section-teams" Class="pa-4 mb-4 setup-section" Elevation="0"
                  Style="background: rgba(255,255,255,0.08); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border: 1px solid rgba(255,255,255,0.12); border-radius: 12px; color: white;">
                     <MudStack Row="true" AlignItems="AlignItems.Center" Class="mb-3">
                         <MudText Typo="Typo.h6" Style="flex:1">@sectionLabel</MudText>
@@ -1331,7 +1361,7 @@
             @* ── Fixtures (hidden when HasDivisions — per-division UI in the Divisions section below) *@
             @if (!Model.HasDivisions)
             {
-            <MudPaper Class="pa-4" Elevation="0"
+            <MudPaper id="section-fixtures" Class="pa-4 setup-section" Elevation="0"
                  Style="background: rgba(255,255,255,0.08); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border: 1px solid rgba(255,255,255,0.12); border-radius: 12px; color: white;">
                 <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="mb-3">
                     <MudText Typo="Typo.h6" Style="flex:1">Fixtures</MudText>

--- a/DropShot/wwwroot/app.css
+++ b/DropShot/wwwroot/app.css
@@ -167,6 +167,68 @@ body.scoring-immersive .top-navbar {
     display: none !important;
 }
 
+/* ── Competition setup — floating section nav ──────────────────────────────
+   Sticky below the top navbar. Placed after the first (Details) section, so
+   it scrolls into view and then sticks — naturally hidden on initial page
+   load and on other tabs. */
+.setup-nav {
+    position: sticky;
+    top: 3.5rem;
+    z-index: 11;
+    margin: 0 -0.5rem 1rem;
+    padding: 0.5rem 0.5rem;
+    background: rgba(18, 18, 18, 0.85);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.setup-nav-inner {
+    display: flex;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    gap: 0.375rem;
+    scrollbar-width: thin;
+}
+
+.setup-nav-inner::-webkit-scrollbar {
+    height: 4px;
+}
+
+.setup-nav-inner::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.2);
+    border-radius: 2px;
+}
+
+.setup-nav a {
+    flex: 0 0 auto;
+    padding: 0.25rem 0.75rem;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    background: rgba(255, 255, 255, 0.06);
+    color: rgba(255, 255, 255, 0.85);
+    font-size: 0.8rem;
+    text-decoration: none;
+    white-space: nowrap;
+    transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.setup-nav a:hover,
+.setup-nav a:focus-visible {
+    background: rgba(255, 255, 255, 0.14);
+    border-color: rgba(255, 255, 255, 0.35);
+    color: white;
+    outline: none;
+}
+
+.setup-section {
+    scroll-margin-top: 7rem;
+}
+
+html:has(.setup-nav) {
+    scroll-behavior: smooth;
+}
+
 /* Legacy — keep for external scoreboard page if still used */
 body.scoreboard-fullscreen .sidebar,
 body.scoreboard-fullscreen .role-banner,


### PR DESCRIPTION
## Summary
- Sticky pill-bar inside the Setup tab gives one-click jumps between Details, Admins, Stages, Match Windows, Rubber, Participants, Template, Divisions, Teams/Pairings, Fixtures.
- Bar appears once the user scrolls past the Details section and sticks under the top navbar; hidden on initial load and on the Email tab.
- Links render conditionally (format / HasDivisions / edit permissions) so there are no dead anchors.
- Pure CSS — no JS: `position: sticky; top: 3.5rem` placed after the Details MudPaper. `scroll-margin-top` keeps targets clear of the sticky bar, and smooth-scroll is scoped via `:has(.setup-nav)` so it doesn't leak elsewhere.

## Test plan
- [ ] Open a competition, scroll the Setup tab — nav slides in after Details and sticks.
- [ ] Click each pill, confirm it jumps to the right section (not hidden under the bar).
- [ ] Switch to the Email tab — nav disappears.
- [ ] Toggle HasDivisions — Match Windows / Teams / Fixtures pills disappear, Divisions pill appears.
- [ ] Toggle TeamMatch format — Rubber pill appears.
- [ ] Narrow viewport — pills scroll horizontally rather than wrapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)