### PR TITLE
UI polish: home adverts, server-select, login, registration, competition view

### DIFF
--- a/DropShot/Components/Account/Pages/Login.razor
+++ b/DropShot/Components/Account/Pages/Login.razor
@@ -19,8 +19,6 @@
             <StatusMessage Message="@errorMessage" />
             <EditForm Model="Input" method="post" OnValidSubmit="LoginUser" FormName="login">
                 <DataAnnotationsValidator />
-                <h2>Use a local account to log in.</h2>
-                <hr />
                 <ValidationSummary class="text-danger" role="alert" />
                 <div class="form-floating mb-3">
                     <InputText @bind-Value="Input.Email" class="form-control" autocomplete="username" aria-required="true" placeholder="name@example.com" />
@@ -72,7 +70,7 @@
     }
     <div class="col-md-4 d-none d-md-block">
         <section>
-            <h3>Scan QR code to log in</h3>
+            <h1>Scan QR code to log in</h1>
             <hr />
             <QrLoginPanel />
         </section>

--- a/DropShot/Components/Account/Pages/Register.razor
+++ b/DropShot/Components/Account/Pages/Register.razor
@@ -52,6 +52,11 @@
                 <label for="confirm-password">Confirm Password</label>
                 <ValidationMessage For="() => Input.ConfirmPassword" class="text-danger" />
             </div>
+            <div class="form-floating mb-3">
+                <InputDate @bind-Value="Input.DateOfBirth" class="form-control" aria-required="true" placeholder="Date of Birth" />
+                <label for="date-of-birth">Date of Birth</label>
+                <ValidationMessage For="() => Input.DateOfBirth" class="text-danger" />
+            </div>
             <fieldset class="mb-3">
                 <legend class="form-label mb-1" style="font-size: 1rem;">Competition category</legend>
                 <small class="form-text text-muted d-block mb-2">Determines which events you're eligible to enter</small>
@@ -106,6 +111,21 @@
 
     public async Task RegisterUser(EditContext editContext)
     {
+        if (Input.DateOfBirth is null || AgeInYears(Input.DateOfBirth.Value, DateTime.UtcNow) < 18)
+        {
+            identityErrors = new[]
+            {
+                new IdentityError
+                {
+                    Code = "Underage",
+                    Description = "You can only register if you are over 18 or if you are an adult. " +
+                        "If you are a child please ask a parent to register. Parents can add child accounts " +
+                        "from within their own account."
+                }
+            };
+            return;
+        }
+
         var user = CreateUser();
         user.DisplayName = Input.DisplayName;
 
@@ -146,6 +166,7 @@
                         invited.UserId = userIdStr;
                         invited.Email = Input.Email;
                         invited.Sex = Input.CompetitionCategory;
+                        invited.DateOfBirth = DateOnly.FromDateTime(Input.DateOfBirth!.Value);
                         if (string.IsNullOrWhiteSpace(invited.DisplayName))
                             invited.DisplayName = Input.DisplayName;
                         invite.AcceptedAt = DateTime.UtcNow;
@@ -178,6 +199,7 @@
             {
                 player.UserId = userIdStr;
                 player.Sex = Input.CompetitionCategory;
+                player.DateOfBirth = DateOnly.FromDateTime(Input.DateOfBirth!.Value);
                 await db.SaveChangesAsync();
                 linkedPlayer = true;
                 Logger.LogInformation("Linked new user {Email} to existing player record.", Input.Email);
@@ -195,6 +217,7 @@
                     lightMatch.UserId = userIdStr;
                     lightMatch.Email = Input.Email;
                     lightMatch.Sex = Input.CompetitionCategory;
+                    lightMatch.DateOfBirth = DateOnly.FromDateTime(Input.DateOfBirth!.Value);
                     await db.SaveChangesAsync();
                     linkedPlayer = true;
                     Logger.LogInformation("Claimed light player record for {DisplayName}.", Input.DisplayName);
@@ -209,6 +232,7 @@
                     Email = Input.Email,
                     UserId = userIdStr,
                     Sex = Input.CompetitionCategory,
+                    DateOfBirth = DateOnly.FromDateTime(Input.DateOfBirth!.Value),
                     CreatedAt = DateTime.UtcNow
                 };
                 db.Players.Add(newPlayer);
@@ -260,6 +284,13 @@
         return (IUserEmailStore<ApplicationUser>)UserStore;
     }
 
