### PR TITLE
Admin division expanders, mobile polish, FixedSets tie support

### DIFF
--- a/DropShot/Components/Layout/NavMenu.razor
+++ b/DropShot/Components/Layout/NavMenu.razor
@@ -21,7 +21,11 @@
             <AuthorizeView Roles="User">
                 <div class="nav-item">
                     <NavLink class="nav-link" href="match">
-                        <MudIcon Icon="@Icons.Material.Filled.SportsTennis" Class="nav-icon" /> <span class="nav-label">Match</span>
+                        <MudIcon Icon="@Icons.Material.Filled.SportsTennis" Class="nav-icon" />
+                        <span class="nav-label-group">
+                            <span class="nav-label">Match</span>
+                            <span class="nav-sublabel">Score or join a match</span>
+                        </span>
                     </NavLink>
                 </div>
             </AuthorizeView>
@@ -30,26 +34,45 @@
                 <div class="nav-item nav-dropdown">
                     <button class="nav-link nav-dropdown-trigger" onclick="event.stopPropagation()">
                         <MudIcon Icon="@Icons.Material.Filled.AdminPanelSettings" Class="nav-icon" />
-                        <span class="nav-label">Admin</span>
+                        <span class="nav-label-group">
+                            <span class="nav-label">Admin</span>
+                            <span class="nav-sublabel">Scoreboards, users &amp; requests</span>
+                        </span>
                         <span class="nav-expand-icon">
                             <MudIcon Icon="@Icons.Material.Filled.ExpandMore" Class="nav-icon" />
                         </span>
                     </button>
                     <div class="nav-dropdown-menu">
                         <NavLink class="nav-link" href="score">
-                            <MudIcon Icon="@Icons.Material.Filled.Tv" Class="nav-icon" /> Scoreboard View
+                            <MudIcon Icon="@Icons.Material.Filled.Tv" Class="nav-icon" />
+                            <span class="nav-label-group">
+                                <span class="nav-label">Scoreboard View</span>
+                                <span class="nav-sublabel">Display live scores</span>
+                            </span>
                         </NavLink>
                         <NavLink class="nav-link" href="score/display-control">
-                            <MudIcon Icon="@Icons.Material.Filled.Settings" Class="nav-icon" /> Display Control
+                            <MudIcon Icon="@Icons.Material.Filled.Settings" Class="nav-icon" />
+                            <span class="nav-label-group">
+                                <span class="nav-label">Display Control</span>
+                                <span class="nav-sublabel">Manage scoreboards</span>
+                            </span>
                         </NavLink>
                         <AuthorizeView Roles="Admin,SuperAdmin" Context="adminCtx">
                             <NavLink class="nav-link" href="admin/users">
-                                <MudIcon Icon="@Icons.Material.Filled.ManageAccounts" Class="nav-icon" /> Users
+                                <MudIcon Icon="@Icons.Material.Filled.ManageAccounts" Class="nav-icon" />
+                                <span class="nav-label-group">
+                                    <span class="nav-label">Users</span>
+                                    <span class="nav-sublabel">Manage accounts and roles</span>
+                                </span>
                             </NavLink>
                         </AuthorizeView>
                         <AuthorizeView Roles="Admin,SuperAdmin,ClubAdmin" Context="linkReqCtx">
                             <NavLink class="nav-link" href="clubadmin/link-requests">
-                                <MudIcon Icon="@Icons.Material.Filled.GroupAdd" Class="nav-icon" /> Link Requests
+                                <MudIcon Icon="@Icons.Material.Filled.GroupAdd" Class="nav-icon" />
+                                <span class="nav-label-group">
+                                    <span class="nav-label">Link Requests</span>
+                                    <span class="nav-sublabel">Approve player links</span>
+                                </span>
                             </NavLink>
                         </AuthorizeView>
                     </div>
@@ -60,7 +83,11 @@
                 <Authorized Context="mainCtx">
                     <div class="nav-item">
                         <NavLink class="nav-link" href="competitions">
-                            <MudIcon Icon="@Icons.Material.Filled.EmojiEvents" Class="nav-icon" /> <span class="nav-label">Competitions</span>
+                            <MudIcon Icon="@Icons.Material.Filled.EmojiEvents" Class="nav-icon" />
+                            <span class="nav-label-group">
+                                <span class="nav-label">Competitions</span>
+                                <span class="nav-sublabel">Browse and manage events</span>
+                            </span>
                         </NavLink>
                     </div>
 
@@ -68,13 +95,21 @@
                         @if (_isClubAdminActive)
                         {
                             <NavLink class="nav-link" href="players/club">
-                                <MudIcon Icon="@Icons.Material.Filled.Groups" Class="nav-icon" /> <span class="nav-label">Club Players</span>
+                                <MudIcon Icon="@Icons.Material.Filled.Groups" Class="nav-icon" />
+                                <span class="nav-label-group">
+                                    <span class="nav-label">Club Players</span>
+                                    <span class="nav-sublabel">Manage your club roster</span>
+                                </span>
                             </NavLink>
                         }
                         else
                         {
                             <NavLink class="nav-link" href="players/mine">
-                                <MudIcon Icon="@Icons.Material.Filled.RecentActors" Class="nav-icon" /> <span class="nav-label">My Players</span>
+                                <MudIcon Icon="@Icons.Material.Filled.RecentActors" Class="nav-icon" />
+                                <span class="nav-label-group">
+                                    <span class="nav-label">My Players</span>
+                                    <span class="nav-sublabel">Your linked players</span>
+                                </span>
                             </NavLink>
                         }
                     </div>
@@ -84,7 +119,11 @@
             <AuthorizeView Roles="SuperAdmin">
                 <div class="nav-item">
                     <NavLink class="nav-link" href="players">
-                        <MudIcon Icon="@Icons.Material.Filled.People" Class="nav-icon" /> <span class="nav-label">Players</span>
+                        <MudIcon Icon="@Icons.Material.Filled.People" Class="nav-icon" />
+                        <span class="nav-label-group">
+                            <span class="nav-label">Players</span>
+                            <span class="nav-sublabel">All players in the system</span>
+                        </span>
                     </NavLink>
                 </div>
             </AuthorizeView>
@@ -92,7 +131,11 @@
             <AuthorizeView Roles="Admin,SuperAdmin">
                 <div class="nav-item">
                     <NavLink class="nav-link" href="clubs">
-                        <MudIcon Icon="@Icons.Material.Filled.Business" Class="nav-icon" /> <span class="nav-label">Clubs</span>
+                        <MudIcon Icon="@Icons.Material.Filled.Business" Class="nav-icon" />
+                        <span class="nav-label-group">
+                            <span class="nav-label">Clubs</span>
+                            <span class="nav-sublabel">Manage tennis clubs</span>
+                        </span>
                     </NavLink>
                 </div>
             </AuthorizeView>
