### PR TITLE
Competition Setup: flatten tabs, move divisional fixtures to Fixtures tab, add Generate Teams for divisions

### DIFF
--- a/DropShot/Components/Competitions/Setup/DivisionsSection.razor
+++ b/DropShot/Components/Competitions/Setup/DivisionsSection.razor
@@ -7,6 +7,14 @@
         <MudText Typo="Typo.h6" Style="flex:1">Divisions</MudText>
         <MudButton Size="Size.Small" Variant="Variant.Outlined" StartIcon="@Icons.Material.Filled.Add"
                    OnClick="@(() => OnStartAddDivision.InvokeAsync())">Add Division</MudButton>
+        @if (Divisions.Count > 0 && Format is CompetitionFormat.Team or CompetitionFormat.TeamMatch or CompetitionFormat.Doubles or CompetitionFormat.MixedDoubles)
+        {
+            <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary"
+                       StartIcon="@Icons.Material.Filled.AutoFixHigh"
+                       OnClick="@(() => OnOpenGenerateDialog.InvokeAsync())">
+                Generate @(Format is CompetitionFormat.Doubles or CompetitionFormat.MixedDoubles ? "Pairings" : "Teams")
+            </MudButton>
+        }
         @if (SeedSourceCandidates.Count > 0 && Divisions.Count == 0)
         {
             <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary"
@@ -15,64 +23,9 @@
         }
     </MudStack>
 
-    @* Competition-wide fixture actions — Schedule / Add / Delete All apply to every division in one shot. *@
-    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="mb-3" Wrap="Wrap.Wrap">
-        <MudText Typo="Typo.caption" Style="flex:1; opacity:0.8">
-            Rank 1 is the top division. Teams, match windows and fixtures for each division are configured within the panels below.
-        </MudText>
-        @if (Stages.Any(s => s.StageType == StageType.RoundRobin) &&
-             Stages.Any(s => s.StageType is StageType.Knockout or StageType.QuarterFinal))
-        {
-            <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Warning"
-                       StartIcon="@Icons.Material.Filled.Leaderboard"
-                       OnClick="@(() => ShowSeedConfirmChanged.InvokeAsync(true))">
-                Seed from Standings
-            </MudButton>
-        }
-        <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Secondary"
-                   StartIcon="@Icons.Material.Filled.AutoAwesome"
-                   OnClick="@(() => OnOpenScheduleConfirm.InvokeAsync())">
-            Auto Schedule
-        </MudButton>
-        <MudButton Size="Size.Small" Variant="Variant.Outlined" StartIcon="@Icons.Material.Filled.Add"
-                   OnClick="@(() => OnOpenAddFixtureDialog.InvokeAsync())">Add Fixture</MudButton>
-        @if (Fixtures.Count > 0)
-        {
-            <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Error"
-                       StartIcon="@Icons.Material.Filled.DeleteSweep"
-                       OnClick="@(() => ShowDeleteAllFixturesConfirmChanged.InvokeAsync(true))">Delete All Fixtures</MudButton>
-        }
-    </MudStack>
-
-    @if (ShowScheduleConfirm)
-    {
-        <MudAlert Severity="Severity.Info" Class="mb-3" ShowCloseIcon="true"
-                  CloseIconClicked="@(() => ShowScheduleConfirmChanged.InvokeAsync(false))">
-            <MudStack Spacing="1">
-                <MudText Typo="Typo.body2">
-                    Auto-scheduling creates missing fixtures based on the current stages, participants and divisions. Fixtures that already have a scheduled date will be preserved.
-                </MudText>
-                <MudCheckBox Value="ScheduleDeleteExisting"
-                             ValueChanged="@((bool v) => ScheduleDeleteExistingChanged.InvokeAsync(v))"
-                             T="bool" Dense="true"
-                             Label="Also delete existing unscheduled fixtures" />
-                <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Secondary"
-                           OnClick="@(() => OnScheduleFixtures.InvokeAsync())">Schedule</MudButton>
-            </MudStack>
-        </MudAlert>
-    }
-
-    @if (ShowDeleteAllFixturesConfirm)
-    {
-        <MudAlert Severity="Severity.Warning" Class="mb-3" ShowCloseIcon="true"
-                  CloseIconClicked="@(() => ShowDeleteAllFixturesConfirmChanged.InvokeAsync(false))">
-            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
-                <MudText Typo="Typo.body2">Delete all @Fixtures.Count fixture(s)? This cannot be undone.</MudText>
-                <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Error"
-                           OnClick="@(() => OnDeleteAllFixtures.InvokeAsync())">Confirm Delete</MudButton>
-            </MudStack>
-        </MudAlert>
-    }
+    <MudText Typo="Typo.caption" Class="mb-3" Style="opacity:0.8">
+        Rank 1 is the top division. Teams and match windows for each division are configured within the panels below. Fixtures for each division are managed on the <b>Fixtures</b> tab.
+    </MudText>
 
     @if (AddingDivision)
     {
@@ -112,11 +65,10 @@
                 var divTeams = Teams.Where(t => t.CompetitionDivisionId == divId).ToList();
                 var divParts = Participants.Where(p => p.CompetitionDivisionId == divId).ToList();
                 var divWindows = MatchWindows.Where(w => w.CompetitionDivisionId == divId).ToList();
-                var divFixtures = Fixtures.Where(f => FixtureBelongsToDivision(f, divId)).ToList();
                 var windowForm = GetDivisionWindowForm(divId);
                 var editingThis = InlineEditDivisionId == divId;
 
-                <MudExpansionPanel Text="@($"Division {d.Rank} - {d.Name}  ({divTeams.Count} teams, {divParts.Count} participants, {divFixtures.Count} fixtures)")">
+                <MudExpansionPanel Text="@($"Division {d.Rank} - {d.Name}  ({divTeams.Count} teams, {divParts.Count} participants)")">
 
                     @* Division identity form *@
                     <MudPaper Class="pa-3 mb-3" Elevation="0" Style="background: rgba(255,255,255,0.04); border-radius: 8px;">
@@ -301,43 +253,6 @@
                         </MudText>
                     }
 
