### PR TITLE
Cap desktop page content at 1280px

### DIFF
--- a/DropShot/Components/Layout/MainLayout.razor.css
+++ b/DropShot/Components/Layout/MainLayout.razor.css
@@ -13,6 +13,10 @@ main {
 
 main ::deep .content {
     flex: 1;
+    width: 100%;
+    max-width: 1280px;
+    margin-left: auto;
+    margin-right: auto;
     padding-bottom: 3rem;
 }
 


### PR DESCRIPTION
## Summary
- Add `max-width: 1280px` + auto margins to `.content` in `MainLayout.razor.css` so body content renders as a centred column on wide screens
- Top nav and footer were already full-width, so the banner and footer backgrounds still bleed edge-to-edge — only the page body narrows

## Test plan
- [ ] On a desktop viewport (>1280px) page content centres with equal gutters, while the header banner and footer background fill the viewport edge-to-edge
- [ ] Below 1280px the layout behaves as before (no horizontal scroll, no extra whitespace)
- [ ] Mobile viewports look unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)