@@ -109,7 +152,10 @@
                             <svg class="nav-icon theme-toggle-icon theme-icon-dark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="currentColor">
                                 <path d="M12 3a9 9 0 109 9c0-.46-.04-.92-.1-1.36a5.389 5.389 0 01-4.4 2.26 5.403 5.403 0 01-3.14-9.8c-.44-.06-.9-.1-1.36-.1z"/>
                             </svg>
-                            <span class="theme-toggle-label">Light Mode</span>
+                            <span class="nav-label-group theme-toggle-label">
+                                <span class="nav-label">Light Mode</span>
+                                <span class="nav-sublabel">Switch theme</span>
+                            </span>
                         </button>
                     </div>
                 </Authorized>
@@ -127,24 +173,39 @@
                             {
                                 <MudIcon Icon="@Icons.Material.Filled.Person" Class="nav-icon" />
                             }
-                            <span class="nav-label">@context.User.Identity?.Name</span>
+                            <span class="nav-label-group">
+                                <span class="nav-label">@context.User.Identity?.Name</span>
+                                <span class="nav-sublabel">Account menu</span>
+                            </span>
                             <span class="nav-expand-icon">
                                 <MudIcon Icon="@Icons.Material.Filled.ExpandMore" Class="nav-icon" />
                             </span>
                         </button>
                         <div class="nav-dropdown-menu">
                             <NavLink class="nav-link" href="upgrade">
-                                <MudIcon Icon="@Icons.Material.Filled.Star" Class="nav-icon" /> Upgrade
+                                <MudIcon Icon="@Icons.Material.Filled.Star" Class="nav-icon" />
+                                <span class="nav-label-group">
+                                    <span class="nav-label">Upgrade</span>
+                                    <span class="nav-sublabel">Unlock more features</span>
+                                </span>
                             </NavLink>
                             <a class="nav-link" href="Account/Manage" data-enhance-nav="false">
-                                <MudIcon Icon="@Icons.Material.Filled.Person" Class="nav-icon" /> Account
+                                <MudIcon Icon="@Icons.Material.Filled.Person" Class="nav-icon" />
+                                <span class="nav-label-group">
+                                    <span class="nav-label">Account</span>
+                                    <span class="nav-sublabel">Profile &amp; settings</span>
+                                </span>
                             </a>
                             <div class="nav-dropdown-item">
                                 <form action="Account/Logout" method="post">
                                     <AntiforgeryToken />
                                     <input type="hidden" name="ReturnUrl" value="@currentUrl" />
                                     <button type="submit" class="nav-link">
-                                        <MudIcon Icon="@Icons.Material.Filled.Logout" Class="nav-icon" /> Logout
+                                        <MudIcon Icon="@Icons.Material.Filled.Logout" Class="nav-icon" />
+                                        <span class="nav-label-group">
+                                            <span class="nav-label">Logout</span>
+                                            <span class="nav-sublabel">End your session</span>
+                                        </span>
                                     </button>
                                 </form>
                             </div>
@@ -154,12 +215,20 @@
                 <NotAuthorized>
                     <div class="nav-item">
                         <a class="nav-link" href="Account/Register" data-enhance-nav="false">
-                            <MudIcon Icon="@Icons.Material.Filled.PersonAdd" Class="nav-icon" /> <span class="nav-label">Register</span>
+                            <MudIcon Icon="@Icons.Material.Filled.PersonAdd" Class="nav-icon" />
+                            <span class="nav-label-group">
+                                <span class="nav-label">Register</span>
+                                <span class="nav-sublabel">Create an account</span>
+                            </span>
                         </a>
                     </div>
                     <div class="nav-item">
                         <a class="nav-link" href="Account/Login" data-enhance-nav="false">
-                            <MudIcon Icon="@Icons.Material.Filled.Login" Class="nav-icon" /> <span class="nav-label">Login</span>
+                            <MudIcon Icon="@Icons.Material.Filled.Login" Class="nav-icon" />
+                            <span class="nav-label-group">
+                                <span class="nav-label">Login</span>
+                                <span class="nav-sublabel">Sign in</span>
+                            </span>
                         </a>
                     </div>
                 </NotAuthorized>

--- a/DropShot/Components/Layout/NavMenu.razor.css
+++ b/DropShot/Components/Layout/NavMenu.razor.css
@@ -235,6 +235,24 @@
     display: inline;
 }
 
+/* Label + sublabel wrapper — only splits into two lines on the mobile
+   hamburger menu. On desktop / medium the sublabel is hidden so the
+   group renders inline with the icon like before. */
+.nav-label-group {
+    display: inline-flex;
+    flex-direction: column;
+    line-height: 1.15;
+    min-width: 0;
+}
+
+.nav-sublabel {
+    display: none;
+    font-size: 0.75rem;
+    color: rgba(255, 255, 255, 0.55);
+    white-space: normal;
+    margin-top: 2px;
+}
+
 /* ══════════════════════════════════════════════════════════════════════
    Desktop (>=641px)
    ══════════════════════════════════════════════════════════════════════ */
@@ -317,10 +335,12 @@
 
     .nav-item ::deep .nav-link,
     .nav-item > .nav-link {
-        height: 3rem;
-        padding: 0 1.25rem;
+        min-height: 3rem;
+        height: auto;
+        padding: 0.5rem 1.25rem;
         width: 100%;
         border-radius: 0;
+        align-items: center;
     }
 
     .nav-item ::deep .nav-link:hover,
@@ -354,7 +374,8 @@
     .nav-dropdown-menu a.nav-link,
     .nav-dropdown-item .nav-link {
         padding: 0.5rem 1.25rem 0.5rem 2.75rem;
-        height: 3rem;
+        min-height: 3rem;
+        height: auto;
     }
 
     .nav-expand-icon {
@@ -362,19 +383,34 @@
     }
 
     .nav-dropdown-trigger {
-        height: 3rem;
-        padding: 0 1.25rem;
+        min-height: 3rem;
+        height: auto;
+        padding: 0.5rem 1.25rem;
         width: 100%;
+        align-items: center;
     }
 
     .theme-toggle-label {
-        display: inline;
+        display: inline-flex;
+    }
+
+    /* Show the descriptive second line for each menu item on mobile. */
+    .nav-sublabel {
+        display: block;
+    }
+
+    /* Dropdown-trigger items (Admin, Account) need the label group to
+       take the remaining width so the chevron stays right-aligned. */
+    .nav-dropdown-trigger .nav-label-group {
+        flex: 1;
     }
 
     .theme-toggle-btn {
-        height: 3rem;
-        padding: 0 1.25rem;
+        min-height: 3rem;
+        height: auto;
+        padding: 0.5rem 1.25rem;
         width: 100%;
+        align-items: center;
     }
 
     .theme-toggle-btn:hover {

--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -53,6 +53,7 @@
             <MudButton Variant="@(_isStarted ? Variant.Outlined : Variant.Filled)"
                        Color="@(_isStarted ? Color.Warning : Color.Success)"
                        StartIcon="@(_isStarted ? Icons.Material.Filled.Stop : Icons.Material.Filled.PlayArrow)"
+                       Class="px-4"
                        OnClick="ToggleStartedAsync">
                 @(_isStarted ? "Stop Competition" : "Start Competition")
             </MudButton>
@@ -62,6 +63,7 @@
             <MudChip T="string" Color="Color.Warning" Variant="Variant.Outlined">Not Started</MudChip>
         }
         <MudButton Variant="Variant.Outlined" Color="Color.Info" StartIcon="@Icons.Material.Filled.Visibility"