-                    @* Fixtures sub-section *@
-                    <MudDivider Class="my-3" />
-                    <MudText Typo="Typo.subtitle1" Class="mb-2">Fixtures</MudText>
-                    @if (divFixtures.Count == 0)
-                    {
-                        <MudText Typo="Typo.caption" Color="Color.Secondary">
-                            No fixtures scheduled for this division yet. Use the <b>Schedule</b> action at the bottom of the page to auto-generate.
-                        </MudText>
-                    }
-                    else
-                    {
-                        <MudSimpleTable Dense="true" Hover="true" Class="mb-2">
-                            <thead>
-                                <tr>
-                                    <th>Match</th>
-                                    <th>Date / Time</th>
-                                    <th>Players</th>
-                                    <th>Court</th>
-                                    <th>Status</th>
-                                    <th>Result</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                @foreach (var f in divFixtures)
-                                {
-                                    <tr>
-                                        <td>@(string.IsNullOrEmpty(f.FixtureLabel) ? (f.Stage?.Name ?? "") : f.FixtureLabel)</td>
-                                        <td>@(f.ScheduledAt?.ToString("dd MMM yyyy HH:mm") ?? "-")</td>
-                                        <td>@FixturePlayersDisplay(f)</td>
-                                        <td>@FixtureCourtDisplay(f)</td>
-                                        <td>@f.Status</td>
-                                        <td>@(f.ResultSummary ?? "-")</td>
-                                    </tr>
-                                }
-                            </tbody>
-                        </MudSimpleTable>
-                    }
                 </MudExpansionPanel>
             }
         </MudExpansionPanels>
@@ -404,9 +319,7 @@
     [Parameter, EditorRequired] public IReadOnlyList<CompetitionTeam> Teams { get; set; } = [];
     [Parameter, EditorRequired] public IReadOnlyList<CompetitionParticipant> Participants { get; set; } = [];
     [Parameter, EditorRequired] public IReadOnlyList<CompetitionMatchWindow> MatchWindows { get; set; } = [];
