### PR TITLE
Court claim: activity timeout + still-playing challenge

### DIFF
--- a/DropShot/Components/ClaimCourtDialog.razor
+++ b/DropShot/Components/ClaimCourtDialog.razor
@@ -1,0 +1,104 @@
+@using DropShot.Services
+@using Microsoft.AspNetCore.SignalR.Client
+@inject NavigationManager Navigation
+@inject CourtClaimService CourtClaim
+@implements IAsyncDisposable
+
+<MudDialog>
+    <DialogContent>
+        <MudStack Spacing="3" AlignItems="AlignItems.Center" Class="pa-3">
+            <MudProgressCircular Indeterminate="true" Color="Color.Primary" Size="Size.Large" />
+            <MudText Typo="Typo.body1" Align="Align.Center">
+                Asking <strong>@OccupantLabel</strong> if they're still on this court&hellip;
+            </MudText>
+            <MudText Typo="Typo.caption" Color="Color.Secondary">
+                We'll release the court automatically if they don't reply in @_secondsLeft s.
+            </MudText>
+        </MudStack>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="CancelAsync">Cancel</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    private const int TimeoutSeconds = 20;
+
+    [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = default!;
+
+    [Parameter, EditorRequired] public int CourtId { get; set; }
+    [Parameter, EditorRequired] public int SavedMatchId { get; set; }
+    [Parameter, EditorRequired] public string OccupantLabel { get; set; } = "";
+
+    private HubConnection? _hub;
+    private int _secondsLeft = TimeoutSeconds;
+    private System.Threading.Timer? _countdown;
+    private bool _resolved;
+
+    protected override async Task OnInitializedAsync()
+    {
+        _hub = new HubConnectionBuilder()
+            .WithUrl(Navigation.ToAbsoluteUri("/chathub"))
+            .Build();
+
+        _hub.On<int, int, bool>("CourtChallengeResponse", OnResponse);
+
+        await _hub.StartAsync();
+        await _hub.SendAsync("JoinCourtGroup", CourtId);
+        await _hub.SendAsync("ChallengeCourt", CourtId, SavedMatchId);
+
+        _countdown = new System.Threading.Timer(OnTick, null,
+            TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
+    }
+
+    private async void OnTick(object? _)
+    {
+        if (_resolved) return;
+        _secondsLeft--;
+        if (_secondsLeft <= 0)
+        {
+            // Scorer didn't respond — treat as abandoned and free the court.
+            await ResolveAsync(allowClaim: true, autoExpireStale: true);
+            return;
+        }
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private async void OnResponse(int courtId, int savedMatchId, bool stillPlaying)
+    {
+        if (courtId != CourtId || savedMatchId != SavedMatchId) return;
+        // stillPlaying == true  → court is held, deny the claim.
+        // stillPlaying == false → scorer said they're done, match was ended,
+        //                         so the claim can proceed.
+        await ResolveAsync(allowClaim: !stillPlaying, autoExpireStale: false);
+    }
+
+    private async Task ResolveAsync(bool allowClaim, bool autoExpireStale)
+    {
+        if (_resolved) return;
+        _resolved = true;
+
+        if (autoExpireStale)
+        {
+            try { await CourtClaim.EndMatchAsync(SavedMatchId); }
+            catch { /* not fatal — evaluate will retry on the next attempt */ }
+        }
+
+        await InvokeAsync(() => MudDialog.Close(DialogResult.Ok(allowClaim)));
+    }
+
+    private async Task CancelAsync()
+    {
+        _resolved = true;
+        await InvokeAsync(() => MudDialog.Cancel());
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _countdown?.Dispose();
+        if (_hub is not null)
+        {
+            try { await _hub.DisposeAsync(); } catch { }
+        }
+    }
+}

--- a/DropShot/Components/MatchSetupWizard.razor
+++ b/DropShot/Components/MatchSetupWizard.razor
@@ -9,6 +9,7 @@
 @inject FuzzySearchService FuzzySearch
 @inject ISnackbar Snackbar
 @inject IDialogService DialogService
+@inject CourtClaimService CourtClaim
 
 <MudStack Spacing="3">
 
@@ -290,7 +291,7 @@
                            OnClick="@(() => GoToStep(0))">Back</MudButton>
                 <MudButton Variant="Variant.Filled" Color="Color.Primary"
                            EndIcon="@Icons.Material.Filled.ArrowForward"
-                           OnClick="@(() => GoToStep(2))">
+                           OnClick="AdvanceFromCourtAsync">
                     @(_selectedCourtId == null ? "Skip" : "Next")
                 </MudButton>
             </div>
@@ -712,6 +713,62 @@
         }
         _showPlayerValidation = false;
         GoToStep(1);
+    }
+
+    private async Task AdvanceFromCourtAsync()
+    {
+        if (_selectedCourtId is not > 0)
+        {
+            GoToStep(2);
+            return;
+        }
+
+        var result = await CourtClaim.EvaluateAsync(_selectedCourtId.Value);
+        switch (result.Outcome)
+        {
+            case CourtClaimOutcome.Free:
+            case CourtClaimOutcome.StaleAutoClosed:
+                GoToStep(2);
+                return;
+
+            case CourtClaimOutcome.InGrace:
+                var until = result.GraceUntilUtc?.ToLocalTime().ToString("HH:mm") ?? "later";
+                Snackbar.Add(
+                    $"Court is in use by {result.OccupantLabel}. Try again after {until}.",
+                    Severity.Warning);
+                return;
+
+            case CourtClaimOutcome.NeedsChallenge:
+                var parameters = new DialogParameters<ClaimCourtDialog>
+                {
+                    { x => x.CourtId, _selectedCourtId.Value },
+                    { x => x.SavedMatchId, result.SavedMatchId!.Value },
+                    { x => x.OccupantLabel, result.OccupantLabel ?? "another match" }
+                };
+                var dialog = await DialogService.ShowAsync<ClaimCourtDialog>(
+                    "Claiming court",
+                    parameters,
+                    new DialogOptions
+                    {
+                        CloseButton = false,
+                        BackdropClick = false,
+                        MaxWidth = MaxWidth.ExtraSmall,
+                        FullWidth = true
+                    });
+                var dlgResult = await dialog.Result;
+                if (dlgResult is null || dlgResult.Canceled) return;
+                if (dlgResult.Data is true)
+                {
+                    GoToStep(2);
+                }
+                else
+                {
+                    Snackbar.Add(
+                        $"{result.OccupantLabel} is still playing — pick another court.",
+                        Severity.Info);
+                }
+                return;
+        }
     }
 
     private void ToggleMatchType()

