### PR TITLE
Restrict standard users to their own division on competition view

### DIFF
--- a/DropShot/Components/Pages/ViewCompetition.razor
+++ b/DropShot/Components/Pages/ViewCompetition.razor
@@ -465,6 +465,47 @@ else
 
             _divisions = _competition.Divisions.OrderBy(d => d.Rank).ToList();
 
+            // Restrict non-editors to their own division in competitions with divisions.
+            // Editors (admins / club admins / competition admins) keep the full grouped view.
+            if (!_canEdit && _canView && _competition.HasDivisions)
+            {
+                var playerUserId = authState.User.FindFirstValue(ClaimTypes.NameIdentifier);
+                if (!string.IsNullOrEmpty(playerUserId))
+                {
+                    var myParticipant = _competition.Participants
+                        .FirstOrDefault(p => p.Player?.UserId == playerUserId);
+                    if (myParticipant != null)
+                    {
+                        int? userDivisionId = myParticipant.CompetitionDivisionId
+                            ?? _teams.FirstOrDefault(t => t.CompetitionTeamId == myParticipant.TeamId)?.CompetitionDivisionId;
+
+                        _teams = _teams
+                            .Where(t => t.CompetitionDivisionId == userDivisionId)
+                            .ToList();
+                        var visibleTeamIds = _teams.Select(t => t.CompetitionTeamId).ToHashSet();
+
+                        _participants = _participants
+                            .Where(p => (p.TeamId.HasValue && visibleTeamIds.Contains(p.TeamId.Value))
+                                || (!p.TeamId.HasValue && p.CompetitionDivisionId == userDivisionId))
+                            .ToList();
+                        var visiblePlayerIds = _participants.Select(p => p.PlayerId).ToHashSet();
+
+                        _fixtures = _fixtures
+                            .Where(f =>
+                                (f.HomeTeamId.HasValue || f.AwayTeamId.HasValue)
+                                    ? (f.HomeTeamId.HasValue && visibleTeamIds.Contains(f.HomeTeamId.Value))
+                                        || (f.AwayTeamId.HasValue && visibleTeamIds.Contains(f.AwayTeamId.Value))
+                                    : new[] { f.Player1Id, f.Player2Id, f.Player3Id, f.Player4Id }
+                                        .Any(pid => pid.HasValue && visiblePlayerIds.Contains(pid.Value)))
+                            .ToList();
+
+                        _divisions = _divisions
+                            .Where(d => d.CompetitionDivisionId == userDivisionId)
+                            .ToList();
+                    }
+                }
+            }
+
             // Group fixtures by stage name (preserve stage order)
 #pragma warning disable CS8714
             _fixturesByStage = _competition.Stages


### PR DESCRIPTION
## Summary
- In a team competition with divisions, a non-editor user now sees only their own division's teams, participants, fixtures, and league table on the Competition view.
- Admins, club admins, and competition admins keep the existing view, with divisions grouped (unchanged).
- User's division is resolved from their `CompetitionParticipant.CompetitionDivisionId`, falling back to the division of the team they belong to.

## Test plan
- [ ] Log in as a standard user who is a participant in a team competition with divisions — confirm only their division's fixtures, league table, teams and players are visible.
- [ ] Log in as an admin / club admin / competition admin — confirm all divisions are visible, grouped as before.
- [ ] Verify individual fixtures (if any) are filtered correctly by participating players.
- [ ] Verify unassigned participants (no division yet) see only the unassigned bucket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)