+                   Class="px-4"
                    OnClick="@(() => Nav.NavigateTo($"/competition/{Id}/view"))">
             View Competition
         </MudButton>

--- a/DropShot/Components/Pages/CompetitionPage.razor.css
+++ b/DropShot/Components/Pages/CompetitionPage.razor.css
@@ -1,0 +1,12 @@
+/* Competition edit page – mobile-specific polish */
+
+@media (max-width: 640.98px) {
+    /* Breathing room between the tab strip (Setup / Roster / Fixtures / Email)
+       and the active panel's content. MudBlazor renders the tab headers in
+       `.mud-tabs-toolbar`; push the content panel below it away from that bar. */
+    ::deep .mud-tabs-panels,
+    ::deep .mud-tabs-tabbar + div,
+    ::deep .mud-tab-panel {
+        padding-top: 1rem;
+    }
+}

--- a/DropShot/Components/Pages/ViewCompetition.razor
+++ b/DropShot/Components/Pages/ViewCompetition.razor
@@ -80,11 +80,15 @@ else
 
     <MudDivider Class="mb-4" />
 
+    <MudExpansionPanels MultiExpansion="true" Class="mb-4">
+
     @* ── Fixtures by stage ───────────────────────────────────── *@
     @if (!(_canEdit && _competition.HasDivisions))
     {
-    <MudText Typo="Typo.h5" Class="mb-3">Scheduled Matches</MudText>
+    var visibleDivisionCount = _fixturesByDivision.Count(g => g.StageGroups.Count > 0);
+    var showDivisionHeadings = _competition.HasDivisions && visibleDivisionCount > 1;
 
+    <MudExpansionPanel Text="Scheduled Matches">
     @if (!_fixtures.Any())
     {
         <MudAlert Severity="Severity.Info" Class="mb-4">No matches scheduled yet.</MudAlert>
@@ -93,17 +97,17 @@ else
     {
         @foreach (var divGroup in _fixturesByDivision.Where(g => g.StageGroups.Count > 0))
         {
-            @if (_competition.HasDivisions)
+            @if (showDivisionHeadings)
             {
                 <MudText Typo="Typo.h6" Class="mt-3 mb-2">@(divGroup.Division?.Name ?? "Unassigned")</MudText>
             }
             @foreach (var stageGroup in divGroup.StageGroups)
             {
-                <MudText Typo="@(_competition.HasDivisions ? Typo.subtitle1 : Typo.h6)"
-                         Class="@(_competition.HasDivisions ? "mt-2 mb-1 ms-3" : "mt-3 mb-2")">
+                <MudText Typo="@(showDivisionHeadings ? Typo.subtitle1 : Typo.h6)"
+                         Class="@(showDivisionHeadings ? "mt-2 mb-1 ms-3" : "mt-3 mb-2")">
                     @(stageGroup.StageName ?? "Unassigned")
                 </MudText>
-            <MudTable Items="@stageGroup.Fixtures" Dense="true" Hover="true" Class="mb-4">
+            <MudTable Items="@stageGroup.Fixtures" Dense="true" Hover="true" Breakpoint="Breakpoint.Sm" Class="mb-4 mobile-stack-table">
                 <HeaderContent>
                     <MudTh>Date / Time</MudTh>
                     <MudTh>Match</MudTh>
@@ -190,15 +194,14 @@ else
             }
         }
     }
+    </MudExpansionPanel>
     }
 
     @* ── Admin: per-division expanders (fixtures + teams combined) ─── *@
     @if (_canEdit && _competition.HasDivisions)
     {
-        <MudText Typo="Typo.h5" Class="mb-3">Divisions</MudText>
-        <MudExpansionPanels MultiExpansion="true">
-            @foreach (var divGroup in _fixturesByDivision)
-            {
+        @foreach (var divGroup in _fixturesByDivision)
+        {
                 var divKey = divGroup.Division?.CompetitionDivisionId;
                 var divTeams = _teamsByDivision
                     .FirstOrDefault(g => g.Division?.CompetitionDivisionId == divKey).Teams
@@ -218,7 +221,7 @@ else
                         @foreach (var stageGroup in stageGroups)
                         {
                             <MudText Typo="Typo.body1" Class="mt-2 mb-1">@(stageGroup.StageName ?? "Unassigned")</MudText>
-                            <MudTable Items="@stageGroup.Fixtures" Dense="true" Hover="true" Class="mb-3">
+                            <MudTable Items="@stageGroup.Fixtures" Dense="true" Hover="true" Breakpoint="Breakpoint.Sm" Class="mb-3 mobile-stack-table">
                                 <HeaderContent>
                                     <MudTh>Date / Time</MudTh>
                                     <MudTh>Match</MudTh>
@@ -318,16 +321,16 @@ else
                         {
                             var members = _participants.Where(p => p.TeamId == team.CompetitionTeamId).ToList();
                             <MudExpansionPanel Text="@($"{team.Name} ({members.Count} players)")" Class="mb-2">
-                                <MudTable Items="@members" Dense="true" Hover="true">
+                                <MudTable Items="@members" Dense="true" Hover="true" Breakpoint="Breakpoint.Sm" Class="mobile-stack-table">
                                     <HeaderContent>
                                         <MudTh>Player</MudTh>
                                         <MudTh>Mobile</MudTh>
                                         <MudTh>Status</MudTh>
                                     </HeaderContent>
                                     <RowTemplate>
-                                        <MudTd>@context.Player?.DisplayName</MudTd>
-                                        <MudTd>@(context.Player?.MobileNumber ?? "—")</MudTd>
-                                        <MudTd>
+                                        <MudTd DataLabel="Player">@context.Player?.DisplayName</MudTd>
+                                        <MudTd DataLabel="Mobile">@(context.Player?.MobileNumber ?? "—")</MudTd>
+                                        <MudTd DataLabel="Status">
                                             <MudChip T="string" Size="Size.Small" Color="@ParticipantColor(context.Status)">
                                                 @context.Status
                                             </MudChip>
@@ -339,8 +342,7 @@ else
                         }
                     }
                 </MudExpansionPanel>
-            }
-        </MudExpansionPanels>
+        }
     }
 
     @* ── League Table (round-robin stages only) ──────────────── *@
@@ -360,41 +362,47 @@ else
         };
         var forTooltip = $"{_scoringUnitLabel} won";
         var againstTooltip = $"{_scoringUnitLabel} against";
