### PR TITLE
Ask challenger before claiming a busy court

### DIFF
--- a/DropShot/Components/MatchSetupWizard.razor
+++ b/DropShot/Components/MatchSetupWizard.razor
@@ -739,11 +739,19 @@
                 return;
 
             case CourtClaimOutcome.NeedsChallenge:
+                var occupant = result.OccupantLabel ?? "another match";
+                var proceed = await DialogService.ShowMessageBox(
+                    title: "Court in use",
+                    message: $"{occupant} is currently on this court. Do you want to ask them if they've finished?",
+                    yesText: "Ask them",
+                    noText: "Pick another court");
+                if (proceed != true) return;
+
                 var parameters = new DialogParameters<ClaimCourtDialog>
                 {
                     { x => x.CourtId, _selectedCourtId.Value },
                     { x => x.SavedMatchId, result.SavedMatchId!.Value },
-                    { x => x.OccupantLabel, result.OccupantLabel ?? "another match" }
+                    { x => x.OccupantLabel, occupant }
                 };
                 var dialog = await DialogService.ShowAsync<ClaimCourtDialog>(
                     "Claiming court",
@@ -764,7 +772,7 @@
                 else
                 {
                     Snackbar.Add(
-                        $"{result.OccupantLabel} is still playing — pick another court.",
+                        $"{occupant} is still playing — pick another court.",
                         Severity.Info);
                 }
                 return;


### PR DESCRIPTION
## Summary
When the court step's Next button evaluates a `NeedsChallenge` outcome, we now ask the **new** user first — \"*X is currently on this court. Do you want to ask them if they've finished?*\" — with **Ask them** / **Pick another court**. Only **Ask them** opens `ClaimCourtDialog` (which still issues the SignalR challenge and runs the 20 s timeout).

## Test plan
- [ ] Selecting a court in active use shows the confirmation prompt with the occupant's name
- [ ] \"Pick another court\" closes the prompt, stays on the court step, does not disturb the existing scorer
- [ ] \"Ask them\" flows into the existing claim dialog and challenge behaviour
- [ ] Free / stale / in-grace outcomes are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)