+    private static int AgeInYears(DateTime dob, DateTime asOf)
+    {
+        var age = asOf.Year - dob.Year;
+        if (asOf < dob.AddYears(age)) age--;
+        return age;
+    }
+
     private sealed class InputModel
     {
         [Required]
@@ -286,5 +317,10 @@
         [Required(ErrorMessage = "Please select a competition category.")]
         [Display(Name = "Competition category")]
         public PlayerSex? CompetitionCategory { get; set; }
+
+        [Required(ErrorMessage = "Please enter your date of birth.")]
+        [DataType(DataType.Date)]
+        [Display(Name = "Date of Birth")]
+        public DateTime? DateOfBirth { get; set; }
     }
 }

--- a/DropShot/Components/Pages/Home.razor
+++ b/DropShot/Components/Pages/Home.razor
@@ -90,9 +90,9 @@
         <div class="d-flex align-center justify-center" style="height:100%; background: linear-gradient(135deg, #0f4c3a 0%, #1b8759 55%, #ffd54f 100%); color:#fff; padding: 24px; text-align:center;">
             <div>
                 <MudText Typo="Typo.overline" Style="letter-spacing:3px; opacity:0.85;">DROPSHOT SUMMER SLAM</MudText>
-                <MudText Typo="Typo.h3" Style="font-weight:800; margin-top:8px;">Enter the Clay Court Classic</MudText>
+                <MudText Typo="Typo.h3" Style="font-weight:800; margin-top:8px;">Enter the Hard Court Classic</MudText>
                 <MudText Typo="Typo.h6" Style="font-weight:400; margin-top:8px; max-width:640px;">
-                    Singles &amp; doubles brackets · Prize pool £1,500 · Registration closes 14 June
+                    Singles &amp; doubles brackets · Family barbecue on finals day · Registration closes 14 June
                 </MudText>
                 <MudButton Variant="Variant.Filled" Color="Color.Warning" Size="Size.Large"
                            StartIcon="@Icons.Material.Filled.EmojiEvents"
@@ -108,7 +108,7 @@
                 <MudText Typo="Typo.overline" Style="letter-spacing:3px; opacity:0.85;">RIVERSIDE LAWN TENNIS CLUB</MudText>
                 <MudText Typo="Typo.h3" Style="font-weight:800; margin-top:8px;">Your Game. Your Club. Year Round.</MudText>
                 <MudText Typo="Typo.h6" Style="font-weight:400; margin-top:8px; max-width:640px;">
-                    12 floodlit courts · Coaching for all ages · Social mixers every Friday
+                    Seven outdoor courts · Four indoor courts · Club night every Thursday
                 </MudText>
                 <MudText Typo="Typo.body2" Class="mt-2" Style="opacity:0.9;">
                     New member offer — first month free. Visit riverside-ltc.example

--- a/DropShot/Components/Pages/ViewCompetition.razor
+++ b/DropShot/Components/Pages/ViewCompetition.razor
@@ -69,6 +69,13 @@ else
                 <MudText Typo="Typo.body1">@_competition.HostClub.Name</MudText>
             </MudItem>
         }