+        var visibleLeagueGroups = _teamLeagueTablesByDivision.Where(g => g.Rows.Any()).ToList();
+        var showLeagueHeadings = visibleLeagueGroups.Count > 1;
+        var leagueTitle = showLeagueHeadings ? "Division League Tables" : "League Table";
 
-        <MudDivider Class="my-4" />
-        <MudText Typo="Typo.h5" Class="mb-3">Division League Tables</MudText>
-        @foreach (var group in _teamLeagueTablesByDivision.Where(g => g.Rows.Any()))
-        {
-            var rows = group.Rows;
-            var heading = group.Division?.Name ?? "Unassigned";
-            <MudText Typo="Typo.h6" Class="mt-3 mb-2">@heading</MudText>
-            <MudTable Items="@rows" Dense="true" Hover="true" Class="mb-4">
-                <HeaderContent>
-                    <MudTh>Pos</MudTh>
-                    <MudTh>Team</MudTh>
-                    <MudTh>Captain</MudTh>
-                    <MudTh>P</MudTh>
-                    <MudTh>W</MudTh>
-                    <MudTh>D</MudTh>
-                    <MudTh>L</MudTh>
-                    <MudTh><MudTooltip Text="@forTooltip">@forHeader</MudTooltip></MudTh>
-                    <MudTh><MudTooltip Text="@againstTooltip">@againstHeader</MudTooltip></MudTh>
-                    <MudTh>Pts</MudTh>
-                </HeaderContent>
-                <RowTemplate>
-                    <MudTd>@(rows.IndexOf(context) + 1)</MudTd>
-                    <MudTd Style="font-weight:500">@context.TeamName</MudTd>
-                    <MudTd>@(context.CaptainName ?? "—")</MudTd>
-                    <MudTd>@context.Played</MudTd>
-                    <MudTd>@context.Won</MudTd>
-                    <MudTd>@context.Drawn</MudTd>
-                    <MudTd>@context.Lost</MudTd>
-                    <MudTd>@context.ScoringFor</MudTd>
-                    <MudTd>@context.ScoringAgainst</MudTd>
-                    <MudTd Style="font-weight:bold">@context.Points</MudTd>
-                </RowTemplate>
-            </MudTable>
-        }
+        <MudExpansionPanel Text="@leagueTitle">
+            @foreach (var group in visibleLeagueGroups)
+            {
+                var rows = group.Rows;
+                var heading = group.Division?.Name ?? "Unassigned";
+                @if (showLeagueHeadings)
+                {
+                    <MudText Typo="Typo.h6" Class="mt-3 mb-2">@heading</MudText>
+                }
+                <MudTable Items="@rows" Dense="true" Hover="true" Breakpoint="Breakpoint.Sm" Class="mb-4 mobile-stack-table">
+                    <HeaderContent>
+                        <MudTh>Pos</MudTh>
+                        <MudTh>Team</MudTh>
+                        <MudTh>Captain</MudTh>
+                        <MudTh>P</MudTh>
+                        <MudTh>W</MudTh>
+                        <MudTh>D</MudTh>
+                        <MudTh>L</MudTh>
+                        <MudTh><MudTooltip Text="@forTooltip">@forHeader</MudTooltip></MudTh>
+                        <MudTh><MudTooltip Text="@againstTooltip">@againstHeader</MudTooltip></MudTh>
+                        <MudTh>Pts</MudTh>
+                    </HeaderContent>
+                    <RowTemplate>
+                        <MudTd DataLabel="Pos">@(rows.IndexOf(context) + 1)</MudTd>
+                        <MudTd DataLabel="Team" Style="font-weight:500">@context.TeamName</MudTd>
+                        <MudTd DataLabel="Captain">@(context.CaptainName ?? "—")</MudTd>
+                        <MudTd DataLabel="P">@context.Played</MudTd>
+                        <MudTd DataLabel="W">@context.Won</MudTd>
+                        <MudTd DataLabel="D">@context.Drawn</MudTd>
+                        <MudTd DataLabel="L">@context.Lost</MudTd>
+                        <MudTd DataLabel="@forHeader">@context.ScoringFor</MudTd>
+                        <MudTd DataLabel="@againstHeader">@context.ScoringAgainst</MudTd>
+                        <MudTd DataLabel="Pts" Style="font-weight:bold">@context.Points</MudTd>
+                    </RowTemplate>
+                </MudTable>
+            }
+        </MudExpansionPanel>
     }
     else if (_teamLeagueTable.Any())
     {
@@ -413,57 +421,57 @@ else
         var forTooltip = $"{_scoringUnitLabel} won";
         var againstTooltip = $"{_scoringUnitLabel} against";
 
-        <MudDivider Class="my-4" />
-        <MudText Typo="Typo.h5" Class="mb-3">Team League Table</MudText>
-        <MudTable Items="@_teamLeagueTable" Dense="true" Hover="true" Class="mb-4">
-            <HeaderContent>
-                <MudTh>Pos</MudTh>
-                <MudTh>Team</MudTh>
-                <MudTh>Captain</MudTh>
-                <MudTh>P</MudTh>
-                <MudTh>W</MudTh>
-                <MudTh>D</MudTh>
-                <MudTh>L</MudTh>
-                <MudTh><MudTooltip Text="@forTooltip">@forHeader</MudTooltip></MudTh>
-                <MudTh><MudTooltip Text="@againstTooltip">@againstHeader</MudTooltip></MudTh>
-                <MudTh>Pts</MudTh>
-            </HeaderContent>
-            <RowTemplate>
-                <MudTd>@(_teamLeagueTable.IndexOf(context) + 1)</MudTd>
-                <MudTd Style="font-weight:500">@context.TeamName</MudTd>
-                <MudTd>@(context.CaptainName ?? "—")</MudTd>
-                <MudTd>@context.Played</MudTd>
-                <MudTd>@context.Won</MudTd>
-                <MudTd>@context.Drawn</MudTd>
-                <MudTd>@context.Lost</MudTd>
-                <MudTd>@context.ScoringFor</MudTd>
-                <MudTd>@context.ScoringAgainst</MudTd>
-                <MudTd Style="font-weight:bold">@context.Points</MudTd>
-            </RowTemplate>
-        </MudTable>
+        <MudExpansionPanel Text="Team League Table">
+            <MudTable Items="@_teamLeagueTable" Dense="true" Hover="true" Breakpoint="Breakpoint.Sm" Class="mb-4 mobile-stack-table">
+                <HeaderContent>
+                    <MudTh>Pos</MudTh>
+                    <MudTh>Team</MudTh>
+                    <MudTh>Captain</MudTh>
+                    <MudTh>P</MudTh>
+                    <MudTh>W</MudTh>
+                    <MudTh>D</MudTh>
+                    <MudTh>L</MudTh>
+                    <MudTh><MudTooltip Text="@forTooltip">@forHeader</MudTooltip></MudTh>
+                    <MudTh><MudTooltip Text="@againstTooltip">@againstHeader</MudTooltip></MudTh>
+                    <MudTh>Pts</MudTh>
+                </HeaderContent>
+                <RowTemplate>
+                    <MudTd DataLabel="Pos">@(_teamLeagueTable.IndexOf(context) + 1)</MudTd>
+                    <MudTd DataLabel="Team" Style="font-weight:500">@context.TeamName</MudTd>
+                    <MudTd DataLabel="Captain">@(context.CaptainName ?? "—")</MudTd>
+                    <MudTd DataLabel="P">@context.Played</MudTd>
+                    <MudTd DataLabel="W">@context.Won</MudTd>
+                    <MudTd DataLabel="D">@context.Drawn</MudTd>
+                    <MudTd DataLabel="L">@context.Lost</MudTd>
+                    <MudTd DataLabel="@forHeader">@context.ScoringFor</MudTd>
+                    <MudTd DataLabel="@againstHeader">@context.ScoringAgainst</MudTd>
+                    <MudTd DataLabel="Pts" Style="font-weight:bold">@context.Points</MudTd>
+                </RowTemplate>
+            </MudTable>
+        </MudExpansionPanel>
     }
     else if (_leagueTable.Any())
     {
-        <MudDivider Class="my-4" />
-        <MudText Typo="Typo.h5" Class="mb-3">League Table</MudText>
-        <MudTable Items="@_leagueTable" Dense="true" Hover="true" Class="mb-4" Style="max-width:600px">
-            <HeaderContent>
-                <MudTh>Pos</MudTh>
-                <MudTh>Player</MudTh>
-                <MudTh>P</MudTh>
-                <MudTh>W</MudTh>
-                <MudTh>L</MudTh>
-                <MudTh>Pts</MudTh>
-            </HeaderContent>
-            <RowTemplate>
-                <MudTd>@(_leagueTable.IndexOf(context) + 1)</MudTd>
-                <MudTd Style="font-weight:500">@context.PlayerName</MudTd>
-                <MudTd>@context.Played</MudTd>
-                <MudTd>@context.Won</MudTd>
-                <MudTd>@context.Lost</MudTd>
-                <MudTd Style="font-weight:bold">@context.Points</MudTd>
-            </RowTemplate>
-        </MudTable>
+        <MudExpansionPanel Text="League Table">
+            <MudTable Items="@_leagueTable" Dense="true" Hover="true" Breakpoint="Breakpoint.Sm" Class="mb-4 mobile-stack-table" Style="max-width:600px">
+                <HeaderContent>
+                    <MudTh>Pos</MudTh>
+                    <MudTh>Player</MudTh>
+                    <MudTh>P</MudTh>
+                    <MudTh>W</MudTh>
+                    <MudTh>L</MudTh>
+                    <MudTh>Pts</MudTh>
+                </HeaderContent>
+                <RowTemplate>
+                    <MudTd DataLabel="Pos">@(_leagueTable.IndexOf(context) + 1)</MudTd>
+                    <MudTd DataLabel="Player" Style="font-weight:500">@context.PlayerName</MudTd>
+                    <MudTd DataLabel="P">@context.Played</MudTd>
+                    <MudTd DataLabel="W">@context.Won</MudTd>
+                    <MudTd DataLabel="L">@context.Lost</MudTd>
+                    <MudTd DataLabel="Pts" Style="font-weight:bold">@context.Points</MudTd>
+                </RowTemplate>
+            </MudTable>
+        </MudExpansionPanel>
     }
 
     @* ── Competitors ─────────────────────────────────────────── *@
