### PR TITLE
Show team-match fixtures on home upcoming list

### DIFF
--- a/DropShot/Components/Pages/Home.razor
+++ b/DropShot/Components/Pages/Home.razor
@@ -211,7 +211,7 @@
                                     <MudStack Row="true" Spacing="2">
                                         <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary"
                                                    StartIcon="@Icons.Material.Filled.PlayArrow"
-                                                   OnClick="@(() => Navigation.NavigateTo($"/match/0?fixtureId={context.CompetitionFixtureId}&autoStart=true"))">
+                                                   OnClick="@(() => Navigation.NavigateTo(FixturePlayUrl(context)))">
                                             Play
                                         </MudButton>
                                         <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Secondary"
@@ -313,6 +313,7 @@
     private List<CompetitionFixture> _pendingReviews = [];
     private List<CompetitionFixture> _recentResults = [];
     private List<RecentMatchItem> _recentItems = [];
+    private List<int> _myTeamIds = [];
 
     private sealed record RecentMatchItem(DateTime Date, CompetitionFixture? Fixture, SavedMatch? CasualMatch);
     private bool _showUpgradeBanner;
@@ -360,6 +361,16 @@
         if (player == null) return;
 
         var pid = player.PlayerId;
+
+        // TeamMatch fixtures don't populate Player1–4 — the player's match
+        // is inferred from the Home/Away team. Collect every team this player
+        // is on so we can match those too.
+        _myTeamIds = await db.CompetitionParticipants
+            .Where(cp => cp.PlayerId == pid && cp.TeamId != null)
+            .Select(cp => cp.TeamId!.Value)
+            .ToListAsync();
+        var myTeamIdList = _myTeamIds;
+
         _upcomingFixtures = await db.CompetitionFixtures
             .Include(f => f.Competition)
             .Include(f => f.Stage)
@@ -367,8 +378,13 @@
             .Include(f => f.Player2)
             .Include(f => f.Player3)
             .Include(f => f.Player4)
-            .Where(f => (f.Player1Id == pid || f.Player2Id == pid || f.Player3Id == pid || f.Player4Id == pid)
-                     && (f.Status == FixtureStatus.Scheduled || f.Status == FixtureStatus.InProgress))
+            .Include(f => f.HomeTeam)
+            .Include(f => f.AwayTeam)
+            .Where(f => (
+                    f.Player1Id == pid || f.Player2Id == pid || f.Player3Id == pid || f.Player4Id == pid
+                    || (f.HomeTeamId.HasValue && myTeamIdList.Contains(f.HomeTeamId.Value))
+                    || (f.AwayTeamId.HasValue && myTeamIdList.Contains(f.AwayTeamId.Value)))
+                 && (f.Status == FixtureStatus.Scheduled || f.Status == FixtureStatus.InProgress))
             .OrderBy(f => f.ScheduledAt)
             .ToListAsync();
 
@@ -378,9 +394,14 @@
             .Include(f => f.Player2)
             .Include(f => f.Player3)
             .Include(f => f.Player4)
-            .Where(f => (f.Player1Id == pid || f.Player2Id == pid || f.Player3Id == pid || f.Player4Id == pid)
-                     && f.Status == FixtureStatus.Completed
-                     && f.ResultSummary != null)
+            .Include(f => f.HomeTeam)
+            .Include(f => f.AwayTeam)
+            .Where(f => (
+                    f.Player1Id == pid || f.Player2Id == pid || f.Player3Id == pid || f.Player4Id == pid
+                    || (f.HomeTeamId.HasValue && myTeamIdList.Contains(f.HomeTeamId.Value))
+                    || (f.AwayTeamId.HasValue && myTeamIdList.Contains(f.AwayTeamId.Value)))
+                 && f.Status == FixtureStatus.Completed
+                 && f.ResultSummary != null)
             .OrderByDescending(f => f.CompletedAt ?? f.ScheduledAt)
             .Take(6)
             .ToListAsync();
@@ -417,13 +438,29 @@
 
     private string FixtureOpponents(CompetitionFixture f)
     {
-        // Show the other side — from perspective of the logged-in player
+        // TeamMatch fixtures carry only Home/Away teams. Show the opposing
+        // team from the logged-in player's perspective where possible.
+        if (f.HomeTeamId.HasValue || f.AwayTeamId.HasValue)
+        {
+            var home = f.HomeTeam?.Name ?? "TBD";
+            var away = f.AwayTeam?.Name ?? "TBD";
+            if (f.HomeTeamId.HasValue && _myTeamIds.Contains(f.HomeTeamId.Value)) return $"vs {away}";
+            if (f.AwayTeamId.HasValue && _myTeamIds.Contains(f.AwayTeamId.Value)) return $"vs {home}";
+            return $"{home} vs {away}";
+        }
+
+        // Player-based (singles / doubles) — show both sides.
         var side1 = new[] { f.Player1?.DisplayName, f.Player3?.DisplayName }
             .Where(n => n != null).DefaultIfEmpty("TBD").Aggregate((a, b) => $"{a} & {b}");
         var side2 = new[] { f.Player2?.DisplayName, f.Player4?.DisplayName }
             .Where(n => n != null).DefaultIfEmpty("TBD").Aggregate((a, b) => $"{a} & {b}");
         return $"{side1} vs {side2}";
     }
+
+    private string FixturePlayUrl(CompetitionFixture f) =>
+        (f.HomeTeamId.HasValue || f.AwayTeamId.HasValue)
+            ? $"/team-match/{f.CompetitionFixtureId}"
+            : $"/match/0?fixtureId={f.CompetitionFixtureId}&autoStart=true";
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {


### PR DESCRIPTION
## Summary

The Home page's "Your Upcoming Matches" (and recent-results) queries only matched fixtures via `Player1Id` / `Player2Id` / `Player3Id` / `Player4Id`. **TeamMatch fixtures carry only `HomeTeamId` / `AwayTeamId` — never Player1-4 — so every team-match fixture was invisible** to the player even when they were rostered on one of the teams.

## What changed

- Load the player's team memberships (`CompetitionParticipants` where `TeamId != null`) and include fixtures whose `HomeTeamId` / `AwayTeamId` matches any of them.
- Same team filter applied to the recent-results query.
- Include `HomeTeam` + `AwayTeam` navs so the Opponent column can show team names without another round-trip.
- `FixtureOpponents` now shows `vs <OpposingTeam>` for team fixtures from the logged-in player's perspective, falling back to `Home vs Away` if neither team is theirs (covers the edge case where the player is on neither team but still somehow has a fixture in the list).
- Play button routes to `/team-match/{id}` for team fixtures and keeps `/match/0?fixtureId=...&autoStart=true` for singles / doubles.

## Test plan

- [ ] Log in as a player rostered on a TeamMatch team — scheduled team fixtures now appear on their home page.
- [ ] Opponent column shows just the opposing team's name.
- [ ] Clicking Play opens the team-match scoring screen.
- [ ] Completed team fixtures appear in recent results.
- [ ] Singles / doubles player behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)