### PR TITLE
Fix floating Setup nav hover and anchor redirect

### DIFF
--- a/DropShot/Components/App.razor
+++ b/DropShot/Components/App.razor
@@ -38,6 +38,7 @@
     <script src="https://cdn.jsdelivr.net/npm/qrcode-generator@1.4.4/qrcode.min.js"></script>
     <script src="js/qrcode-helper.js"></script>
     <script src="js/paypal-interop.js"></script>
+    <script src="js/competition-nav.js"></script>
     <script src="_framework/blazor.web.js"></script>
     <script src="js/theme-switcher.js"></script>
     <script>if ('serviceWorker' in navigator) navigator.serviceWorker.register('service-worker.js');</script>

--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -309,20 +309,20 @@
             var _navTeamsLabel = EffectivePersistedFormat() is CompetitionFormat.Doubles or CompetitionFormat.MixedDoubles ? "Pairings" : "Teams";
             var _navShowFixtures = IsEdit && !Model.HasDivisions;
         }
-        <nav class="setup-nav" aria-label="Competition setup sections">
+        <nav id="setup-nav" class="setup-nav" aria-label="Competition setup sections">
             <div class="setup-nav-inner">
-                <a href="#section-details">Details</a>
-                @if (_navShowAdmins) { <a href="#section-admins">Admins</a> }
+                <button type="button" onclick="scrollToSectionId('section-details')">Details</button>
+                @if (_navShowAdmins) { <button type="button" onclick="scrollToSectionId('section-admins')">Admins</button> }
                 @if (IsEdit)
                 {
-                    <a href="#section-stages">Stages</a>
-                    @if (_navShowMatchWindows) { <a href="#section-match-windows">Match Windows</a> }
-                    @if (_navShowRubber) { <a href="#section-rubber-template">Rubber</a> }
-                    <a href="#section-participants">Participants</a>
-                    @if (_navShowTemplates) { <a href="#section-templates">Template</a> }
-                    @if (_navShowDivisions) { <a href="#section-divisions">Divisions</a> }
-                    @if (_navShowTeams) { <a href="#section-teams">@_navTeamsLabel</a> }
-                    @if (_navShowFixtures) { <a href="#section-fixtures">Fixtures</a> }
+                    <button type="button" onclick="scrollToSectionId('section-stages')">Stages</button>
+                    @if (_navShowMatchWindows) { <button type="button" onclick="scrollToSectionId('section-match-windows')">Match Windows</button> }
+                    @if (_navShowRubber) { <button type="button" onclick="scrollToSectionId('section-rubber-template')">Rubber</button> }
+                    <button type="button" onclick="scrollToSectionId('section-participants')">Participants</button>
+                    @if (_navShowTemplates) { <button type="button" onclick="scrollToSectionId('section-templates')">Template</button> }
+                    @if (_navShowDivisions) { <button type="button" onclick="scrollToSectionId('section-divisions')">Divisions</button> }
+                    @if (_navShowTeams) { <button type="button" onclick="scrollToSectionId('section-teams')">@_navTeamsLabel</button> }
+                    @if (_navShowFixtures) { <button type="button" onclick="scrollToSectionId('section-fixtures')">Fixtures</button> }
                 }
             </div>
         </nav>
@@ -2333,6 +2333,17 @@
         public DateTime? ScheduledAt => DatePart.HasValue
             ? DatePart.Value.Date + (TimePart ?? TimeSpan.Zero)
             : null;
+    }
+
+    private bool _setupNavInitialised;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender && !_setupNavInitialised)
+        {
+            _setupNavInitialised = true;
+            await JS.InvokeVoidAsync("initSetupNav", "setup-nav", "section-details");
+        }
     }
 
     protected override async Task OnParametersSetAsync()