@@ -475,36 +483,36 @@ else
     {
         @if (_participants.Any(p => p.TeamId == null))
         {
-            <MudDivider Class="my-4" />
-            <MudText Typo="Typo.subtitle1" Class="mb-2">Unassigned Participants</MudText>
-            <MudTable Items="@_participants.Where(p => p.TeamId == null).ToList()" Dense="true" Hover="true">
-                <HeaderContent>
-                    <MudTh>Player</MudTh>
-                    <MudTh>Mobile</MudTh>
-                    <MudTh>Status</MudTh>
-                </HeaderContent>
-                <RowTemplate>
-                    <MudTd>@context.Player?.DisplayName</MudTd>
-                    <MudTd>@(context.Player?.MobileNumber ?? "—")</MudTd>
-                    <MudTd>
-                        <MudChip T="string" Size="Size.Small" Color="@ParticipantColor(context.Status)">
-                            @context.Status
-                        </MudChip>
-                    </MudTd>
-                </RowTemplate>
-            </MudTable>
+            <MudExpansionPanel Text="Unassigned Participants">
+                <MudTable Items="@_participants.Where(p => p.TeamId == null).ToList()" Dense="true" Hover="true" Breakpoint="Breakpoint.Sm" Class="mobile-stack-table">
+                    <HeaderContent>
+                        <MudTh>Player</MudTh>
+                        <MudTh>Mobile</MudTh>
+                        <MudTh>Status</MudTh>
+                    </HeaderContent>
+                    <RowTemplate>
+                        <MudTd DataLabel="Player">@context.Player?.DisplayName</MudTd>
+                        <MudTd DataLabel="Mobile">@(context.Player?.MobileNumber ?? "—")</MudTd>
+                        <MudTd DataLabel="Status">
+                            <MudChip T="string" Size="Size.Small" Color="@ParticipantColor(context.Status)">
+                                @context.Status
+                            </MudChip>
+                        </MudTd>
+                    </RowTemplate>
+                </MudTable>
+            </MudExpansionPanel>
         }
     }
     else
     {
-    <MudDivider Class="my-4" />
-    <MudText Typo="Typo.h5" Class="mb-3">Competitors</MudText>
-
+    <MudExpansionPanel Text="Competitors">
     @if (_competition.CompetitionFormat is CompetitionFormat.Team or CompetitionFormat.TeamMatch && _teams.Any())
     {
-        @foreach (var teamsGroup in _teamsByDivision.Where(g => g.Teams.Count > 0))
+        var visibleTeamGroups = _teamsByDivision.Where(g => g.Teams.Count > 0).ToList();
+        var showTeamsDivisionHeadings = _competition.HasDivisions && visibleTeamGroups.Count > 1;
+        @foreach (var teamsGroup in visibleTeamGroups)
         {
-            @if (_competition.HasDivisions)
+            @if (showTeamsDivisionHeadings)
             {
                 <MudText Typo="Typo.h6" Class="mt-3 mb-2">@(teamsGroup.Division?.Name ?? "Unassigned")</MudText>
             }
@@ -512,16 +520,16 @@ else
             {
                 var members = _participants.Where(p => p.TeamId == team.CompetitionTeamId).ToList();
                 <MudExpansionPanel Text="@($"{team.Name} ({members.Count} players)")" Class="mb-2">
-                    <MudTable Items="@members" Dense="true" Hover="true">
+                    <MudTable Items="@members" Dense="true" Hover="true" Breakpoint="Breakpoint.Sm" Class="mobile-stack-table">
                         <HeaderContent>
                             <MudTh>Player</MudTh>
                             <MudTh>Mobile</MudTh>
                             <MudTh>Status</MudTh>
                         </HeaderContent>
                         <RowTemplate>
-                            <MudTd>@context.Player?.DisplayName</MudTd>
-                            <MudTd>@(context.Player?.MobileNumber ?? "—")</MudTd>
-                            <MudTd>
+                            <MudTd DataLabel="Player">@context.Player?.DisplayName</MudTd>
+                            <MudTd DataLabel="Mobile">@(context.Player?.MobileNumber ?? "—")</MudTd>
+                            <MudTd DataLabel="Status">
                                 <MudChip T="string" Size="Size.Small" Color="@ParticipantColor(context.Status)">
                                     @context.Status
                                 </MudChip>
@@ -536,16 +544,16 @@ else
         @if (_participants.Any(p => p.TeamId == null))
         {
             <MudText Typo="Typo.subtitle2" Class="mt-3 mb-2">Unassigned</MudText>
-            <MudTable Items="@_participants.Where(p => p.TeamId == null).ToList()" Dense="true" Hover="true">
+            <MudTable Items="@_participants.Where(p => p.TeamId == null).ToList()" Dense="true" Hover="true" Breakpoint="Breakpoint.Sm" Class="mobile-stack-table">
                 <HeaderContent>
                     <MudTh>Player</MudTh>
                     <MudTh>Mobile</MudTh>
                     <MudTh>Status</MudTh>
                 </HeaderContent>
                 <RowTemplate>
-                    <MudTd>@context.Player?.DisplayName</MudTd>
-                    <MudTd>@(context.Player?.MobileNumber ?? "—")</MudTd>
-                    <MudTd>
+                    <MudTd DataLabel="Player">@context.Player?.DisplayName</MudTd>
+                    <MudTd DataLabel="Mobile">@(context.Player?.MobileNumber ?? "—")</MudTd>
+                    <MudTd DataLabel="Status">
                         <MudChip T="string" Size="Size.Small" Color="@ParticipantColor(context.Status)">
                             @context.Status
                         </MudChip>
@@ -556,7 +564,7 @@ else
     }
     else
     {
-        <MudTable Items="@_participants" Dense="true" Hover="true" Class="mb-4" Style="max-width:700px">
+        <MudTable Items="@_participants" Dense="true" Hover="true" Breakpoint="Breakpoint.Sm" Class="mb-4 mobile-stack-table" Style="max-width:700px">
             <HeaderContent>
                 <MudTh>Player</MudTh>
                 <MudTh>Mobile</MudTh>
@@ -564,19 +572,22 @@ else
                 <MudTh>Registered</MudTh>
             </HeaderContent>
             <RowTemplate>
-                <MudTd Style="font-weight:500">@context.Player?.DisplayName</MudTd>
-                <MudTd>@(context.Player?.MobileNumber ?? "—")</MudTd>
-                <MudTd>
+                <MudTd DataLabel="Player" Style="font-weight:500">@context.Player?.DisplayName</MudTd>
+                <MudTd DataLabel="Mobile">@(context.Player?.MobileNumber ?? "—")</MudTd>
+                <MudTd DataLabel="Status">
                     <MudChip T="string" Size="Size.Small" Color="@ParticipantColor(context.Status)">
                         @context.Status
                     </MudChip>
                 </MudTd>
-                <MudTd>@context.RegisteredAt.ToString("dd MMM yyyy")</MudTd>
+                <MudTd DataLabel="Registered">@context.RegisteredAt.ToString("dd MMM yyyy")</MudTd>
             </RowTemplate>
             <NoRecordsContent><MudText Typo="Typo.caption">No competitors registered.</MudText></NoRecordsContent>
         </MudTable>
     }
+    </MudExpansionPanel>
     }
+
+    </MudExpansionPanels>
 }
 
 @code {

--- a/DropShot/Components/Pages/ViewCompetition.razor
+++ b/DropShot/Components/Pages/ViewCompetition.razor
@@ -81,6 +81,8 @@ else
     <MudDivider Class="mb-4" />
 
     @* ── Fixtures by stage ───────────────────────────────────── *@
+    @if (!(_canEdit && _competition.HasDivisions))
+    {
     <MudText Typo="Typo.h5" Class="mb-3">Scheduled Matches</MudText>
 
     @if (!_fixtures.Any())
@@ -187,6 +189,158 @@ else
             </MudTable>
             }
         }
+    }
+    }
+
+    @* ── Admin: per-division expanders (fixtures + teams combined) ─── *@
+    @if (_canEdit && _competition.HasDivisions)
+    {
+        <MudText Typo="Typo.h5" Class="mb-3">Divisions</MudText>
+        <MudExpansionPanels MultiExpansion="true">
+            @foreach (var divGroup in _fixturesByDivision)
+            {
+                var divKey = divGroup.Division?.CompetitionDivisionId;
+                var divTeams = _teamsByDivision
+                    .FirstOrDefault(g => g.Division?.CompetitionDivisionId == divKey).Teams
+                    ?? new List<CompetitionTeam>();
+                var stageGroups = divGroup.StageGroups;
+                var fxCount = stageGroups.Sum(sg => sg.Fixtures.Count);
+                var panelTitle = $"{divGroup.Division?.Name ?? "Unassigned"} — {divTeams.Count} team{(divTeams.Count == 1 ? "" : "s")}, {fxCount} match{(fxCount == 1 ? "" : "es")}";
+
+                <MudExpansionPanel Text="@panelTitle">
+                    <MudText Typo="Typo.subtitle1" Class="mt-1 mb-2">Scheduled Matches</MudText>
+                    @if (stageGroups.Count == 0)
+                    {
+                        <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mb-3">No matches scheduled.</MudText>
+                    }
+                    else
+                    {
+                        @foreach (var stageGroup in stageGroups)
+                        {
+                            <MudText Typo="Typo.body1" Class="mt-2 mb-1">@(stageGroup.StageName ?? "Unassigned")</MudText>
+                            <MudTable Items="@stageGroup.Fixtures" Dense="true" Hover="true" Class="mb-3">
+                                <HeaderContent>
+                                    <MudTh>Date / Time</MudTh>
+                                    <MudTh>Match</MudTh>
+                                    <MudTh>Players</MudTh>
+                                    <MudTh>Court</MudTh>
+                                    <MudTh>Status</MudTh>
+                                    <MudTh>Result</MudTh>
+                                </HeaderContent>
+                                <RowTemplate>
+                                    <MudTd DataLabel="Date / Time">@(((context.Status == FixtureStatus.Completed || context.Status == FixtureStatus.AwaitingVerification) ? (context.CompletedAt ?? context.ScheduledAt) : context.ScheduledAt)?.ToString("dd MMM yyyy HH:mm") ?? "—")</MudTd>
+                                    <MudTd DataLabel="Match">@(context.FixtureLabel ?? "—")</MudTd>
+                                    <MudTd DataLabel="Players">@FixturePlayers(context)</MudTd>
+                                    <MudTd DataLabel="Court">@FixtureCourtLabel(context)</MudTd>
+                                    <MudTd DataLabel="Status">
+                                        <MudChip T="string" Size="Size.Small" Color="@StatusColor(context.Status)">@context.Status</MudChip>
+                                    </MudTd>
+                                    <MudTd DataLabel="Result">
+                                        @{
+                                            bool isTeamFixtureRow = context.HomeTeamId.HasValue && context.AwayTeamId.HasValue;
+                                            bool hasResult = context.Status == FixtureStatus.Completed
+                                                || context.Status == FixtureStatus.AwaitingVerification;
+                                            var teamResult = (isTeamFixtureRow && context.Rubbers.Any(r => r.IsComplete))
+                                                ? RubberResolutionService.ComputeLeagueScore(
+                                                    context.Rubbers,
+                                                    context.HomeTeamId!.Value,
+                                                    context.AwayTeamId!.Value,
+                                                    _competition?.LeagueScoring ?? LeagueScoringMode.WinPoints)
+                                                : (homeFor: 0, awayFor: 0, unitLabel: "");
+                                            bool homeWon = context.WinnerTeamId == context.HomeTeamId;
+                                            bool awayWon = context.WinnerTeamId == context.AwayTeamId;
+                                        }
+                                        @if (hasResult && isTeamFixtureRow && context.Rubbers.Any(r => r.IsComplete))
+                                        {
+                                            <MudStack Spacing="0" Style="min-width:160px">
+                                                <MudStack Row="true" Justify="Justify.SpaceBetween" Spacing="2">
+                                                    <MudText Typo="Typo.body2" Style="@(homeWon ? "font-weight:700" : "opacity:0.85")">
+                                                        @(context.HomeTeam?.Name ?? "Home")
+                                                    </MudText>
+                                                    <MudText Typo="Typo.body2" Style="@(homeWon ? "font-weight:700" : "opacity:0.85")">
+                                                        @teamResult.homeFor
+                                                    </MudText>
+                                                </MudStack>
+                                                <MudStack Row="true" Justify="Justify.SpaceBetween" Spacing="2">
+                                                    <MudText Typo="Typo.body2" Style="@(awayWon ? "font-weight:700" : "opacity:0.85")">
+                                                        @(context.AwayTeam?.Name ?? "Away")
+                                                    </MudText>
+                                                    <MudText Typo="Typo.body2" Style="@(awayWon ? "font-weight:700" : "opacity:0.85")">
+                                                        @teamResult.awayFor
+                                                    </MudText>
+                                                </MudStack>
+                                            </MudStack>
+                                            @if (context.Status == FixtureStatus.AwaitingVerification)
+                                            {
+                                                <MudChip T="string" Size="Size.Small" Color="Color.Secondary" Variant="Variant.Text">Pending</MudChip>
+                                            }
+                                        }
+                                        else if (hasResult && !isTeamFixtureRow && !string.IsNullOrEmpty(context.ResultSummary))
+                                        {
+                                            <ResultCard Fixture="context" Compact="true" />
+                                            @if (context.ResultModifiedByAdmin)
+                                            {
+                                                <MudTooltip Text="@($"Original: {context.OriginalResultSummary}")">
+                                                    <MudChip T="string" Size="Size.Small" Color="Color.Warning" Variant="Variant.Text">Modified</MudChip>
+                                                </MudTooltip>
+                                            }
+                                            @if (context.Status == FixtureStatus.AwaitingVerification)
+                                            {
+                                                <MudChip T="string" Size="Size.Small" Color="Color.Secondary" Variant="Variant.Text">Pending</MudChip>
+                                            }
+                                        }
+                                        else if (hasResult)
+                                        {
+                                            <MudText Typo="Typo.body2" Style="font-weight:500">
+                                                @(WinnerName(context))
+                                            </MudText>
+                                        }
+                                        else
+                                        {
+                                            <MudText Typo="Typo.caption" Color="Color.Secondary">—</MudText>
+                                        }
+                                    </MudTd>
+                                </RowTemplate>
+                            </MudTable>
+                        }
+                    }
+
+                    <MudDivider Class="my-3" />
+
+                    <MudText Typo="Typo.subtitle1" Class="mt-1 mb-2">Teams</MudText>
+                    @if (divTeams.Count == 0)
+                    {
+                        <MudText Typo="Typo.body2" Color="Color.Secondary">No teams assigned.</MudText>
+                    }
+                    else
+                    {
+                        @foreach (var team in divTeams)
+                        {
+                            var members = _participants.Where(p => p.TeamId == team.CompetitionTeamId).ToList();
+                            <MudExpansionPanel Text="@($"{team.Name} ({members.Count} players)")" Class="mb-2">
+                                <MudTable Items="@members" Dense="true" Hover="true">
+                                    <HeaderContent>
+                                        <MudTh>Player</MudTh>
+                                        <MudTh>Mobile</MudTh>
+                                        <MudTh>Status</MudTh>
+                                    </HeaderContent>
+                                    <RowTemplate>
+                                        <MudTd>@context.Player?.DisplayName</MudTd>
+                                        <MudTd>@(context.Player?.MobileNumber ?? "—")</MudTd>
+                                        <MudTd>
+                                            <MudChip T="string" Size="Size.Small" Color="@ParticipantColor(context.Status)">
+                                                @context.Status
+                                            </MudChip>
+                                        </MudTd>
+                                    </RowTemplate>
+                                    <NoRecordsContent><MudText Typo="Typo.caption">No players in this team.</MudText></NoRecordsContent>
+                                </MudTable>
+                            </MudExpansionPanel>
+                        }
+                    }
+                </MudExpansionPanel>
+            }
+        </MudExpansionPanels>
     }
 
     @* ── League Table (round-robin stages only) ──────────────── *@