-    [Parameter, EditorRequired] public IReadOnlyList<CompetitionFixture> Fixtures { get; set; } = [];
     [Parameter, EditorRequired] public IReadOnlyList<Court> Courts { get; set; } = [];
-    [Parameter, EditorRequired] public IReadOnlyList<CompetitionStage> Stages { get; set; } = [];
     [Parameter, EditorRequired] public IReadOnlyList<Competition> SeedSourceCandidates { get; set; } = [];
     [Parameter] public CompetitionFormat? Format { get; set; }
 
@@ -439,22 +352,7 @@
 
     [Parameter] public bool SeedingDivisions { get; set; }
 
-    [Parameter] public bool ShowScheduleConfirm { get; set; }
-    [Parameter] public EventCallback<bool> ShowScheduleConfirmChanged { get; set; }
-
-    [Parameter] public bool ScheduleDeleteExisting { get; set; }
-    [Parameter] public EventCallback<bool> ScheduleDeleteExistingChanged { get; set; }
-
-    [Parameter] public bool ShowSeedConfirm { get; set; }
-    [Parameter] public EventCallback<bool> ShowSeedConfirmChanged { get; set; }
-
-    [Parameter] public bool ShowDeleteAllFixturesConfirm { get; set; }
-    [Parameter] public EventCallback<bool> ShowDeleteAllFixturesConfirmChanged { get; set; }
-
     [Parameter, EditorRequired] public Func<int, CompetitionPage.DivisionWindowForm> GetDivisionWindowForm { get; set; } = _ => new();
-    [Parameter, EditorRequired] public Func<CompetitionFixture, int, bool> FixtureBelongsToDivision { get; set; } = (_, _) => false;
-    [Parameter, EditorRequired] public Func<CompetitionFixture, string> FixturePlayersDisplay { get; set; } = _ => "";
-    [Parameter, EditorRequired] public Func<CompetitionFixture, string> FixtureCourtDisplay { get; set; } = _ => "";
 
     [Parameter] public EventCallback OnStartAddDivision { get; set; }
     [Parameter] public EventCallback OnCancelAddDivision { get; set; }
@@ -464,10 +362,7 @@
     [Parameter] public EventCallback<CompetitionDivision> OnDeleteDivision { get; set; }
     [Parameter] public EventCallback OnOpenSeedDivisionsDialog { get; set; }
     [Parameter] public EventCallback OnRunSeedDivisions { get; set; }
-    [Parameter] public EventCallback OnOpenScheduleConfirm { get; set; }
-    [Parameter] public EventCallback OnScheduleFixtures { get; set; }
-    [Parameter] public EventCallback OnOpenAddFixtureDialog { get; set; }
-    [Parameter] public EventCallback OnDeleteAllFixtures { get; set; }
+    [Parameter] public EventCallback OnOpenGenerateDialog { get; set; }
     [Parameter] public EventCallback<int> OnAddDivisionMatchWindow { get; set; }
     [Parameter] public EventCallback<int> OnCancelEditDivisionMatchWindow { get; set; }
     [Parameter] public EventCallback<CompetitionMatchWindow> OnCopyDivisionMatchWindowToForm { get; set; }

--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -649,9 +649,7 @@
                     Teams="_teams"
                     Participants="_participants"
                     MatchWindows="_matchWindows"
-                    Fixtures="_fixtures"
                     Courts="_courts"
-                    Stages="_stages"
                     SeedSourceCandidates="_seedSourceCandidates"
                     Format="EffectivePersistedFormat()"
                     AddingDivision="_addingDivision"
@@ -673,18 +671,7 @@
                     SeedDemoteCount="_seedDemoteCount"
                     SeedDemoteCountChanged="@(v => _seedDemoteCount = v)"
                     SeedingDivisions="_seedingDivisions"
-                    ShowScheduleConfirm="_showScheduleConfirm"
-                    ShowScheduleConfirmChanged="@(v => _showScheduleConfirm = v)"
-                    ScheduleDeleteExisting="_scheduleDeleteExisting"
-                    ScheduleDeleteExistingChanged="@(v => _scheduleDeleteExisting = v)"
-                    ShowSeedConfirm="_showSeedConfirm"
-                    ShowSeedConfirmChanged="@(v => _showSeedConfirm = v)"
-                    ShowDeleteAllFixturesConfirm="_showDeleteAllFixturesConfirm"
-                    ShowDeleteAllFixturesConfirmChanged="@(v => _showDeleteAllFixturesConfirm = v)"
                     GetDivisionWindowForm="GetDivisionWindowForm"