--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -21,6 +21,7 @@
 @inject UserState State
 @inject IDialogService DialogService
 @inject TennisScoreService ScoreService
+@inject CourtClaimService CourtClaim
 @inject ISnackbar Snackbar
 @inject AuthenticationStateProvider AuthStateProvider
 @inject IJSRuntime JS
@@ -710,6 +711,14 @@
         // Persist the new match immediately so we get a stable SavedMatchId for the URL.
         await SaveInitialMatchAsync();
 
+        // Join the court group so we hear court-challenge requests from
+        // any other user who later tries to claim this court.
+        if (hubConnection is not null && CurrentMatch?.CourtId is > 0
+            && hubConnection.State == HubConnectionState.Connected)
+        {
+            await hubConnection.SendAsync("JoinCourtGroup", CurrentMatch.CourtId.Value);
+        }
+
         // Navigate to /match/{id} so that refreshing the page restores this exact match.
         // Preserve rubber/return-url query params — without them the component would lose
         // its rubber context on re-initialisation, so the rubber-completion block at match
@@ -737,6 +746,48 @@
         }
     }
 
+    private async Task HandleCourtChallengeAsync(int courtId, int savedMatchId, string challengerConnectionId)
+    {
+        // Only answer challenges that target the match we're scoring right now.
+        if (_savedMatchId <= 0 || _savedMatchId != savedMatchId) return;
+
+        try
+        {
+            var stillPlaying = await DialogService.ShowMessageBox(
+                title: "Are you still playing?",
+                message: "Another user is trying to claim this court. Are you still playing the match?",
+                yesText: "Yes, still playing",
+                noText: "No, I'm done");
+
+            var answer = stillPlaying == true;
+
+            if (hubConnection is not null && hubConnection.State == HubConnectionState.Connected)
+            {
+                await hubConnection.SendAsync("RespondToCourtChallenge",
+                    challengerConnectionId, courtId, savedMatchId, answer);
+            }
+
+            if (answer)
+            {
+                await CourtClaim.ExtendGraceAsync(savedMatchId);
+                Snackbar.Add(
+                    $"Court held for {CourtClaimService.GraceAfterYes.TotalMinutes:0} more minutes.",
+                    Severity.Info);
+            }
+            else
+            {
+                await CourtClaim.EndMatchAsync(savedMatchId);
+                Snackbar.Add("Match ended — court released.", Severity.Info);
+                await SetScoringFullscreen(false);
+                Navigation.NavigateTo("/", forceLoad: false);
+            }
+        }
+        catch (Exception)
+        {
+            // Keep scoring view alive even if the dialog/hub round-trip fails.
+        }
+    }
+
     private async Task SaveInitialMatchAsync()
     {
         if (CurrentMatch == null) return;
@@ -761,6 +812,7 @@
             Player4Id = _player4Id,
             CourtId = (_selectedCourtId is > 0) ? _selectedCourtId : null,
             CreatedAt = DateTime.UtcNow,
+            LastActivityAt = DateTime.UtcNow,
             UserId = _currentUserId,
             DeviceToken = _currentUserId == null ? _deviceToken : null
         };