@@ -313,6 +467,36 @@ else
     }
 
     @* ── Competitors ─────────────────────────────────────────── *@
+    @* For admin + divisions, teams are rendered inside the Divisions expanders above;
+       this section still renders for non-team formats, non-division competitions,
+       and non-admin users. Unassigned participants (no team) are still shown as a
+       fallback for admin + divisions. *@
+    @if (_canEdit && _competition.HasDivisions)
+    {
+        @if (_participants.Any(p => p.TeamId == null))
+        {
+            <MudDivider Class="my-4" />
+            <MudText Typo="Typo.subtitle1" Class="mb-2">Unassigned Participants</MudText>
+            <MudTable Items="@_participants.Where(p => p.TeamId == null).ToList()" Dense="true" Hover="true">
+                <HeaderContent>
+                    <MudTh>Player</MudTh>
+                    <MudTh>Mobile</MudTh>
+                    <MudTh>Status</MudTh>
+                </HeaderContent>
+                <RowTemplate>
+                    <MudTd>@context.Player?.DisplayName</MudTd>
+                    <MudTd>@(context.Player?.MobileNumber ?? "—")</MudTd>
+                    <MudTd>
+                        <MudChip T="string" Size="Size.Small" Color="@ParticipantColor(context.Status)">
+                            @context.Status
+                        </MudChip>
+                    </MudTd>
+                </RowTemplate>
+            </MudTable>
+        }
+    }
+    else
+    {
     <MudDivider Class="my-4" />
     <MudText Typo="Typo.h5" Class="mb-3">Competitors</MudText>
 
@@ -391,6 +575,7 @@ else
             </RowTemplate>
             <NoRecordsContent><MudText Typo="Typo.caption">No competitors registered.</MudText></NoRecordsContent>
         </MudTable>
+    }
     }
 }
 