-                    FixtureBelongsToDivision="FixtureBelongsToDivision"
-                    FixturePlayersDisplay="FixturePlayersDisplay"
-                    FixtureCourtDisplay="FixtureCourtDisplay"
                     OnStartAddDivision="StartAddDivision"
                     OnCancelAddDivision="CancelAddDivision"
                     OnSaveDivision="SaveDivisionDialog"
@@ -693,10 +680,7 @@
                     OnDeleteDivision="DeleteDivision"
                     OnOpenSeedDivisionsDialog="OpenSeedDivisionsDialog"
                     OnRunSeedDivisions="RunSeedDivisions"
-                    OnOpenScheduleConfirm="OpenScheduleConfirm"
-                    OnScheduleFixtures="ScheduleFixtures"
-                    OnOpenAddFixtureDialog="OpenAddFixtureDialog"
-                    OnDeleteAllFixtures="DeleteAllFixtures"
+                    OnOpenGenerateDialog="OpenGenerateDialog"
                     OnAddDivisionMatchWindow="AddDivisionMatchWindow"
                     OnCancelEditDivisionMatchWindow="CancelEditDivisionMatchWindow"
                     OnCopyDivisionMatchWindowToForm="CopyDivisionMatchWindowToForm"
@@ -736,7 +720,6 @@
         </MudTabPanel>
 
         <MudTabPanel Text="Fixtures">
