### PR TITLE
Fix scheduler hang: AsSplitQuery + AsNoTracking

### DIFF
--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -4732,9 +4732,11 @@
         var result = await Scheduler.ScheduleAsync(Id, new ScheduleFixturesRequest(mode));
 
         // Reload fixtures with nav props + the current CourtPair list in case the
-        // service auto-created pairs for a TeamMatch competition.
+        // service auto-created pairs for a TeamMatch competition. Split into
+        // separate SELECTs so the 11-Include graph doesn't cartesian-explode
+        // when the competition has hundreds of fixtures.
         await using var db = DbFactory.CreateDbContext();
-        _fixtures = await db.CompetitionFixtures
+        _fixtures = await db.CompetitionFixtures.AsNoTracking()
             .Where(f => f.CompetitionId == Id)
             .Include(f => f.Stage)
             .Include(f => f.Court)
@@ -4747,6 +4749,7 @@
             .Include(f => f.CourtPair).ThenInclude(cp => cp!.Court1)
             .Include(f => f.CourtPair).ThenInclude(cp => cp!.Court2)
             .Include(f => f.Rubbers)
+            .AsSplitQuery()
             .OrderBy(f => f.RoundNumber)
             .ThenBy(f => f.ScheduledAt)
             .ToListAsync();

--- a/DropShot/Services/CompetitionSchedulerService.cs
+++ b/DropShot/Services/CompetitionSchedulerService.cs
@@ -37,6 +37,11 @@ public class CompetitionSchedulerService(IDbContextFactory<MyDbContext> dbFactor
     {
         await using var db = dbFactory.CreateDbContext();
 
+        // Split into separate SELECTs (and skip change-tracking) so the 6-way
+        // Include graph doesn't cartesian-explode for a 128-participant,
+        // 32-team, 4-division competition. The scheduler only CREATES new
+        // fixtures — it never mutates the loaded comp / participant / team
+        // rows, so no tracking is needed.
         var comp = await db.Competition
             .Include(c => c.Stages.OrderBy(s => s.StageOrder))
             .Include(c => c.Participants).ThenInclude(p => p.Player)
@@ -44,6 +49,8 @@ public class CompetitionSchedulerService(IDbContextFactory<MyDbContext> dbFactor
             .Include(c => c.CourtPairs)
             .Include(c => c.MatchWindows).ThenInclude(w => w.Court)
             .Include(c => c.Divisions)
+            .AsSplitQuery()
+            .AsNoTracking()
             .FirstOrDefaultAsync(c => c.CompetitionID == competitionId);
         if (comp is null) return new ScheduleFixturesResult(0, 0);
 
@@ -75,10 +82,12 @@ public class CompetitionSchedulerService(IDbContextFactory<MyDbContext> dbFactor
 
         // ── Reload anything the generator needs ──────────────────────────────
         var courts = comp.HostClubId.HasValue
-            ? await db.Courts.Where(c => c.ClubId == comp.HostClubId.Value).OrderBy(c => c.Name).ToListAsync()
+            ? await db.Courts.AsNoTracking()
+                .Where(c => c.ClubId == comp.HostClubId.Value)
+                .OrderBy(c => c.Name).ToListAsync()
             : new List<Court>();
 
-        var existing = await db.CompetitionFixtures
+        var existing = await db.CompetitionFixtures.AsNoTracking()
             .Where(f => f.CompetitionId == competitionId)
             .ToListAsync();
 


### PR DESCRIPTION
## Summary

Follow-up to your hint that #388 is where things went wrong. The pre-consolidation client-side scheduler ran against already-loaded in-memory collections (`_teams`, `_participants`, `_fixtures`), so it paid almost no query cost when the user clicked Schedule. After #388 routed everything through `CompetitionSchedulerService.ScheduleAsync`, each invocation does a fresh comp load with six `Include` chains plus an existing-fixtures scan and a courts scan. Without `AsSplitQuery`, EF materialises that as one giant JOIN that cartesian-explodes for a competition with ~128 participants across 4 divisions.

## What changed

- **Scheduler comp load** now uses `AsSplitQuery` + `AsNoTracking`. The service never mutates the loaded graph — it only `AddRange()`s brand-new `CompetitionFixture` rows — so tracking is pure overhead.
- **Courts / existing-fixtures reads** also switched to `AsNoTracking`.
- **Page's post-schedule fixture reload** (11 Includes including the Rubbers collection) gets `AsSplitQuery` + `AsNoTracking` for the same reason — the reload was itself a second bottleneck on a divisional comp with hundreds of fixtures.

## Test plan

- [ ] 4-division, 32-team TeamMatch competition: click Schedule — fixtures appear within a couple of seconds instead of hanging.
- [ ] Non-divisional singles: still schedules the full RR correctly.
- [ ] Re-clicking Schedule without the "delete unscheduled" checkbox dedupes as expected (no duplicate fixtures).
- [ ] Checkbox checked → existing unscheduled fixtures are removed, the rest rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)