+        @if (!_canEdit && _competition.HasDivisions && _userDivision != null)
+        {
+            <MudItem xs="6" sm="3">
+                <MudText Typo="Typo.caption" Color="Color.Secondary">Division</MudText>
+                <MudText Typo="Typo.body1">@_userDivision.Name</MudText>
+            </MudItem>
+        }
         @if (_competition.Rules != null)
         {
             <MudItem xs="6" sm="3">
@@ -320,25 +327,26 @@ else
                         @foreach (var team in divTeams)
                         {
                             var members = _participants.Where(p => p.TeamId == team.CompetitionTeamId).ToList();
-                            <MudExpansionPanel Text="@($"{team.Name} ({members.Count} players)")" Class="mb-2">
-                                <MudTable Items="@members" Dense="true" Hover="true" Breakpoint="Breakpoint.Sm" Class="mobile-stack-table">
-                                    <HeaderContent>
-                                        <MudTh>Player</MudTh>
-                                        <MudTh>Mobile</MudTh>
-                                        <MudTh>Status</MudTh>
-                                    </HeaderContent>
-                                    <RowTemplate>
-                                        <MudTd DataLabel="Player">@context.Player?.DisplayName</MudTd>
-                                        <MudTd DataLabel="Mobile">@(context.Player?.MobileNumber ?? "—")</MudTd>
-                                        <MudTd DataLabel="Status">
-                                            <MudChip T="string" Size="Size.Small" Color="@ParticipantColor(context.Status)">
-                                                @context.Status
-                                            </MudChip>
-                                        </MudTd>
-                                    </RowTemplate>
-                                    <NoRecordsContent><MudText Typo="Typo.caption">No players in this team.</MudText></NoRecordsContent>
-                                </MudTable>
-                            </MudExpansionPanel>
+                            <MudText Typo="Typo.subtitle2" Class="mt-3 mb-1" Style="font-weight:600">
+                                @team.Name <MudText Inline="true" Typo="Typo.caption" Color="Color.Secondary">(@members.Count player@(members.Count == 1 ? "" : "s"))</MudText>
+                            </MudText>
+                            <MudTable Items="@members" Dense="true" Hover="true" Breakpoint="Breakpoint.Sm" Class="mb-2 mobile-stack-table team-members-table">
+                                <HeaderContent>
+                                    <MudTh Style="width:auto">Player</MudTh>
+                                    <MudTh Style="width:180px">Mobile</MudTh>
+                                    <MudTh Style="width:140px">Status</MudTh>
+                                </HeaderContent>
+                                <RowTemplate>
+                                    <MudTd DataLabel="Player">@context.Player?.DisplayName</MudTd>
+                                    <MudTd DataLabel="Mobile">@(context.Player?.MobileNumber ?? "—")</MudTd>
+                                    <MudTd DataLabel="Status">
+                                        <MudChip T="string" Size="Size.Small" Color="@ParticipantColor(context.Status)">
+                                            @context.Status
+                                        </MudChip>
+                                    </MudTd>
+                                </RowTemplate>
+                                <NoRecordsContent><MudText Typo="Typo.caption">No players in this team.</MudText></NoRecordsContent>
+                            </MudTable>
                         }
                     }
                 </MudExpansionPanel>