-            @* ── Fixtures (hidden when HasDivisions — per-division UI in the Divisions sub-tab) *@
             @if (!Model.HasDivisions)
             {
                 <DropShot.Components.Competitions.Setup.FixturesSection
@@ -764,6 +747,153 @@
                     OnShowQr="ShowQrCode"
                     OnOpenEditDialog="OpenEditFixtureDialog"
                     OnDeleteFixture="DeleteFixture" />
+            }
+            else
+            {
+                @* ── Divisional fixtures: scheduling controls + per-division grouping ─────── *@
+                <MudPaper Class="pa-4 mb-4 setup-section" Elevation="0"
+                     Style="background: rgba(255,255,255,0.08); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border: 1px solid rgba(255,255,255,0.12); border-radius: 12px; color: white;">
+                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="mb-3" Wrap="Wrap.Wrap">
+                        <MudText Typo="Typo.h6" Style="flex:1">Fixtures</MudText>
+                        @if (_stages.Any(s => s.StageType == StageType.RoundRobin) &&
+                             _stages.Any(s => s.StageType is StageType.Knockout or StageType.QuarterFinal))
+                        {
+                            <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Warning"
+                                       StartIcon="@Icons.Material.Filled.Leaderboard"
+                                       OnClick="@(() => _showSeedConfirm = true)">
+                                Seed from Standings
+                            </MudButton>
+                        }
+                        <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Secondary"
+                                   StartIcon="@Icons.Material.Filled.AutoAwesome"
+                                   OnClick="OpenScheduleConfirm">
+                            Auto Schedule
+                        </MudButton>
+                        <MudButton Size="Size.Small" Variant="Variant.Outlined" StartIcon="@Icons.Material.Filled.Add"
+                                   OnClick="OpenAddFixtureDialog">Add Fixture</MudButton>
+                        @if (_fixtures.Count > 0)
+                        {
+                            <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Error"
+                                       StartIcon="@Icons.Material.Filled.DeleteSweep"
+                                       OnClick="@(() => _showDeleteAllFixturesConfirm = true)">Delete All Fixtures</MudButton>
+                        }
+                    </MudStack>
+
+                    @if (_showScheduleConfirm)
+                    {
+                        <MudAlert Severity="Severity.Info" Class="mb-3" ShowCloseIcon="true"
+                                  CloseIconClicked="@(() => _showScheduleConfirm = false)">
+                            <MudStack Spacing="1">
+                                <MudText Typo="Typo.body2">
+                                    Auto-scheduling creates missing fixtures based on the current stages, participants and divisions. Fixtures that already have a scheduled date will be preserved.
+                                </MudText>
+                                <MudCheckBox @bind-Value="_scheduleDeleteExisting" Dense="true"
+                                             Label="Also delete existing unscheduled fixtures" />
+                                <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Secondary"
+                                           OnClick="ScheduleFixtures">Schedule</MudButton>
+                            </MudStack>
+                        </MudAlert>
+                    }
+
+                    @if (_showDeleteAllFixturesConfirm)
+                    {
+                        <MudAlert Severity="Severity.Warning" Class="mb-3" ShowCloseIcon="true"
+                                  CloseIconClicked="@(() => _showDeleteAllFixturesConfirm = false)">
+                            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                                <MudText Typo="Typo.body2">Delete all @_fixtures.Count fixture(s)? This cannot be undone.</MudText>
+                                <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Error"
+                                           OnClick="DeleteAllFixtures">Confirm Delete</MudButton>
+                            </MudStack>
+                        </MudAlert>
+                    }
+
+                    @if (_divisions.Count == 0)
+                    {
+                        <MudText Typo="Typo.caption" Color="Color.Secondary">
+                            No divisions defined yet. Add divisions on the <b>Setup</b> tab first.
+                        </MudText>
+                    }
+                    else
+                    {
+                        <MudExpansionPanels MultiExpansion="true">
+                            @foreach (var d in _divisions.OrderBy(x => x.Rank))
+                            {
+                                var divId = d.CompetitionDivisionId;
+                                var divFixtures = _fixtures.Where(f => FixtureBelongsToDivision(f, divId)).ToList();
+                                <MudExpansionPanel Text="@($"Division {d.Rank} - {d.Name}  ({divFixtures.Count} fixtures)")">
+                                    @if (divFixtures.Count == 0)
+                                    {
+                                        <MudText Typo="Typo.caption" Color="Color.Secondary">
+                                            No fixtures scheduled for this division yet. Use <b>Auto Schedule</b> above to generate.
+                                        </MudText>
+                                    }
+                                    else
+                                    {
+                                        <MudSimpleTable Dense="true" Hover="true">
+                                            <thead>
+                                                <tr>
+                                                    <th>Match</th>
+                                                    <th>Date / Time</th>
+                                                    <th>Players</th>
+                                                    <th>Court</th>
+                                                    <th>Result</th>
+                                                    <th>Status</th>
+                                                    <th></th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                @foreach (var f in divFixtures)
+                                                {
+                                                    <tr>
+                                                        <td>@(!string.IsNullOrEmpty(f.FixtureLabel) ? f.FixtureLabel : f.Stage?.Name ?? "—")</td>
+                                                        <td>@(f.ScheduledAt?.ToString("dd MMM yyyy HH:mm") ?? "—")</td>
+                                                        <td>@FixturePlayers(f)</td>
+                                                        <td>@FixtureCourtLabel(f)</td>
+                                                        <td>
+                                                            @{
+                                                                var resultText = FixtureResultDisplay(f);
+                                                            }
+                                                            @(!string.IsNullOrEmpty(resultText) ? resultText : "—")
+                                                        </td>
+                                                        <td>
+                                                            <MudChip T="string" Size="Size.Small" Color="@StatusColor(f.Status)">@f.Status</MudChip>
+                                                        </td>
+                                                        <td>
+                                                            @if (f.HomeTeamId.HasValue && f.AwayTeamId.HasValue
+                                                                 && f.Status is not (FixtureStatus.Completed or FixtureStatus.Cancelled or FixtureStatus.Walkover or FixtureStatus.AwaitingVerification))
+                                                            {
+                                                                <MudIconButton Icon="@Icons.Material.Filled.SportsTennis" Size="Size.Small"
+                                                                               Color="Color.Success" aria-label="Play Team Match"
+                                                                               Href="@($"/team-match/{f.CompetitionFixtureId}")" />
+                                                            }
+                                                            else if (f.Player1Id.HasValue && f.Player2Id.HasValue
+                                                                 && f.Status is not (FixtureStatus.Completed or FixtureStatus.Cancelled or FixtureStatus.Walkover or FixtureStatus.AwaitingVerification))
+                                                            {
+                                                                <MudIconButton Icon="@Icons.Material.Filled.Scoreboard" Size="Size.Small"
+                                                                               Color="Color.Success" aria-label="Submit Score"
+                                                                               OnClick="@(() => OpenSubmitScoreAsync(f))" />
+                                                            }
+                                                            @if (f.Status == FixtureStatus.AwaitingVerification && _canEdit)
+                                                            {
+                                                                <MudIconButton Icon="@Icons.Material.Filled.AdminPanelSettings" Size="Size.Small"
+                                                                               Color="Color.Warning" aria-label="Override / Enter Result"
+                                                                               OnClick="@(() => OpenOverrideResultAsync(f))" />
+                                                            }
+                                                            <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="Size.Small"
+                                                                           OnClick="@(() => OpenEditFixtureDialog(f))" />
+                                                            <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small"
+                                                                           Color="Color.Error" OnClick="@(() => DeleteFixture(f))" />
+                                                        </td>
+                                                    </tr>
+                                                }
+                                            </tbody>
+                                        </MudSimpleTable>
+                                    }
+                                </MudExpansionPanel>
+                            }
+                        </MudExpansionPanels>
+                    }
+                </MudPaper>
             }
         </MudTabPanel>
     }

