### PR TITLE
Multi-court scoreboards and stable fullscreen toggle

### DIFF
--- a/DropShot/Components/Pages/DisplayControl.razor
+++ b/DropShot/Components/Pages/DisplayControl.razor
@@ -135,10 +135,8 @@
                 .Build();
 
             // Listen for display commands from other admins or scoreboard viewers
-            _hub.On<string, string>("ReceiveDisplayCommand", async (command, value) =>
+            _hub.On<int, string, string>("ReceiveDisplayCommand", async (courtId, command, value) =>
             {
-                // Determine which court this came from by reloading from DB
-                // (SignalR group delivers to the court, but we need the courtId)
                 await ReloadSettingsFromDbAsync();
                 await InvokeAsync(StateHasChanged);
             });

--- a/DropShot/Components/Pages/Scoreboard.razor
+++ b/DropShot/Components/Pages/Scoreboard.razor
@@ -20,107 +20,155 @@
 <MudProviders />
 
 <div class="scoreboard-page">
+    @* Always-mounted in the same place so the icon never jumps when the
+       toolbar collapses on fullscreen. *@
+    <MudIconButton Icon="@(_isFullscreen ? Icons.Material.Filled.FullscreenExit : Icons.Material.Filled.Fullscreen)"
+                   aria-label="@(_isFullscreen ? "Exit fullscreen (ESC)" : "Enter fullscreen")"
+                   OnClick="ToggleFullscreenAsync"
+                   Class="scoreboard-fullscreen-toggle"
+                   Size="Size.Large" />
+
     @if (!_isFullscreen)
     {
         <div class="scoreboard-toolbar">
-            <div class="toolbar-court">
-                <MudSelect T="int?" Value="_selectedCourtId" ValueChanged="OnCourtChanged" Label="Select Court"
-                           Variant="Variant.Outlined" Style="max-width: min(300px, 45vw);" Clearable="true">
-                    @foreach (var court in _allCourts)
+            @for (int i = 0; i < _slots.Count; i++)
+            {
+                var idx = i;
+                var slot = _slots[idx];
+                <div class="toolbar-court-group">
+                    <MudSelect T="int?" Value="slot.CourtId"
+                               ValueChanged="@(c => OnSlotCourtChangedAsync(idx, c))"
+                               Label="@($"Court {idx + 1}")"
+                               Variant="Variant.Outlined"
+                               Style="min-width: 220px; max-width: min(320px, 45vw);"
+                               Clearable="true">
+                        @foreach (var court in AvailableCourtsForSlot(idx))
+                        {
+                            <MudSelectItem T="int?" Value="@((int?)court.CourtId)">@court.Club.Name — @court.Name</MudSelectItem>
+                        }
+                    </MudSelect>
+                    @if (_slots.Count > 1)
                     {
-                        <MudSelectItem T="int?" Value="@((int?)court.CourtId)">@court.Club.Name — @court.Name</MudSelectItem>
+                        <MudIconButton Icon="@Icons.Material.Filled.Close"
+                                       aria-label="Remove court"
+                                       OnClick="@(() => RemoveSlotAsync(idx))"
+                                       Size="Size.Small" />
                     }
-                </MudSelect>
-            </div>
+                </div>
+            }
+            @if (_slots.Count < MaxSlots)
+            {
+                <MudIconButton Icon="@Icons.Material.Filled.AddCircle"
+                               aria-label="Add court"
+                               Color="Color.Primary"
+                               OnClick="AddSlot"
+                               Size="Size.Large" />
+            }
             <div class="toolbar-layout">
-                <MudSelect T="string" Value="_selectedLayout" ValueChanged="OnLayoutChanged" Label="Layout"
-                           Variant="Variant.Outlined" Style="max-width: min(180px, 30vw);">
+                <MudSelect T="string" Value="_selectedLayout" ValueChanged="OnLayoutChanged"
+                           Label="Layout" Variant="Variant.Outlined"
+                           Style="min-width: 160px; max-width: min(200px, 30vw);">
                     <MudSelectItem T="string" Value=@("default")>Default</MudSelectItem>
                     <MudSelectItem T="string" Value=@("wimbledon")>Wimbledon</MudSelectItem>
                 </MudSelect>
             </div>
-            <div class="toolbar-fullscreen">
-                <MudIconButton Icon="@Icons.Material.Filled.Fullscreen" aria-label="Enter fullscreen"
-                               OnClick="EnterFullscreenAsync" Size="Size.Large" />
-            </div>
         </div>
     }
-    else
-    {
-        <MudIconButton Icon="@Icons.Material.Filled.FullscreenExit" aria-label="Exit fullscreen (ESC)"
-                       OnClick="ExitFullscreenAsync"
-                       Style="position: fixed; top: 8px; right: 8px; z-index: 9999; opacity: 0.3;"
-                       Size="Size.Large" />
+
+    @{
+        var activeSlots = _slots.Where(s => s.CourtId.HasValue).ToList();
+        var gridClass = activeSlots.Count > 0 ? $"scoreboard-grid count-{Math.Min(activeSlots.Count, MaxSlots)}" : "";
     }
-
-    <div class="scoreboard-content">
-        @if (_streamEnabled && !string.IsNullOrWhiteSpace(_streamEmbedUrl))
+    <div class="scoreboard-content @gridClass">
+        @if (activeSlots.Count == 0)
         {
-            <div class="stream-container">
-                <iframe src="@_streamEmbedUrl" style="position: relative; z-index: 1; width: 100%; height: 100%; border: none;"
-                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                        allowfullscreen></iframe>
-
-                @if (_activeMatch != null)
-                {
-                    <div class="tv-overlay">
-                        <div class="tv-row @(currentScore.IsUserServing ? "tv-serving" : "")">
-                            <span class="tv-serve">@(currentScore.IsUserServing ? "\u25CF" : "")</span>
-                            <span class="tv-name">@(OverlayName(string.IsNullOrWhiteSpace(currentScore.UserName) ? _activeMatch.Player1 : currentScore.UserName))</span>
-                            @foreach (var set in currentScore.SetScores ?? Enumerable.Empty<SetScore>())
-                            {
-                                <span class="tv-set">@set.UserGames</span>
-                            }
-                            @if (!currentScore.isComplete)
-                            {
-                                <span class="tv-game">@currentScore.UserG</span>
-                                <span class="tv-pts">@PointDisplay(currentScore.UserPts, currentScore.OppPts, currentScore.DeuceCount, currentScore.TieBreak, true)</span>
-                            }
-                        </div>
-                        <div class="tv-row @(!currentScore.IsUserServing ? "tv-serving" : "")">
-                            <span class="tv-serve">@(!currentScore.IsUserServing ? "\u25CF" : "")</span>
-                            <span class="tv-name">@(OverlayName(string.IsNullOrWhiteSpace(currentScore.OpponentName) ? _activeMatch.Player2 : currentScore.OpponentName))</span>
-                            @foreach (var set in currentScore.SetScores ?? Enumerable.Empty<SetScore>())
-                            {
-                                <span class="tv-set">@set.OpponentGames</span>
-                            }
-                            @if (!currentScore.isComplete)
-                            {
-                                <span class="tv-game">@currentScore.OppG</span>
-                                <span class="tv-pts">@PointDisplay(currentScore.OppPts, currentScore.UserPts, currentScore.DeuceCount, currentScore.TieBreak, false)</span>
-                            }
-                        </div>
-                    </div>
-                }
-            </div>
-        }
-        else if (_selectedLayout == "wimbledon")
-        {
-            <WimbledonScoreboard Score="currentScore" ActiveMatch="_activeMatch" SelectedCourt="_selectedCourt" ActiveFixture="_activeFixture" />
+            <div class="scoreboard-empty-hint">Select a court to display its scoreboard.</div>
         }
         else
         {
-            <DefaultScoreboard Score="currentScore" ActiveMatch="_activeMatch" SelectedCourt="_selectedCourt" ActiveFixture="_activeFixture" />
+            @foreach (var slot in activeSlots)
+            {
+                var court = _allCourts.FirstOrDefault(c => c.CourtId == slot.CourtId);
+                <div class="scoreboard-cell">
+                    @if (slot.StreamEnabled && !string.IsNullOrWhiteSpace(slot.StreamEmbedUrl))
+                    {
+                        <div class="stream-container">
+                            <iframe src="@slot.StreamEmbedUrl" style="position: relative; z-index: 1; width: 100%; height: 100%; border: none;"
+                                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                                    allowfullscreen></iframe>
+
+                            @if (slot.ActiveMatch != null)
+                            {
+                                <div class="tv-overlay">
+                                    <div class="tv-row @(slot.CurrentScore.IsUserServing ? "tv-serving" : "")">
+                                        <span class="tv-serve">@(slot.CurrentScore.IsUserServing ? "\u25CF" : "")</span>
+                                        <span class="tv-name">@(OverlayName(string.IsNullOrWhiteSpace(slot.CurrentScore.UserName) ? slot.ActiveMatch.Player1 : slot.CurrentScore.UserName))</span>
+                                        @foreach (var set in slot.CurrentScore.SetScores ?? Enumerable.Empty<SetScore>())
+                                        {
+                                            <span class="tv-set">@set.UserGames</span>
+                                        }
+                                        @if (!slot.CurrentScore.isComplete)
+                                        {
+                                            <span class="tv-game">@slot.CurrentScore.UserG</span>
+                                            <span class="tv-pts">@PointDisplay(slot.CurrentScore.UserPts, slot.CurrentScore.OppPts, slot.CurrentScore.DeuceCount, slot.CurrentScore.TieBreak, true)</span>
+                                        }
+                                    </div>
+                                    <div class="tv-row @(!slot.CurrentScore.IsUserServing ? "tv-serving" : "")">
+                                        <span class="tv-serve">@(!slot.CurrentScore.IsUserServing ? "\u25CF" : "")</span>
+                                        <span class="tv-name">@(OverlayName(string.IsNullOrWhiteSpace(slot.CurrentScore.OpponentName) ? slot.ActiveMatch.Player2 : slot.CurrentScore.OpponentName))</span>
+                                        @foreach (var set in slot.CurrentScore.SetScores ?? Enumerable.Empty<SetScore>())
+                                        {
+                                            <span class="tv-set">@set.OpponentGames</span>
+                                        }
+                                        @if (!slot.CurrentScore.isComplete)
+                                        {
+                                            <span class="tv-game">@slot.CurrentScore.OppG</span>
+                                            <span class="tv-pts">@PointDisplay(slot.CurrentScore.OppPts, slot.CurrentScore.UserPts, slot.CurrentScore.DeuceCount, slot.CurrentScore.TieBreak, false)</span>
+                                        }
+                                    </div>
+                                </div>
+                            }
+                        </div>
+                    }
+                    else if (_selectedLayout == "wimbledon")
+                    {
+                        <WimbledonScoreboard Score="slot.CurrentScore" ActiveMatch="slot.ActiveMatch" SelectedCourt="court" ActiveFixture="slot.ActiveFixture" />
+                    }
+                    else
+                    {
+                        <DefaultScoreboard Score="slot.CurrentScore" ActiveMatch="slot.ActiveMatch" SelectedCourt="court" ActiveFixture="slot.ActiveFixture" />
+                    }
+                </div>
+            }
         }
     </div>
 </div>
 
 @code {
+    private const int MaxSlots = 12;
+
     private HubConnection? hubConnection;
     private List<Court> _allCourts = [];
-    private int? _selectedCourtId;
+    private List<ScoreboardSlot> _slots = new() { new ScoreboardSlot() };
     private string _selectedLayout = "default";
-    private Court? _selectedCourt => _allCourts.FirstOrDefault(c => c.CourtId == _selectedCourtId);
-    private SavedMatch? _activeMatch;
-    private CompetitionFixture? _activeFixture;
-    GameState currentScore = new(0, 0, 0, 0, 0, 0, false, 0, true, 0, 0, new List<SetScore>(), DateTime.Now, false, "", "");
 
     private bool _isFullscreen;
-    private bool _streamEnabled;
-    private string _streamUrl = "";
-    private string _streamEmbedUrl = "";
     private DotNetObjectReference<Scoreboard>? _dotNetRef;
     private IJSObjectReference? _jsModule;
+
+    private sealed class ScoreboardSlot
+    {
+        public int? CourtId { get; set; }
+        public GameState CurrentScore { get; set; } = EmptyScore();
+        public SavedMatch? ActiveMatch { get; set; }
+        public CompetitionFixture? ActiveFixture { get; set; }
+        public bool StreamEnabled { get; set; }
+        public string StreamUrl { get; set; } = "";
+        public string StreamEmbedUrl { get; set; } = "";
+    }
+
+    private static GameState EmptyScore() =>
+        new(0, 0, 0, 0, 0, 0, false, 0, true, 0, 0, new List<SetScore>(), DateTime.Now, false, "", "");
 
     protected override async Task OnInitializedAsync()
     {
@@ -135,192 +183,261 @@
         }
         _allCourts = await courtsQuery.OrderBy(c => c.Club.Name).ThenBy(c => c.Name).ToListAsync();
 
-        // Parse query string for kiosk mode
         var uri = new Uri(Navigation.Uri);
         var query = System.Web.HttpUtility.ParseQueryString(uri.Query);
 
         if (query["layout"] is string layout && (layout == "default" || layout == "wimbledon"))
             _selectedLayout = layout;
 
-        if (int.TryParse(query["court"], out int qsCourtId))
-            await OnCourtChanged(qsCourtId);
+        var queryCourtIds = ParseCourtIds(query["courts"] ?? query["court"]);
+        if (queryCourtIds.Count > 0)
+        {
+            _slots = queryCourtIds.Take(MaxSlots)
+                .Select(id => new ScoreboardSlot { CourtId = id })
+                .ToList();
+        }
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (firstRender)
+        if (!firstRender) return;
+
+        var uri = new Uri(Navigation.Uri);
+        var query = System.Web.HttpUtility.ParseQueryString(uri.Query);
+        bool hasQueryParams = query["fullscreen"] != null
+            || query["court"] != null
+            || query["courts"] != null
+            || query["layout"] != null;
+
+        if (!hasQueryParams)
         {
-            // Restore saved preferences (only if not overridden by query string)
-            var uri = new Uri(Navigation.Uri);
-            var query = System.Web.HttpUtility.ParseQueryString(uri.Query);
-            bool hasQueryParams = query["fullscreen"] != null || query["court"] != null || query["layout"] != null;
+            var savedLayout = await JS.InvokeAsync<string?>("localStorage.getItem", "scoreboard-layout");
+            if (!string.IsNullOrEmpty(savedLayout))
+                _selectedLayout = savedLayout;
 
-            if (!hasQueryParams)
+            var savedCourts = await JS.InvokeAsync<string?>("localStorage.getItem", "scoreboard-courts");
+            List<int> restored;
+            if (!string.IsNullOrEmpty(savedCourts))
             {
-                var savedLayout = await JS.InvokeAsync<string?>("localStorage.getItem", "scoreboard-layout");
-                if (!string.IsNullOrEmpty(savedLayout))
-                    _selectedLayout = savedLayout;
-
+                restored = ParseCourtIds(savedCourts);
+            }
+            else
+            {
                 var savedCourt = await JS.InvokeAsync<string?>("localStorage.getItem", "scoreboard-court");
-                if (int.TryParse(savedCourt, out int courtId))
-                    await OnCourtChanged(courtId);
+                restored = int.TryParse(savedCourt, out int one) ? new List<int> { one } : new List<int>();
             }
 
-            StateHasChanged();
-
-            // Register ESC key handler
-            _jsModule = await JS.InvokeAsync<IJSObjectReference>("import", "./js/scoreboard.js");
-            _dotNetRef = DotNetObjectReference.Create(this);
-            await _jsModule.InvokeVoidAsync("registerEscHandler", _dotNetRef);
-
-            // Apply fullscreen from query string (needs JS module to be loaded)
-            if (query["fullscreen"] == "true")
-                await EnterFullscreenAsync();
+            if (restored.Count > 0)
+            {
+                _slots = restored.Take(MaxSlots)
+                    .Select(id => new ScoreboardSlot { CourtId = id })
+                    .ToList();
+            }
         }
 
-        if (firstRender && hubConnection is null)
+        _jsModule = await JS.InvokeAsync<IJSObjectReference>("import", "./js/scoreboard.js");
+        _dotNetRef = DotNetObjectReference.Create(this);
+        await _jsModule.InvokeVoidAsync("registerEscHandler", _dotNetRef);
+
+        hubConnection = new HubConnectionBuilder()
+            .WithUrl(Navigation.ToAbsoluteUri("/chathub"))
+            .Build();
+
+        hubConnection.On<string, string>("ReceiveMessage", OnReceiveMatchMessageAsync);
+        hubConnection.On<int, string, string>("ReceiveDisplayCommand", OnReceiveDisplayCommandAsync);
+
+        hubConnection.Reconnected += async _ =>
         {
-            hubConnection = new HubConnectionBuilder()
-                .WithUrl(Navigation.ToAbsoluteUri("/chathub"))
-                .Build();
+            foreach (var slot in _slots.Where(s => s.CourtId.HasValue))
+                await hubConnection!.SendAsync("JoinCourtGroup", slot.CourtId!.Value);
+        };
 
-            hubConnection.On<string, string>("ReceiveMessage", async (user, message) =>
+        await hubConnection.StartAsync();
+
+        foreach (var slot in _slots.Where(s => s.CourtId.HasValue).ToList())
+        {
+            await LoadSlotDataAsync(slot);
+            await hubConnection.SendAsync("JoinCourtGroup", slot.CourtId!.Value);
+        }
+
+        StateHasChanged();
+
+        if (query["fullscreen"] == "true")
+            await EnterFullscreenAsync();
+    }
+
+    private async Task OnReceiveMatchMessageAsync(string user, string message)
+    {
+        try
+        {
+            if (!int.TryParse(message, out int msgCourtId)) return;
+            var slot = _slots.FirstOrDefault(s => s.CourtId == msgCourtId);
+            if (slot == null) return;
+
+            GameState? gameState;
+            try { gameState = JsonConvert.DeserializeObject<GameState>(user); }
+            catch (JsonException) { return; }
+            if (gameState != null)
+                slot.CurrentScore = gameState;
+
+            if (slot.ActiveMatch == null)
             {
-                try
-                {
-                    if (_selectedCourtId.HasValue)
-                    {
-                        if (!int.TryParse(message, out int msgCourtId) || msgCourtId != _selectedCourtId.Value)
-                            return;
-                    }
+                using var dbc = DbFactory.CreateDbContext();
+                slot.ActiveMatch = await dbc.SavedMatch
+                    .FirstOrDefaultAsync(m => m.CourtId == slot.CourtId && !m.Complete);
+                slot.ActiveFixture = await LoadFixtureForMatchAsync(slot.ActiveMatch);
+            }
 
-                    GameState? gameState;
-                    try { gameState = JsonConvert.DeserializeObject<GameState>(user); }
-                    catch (JsonException) { return; }
-                    if (gameState != null)
-                        currentScore = gameState;
-
-                    // Refresh match details when scoring starts
-                    if (_activeMatch == null && _selectedCourtId.HasValue)
-                    {
-                        using var dbc = DbFactory.CreateDbContext();
-                        _activeMatch = await dbc.SavedMatch
-                            .FirstOrDefaultAsync(m => m.CourtId == _selectedCourtId && !m.Complete);
-                        _activeFixture = await LoadFixtureForMatchAsync(_activeMatch);
-                    }
-
-                    await InvokeAsync(StateHasChanged);
-                }
-                catch (Exception)
-                {
-                    // Silently handle — component may be disposed or state inconsistent
-                }
-            });
-
-            // Listen for display commands from admin
-            hubConnection.On<string, string>("ReceiveDisplayCommand", async (command, value) =>
-            {
-                try
-                {
-                    switch (command)
-                    {
-                        case "setFullscreen":
-                            if (value == "true")
-                                await EnterFullscreenAsync();
-                            else
-                                await ExitFullscreenAsync();
-                            break;
-                        case "setLayout":
-                            _selectedLayout = value;
-                            await JS.InvokeVoidAsync("localStorage.setItem", "scoreboard-layout", value);
-                            break;
-                        case "setStreamUrl":
-                            _streamUrl = value ?? "";
-                            _streamEmbedUrl = BuildYouTubeEmbedUrl(_streamUrl);
-                            break;
-                        case "setStreamEnabled":
-                            _streamEnabled = value == "true";
-                            break;
-                    }
-                    await InvokeAsync(StateHasChanged);
-                }
-                catch (Exception)
-                {
-                    // Silently handle — component may be disposed or state inconsistent
-                }
-            });
-
-            // Re-join court group on reconnection
-            hubConnection.Reconnected += async _ =>
-            {
-                if (_selectedCourtId.HasValue)
-                    await hubConnection.SendAsync("JoinCourtGroup", _selectedCourtId.Value);
-            };
-
-            await hubConnection.StartAsync();
-
-            // Join initial court group
-            if (_selectedCourtId.HasValue)
-                await hubConnection.SendAsync("JoinCourtGroup", _selectedCourtId.Value);
+            await InvokeAsync(StateHasChanged);
+        }
+        catch (Exception)
+        {
+            // Silently handle — component may be disposed or state inconsistent
         }
     }
 
-    private async Task OnCourtChanged(int? courtId)
+    private async Task OnReceiveDisplayCommandAsync(int courtId, string command, string value)
     {
-        // Verify the user is authorized for this court's club.
-        // _allCourts is already filtered to clubs the user can admin,
-        // so reject any courtId not in that list to prevent query-string bypass.
-        if (courtId.HasValue && !_allCourts.Any(c => c.CourtId == courtId.Value))
-            return;
+        try
+        {
+            var slot = _slots.FirstOrDefault(s => s.CourtId == courtId);
+            switch (command)
+            {
+                case "setFullscreen":
+                    if (value == "true")
+                        await EnterFullscreenAsync(broadcast: false);
+                    else
+                        await ExitFullscreenAsync(broadcast: false);
+                    break;
+                case "setLayout":
+                    _selectedLayout = value;
+                    await JS.InvokeVoidAsync("localStorage.setItem", "scoreboard-layout", value);
+                    break;
+                case "setStreamUrl":
+                    if (slot != null)
+                    {
+                        slot.StreamUrl = value ?? "";
+                        slot.StreamEmbedUrl = BuildYouTubeEmbedUrl(slot.StreamUrl);
+                    }
+                    break;
+                case "setStreamEnabled":
+                    if (slot != null)
+                        slot.StreamEnabled = value == "true";
+                    break;
+            }
+            await InvokeAsync(StateHasChanged);
+        }
+        catch (Exception)
+        {
+            // Silently handle — component may be disposed or state inconsistent
+        }
+    }
 
-        // Leave old court group
-        if (_selectedCourtId.HasValue && hubConnection?.State == HubConnectionState.Connected)
-            await hubConnection.SendAsync("LeaveCourtGroup", _selectedCourtId.Value);
+    private IEnumerable<Court> AvailableCourtsForSlot(int slotIndex)
+    {
+        var used = _slots
+            .Where((s, i) => i != slotIndex && s.CourtId.HasValue)
+            .Select(s => s.CourtId!.Value)
+            .ToHashSet();
+        return _allCourts.Where(c => !used.Contains(c.CourtId));
+    }
 
-        _selectedCourtId = courtId;
-        await JS.InvokeVoidAsync("localStorage.setItem", "scoreboard-court", courtId?.ToString() ?? "");
-        currentScore = new GameState(0, 0, 0, 0, 0, 0, false, 0, true, 0, 0, new List<SetScore>(), DateTime.Now, false, "", "");
-        _activeMatch = null;
-        _activeFixture = null;
-
-        // Stream settings are per-court; reset then load from DB for the new court
-        _streamUrl = "";
-        _streamEmbedUrl = "";
-        _streamEnabled = false;
+    private async Task OnSlotCourtChangedAsync(int slotIndex, int? courtId)
+    {
+        if (slotIndex < 0 || slotIndex >= _slots.Count) return;
+        var slot = _slots[slotIndex];
 
         if (courtId.HasValue)
         {
-            using (var dbc = DbFactory.CreateDbContext())
-            {
-                var setting = await dbc.ScoreboardDisplaySettings
-                    .FirstOrDefaultAsync(s => s.CourtId == courtId);
-                if (setting is not null)
-                {
-                    _streamUrl = setting.LiveStreamUrl ?? "";
-                    _streamEmbedUrl = BuildYouTubeEmbedUrl(_streamUrl);
-                    _streamEnabled = setting.ShowLiveStream;
-                }
-            }
+            if (!_allCourts.Any(c => c.CourtId == courtId.Value)) return;
+            if (_slots.Where((s, i) => i != slotIndex).Any(s => s.CourtId == courtId.Value)) return;
+        }
 
-            _activeMatch = await DbContext.SavedMatch
-                .FirstOrDefaultAsync(m => m.CourtId == courtId && !m.Complete);
+        if (slot.CourtId.HasValue
+            && hubConnection?.State == HubConnectionState.Connected
+            && _slots.Count(s => s.CourtId == slot.CourtId.Value) == 1)
+        {
+            await hubConnection.SendAsync("LeaveCourtGroup", slot.CourtId.Value);
+        }
 
-            if (_activeMatch?.MatchJson is { } json)
-            {
-                DropShot.Models.Match? match;
-                try { match = JsonConvert.DeserializeObject<DropShot.Models.Match>(json); }
-                catch (JsonException) { match = null; }
-                var latest = match?.HistoryList?.LastOrDefault();
-                if (latest != null)
-                    currentScore = latest;
-            }
+        slot.CourtId = courtId;
+        slot.CurrentScore = EmptyScore();
+        slot.ActiveMatch = null;
+        slot.ActiveFixture = null;
+        slot.StreamUrl = "";
+        slot.StreamEmbedUrl = "";
+        slot.StreamEnabled = false;
 
-            _activeFixture = await LoadFixtureForMatchAsync(_activeMatch);
-
-            // Join new court group
+        if (courtId.HasValue)
+        {
+            await LoadSlotDataAsync(slot);
             if (hubConnection?.State == HubConnectionState.Connected)
                 await hubConnection.SendAsync("JoinCourtGroup", courtId.Value);
         }
+
+        await SaveSelectedCourtsAsync();
+    }
+
+    private async Task LoadSlotDataAsync(ScoreboardSlot slot)
+    {
+        if (!slot.CourtId.HasValue) return;
+
+        using var dbc = DbFactory.CreateDbContext();
+
+        var setting = await dbc.ScoreboardDisplaySettings
+            .FirstOrDefaultAsync(s => s.CourtId == slot.CourtId);
+        if (setting is not null)
+        {
+            slot.StreamUrl = setting.LiveStreamUrl ?? "";
+            slot.StreamEmbedUrl = BuildYouTubeEmbedUrl(slot.StreamUrl);
+            slot.StreamEnabled = setting.ShowLiveStream;
+        }
+
+        slot.ActiveMatch = await dbc.SavedMatch
+            .FirstOrDefaultAsync(m => m.CourtId == slot.CourtId && !m.Complete);
+
+        if (slot.ActiveMatch?.MatchJson is { } json)
+        {
+            DropShot.Models.Match? match;
+            try { match = JsonConvert.DeserializeObject<DropShot.Models.Match>(json); }
+            catch (JsonException) { match = null; }
+            var latest = match?.HistoryList?.LastOrDefault();
+            if (latest != null)
+                slot.CurrentScore = latest;
+        }
+
+        slot.ActiveFixture = await LoadFixtureForMatchAsync(slot.ActiveMatch);
+    }
+
+    private void AddSlot()
+    {
+        if (_slots.Count >= MaxSlots) return;
+        _slots.Add(new ScoreboardSlot());
+    }
+
+    private async Task RemoveSlotAsync(int slotIndex)
+    {
+        if (slotIndex < 0 || slotIndex >= _slots.Count) return;
+        if (_slots.Count <= 1) return;
+
+        var slot = _slots[slotIndex];
+        if (slot.CourtId.HasValue
+            && hubConnection?.State == HubConnectionState.Connected
+            && _slots.Count(s => s.CourtId == slot.CourtId.Value) == 1)
+        {
+            await hubConnection.SendAsync("LeaveCourtGroup", slot.CourtId.Value);
+        }
+
+        _slots.RemoveAt(slotIndex);
+        await SaveSelectedCourtsAsync();
+    }
+
+    private async Task SaveSelectedCourtsAsync()
+    {
+        var ids = _slots.Where(s => s.CourtId.HasValue).Select(s => s.CourtId!.Value).ToList();
+        await JS.InvokeVoidAsync("localStorage.setItem", "scoreboard-courts", string.Join(",", ids));
+        await JS.InvokeVoidAsync("localStorage.setItem", "scoreboard-court",
+            ids.FirstOrDefault().ToString());
     }
 
     private async Task<CompetitionFixture?> LoadFixtureForMatchAsync(SavedMatch? match)
@@ -338,18 +455,16 @@
         _selectedLayout = layout;
         await JS.InvokeVoidAsync("localStorage.setItem", "scoreboard-layout", layout);
 
-        // Persist to DB and notify display control / other scoreboards
-        if (_selectedCourtId.HasValue)
+        foreach (var slot in _slots.Where(s => s.CourtId.HasValue))
         {
-            await SaveDisplaySettingToDbAsync(_selectedCourtId.Value, s => s.Layout = layout);
+            await SaveDisplaySettingToDbAsync(slot.CourtId!.Value, s => s.Layout = layout);
             if (hubConnection?.State == HubConnectionState.Connected)
-                await hubConnection.SendAsync("SendDisplayCommand", _selectedCourtId.Value, "setLayout", layout);
+                await hubConnection.SendAsync("SendDisplayCommand", slot.CourtId!.Value, "setLayout", layout);
         }
     }
 
     private async Task SaveDisplaySettingToDbAsync(int courtId, Action<ScoreboardDisplaySetting> update)
     {
-        // Verify club-level authorization before persisting display settings
         if (!_allCourts.Any(c => c.CourtId == courtId))
             return;
 
@@ -364,31 +479,36 @@
         await db.SaveChangesAsync();
     }
 