--- a/DropShot/Components/RubberScoreDialog.razor
+++ b/DropShot/Components/RubberScoreDialog.razor
@@ -145,7 +145,8 @@
             lastHome = h; lastAway = a;
         }
 
-        if (homeSets == awaySets)
+        bool isFixedSets = _competition?.MatchFormat == MatchFormatType.FixedSets;
+        if (homeSets == awaySets && !isFixedSets)
         {
             _error = "Sets are tied — enter more sets or correct the scores.";
             return;
@@ -171,7 +172,11 @@
             rub.AwayGamesTotal = awayGames;
             rub.HomeGames = lastHome;
             rub.AwayGames = lastAway;
-            rub.WinnerTeamId = homeSets > awaySets ? rub.Fixture.HomeTeamId : rub.Fixture.AwayTeamId;
+            rub.WinnerTeamId = homeSets > awaySets
+                ? rub.Fixture.HomeTeamId
+                : awaySets > homeSets
+                    ? rub.Fixture.AwayTeamId
+                    : (int?)null;
             // No SavedMatch for direct-entry rubbers — there's no point-by-point
             // history to preserve.
             rub.SavedMatchId = null;

--- a/DropShot/Components/SubmitScoreDialog.razor
+++ b/DropShot/Components/SubmitScoreDialog.razor
@@ -272,10 +272,27 @@
             }
         }
 