--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -68,14 +68,10 @@
     }
 </MudStack>
 
-<MudTabs Elevation="2" Rounded="true" ApplyEffectsToContainer="true" Class="mb-4" @bind-ActivePanelIndex="_activeTabIndex">
-<MudTabPanel Text="Setup" Icon="@Icons.Material.Filled.Settings">
 <CascadingValue Value="this" IsFixed="true">
+<MudTabs Elevation="2" Rounded="true" ApplyEffectsToContainer="true" Class="mb-4" @bind-ActivePanelIndex="_activeTabIndex">
 
-    <MudTabs Elevation="0" Rounded="true" ApplyEffectsToContainer="true" Class="mb-4"
-             @bind-ActivePanelIndex="_activeSetupSubTabIndex">
-
-    <MudTabPanel Text="Setup">
+    <MudTabPanel Text="Setup" Icon="@Icons.Material.Filled.Settings">
     @* ── Details form ───────────────────────────────────────── *@
     <MudPaper id="section-details" Class="pa-4 mb-4 setup-section" Elevation="0"
                  Style="background: rgba(255,255,255,0.08); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border: 1px solid rgba(255,255,255,0.12); border-radius: 12px; color: white;">
@@ -772,27 +768,8 @@
         </MudTabPanel>
     }
 
-    </MudTabs>
-
-    @if (_errors.Length > 0)
-    {
-        <MudPaper Class="pa-4 mb-4" Elevation="0"
-                 Style="background: rgba(255,255,255,0.08); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border: 1px solid rgba(255,255,255,0.12); border-radius: 12px; color: white;">
-            <MudText Typo="Typo.subtitle2">Validation errors</MudText>
-            <MudDivider Class="my-2" />
-            @foreach (var e in _errors)
-            {
-                <MudText Color="Color.Error">@e</MudText>
-            }
-        </MudPaper>
-    }
-
-</CascadingValue>
-</MudTabPanel>
-
-
-@* ── Email Tab ─────────────────────────────────────────────── *@
-<MudTabPanel Text="Email" Icon="@Icons.Material.Filled.Email" Disabled="@(!IsEdit || !_canEdit)">
+    @* ── Email Tab ─────────────────────────────────────────────── *@
+    <MudTabPanel Text="Email" Icon="@Icons.Material.Filled.Email" Disabled="@(!IsEdit || !_canEdit)">
     <MudPaper Class="pa-4 mb-4" Elevation="0"
                  Style="background: rgba(255,255,255,0.08); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border: 1px solid rgba(255,255,255,0.12); border-radius: 12px; color: white;">
         <MudText Typo="Typo.h6" Class="mb-3">Match-Specific Email</MudText>