-    private async Task EnterFullscreenAsync()
+    private Task ToggleFullscreenAsync() =>
+        _isFullscreen ? ExitFullscreenAsync() : EnterFullscreenAsync();
+
+    private async Task EnterFullscreenAsync(bool broadcast = true)
     {
         _isFullscreen = true;
         if (_jsModule is not null)
             await _jsModule.InvokeVoidAsync("setFullscreen", true);
 
-        if (_selectedCourtId.HasValue)
+        if (!broadcast) return;
+        foreach (var slot in _slots.Where(s => s.CourtId.HasValue))
         {
-            await SaveDisplaySettingToDbAsync(_selectedCourtId.Value, s => s.Fullscreen = true);
+            await SaveDisplaySettingToDbAsync(slot.CourtId!.Value, s => s.Fullscreen = true);
             if (hubConnection?.State == HubConnectionState.Connected)
-                await hubConnection.SendAsync("SendDisplayCommand", _selectedCourtId.Value, "setFullscreen", "true");
+                await hubConnection.SendAsync("SendDisplayCommand", slot.CourtId!.Value, "setFullscreen", "true");
         }
     }
 
-    private async Task ExitFullscreenAsync()
+    private async Task ExitFullscreenAsync(bool broadcast = true)
     {
         _isFullscreen = false;
         if (_jsModule is not null)
             await _jsModule.InvokeVoidAsync("setFullscreen", false);
 
-        if (_selectedCourtId.HasValue)
+        if (!broadcast) return;
+        foreach (var slot in _slots.Where(s => s.CourtId.HasValue))
         {
-            await SaveDisplaySettingToDbAsync(_selectedCourtId.Value, s => s.Fullscreen = false);
+            await SaveDisplaySettingToDbAsync(slot.CourtId!.Value, s => s.Fullscreen = false);
             if (hubConnection?.State == HubConnectionState.Connected)
-                await hubConnection.SendAsync("SendDisplayCommand", _selectedCourtId.Value, "setFullscreen", "false");
+                await hubConnection.SendAsync("SendDisplayCommand", slot.CourtId!.Value, "setFullscreen", "false");
         }
     }
 