-        if (_winnerPlayerId == null)
+        bool isFixedSets = Fixture.Competition?.MatchFormat == MatchFormatType.FixedSets;
+        int side1Sets = 0, side2Sets = 0;
+        for (int i = 0; i < _bestOf; i++)
+        {
+            if (_score1[i].HasValue && _score2[i].HasValue)
+            {
+                if (_score1[i] > _score2[i]) side1Sets++;
+                else if (_score2[i] > _score1[i]) side2Sets++;
+            }
+        }
+        bool matchIsTied = side1Sets == side2Sets;
+
+        if (_winnerPlayerId == null && !(isFixedSets && matchIsTied))
         {
             _error = "Please select a winner.";
             return;
+        }
+
+        if (isFixedSets && matchIsTied)
+        {
+            _winnerPlayerId = null;
         }
 
         _saving = true;

--- a/DropShot/wwwroot/app.css
+++ b/DropShot/wwwroot/app.css
@@ -216,3 +216,51 @@ body.scoreboard-fullscreen main {
     flex-direction: column;
     justify-content: center;
 }
+
+/* ──────────────────────────────────────────────────────────────────────────
+   Mobile table polish
+   Two things go wrong on phones by default:
+     1. Tables that don't use MudBlazor's responsive breakpoint can overflow
+        the viewport, which scrolls the whole page sideways.
+     2. When tables *do* stack into single-cell-per-row cards (MudBlazor's
+        built-in mobile mode) every row blurs into the next because there's
+        no separator between them.
+   The rules below keep any table contained to its parent (scrolls locally
+   instead of the page) and add a strong border between stacked rows.
+   ────────────────────────────────────────────────────────────────────────── */
+@media (max-width: 640.98px) {
+    /* Tables shouldn't force the page wider than the viewport. */
+    .mud-table-container {
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+
+    /* Opt-in class (`mobile-stack-table`) for grids that use Breakpoint="Sm"
+       and have DataLabel set on every cell: render each row as a labelled
+       card with a clear gap between entries. */
+    .mobile-stack-table .mud-table-root .mud-table-body .mud-table-row {
+        display: block;
+        padding: 0.75rem 0.25rem;
+        border-bottom: 2px solid rgba(255, 255, 255, 0.18);
+    }
+
+    .mobile-stack-table .mud-table-root .mud-table-body .mud-table-row:last-child {
+        border-bottom: none;
+    }
+
+    /* MudBlazor emits `:before` text from DataLabel when stacked – nudge the
+       value so the label and value read as a pair instead of a wall of text. */
+    .mobile-stack-table .mud-table-root .mud-table-body .mud-table-cell {
+        display: flex;
+        justify-content: space-between;
+        gap: 0.75rem;
+        padding: 0.25rem 0.5rem;
+        border-bottom: none;
+    }
+
+    .mobile-stack-table .mud-table-root .mud-table-body .mud-table-cell:before {
+        font-weight: 600;
+        opacity: 0.75;
+        flex-shrink: 0;
+    }
+}


### PR DESCRIPTION
## Summary
- **Admin division expanders**: on `/competition/{id}/view` each division is now a collapsible block that combines its Scheduled Matches, teams and players.
- **Mobile polish across the app**: grids stack as labelled cards with row separators and no longer scroll the page sideways; Scheduled Matches / League Tables / Competitors collapse by default; hamburger menu items gain a descriptive second line; Start/Stop/View Competition buttons get padding; a gap appears between the competition tabs and their content on phones.
- **FixedSets tie support**: `RubberScoreDialog` and `SubmitScoreDialog` no longer block save when set counts are level, provided the competition's `MatchFormat` is `FixedSets` (which is a valid tied result). Winner is stored as null in that case.

## Test plan
- [ ] **Admin + divisions**: `/competition/{id}/view` renders a collapsed expander per division containing fixtures, teams, and players.
- [ ] **Non-admin + divisions**: filtered to own division; redundant division-name sub-headings are gone above Scheduled Matches / League Table / Competitors.
- [ ] **No divisions**: Scheduled Matches, League Table, Competitors all render as three collapsed expanders.
- [ ] **Phone viewport (<600px)**: every `MudTable` stacks to labelled cards with visible separator between rows; fixtures grid does not force horizontal page scroll.
- [ ] **Competition edit page on mobile**: whitespace between the tab strip and the panel content; Start/Stop/View Competition buttons have padding around labels.
- [ ] **Hamburger menu on mobile**: each link shows a subtitle line; desktop nav unchanged.
- [ ] **FixedSets competition**: enter a rubber with level sets (e.g. 1-1 in best-of-2) via RubberScoreDialog — save succeeds, no winner is assigned.
- [ ] **FixedSets competition**: submit a score via SubmitScoreDialog with matching set counts — save succeeds, no winner is assigned.
- [ ] **Non-FixedSets competition**: tied set counts still produce the "Sets are tied" error / "Please select a winner" block as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)