### PR TITLE
Scoreboard: visible fullscreen toggle + refresh stale player names

### DIFF
--- a/DropShot/Components/Pages/Scoreboard.razor
+++ b/DropShot/Components/Pages/Scoreboard.razor
@@ -281,7 +281,10 @@
             if (gameState != null)
                 slot.CurrentScore = gameState;
 
-            if (slot.ActiveMatch == null)
+            // Reload the cached match whenever the incoming scoreboard names
+            // don't match what we have — otherwise a new match on the same
+            // court keeps displaying the previous pairing's names.
+            if (slot.ActiveMatch == null || IsCachedMatchStale(slot.ActiveMatch, gameState))
             {
                 using var dbc = DbFactory.CreateDbContext();
                 slot.ActiveMatch = await dbc.SavedMatch
@@ -295,6 +298,28 @@
         {
             // Silently handle — component may be disposed or state inconsistent
         }
+    }
+
+    private static bool IsCachedMatchStale(SavedMatch cached, GameState? incoming)
+    {
+        if (incoming is null) return false;
+        if (string.IsNullOrWhiteSpace(incoming.UserName) && string.IsNullOrWhiteSpace(incoming.OpponentName))
+            return false;
+
+        var cachedUser = !string.IsNullOrWhiteSpace(cached.Player3)
+            ? $"{cached.Player1} & {cached.Player2}"
+            : cached.Player1;
+        var cachedOpp = !string.IsNullOrWhiteSpace(cached.Player3)
+            ? $"{cached.Player3} & {cached.Player4}"
+            : cached.Player2;
+
+        if (!string.IsNullOrWhiteSpace(incoming.UserName)
+            && !string.Equals(cachedUser, incoming.UserName, StringComparison.Ordinal))
+            return true;
+        if (!string.IsNullOrWhiteSpace(incoming.OpponentName)
+            && !string.Equals(cachedOpp, incoming.OpponentName, StringComparison.Ordinal))
+            return true;
+        return false;
     }
 
     private async Task OnReceiveDisplayCommandAsync(int courtId, string command, string value)

--- a/DropShot/Components/Pages/Scoreboard.razor.css
+++ b/DropShot/Components/Pages/Scoreboard.razor.css
@@ -7,20 +7,27 @@
 }
 
 /* Always-mounted fullscreen toggle — fixed in the top-right corner in
-   every state so the icon never shifts when the toolbar collapses. */
+   every state so the icon never shifts when the toolbar collapses.
+   A dark translucent pill keeps it visible against the top navbar
+   gradient and any scoreboard background. */
 .scoreboard-fullscreen-toggle {
     position: fixed;
-    top: 8px;
-    right: 8px;
+    top: calc(3.5rem + 8px);
+    right: 12px;
     z-index: 9999;
-    opacity: 0.35;
-    transition: opacity 0.2s ease;
+    opacity: 0.75;
+    background: rgba(0, 0, 0, 0.55) !important;
+    color: #ffffff !important;
+    border-radius: 50% !important;
+    transition: opacity 0.2s ease, background 0.2s ease;
 }
 
     .scoreboard-fullscreen-toggle:hover,
     .scoreboard-fullscreen-toggle:focus-visible {
         opacity: 1;
+        background: rgba(0, 0, 0, 0.8) !important;
     }
+
 
 .scoreboard-toolbar {
     display: flex;


### PR DESCRIPTION
## Summary
- The fullscreen toggle now sits just below the top navbar (`top: calc(3.5rem + 8px)`), styled as a dark translucent pill with higher default opacity so it's clearly visible against the navbar gradient. Position is stable across fullscreen on/off.
- `OnReceiveMatchMessageAsync` now reloads the cached `SavedMatch` whenever the incoming `GameState`'s `UserName` / `OpponentName` don't match the cached match's players. Previously the cache was only rebuilt when `ActiveMatch` was null, so a new match on an already-mounted tile kept showing the prior pairing's names.

## Test plan
- [ ] Visit `/score` — the fullscreen icon is visible in the top-right (below the navbar), readable, and stays in the same spot after toggling fullscreen
- [ ] Start a match on a selected court, finish it, start a new one — the scoreboard's player names refresh to the new pairing on the first incoming score update

🤖 Generated with [Claude Code](https://claude.com/claude-code)