@@ -400,6 +520,18 @@
             await ExitFullscreenAsync();
             await InvokeAsync(StateHasChanged);
         }
+    }
+
+    private static List<int> ParseCourtIds(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return [];
+        return raw
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(s => int.TryParse(s, out var i) ? i : (int?)null)
+            .Where(i => i.HasValue)
+            .Select(i => i!.Value)
+            .Distinct()
+            .ToList();
     }
 
     private static string OverlayName(string? name) =>
@@ -427,27 +559,22 @@
 
         url = url.Trim();
 
-        // Already an embed URL
         if (url.Contains("youtube.com/embed/"))
             return url;
 
-        // Extract video ID from various formats
         string? videoId = null;
 
-        // youtube.com/watch?v=VIDEO_ID
         if (url.Contains("youtube.com/watch"))
         {
             var uri = new Uri(url);
             var query = System.Web.HttpUtility.ParseQueryString(uri.Query);
             videoId = query["v"];
         }
-        // youtu.be/VIDEO_ID
         else if (url.Contains("youtu.be/"))
         {
             var uri = new Uri(url);
             videoId = uri.AbsolutePath.TrimStart('/');
         }
-        // youtube.com/live/VIDEO_ID
         else if (url.Contains("youtube.com/live/"))
         {
             var uri = new Uri(url);
@@ -456,7 +583,6 @@
             if (liveIdx >= 0 && liveIdx + 1 < segments.Length)
                 videoId = segments[liveIdx + 1];
         }
