### PR TITLE
Replace Auto Schedule modal with inline confirm alert

### DIFF
--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -887,7 +887,7 @@
                         }
                         <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Secondary"
                                    StartIcon="@Icons.Material.Filled.AutoAwesome"
-                                   OnClick="@(() => _showScheduleConfirm = true)">
+                                   OnClick="OpenScheduleConfirm">
                             Auto Schedule
                         </MudButton>
                         <MudButton Size="Size.Small" Variant="Variant.Outlined" StartIcon="@Icons.Material.Filled.Add"
@@ -899,6 +899,22 @@
                                        OnClick="@(() => _showDeleteAllFixturesConfirm = true)">Delete All Fixtures</MudButton>
                         }
                     </MudStack>
+
+                    @if (_showScheduleConfirm)
+                    {
+                        <MudAlert Severity="Severity.Info" Class="mb-3" ShowCloseIcon="true"
+                                  CloseIconClicked="@(() => _showScheduleConfirm = false)">
+                            <MudStack Spacing="1">
+                                <MudText Typo="Typo.body2">
+                                    Auto-scheduling creates missing fixtures based on the current stages, participants and divisions. Fixtures that already have a scheduled date will be preserved.
+                                </MudText>
+                                <MudCheckBox @bind-Value="_scheduleDeleteExisting" Dense="true"
+                                             Label="Also delete existing unscheduled fixtures" />
+                                <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Secondary"
+                                           OnClick="ScheduleFixtures">Schedule</MudButton>
+                            </MudStack>
+                        </MudAlert>
+                    }
 
                     @if (_showDeleteAllFixturesConfirm)
                     {
@@ -1376,7 +1392,7 @@
                     }
                     <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Secondary"
                                StartIcon="@Icons.Material.Filled.AutoAwesome"
-                               OnClick="@(() => _showScheduleConfirm = true)">
+                               OnClick="OpenScheduleConfirm">
                         Auto Schedule
                     </MudButton>
                     <MudButton Size="Size.Small" Variant="Variant.Outlined" StartIcon="@Icons.Material.Filled.Add"
@@ -1388,6 +1404,22 @@
                                    OnClick="@(() => _showDeleteAllFixturesConfirm = true)">Delete All</MudButton>
                     }
                 </MudStack>
+
+                @if (_showScheduleConfirm)
+                {
+                    <MudAlert Severity="Severity.Info" Class="mb-3" ShowCloseIcon="true"
+                              CloseIconClicked="@(() => _showScheduleConfirm = false)">
+                        <MudStack Spacing="1">
+                            <MudText Typo="Typo.body2">
+                                Auto-scheduling creates missing fixtures based on the current stages and participants. Fixtures that already have a scheduled date will be preserved.
+                            </MudText>
+                            <MudCheckBox @bind-Value="_scheduleDeleteExisting" Dense="true"
+                                         Label="Also delete existing unscheduled fixtures" />
+                            <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Secondary"
+                                       OnClick="ScheduleFixtures">Schedule</MudButton>
+                        </MudStack>
+                    </MudAlert>
+                }
 
                 @if (_showDeleteAllFixturesConfirm)
                 {
@@ -1618,18 +1650,8 @@
     </DialogActions>
 </MudDialog>
 
-@* ── Auto Schedule Confirmation Dialog ────────────────────── *@
-<MudDialog @bind-Visible="_showScheduleConfirm">
-    <TitleContent>Auto Schedule Matches</TitleContent>
-    <DialogContent>
-        <MudText Class="mb-3">Auto-scheduling will create missing fixtures based on the current stages and participants. Fixtures that already have a scheduled date will be preserved.</MudText>
-        <MudCheckBox @bind-Value="_scheduleDeleteExisting" Label="Also delete existing unscheduled fixtures" />
-    </DialogContent>
-    <DialogActions>
-        <MudButton OnClick="@(() => _showScheduleConfirm = false)">Cancel</MudButton>
-        <MudButton Variant="Variant.Filled" Color="Color.Secondary" OnClick="ScheduleFixtures">Schedule</MudButton>
-    </DialogActions>
-</MudDialog>
+@* Auto Schedule confirmation is rendered inline in both the Fixtures section
+   and the Divisions section — see AutoScheduleConfirmAlert below. *@
 
 @* ── Add / Edit Fixture Dialog ─────────────────────────────── *@
 <MudDialog @bind-Visible="_showFixtureDialog" Options="@(new DialogOptions { MaxWidth = MaxWidth.Medium, FullWidth = true })">
@@ -4691,6 +4713,12 @@
         await AdminEmailSvc.SendCompetitionEmailAsync(
             participants, Model.CompetitionName, _compEmailSubject, _compEmailBody, Id);
         Snackbar.Add($"Emails sent to {participants.Count} participant(s).", Severity.Success);
+    }
+
+    private void OpenScheduleConfirm()
+    {
+        _scheduleDeleteExisting = false;
+        _showScheduleConfirm = true;
     }
 
     private async Task ScheduleFixtures()


### PR DESCRIPTION
## Summary

Fix for "Auto Schedule button does nothing" reported after #391 / #392. The inline `<MudDialog @bind-Visible="_showScheduleConfirm">` stopped opening. Swap it for the same inline `MudAlert` pattern that Delete All Fixtures already uses — that one works reliably on MudBlazor 8.

## What changed

- Clicking **Auto Schedule** now flips `_showScheduleConfirm` and an inline `MudAlert` renders immediately below the section header with:
  - The info message
  - A checkbox: *Also delete existing unscheduled fixtures*
  - A **Schedule** button that calls `ScheduleFixtures()` (which still delegates to `CompetitionSchedulerService`)
  - A close icon that cancels
- Rendered in two places matching the **Delete All Fixtures** alert:
  - Inside the **Divisions section header** when `HasDivisions` is on
  - Inside the top-level **Fixtures** section when `HasDivisions` is off
- New `OpenScheduleConfirm()` method resets `_scheduleDeleteExisting` before showing the alert so the checkbox doesn't carry over state.
- The top-level `<MudDialog @bind-Visible="_showScheduleConfirm">` block is removed.

## Test plan

- [ ] `HasDivisions = true` competition: click Auto Schedule → info alert appears with checkbox + Schedule button → clicking Schedule runs the scheduler.
- [ ] `HasDivisions = false`: same flow on the top-level Fixtures section.
- [ ] Checkbox state is reset each time the alert opens.
- [ ] Closing the alert via the X icon cancels without scheduling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)