--- a/DropShot/wwwroot/app.css
+++ b/DropShot/wwwroot/app.css
@@ -168,22 +168,37 @@ body.scoring-immersive .top-navbar {
 }
 
 /* ── Competition setup — floating section nav ──────────────────────────────
-   Sticky below the top navbar. Placed after the first (Details) section, so
-   it scrolls into view and then sticks — naturally hidden on initial page
-   load and on other tabs. */
+   Fixed below the top navbar. Hidden by default; JavaScript (see
+   competition-nav.js) toggles .setup-nav--visible once the Details section
+   scrolls above the viewport. */
 .setup-nav {
-    position: sticky;
+    position: fixed;
     top: 3.5rem;
+    left: 0;
+    right: 0;
     z-index: 11;
-    margin: 0 -0.5rem 1rem;
-    padding: 0.5rem 0.5rem;
-    background: rgba(18, 18, 18, 0.85);
+    padding: 0.5rem 1rem;
+    background: rgba(18, 18, 18, 0.92);
     backdrop-filter: blur(12px);
     -webkit-backdrop-filter: blur(12px);
     border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(-0.5rem);
+    pointer-events: none;
+    transition: opacity 0.15s ease, transform 0.15s ease, visibility 0.15s;
+}
+
+.setup-nav--visible {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+    pointer-events: auto;
 }
 
 .setup-nav-inner {
+    max-width: 1200px;
+    margin: 0 auto;
     display: flex;
     flex-wrap: nowrap;
     overflow-x: auto;
@@ -200,7 +215,7 @@ body.scoring-immersive .top-navbar {
     border-radius: 2px;
 }
 
-.setup-nav a {
+.setup-nav button {
     flex: 0 0 auto;
     padding: 0.25rem 0.75rem;
     border-radius: 999px;
@@ -208,13 +223,14 @@ body.scoring-immersive .top-navbar {
     background: rgba(255, 255, 255, 0.06);
     color: rgba(255, 255, 255, 0.85);
     font-size: 0.8rem;
-    text-decoration: none;
+    font-family: inherit;
     white-space: nowrap;
+    cursor: pointer;
     transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
 }
 
-.setup-nav a:hover,
-.setup-nav a:focus-visible {
+.setup-nav button:hover,
+.setup-nav button:focus-visible {
     background: rgba(255, 255, 255, 0.14);
     border-color: rgba(255, 255, 255, 0.35);
     color: white;
@@ -223,10 +239,6 @@ body.scoring-immersive .top-navbar {
 
 .setup-section {
     scroll-margin-top: 7rem;
-}
-
-html:has(.setup-nav) {
-    scroll-behavior: smooth;
 }
 
 /* Legacy — keep for external scoreboard page if still used */

--- a/DropShot/wwwroot/js/competition-nav.js
+++ b/DropShot/wwwroot/js/competition-nav.js
@@ -1,0 +1,44 @@
+(function () {
+    let observer = null;
+    let currentNavId = null;
+
+    window.initSetupNav = function (navId, sentinelId) {
+        const nav = document.getElementById(navId);
+        const sentinel = document.getElementById(sentinelId);
+        if (!nav || !sentinel) return;
+
+        disposeSetupNav();
+        currentNavId = navId;
+
+        observer = new IntersectionObserver(function (entries) {
+            for (const entry of entries) {
+                // Show nav once the sentinel (Details section) has scrolled
+                // above the top of the viewport.
+                if (!entry.isIntersecting && entry.boundingClientRect.top < 0) {
+                    nav.classList.add('setup-nav--visible');
+                } else {
+                    nav.classList.remove('setup-nav--visible');
+                }
+            }
+        }, { threshold: 0 });
+
+        observer.observe(sentinel);
+    };
+
+    window.disposeSetupNav = function () {
+        if (observer) {
+            observer.disconnect();
+            observer = null;
+        }
+        if (currentNavId) {
+            const nav = document.getElementById(currentNavId);
+            if (nav) nav.classList.remove('setup-nav--visible');
+            currentNavId = null;
+        }
+    };
+
+    window.scrollToSectionId = function (id) {
+        const el = document.getElementById(id);
+        if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    };
+})();


### PR DESCRIPTION
## Summary
Fixes two bugs in the floating Setup nav shipped in #392:

- **Nav didn't hover.** `position: sticky` was broken because the `mud-tabs-panels` container clips overflow. Switched to `position: fixed` with visibility toggled by an `IntersectionObserver` watching the Details section — nav fades in once Details scrolls above the viewport and fades out when scrolled back up.
- **Clicking a pill redirected to home.** Blazor's enhanced navigation intercepted the `#section-x` anchor clicks. Replaced the `<a>` tags with `<button>` elements that call a JS `scrollToSectionId` helper via inline `onclick` — buttons aren't intercepted by enhanced nav.

New `wwwroot/js/competition-nav.js` holds the observer init and scroll helpers; `CompetitionPage.OnAfterRenderAsync` initialises the observer once on first render.

## Test plan
- [ ] Open a competition, Setup tab, scroll past Details — nav fades in at top.
- [ ] Scroll back above Details — nav fades out.
- [ ] Click each pill — smooth-scrolls to the correct section, no navigation/redirect.
- [ ] Switch to Email tab — nav disappears (Details is hidden, so observer reports not-intersecting but `boundingClientRect.top` is 0, not negative; verify).
- [ ] Narrow viewport — pills scroll horizontally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)