@@ -505,8 +513,10 @@ else
     }
     else
     {
-    <MudExpansionPanel Text="Competitors">
-    @if (_competition.CompetitionFormat is CompetitionFormat.Team or CompetitionFormat.TeamMatch && _teams.Any())
+        var isTeamFormat = _competition.CompetitionFormat is CompetitionFormat.Team or CompetitionFormat.TeamMatch && _teams.Any();
+        var competitorsPanelText = isTeamFormat ? "Teams" : "Competitors";
+    <MudExpansionPanel Text="@competitorsPanelText">
+    @if (isTeamFormat)
     {
         var visibleTeamGroups = _teamsByDivision.Where(g => g.Teams.Count > 0).ToList();
         var showTeamsDivisionHeadings = _competition.HasDivisions && visibleTeamGroups.Count > 1;
@@ -519,36 +529,37 @@ else
             @foreach (var team in teamsGroup.Teams)
             {
                 var members = _participants.Where(p => p.TeamId == team.CompetitionTeamId).ToList();
-                <MudExpansionPanel Text="@($"{team.Name} ({members.Count} players)")" Class="mb-2">
-                    <MudTable Items="@members" Dense="true" Hover="true" Breakpoint="Breakpoint.Sm" Class="mobile-stack-table">
-                        <HeaderContent>
-                            <MudTh>Player</MudTh>
-                            <MudTh>Mobile</MudTh>
-                            <MudTh>Status</MudTh>
-                        </HeaderContent>
-                        <RowTemplate>
-                            <MudTd DataLabel="Player">@context.Player?.DisplayName</MudTd>
-                            <MudTd DataLabel="Mobile">@(context.Player?.MobileNumber ?? "—")</MudTd>
-                            <MudTd DataLabel="Status">
-                                <MudChip T="string" Size="Size.Small" Color="@ParticipantColor(context.Status)">
-                                    @context.Status
-                                </MudChip>
-                            </MudTd>
-                        </RowTemplate>
-                        <NoRecordsContent><MudText Typo="Typo.caption">No players in this team.</MudText></NoRecordsContent>
-                    </MudTable>
-                </MudExpansionPanel>
+                <MudText Typo="Typo.subtitle1" Class="mt-3 mb-1" Style="font-weight:600">
+                    @team.Name <MudText Inline="true" Typo="Typo.caption" Color="Color.Secondary">(@members.Count player@(members.Count == 1 ? "" : "s"))</MudText>
+                </MudText>
+                <MudTable Items="@members" Dense="true" Hover="true" Breakpoint="Breakpoint.Sm" Class="mb-2 mobile-stack-table team-members-table">
+                    <HeaderContent>
+                        <MudTh Style="width:auto">Player</MudTh>
+                        <MudTh Style="width:180px">Mobile</MudTh>
+                        <MudTh Style="width:140px">Status</MudTh>
+                    </HeaderContent>
+                    <RowTemplate>
+                        <MudTd DataLabel="Player">@context.Player?.DisplayName</MudTd>
+                        <MudTd DataLabel="Mobile">@(context.Player?.MobileNumber ?? "—")</MudTd>
+                        <MudTd DataLabel="Status">
+                            <MudChip T="string" Size="Size.Small" Color="@ParticipantColor(context.Status)">
+                                @context.Status
+                            </MudChip>
+                        </MudTd>
+                    </RowTemplate>
+                    <NoRecordsContent><MudText Typo="Typo.caption">No players in this team.</MudText></NoRecordsContent>
+                </MudTable>
             }
         }
 
         @if (_participants.Any(p => p.TeamId == null))
         {
             <MudText Typo="Typo.subtitle2" Class="mt-3 mb-2">Unassigned</MudText>
-            <MudTable Items="@_participants.Where(p => p.TeamId == null).ToList()" Dense="true" Hover="true" Breakpoint="Breakpoint.Sm" Class="mobile-stack-table">
+            <MudTable Items="@_participants.Where(p => p.TeamId == null).ToList()" Dense="true" Hover="true" Breakpoint="Breakpoint.Sm" Class="mobile-stack-table team-members-table">
                 <HeaderContent>
-                    <MudTh>Player</MudTh>
-                    <MudTh>Mobile</MudTh>
-                    <MudTh>Status</MudTh>
+                    <MudTh Style="width:auto">Player</MudTh>
+                    <MudTh Style="width:180px">Mobile</MudTh>
+                    <MudTh Style="width:140px">Status</MudTh>
                 </HeaderContent>
                 <RowTemplate>
                     <MudTd DataLabel="Player">@context.Player?.DisplayName</MudTd>
@@ -609,6 +620,7 @@ else
     private string _scoringUnitLabel = "rubbers";
 
     private List<CompetitionDivision> _divisions = [];
+    private CompetitionDivision? _userDivision;
     private List<(CompetitionDivision? Division, List<TeamLeagueRow> Rows)> _teamLeagueTablesByDivision = [];
 
     private record DivisionFixtureGroup(
@@ -694,6 +706,8 @@ else
                         int? userDivisionId = myParticipant.CompetitionDivisionId
                             ?? _teams.FirstOrDefault(t => t.CompetitionTeamId == myParticipant.TeamId)?.CompetitionDivisionId;
 
+                        _userDivision = _divisions.FirstOrDefault(d => d.CompetitionDivisionId == userDivisionId);
+
                         _teams = _teams
                             .Where(t => t.CompetitionDivisionId == userDivisionId)
                             .ToList();
@@ -752,6 +766,18 @@ else
                     if (f.AwayTeamId.HasValue
                         && teamDivisionById.TryGetValue(f.AwayTeamId.Value, out var da)
                         && da.HasValue) return da;
+                    // Knockout fixtures (SF/F etc.) generated per-division have
+                    // no team IDs yet — the scheduler prefixes their label with
+                    // the division name, so we match on that as a fallback.
+                    if (!string.IsNullOrEmpty(f.FixtureLabel))
+                    {
+                        foreach (var d in _divisions.OrderByDescending(x => x.Name?.Length ?? 0))
+                        {
+                            if (!string.IsNullOrEmpty(d.Name)
+                                && f.FixtureLabel.StartsWith(d.Name + " ", StringComparison.OrdinalIgnoreCase))
+                                return d.CompetitionDivisionId;
+                        }
+                    }
                     return null;
                 }
 

--- a/DropShot/Components/Pages/ViewCompetition.razor.css
+++ b/DropShot/Components/Pages/ViewCompetition.razor.css
@@ -1,0 +1,7 @@
+/* Keep team-member tables consistent across teams so the Mobile and
+   Status columns line up vertically between adjacent team blocks. */
+::deep .team-members-table .mud-table-root {
+    table-layout: fixed;
+    width: 100%;
+    max-width: 700px;
+}

--- a/DropShot/Components/ServerSelectScreen.razor
+++ b/DropShot/Components/ServerSelectScreen.razor
@@ -10,54 +10,39 @@
         </MudText>
 
         <div class="server-select-options">
-            @if (IsTeamContext)
-            {
-                @* Team match: home (user) on top, away (opponent) on bottom, vs between *@
-                <MudButton Variant="Variant.Filled" Color="Color.Success"
-                           Size="Size.Large" Class="server-select-btn"
-                           StartIcon="@Icons.Material.Filled.Person"
-                           OnClick="@(() => OnSelected("player1"))">
-                    <div class="server-option-stack">
-                        @if (!string.IsNullOrEmpty(UserTeamName))
-                        {
-                            <span class="server-option-team">@UserTeamName</span>
-                        }
-                        <span class="server-option-name">@UserLabel</span>
-                    </div>
-                </MudButton>
+            <MudButton Variant="Variant.Filled" Color="Color.Success"
+                       Size="Size.Large" Class="server-select-btn"
+                       StartIcon="@Icons.Material.Filled.Person"
+                       OnClick="@(() => OnSelected("player1"))">
+                <div class="server-option-stack">
+                    @if (!string.IsNullOrEmpty(UserTeamName))
+                    {
+                        <span class="server-option-team">@UserTeamName</span>
+                    }
+                    @foreach (var line in SplitNameLines(UserLabel))
+                    {
+                        <span class="server-option-name">@line</span>
+                    }
+                </div>
+            </MudButton>
 
-                <div class="server-select-vs">vs</div>
+            <div class="server-select-vs">vs</div>
 
-                <MudButton Variant="Variant.Filled" Color="Color.Primary"
-                           Size="Size.Large" Class="server-select-btn"
-                           StartIcon="@Icons.Material.Filled.Person"
-                           OnClick="@(() => OnSelected("player2"))">
-                    <div class="server-option-stack">
-                        @if (!string.IsNullOrEmpty(OpponentTeamName))
-                        {
-                            <span class="server-option-team">@OpponentTeamName</span>
-                        }
-                        <span class="server-option-name">@OpponentLabel</span>
-                    </div>
-                </MudButton>
-            }
-            else
-            {
-                @* Non-team match: preserve existing layout *@
-                <MudButton Variant="Variant.Filled" Color="Color.Primary"
-                           Size="Size.Large" Class="server-select-btn"
-                           StartIcon="@Icons.Material.Filled.Person"
-                           OnClick="@(() => OnSelected("player2"))">
-                    @OpponentLabel
-                </MudButton>
-
-                <MudButton Variant="Variant.Filled" Color="Color.Success"
-                           Size="Size.Large" Class="server-select-btn"
-                           StartIcon="@Icons.Material.Filled.Person"
-                           OnClick="@(() => OnSelected("player1"))">
-                    @UserLabel
-                </MudButton>
-            }
+            <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                       Size="Size.Large" Class="server-select-btn"
+                       StartIcon="@Icons.Material.Filled.Person"
+                       OnClick="@(() => OnSelected("player2"))">
+                <div class="server-option-stack">
+                    @if (!string.IsNullOrEmpty(OpponentTeamName))
+                    {
+                        <span class="server-option-team">@OpponentTeamName</span>
+                    }
+                    @foreach (var line in SplitNameLines(OpponentLabel))
+                    {
+                        <span class="server-option-name">@line</span>
+                    }
+                </div>
+            </MudButton>
 
             <MudButton Variant="Variant.Outlined" Color="Color.Warning"
                        Size="Size.Large" Class="server-select-btn"
@@ -87,6 +72,26 @@
 
     private bool IsTeamContext =>
         !string.IsNullOrEmpty(UserTeamName) || !string.IsNullOrEmpty(OpponentTeamName);
+
+    private IEnumerable<string> SplitNameLines(string? label)
+    {
+        if (string.IsNullOrWhiteSpace(label))
+            yield break;
+
+        if (!IsTeamContext || !label.Contains('&'))
+        {
+            yield return label;
+            yield break;
+        }
+
+        var parts = label.Split('&');
+        for (var i = 0; i < parts.Length; i++)
+        {
+            yield return parts[i].Trim();
+            if (i < parts.Length - 1)
+                yield return "&";
+        }
+    }
 
     private async Task OnSelected(string choice)
     {

--- a/DropShot/Components/ServerSelectScreen.razor.css
+++ b/DropShot/Components/ServerSelectScreen.razor.css
@@ -39,7 +39,8 @@
 .server-option-stack {
     display: flex;
     flex-direction: column;
-    align-items: flex-start;
+    align-items: center;
+    width: 100%;
     line-height: 1.2;
 }
 


### PR DESCRIPTION
## Summary
- Refresh the home carousel (hard-court classic + family BBQ copy, updated Riverside tagline)
- Server-select screen: always show the `vs` label, and for team matches centre the team name and stack player names / ampersand on separate lines
- Login page: drop the "Use a local account to log in" heading and size "Scan QR code to log in" to match the "Log in" heading
- Registration: require date of birth, persist it on the linked Player, and block under-18 submissions with the specified message
- View Competition: show the viewer's division alongside Format/Host Club, rename Competitors to Teams for team formats, flatten per-team expanders into grouped tables with aligned Mobile/Status columns, and match knockout (SF/F) fixtures to their division via the scheduler label prefix so they no longer land in the admin Unassigned section

## Test plan
- [ ] Home carousel shows the updated hard-court and Riverside copy
- [ ] Server-select screen always shows `vs`; team doubles render team name + player / & / player each on their own line
- [ ] Login page omits the "Use a local account to log in" heading; QR heading is h1-sized
- [ ] Registration rejects under-18 DOB with the agreed message and stores DOB on the Player for valid submissions
- [ ] View Competition (non-admin, divisioned): division name appears alongside Format/Host Club
- [ ] View Competition team formats: expander reads "Teams", each team shows a heading + table with aligned Mobile and Status columns
- [ ] Admin divisioned competition: SF/F fixtures appear in their division's section instead of Unassigned

🤖 Generated with [Claude Code](https://claude.com/claude-code)