@@ -865,9 +842,24 @@
             </MudItem>
         </MudGrid>
     </MudPaper>
-</MudTabPanel>
+    </MudTabPanel>
 
 </MudTabs>
+
+@if (_errors.Length > 0)
+{
+    <MudPaper Class="pa-4 mb-4" Elevation="0"
+             Style="background: rgba(255,255,255,0.08); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border: 1px solid rgba(255,255,255,0.12); border-radius: 12px; color: white;">
+        <MudText Typo="Typo.subtitle2">Validation errors</MudText>
+        <MudDivider Class="my-2" />
+        @foreach (var e in _errors)
+        {
+            <MudText Color="Color.Error">@e</MudText>
+        }
+    </MudPaper>
+}
+
+</CascadingValue>
 
 @* ── Add Stage Dialog ──────────────────────────────────────── *@
 <MudDialog @bind-Visible="_showStageDialog">
@@ -1276,7 +1268,6 @@
     private bool _nameOverride;
     private bool _isStarted;
     private int _activeTabIndex;
-    private int _activeSetupSubTabIndex;
 
     private CompetitionFormModel Model { get; set; } = new();
 


### PR DESCRIPTION
## Summary

Follow-up to #397 addressing four feedback points from the Competition Setup page:

1. **Flatten the tabs**: the previous shape had `<MudTabs>[Setup, Email]` with a nested `<MudTabs>[Setup, Roster, Fixtures]` inside the outer Setup panel — two levels of tabs for no real reason. Now: one `<MudTabs>` with `[Setup, Roster, Fixtures, Email]`. `CascadingValue<CompetitionPage>` moves outside the tabs so every panel (including Email) can cascade.

2. **Move divisional fixtures to the Fixtures tab**: previously when a competition had divisions, fixtures lived inside each division's expansion panel on the Roster tab — users had to expand each division to see its fixtures. Now the Fixtures tab has a divisional branch with `MudExpansionPanels` per-division, showing each division's fixtures in one place.

3. **Move scheduling controls from the Divisions header to the Fixtures tab**: Auto Schedule / Add Fixture / Delete All Fixtures / Seed from Standings buttons move up into the Fixtures tab header where they belong with the fixtures they act on. The schedule / delete-all confirm alerts follow.

4. **Add Generate Teams for divisional competitions**: the Generate Teams / Generate Pairings button was only surfaced in the flat (non-division) TeamsSection. The backend methods (`ConfirmGenerateTeams`, `GenerateTeamsForBucket`) already supported per-division generation; this just adds the UI entry point in DivisionsSection's header.

Drops the now-unused `_activeSetupSubTabIndex` field and a chunk of parameters from DivisionsSection (Fixtures, Stages, ShowScheduleConfirm, ShowSeedConfirm, ShowDeleteAllFixturesConfirm, ScheduleDeleteExisting, FixtureBelongsToDivision, FixturePlayersDisplay, FixtureCourtDisplay, OnOpenScheduleConfirm, OnScheduleFixtures, OnOpenAddFixtureDialog, OnDeleteAllFixtures) — all consequences of the fixtures move.

## Test plan

- [ ] `dotnet build DropShot/DropShot.csproj` — passes
- [ ] Open a non-divisional competition — Setup / Roster / Fixtures / Email tabs visible as one group, Fixtures tab behaves exactly as before
- [ ] Open a divisional competition — Roster's Divisions section no longer has scheduling buttons or per-division fixtures tables; Fixtures tab shows scheduling header + expansion panel per division with fixtures in each
- [ ] Divisions expansion panel title reads `Division N - name (X teams, Y participants)` (no fixture count)
- [ ] Auto Schedule, Add Fixture, Delete All Fixtures, Seed from Standings all fire from the Fixtures tab
- [ ] Play / Submit Score / Override / Edit / Delete icons on each divisional fixture row work
- [ ] Divisional Team / TeamMatch / Doubles competition — Generate Teams button appears in Divisions header, opens the existing dialog
- [ ] Create a fresh divisional competition, generate teams, add fixtures, score one, verify it all round-trips

🤖 Generated with [Claude Code](https://claude.com/claude-code)