### PR TITLE
Scoreboard page: full-width + 6x2 grid

### DIFF
--- a/DropShot/Components/Pages/Scoreboard.razor
+++ b/DropShot/Components/Pages/Scoreboard.razor
@@ -238,6 +238,7 @@
         _jsModule = await JS.InvokeAsync<IJSObjectReference>("import", "./js/scoreboard.js");
         _dotNetRef = DotNetObjectReference.Create(this);
         await _jsModule.InvokeVoidAsync("registerEscHandler", _dotNetRef);
+        await _jsModule.InvokeVoidAsync("setScoreboardActive", true);
 
         hubConnection = new HubConnectionBuilder()
             .WithUrl(Navigation.ToAbsoluteUri("/chathub"))
@@ -609,6 +610,7 @@
             {
                 if (_isFullscreen)
                     await _jsModule.InvokeVoidAsync("setFullscreen", false);
+                await _jsModule.InvokeVoidAsync("setScoreboardActive", false);
                 await _jsModule.InvokeVoidAsync("unregisterEscHandler");
                 await _jsModule.DisposeAsync();
             }

--- a/DropShot/Components/Pages/Scoreboard.razor.css
+++ b/DropShot/Components/Pages/Scoreboard.razor.css
@@ -75,6 +75,7 @@
     justify-items: stretch;
 }
 
+    /* Up to 6 columns, up to 2 rows — capped at 12 tiles total. */
     .scoreboard-grid.count-1 {
         grid-template-columns: 1fr;
     }
@@ -83,27 +84,38 @@
         grid-template-columns: repeat(2, 1fr);
     }
 
-    .scoreboard-grid.count-3,
-    .scoreboard-grid.count-4 {
-        grid-template-columns: repeat(2, 1fr);
+    .scoreboard-grid.count-3 {
+        grid-template-columns: repeat(3, 1fr);
+    }
+
+    .scoreboard-grid.count-4,
+    .scoreboard-grid.count-7,
+    .scoreboard-grid.count-8 {
+        grid-template-columns: repeat(4, 1fr);
     }
 
     .scoreboard-grid.count-5,
-    .scoreboard-grid.count-6 {
-        grid-template-columns: repeat(3, 1fr);
+    .scoreboard-grid.count-9,
+    .scoreboard-grid.count-10 {
+        grid-template-columns: repeat(5, 1fr);
     }
 
-    .scoreboard-grid.count-7,
-    .scoreboard-grid.count-8,
-    .scoreboard-grid.count-9 {
-        grid-template-columns: repeat(3, 1fr);
+    .scoreboard-grid.count-6,
+    .scoreboard-grid.count-11,
+    .scoreboard-grid.count-12 {
+        grid-template-columns: repeat(6, 1fr);
     }
 
+@media (max-width: 1200px) {
+    .scoreboard-grid.count-5,
+    .scoreboard-grid.count-6,
+    .scoreboard-grid.count-9,
     .scoreboard-grid.count-10,
     .scoreboard-grid.count-11,
     .scoreboard-grid.count-12 {
         grid-template-columns: repeat(4, 1fr);
     }
+}
 
 @media (max-width: 900px) {
     .scoreboard-grid.count-3,

--- a/DropShot/wwwroot/app.css
+++ b/DropShot/wwwroot/app.css
@@ -167,6 +167,14 @@ body.scoring-immersive .top-navbar {
     display: none !important;
 }
 
+/* Scoreboard page opts out of the global 1280px content cap so the
+   grid and individual tiles can fill the full viewport width. */
+body.scoreboard-active .content {
+    max-width: none !important;
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+}
+
 /* Legacy — keep for external scoreboard page if still used */
 body.scoreboard-fullscreen .sidebar,
 body.scoreboard-fullscreen .role-banner,

--- a/DropShot/wwwroot/js/scoreboard.js
+++ b/DropShot/wwwroot/js/scoreboard.js
@@ -24,3 +24,11 @@ export function setFullscreen(enabled) {
         document.body.classList.remove('scoreboard-fullscreen');
     }
 }
+
+export function setScoreboardActive(enabled) {
+    if (enabled) {
+        document.body.classList.add('scoreboard-active');
+    } else {
+        document.body.classList.remove('scoreboard-active');
+    }
+}


### PR DESCRIPTION
## Summary
- `/score` now opts out of the global 1280px content cap by setting a `body.scoreboard-active` class on mount (removed on dispose) — the page fills the viewport so the grid can go edge-to-edge.
- Responsive grid capped at **6 columns × 2 rows** (12 tiles max). Tile counts pack onto a single row up to 6; 7–12 tiles flow onto a second row at 4/5/6 columns depending on count.
- Narrower breakpoints collapse gracefully: ≤1200px → 4 cols, ≤900px → 2 cols, ≤600px → 1 col.

## Test plan
- [ ] On desktop, `/score` spans the full viewport (no 1280px gutters)
- [ ] Navigating away from `/score` restores the normal capped width on other pages
- [ ] Adding 2, 4, 6 courts renders on a single row; 7–12 courts wrap to two rows
- [ ] Shrinking the window progressively drops the column count at the defined breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)