-        // studio.youtube.com/video/VIDEO_ID/livestreaming
         else if (url.Contains("studio.youtube.com/video/"))
         {
             var uri = new Uri(url);

--- a/DropShot/Components/Pages/Scoreboard.razor.css
+++ b/DropShot/Components/Pages/Scoreboard.razor.css
@@ -1,28 +1,51 @@
 /* ── Full-viewport scoreboard page ──────────────────────────── */
 .scoreboard-page {
+    position: relative;
     display: flex;
     flex-direction: column;
     min-height: calc(100vh - 3.5rem);
 }
+
+/* Always-mounted fullscreen toggle — fixed in the top-right corner in
+   every state so the icon never shifts when the toolbar collapses. */
+.scoreboard-fullscreen-toggle {
+    position: fixed;
+    top: 8px;
+    right: 8px;
+    z-index: 9999;
+    opacity: 0.35;
+    transition: opacity 0.2s ease;
+}
+
+    .scoreboard-fullscreen-toggle:hover,
+    .scoreboard-fullscreen-toggle:focus-visible {
+        opacity: 1;
+    }
 
 .scoreboard-toolbar {
     display: flex;
     gap: 12px;
     align-items: flex-end;
     flex-wrap: wrap;
-    padding: 8px 12px;
+    padding: 8px 56px 8px 12px; /* reserve space for the fixed toggle */
     flex-shrink: 0;
 }
 
-@media (max-width: 600px) {
-    .toolbar-fullscreen {
-        margin-left: auto;
-        order: 2;
-    }
+.toolbar-court-group {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
 
+.toolbar-layout {
+    margin-left: auto;
+}
+
+@media (max-width: 600px) {
     .toolbar-layout {
+        margin-left: 0;
         flex: 1 1 100%;
-        order: 3;
+        order: 99;
     }
 }
 
@@ -34,6 +57,113 @@
     align-items: center;
     min-height: 0;
     padding: 0 8px;
+}
+
+.scoreboard-empty-hint {
+    padding: 24px;
+    opacity: 0.5;
+    text-align: center;
+}
+
+/* ── Grid layout for multiple courts ─────────────────────────── */
+.scoreboard-grid {
+    display: grid;
+    gap: 12px;
+    padding: 12px 8px;
+    width: 100%;
+    align-items: stretch;
+    justify-items: stretch;
+}
+
+    .scoreboard-grid.count-1 {
+        grid-template-columns: 1fr;
+    }
+
+    .scoreboard-grid.count-2 {
+        grid-template-columns: repeat(2, 1fr);
+    }
+
+    .scoreboard-grid.count-3,
+    .scoreboard-grid.count-4 {
+        grid-template-columns: repeat(2, 1fr);
+    }
+
+    .scoreboard-grid.count-5,
+    .scoreboard-grid.count-6 {
+        grid-template-columns: repeat(3, 1fr);
+    }
+
+    .scoreboard-grid.count-7,
+    .scoreboard-grid.count-8,
+    .scoreboard-grid.count-9 {
+        grid-template-columns: repeat(3, 1fr);
+    }
+
+    .scoreboard-grid.count-10,
+    .scoreboard-grid.count-11,
+    .scoreboard-grid.count-12 {
+        grid-template-columns: repeat(4, 1fr);
+    }
+
+@media (max-width: 900px) {
+    .scoreboard-grid.count-3,
+    .scoreboard-grid.count-4,
+    .scoreboard-grid.count-5,
+    .scoreboard-grid.count-6,
+    .scoreboard-grid.count-7,
+    .scoreboard-grid.count-8,
+    .scoreboard-grid.count-9,
+    .scoreboard-grid.count-10,
+    .scoreboard-grid.count-11,
+    .scoreboard-grid.count-12 {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+@media (max-width: 600px) {
+    .scoreboard-grid {
+        grid-template-columns: 1fr !important;
+    }
+}
+
+.scoreboard-cell {
+    container-type: inline-size;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    padding: 8px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.02);
+    min-height: 180px;
+}
+
+/* When more than one scoreboard is shown, rescale the font sizes
+   relative to each cell's width instead of the viewport so the
+   scoreboards stay readable inside grid tiles. */
+.scoreboard-grid:not(.count-1) ::deep .default-scoreboard .score-court-name {
+    font-size: clamp(0.75rem, 5cqi, 1.75rem);
+}
+
+.scoreboard-grid:not(.count-1) ::deep .default-scoreboard .score-competition {
+    font-size: clamp(0.55rem, 2.5cqi, 1rem);
+}
+
+.scoreboard-grid:not(.count-1) ::deep .default-scoreboard .score-player-label {
+    font-size: clamp(0.75rem, 3.5cqi, 1.35rem);
+}
+
+.scoreboard-grid:not(.count-1) ::deep .default-scoreboard .score-point-value {
+    font-size: clamp(1.5rem, 10cqi, 4rem);
+}
+
+.scoreboard-grid:not(.count-1) ::deep .default-scoreboard .score-serve-indicator {
+    font-size: clamp(0.9rem, 3.5cqi, 1.75rem);
+}
+
+.scoreboard-grid:not(.count-1) ::deep .default-scoreboard .score-points-row {
+    gap: clamp(10px, 4cqi, 40px);
 }
 
 /* ── YouTube stream container ────────────────────────────────── */

--- a/DropShot/Models/ChatHub.cs
+++ b/DropShot/Models/ChatHub.cs
@@ -22,7 +22,7 @@
 
         public async Task SendDisplayCommand(int courtId, string command, string value)
         {
-            await Clients.OthersInGroup($"court-{courtId}").SendAsync("ReceiveDisplayCommand", command, value);
+            await Clients.OthersInGroup($"court-{courtId}").SendAsync("ReceiveDisplayCommand", courtId, command, value);
         }
     }
 }

--- a/DropShot/wwwroot/app.css
+++ b/DropShot/wwwroot/app.css
@@ -171,12 +171,14 @@ body.scoring-immersive .top-navbar {
 body.scoreboard-fullscreen .sidebar,
 body.scoreboard-fullscreen .role-banner,
 body.scoreboard-fullscreen .top-row,
-body.scoreboard-fullscreen .navbar-toggler {
+body.scoreboard-fullscreen .navbar-toggler,
+body.scoreboard-fullscreen footer.site-footer {
     display: none !important;
 }
 
 body.scoreboard-fullscreen .content {
     padding: 0 !important;
+    max-width: none !important;
 }
 
 body.scoreboard-fullscreen main {


### PR DESCRIPTION
## Summary
- `/score` now supports up to 12 simultaneous scoreboards. A plus icon beside the court selectors adds another slot; each selector has an adjacent close button (for slots 2–12). Active courts render in a responsive grid (1/2/3/4 columns depending on count and viewport) with container-query-based font scaling so each tile stays readable.
- Single shared layout dropdown applies to every tile and is broadcast to each selected court on change.
- Fullscreen toggle is now mounted once as a fixed icon at the top-right corner so it never shifts between states. The toolbar reserves space for it.
- Scoreboard fullscreen mode now hides `footer.site-footer` in addition to the top nav (via `app.css`).
- `ChatHub.SendDisplayCommand` now emits `ReceiveDisplayCommand(courtId, command, value)` so a scoreboard joined to multiple court groups can route stream/layout commands back to the matching tile. `DisplayControl.razor` handler updated to the new signature.
- Query string / localStorage now accept a comma-separated `courts=1,2,3` (legacy `court=1` is still honoured), and restore previous multi-slot selections on reload.

## Test plan
- [ ] `/score` renders one court selector + plus icon + layout dropdown by default
- [ ] Adding courts (up to 12) shows each scoreboard in a grid; dropdowns only offer unused courts
- [ ] Removing a court leaves the remaining grid intact and unsubscribes from that court's SignalR group
- [ ] Fullscreen toggle stays in the same top-right position entering and exiting fullscreen; ESC still exits
- [ ] Footer is hidden alongside the nav bar when fullscreen is on
- [ ] Changing layout updates every tile at once
- [ ] Stream toggles from DisplayControl still reach the matching scoreboard tile

🤖 Generated with [Claude Code](https://claude.com/claude-code)