@@ -1069,7 +1121,15 @@
                     .WithUrl(Navigation.ToAbsoluteUri("/chathub"))
                     .Build();
 
+                hubConnection.On<int, int, string>("CourtChallenge", HandleCourtChallengeAsync);
+
                 await hubConnection.StartAsync();
+
+                // If the component is already scoring an active match on a
+                // known court when the hub connects (e.g. on page refresh),
+                // join the court group so incoming challenges reach us.
+                if (_savedMatchId > 0 && CurrentMatch?.CourtId is > 0)
+                    await hubConnection.SendAsync("JoinCourtGroup", CurrentMatch.CourtId.Value);
             }
 
             if (_restoreFullscreen)
@@ -1145,6 +1205,7 @@
             matchToSave.CompletedAt = DateTime.UtcNow;
         else if (!matchToSave.Complete)
             matchToSave.CompletedAt = null;
+        matchToSave.LastActivityAt = DateTime.UtcNow;
         matchToSave.Player1 = CurrentMatch.Player1;
         matchToSave.Player2 = CurrentMatch.Player2;
         matchToSave.Player3 = CurrentMatch.Player3;

--- a/DropShot/Data/Migrations/20260423175104_AddSavedMatchActivityTracking.Designer.cs
+++ b/DropShot/Data/Migrations/20260423175104_AddSavedMatchActivityTracking.Designer.cs
@@ -4,16 +4,19 @@ using DropShot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace DropShot.Migrations
+namespace DropShot.Data.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260423175104_AddSavedMatchActivityTracking")]
+    partial class AddSavedMatchActivityTracking
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DropShot/Data/Migrations/20260423175104_AddSavedMatchActivityTracking.cs
+++ b/DropShot/Data/Migrations/20260423175104_AddSavedMatchActivityTracking.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropShot.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSavedMatchActivityTracking : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "ClaimGraceUntilUtc",
+                table: "SavedMatch",
+                type: "datetime2",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LastActivityAt",
+                table: "SavedMatch",
+                type: "datetime2",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ClaimGraceUntilUtc",
+                table: "SavedMatch");
+
+            migrationBuilder.DropColumn(
+                name: "LastActivityAt",
+                table: "SavedMatch");
+        }
+    }
+}

--- a/DropShot/Models/ChatHub.cs
+++ b/DropShot/Models/ChatHub.cs
@@ -24,5 +24,23 @@
         {
             await Clients.OthersInGroup($"court-{courtId}").SendAsync("ReceiveDisplayCommand", courtId, command, value);
         }
+
+        // ── Court claim challenge flow ──────────────────────────────────
+        // When a new user picks a court that has an active match, they
+        // call ChallengeCourt. Every existing scorer in the court group
+        // receives CourtChallenge with the challenger's connection id so
+        // they can reply directly via RespondToCourtChallenge.
+
+        public async Task ChallengeCourt(int courtId, int savedMatchId)
+        {
+            await Clients.OthersInGroup($"court-{courtId}")
+                .SendAsync("CourtChallenge", courtId, savedMatchId, Context.ConnectionId);
+        }
+
+        public async Task RespondToCourtChallenge(string challengerConnectionId, int courtId, int savedMatchId, bool stillPlaying)
+        {
+            await Clients.Client(challengerConnectionId)
+                .SendAsync("CourtChallengeResponse", courtId, savedMatchId, stillPlaying);
+        }
     }
 }

--- a/DropShot/Models/SavedMatch.cs
+++ b/DropShot/Models/SavedMatch.cs
@@ -20,4 +20,12 @@ public class SavedMatch
     public int? CourtId { get; set; }
     public string? UserId { get; set; }
     public string? DeviceToken { get; set; }
+
+    // Updated on every score write. Used to spot abandoned matches so a
+    // new user can claim the court if the previous scorer disappeared.
+    public DateTime? LastActivityAt { get; set; }
+
+    // When the current scorer has confirmed "still playing" in response
+    // to a court challenge, other users are blocked until this timestamp.
+    public DateTime? ClaimGraceUntilUtc { get; set; }
 }

--- a/DropShot/Program.cs
+++ b/DropShot/Program.cs
@@ -112,6 +112,7 @@ builder.Services.AddHttpContextAccessor();
 builder.Services.AddScoped<UserState>();
 builder.Services.AddScoped<TennisScoreService>();
 builder.Services.AddScoped<ClubAuthorizationService>();
+builder.Services.AddSingleton<CourtClaimService>();
 builder.Services.AddScoped<JwtTokenService>();
 builder.Services.AddSingleton<EmailService>();
 builder.Services.AddSingleton<EmailTemplateService>();

--- a/DropShot/Services/CourtClaimService.cs
+++ b/DropShot/Services/CourtClaimService.cs
@@ -1,0 +1,113 @@
+using DropShot.Data;
+using DropShot.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace DropShot.Services;
+
+/// <summary>
+/// Resolves who currently owns a court when a new scorer tries to
+/// start a match. Matches with no score activity for longer than
+/// <see cref="AbandonAfter"/> are treated as abandoned and auto-closed
+/// so the next user can claim the court without interaction.
+/// </summary>
+public sealed class CourtClaimService
+{
+    public static readonly TimeSpan AbandonAfter = TimeSpan.FromMinutes(60);
+    public static readonly TimeSpan GraceAfterYes = TimeSpan.FromMinutes(15);
+
+    private readonly IDbContextFactory<MyDbContext> _dbFactory;
+
+    public CourtClaimService(IDbContextFactory<MyDbContext> dbFactory)
+    {
+        _dbFactory = dbFactory;
+    }
+
+    public async Task<CourtClaimResult> EvaluateAsync(int courtId, CancellationToken ct = default)
+    {
+        await using var db = await _dbFactory.CreateDbContextAsync(ct);
+        var active = await db.SavedMatch
+            .Where(m => m.CourtId == courtId && !m.Complete)
+            .OrderByDescending(m => m.CreatedAt)
+            .FirstOrDefaultAsync(ct);
+
+        if (active is null)
+            return CourtClaimResult.Free();
+
+        var now = DateTime.UtcNow;
+        var lastSeen = active.LastActivityAt ?? active.CreatedAt;
+
+        if (now - lastSeen >= AbandonAfter)
+        {
+            active.Complete = true;
+            active.CompletedAt = now;
+            active.ClaimGraceUntilUtc = null;
+            await db.SaveChangesAsync(ct);
+            return CourtClaimResult.StaleAutoClosed(active.SavedMatchId);
+        }
+
+        if (active.ClaimGraceUntilUtc is { } until && until > now)
+            return CourtClaimResult.InGrace(active.SavedMatchId, until,
+                BuildOccupantLabel(active));
+
+        return CourtClaimResult.NeedsChallenge(active.SavedMatchId,
+            BuildOccupantLabel(active));
+    }
+
+    public async Task ExtendGraceAsync(int savedMatchId, CancellationToken ct = default)
+    {
+        await using var db = await _dbFactory.CreateDbContextAsync(ct);
+        var match = await db.SavedMatch.FirstOrDefaultAsync(m => m.SavedMatchId == savedMatchId, ct);
+        if (match is null || match.Complete) return;
+        match.ClaimGraceUntilUtc = DateTime.UtcNow.Add(GraceAfterYes);
+        match.LastActivityAt = DateTime.UtcNow;
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task EndMatchAsync(int savedMatchId, CancellationToken ct = default)
+    {
+        await using var db = await _dbFactory.CreateDbContextAsync(ct);
+        var match = await db.SavedMatch.FirstOrDefaultAsync(m => m.SavedMatchId == savedMatchId, ct);
+        if (match is null || match.Complete) return;
+        match.Complete = true;
+        match.CompletedAt = DateTime.UtcNow;
+        match.ClaimGraceUntilUtc = null;
+        await db.SaveChangesAsync(ct);
+    }
+
+    private static string BuildOccupantLabel(SavedMatch m)
+    {
+        var a = !string.IsNullOrWhiteSpace(m.Player3)
+            ? $"{m.Player1} & {m.Player2}"
+            : m.Player1 ?? "";
+        var b = !string.IsNullOrWhiteSpace(m.Player3)
+            ? $"{m.Player3} & {m.Player4}"
+            : m.Player2 ?? "";
+        if (string.IsNullOrWhiteSpace(a) && string.IsNullOrWhiteSpace(b))
+            return "another match";
+        if (string.IsNullOrWhiteSpace(b)) return a;
+        return $"{a} vs {b}";
+    }
+}
+
+public enum CourtClaimOutcome
+{
+    Free,
+    StaleAutoClosed,
+    InGrace,
+    NeedsChallenge
+}
+
+public sealed record CourtClaimResult(
+    CourtClaimOutcome Outcome,
+    int? SavedMatchId = null,
+    DateTime? GraceUntilUtc = null,
+    string? OccupantLabel = null)
+{
+    public static CourtClaimResult Free() => new(CourtClaimOutcome.Free);
+    public static CourtClaimResult StaleAutoClosed(int savedMatchId) =>
+        new(CourtClaimOutcome.StaleAutoClosed, savedMatchId);
+    public static CourtClaimResult InGrace(int savedMatchId, DateTime until, string label) =>
+        new(CourtClaimOutcome.InGrace, savedMatchId, until, label);
+    public static CourtClaimResult NeedsChallenge(int savedMatchId, string label) =>
+        new(CourtClaimOutcome.NeedsChallenge, savedMatchId, null, label);
+}


### PR DESCRIPTION
## Summary
Fixes the root cause of the \"scoreboard shows wrong players\" bug — two scorers were able to start matches on the same court simultaneously. This PR gates new matches on a court that already has an active match and auto-expires idle ones.

### Data
- `SavedMatch.LastActivityAt` (stamped on every score write).
- `SavedMatch.ClaimGraceUntilUtc` (set when the current scorer confirms they're still playing).
- Migration `20260423175104_AddSavedMatchActivityTracking`.

### Service
- `CourtClaimService.EvaluateAsync` returns one of:
  - **Free** — no active match.
  - **StaleAutoClosed** — active match hasn't touched `LastActivityAt` in ≥ **60 min**, auto-completed, caller can proceed.
  - **InGrace** — a scorer confirmed still-playing within the last **15 min**; caller is blocked until `ClaimGraceUntilUtc`.
  - **NeedsChallenge** — active + recent, so we need to ask the scorer.
- `ExtendGraceAsync` / `EndMatchAsync` helpers for the hub path.

### Hub
- `ChatHub.ChallengeCourt(courtId, savedMatchId)` — broadcasts `CourtChallenge(courtId, savedMatchId, challengerConnectionId)` to the court group (excluding the caller).
- `ChatHub.RespondToCourtChallenge(challengerConnectionId, courtId, savedMatchId, stillPlaying)` — delivers `CourtChallengeResponse` back to the challenger's connection.

### Scorer UX (TennisScore.razor)
- Joins its court's SignalR group as soon as the match is created (or on page refresh).
- On `CourtChallenge` shows a MudBlazor Yes / No message box:
  - **Yes** — calls `ExtendGraceAsync`, snackbar confirms the hold, scoring continues.
  - **No** — calls `EndMatchAsync`, snackbar confirms release, navigates back to the home page.

### Challenger UX (MatchSetupWizard)
- Court-step Next now runs `EvaluateAsync` first:
  - Free / StaleAutoClosed → proceed.
  - InGrace → warning snackbar (`\"Court is in use by X. Try again after HH:mm.\"`), stays on step.
  - NeedsChallenge → opens **ClaimCourtDialog**: issues the hub challenge, shows a spinner + 20 s countdown, auto-expires the stale match and proceeds on timeout, proceeds on a \"No\" reply, stays on step on a \"Yes\" reply.

## Test plan
- [ ] Start match on court A, finish naturally — the next match on A proceeds without a challenge
- [ ] Start match on court A, leave it idle 60 min — another user is allowed to take A silently (old match auto-completes)
- [ ] Start match on court A, another user picks A and presses Next → scorer on A sees the \"Are you still playing?\" dialog
- [ ] Scorer picks **Yes** → challenger is told the court is still in use; subsequent attempts within 15 min are blocked with the grace-period warning
- [ ] Scorer picks **No** → old match marked complete; challenger proceeds to match settings
- [ ] Scorer offline / tab closed → challenger waits 20 s, old match auto-completes, challenger proceeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)