### PR TITLE
Court claim: shorter stale threshold, preserve active matches, fix grace time

### DIFF
--- a/DropShot/Components/ClaimCourtDialog.razor
+++ b/DropShot/Components/ClaimCourtDialog.razor
@@ -12,7 +12,7 @@
                 Asking <strong>@OccupantLabel</strong> if they're still on this court&hellip;
             </MudText>
             <MudText Typo="Typo.caption" Color="Color.Secondary">
-                We'll release the court automatically if they don't reply in @_secondsLeft s.
+                Waiting for a reply — @_secondsLeft s
             </MudText>
         </MudStack>
     </DialogContent>
@@ -57,8 +57,12 @@
         _secondsLeft--;
         if (_secondsLeft <= 0)
         {
-            // Scorer didn't respond — treat as abandoned and free the court.
-            await ResolveAsync(allowClaim: true, autoExpireStale: true);
+            // Scorer didn't respond. Only free the court if the match is
+            // actually stale (no activity for the abandon threshold) —
+            // otherwise the match is presumed still active and we deny
+            // the claim so the challenger picks another court.
+            var stale = await CourtClaim.IsStaleAsync(SavedMatchId);
+            await ResolveAsync(allowClaim: stale, autoExpireStale: stale);
             return;
         }
         await InvokeAsync(StateHasChanged);

--- a/DropShot/Services/CourtClaimService.cs
+++ b/DropShot/Services/CourtClaimService.cs
@@ -12,7 +12,7 @@ namespace DropShot.Services;
 /// </summary>
 public sealed class CourtClaimService
 {
-    public static readonly TimeSpan AbandonAfter = TimeSpan.FromMinutes(60);
+    public static readonly TimeSpan AbandonAfter = TimeSpan.FromMinutes(10);
     public static readonly TimeSpan GraceAfterYes = TimeSpan.FromMinutes(15);
 
     private readonly IDbContextFactory<MyDbContext> _dbFactory;
@@ -34,7 +34,13 @@ public sealed class CourtClaimService
             return CourtClaimResult.Free();
 
         var now = DateTime.UtcNow;
-        var lastSeen = active.LastActivityAt ?? active.CreatedAt;
+        // EF Core strips DateTimeKind on round-trip, so columns read back as
+        // Kind=Unspecified. Pin them to UTC so callers can safely do local
+        // conversions ("until HH:mm") without getting a past time.
+        var lastSeen = AsUtc(active.LastActivityAt ?? active.CreatedAt);
+        var graceUntil = active.ClaimGraceUntilUtc.HasValue
+            ? (DateTime?)AsUtc(active.ClaimGraceUntilUtc.Value)
+            : null;
 
         if (now - lastSeen >= AbandonAfter)
         {
@@ -45,13 +51,25 @@ public sealed class CourtClaimService
             return CourtClaimResult.StaleAutoClosed(active.SavedMatchId);
         }
 
-        if (active.ClaimGraceUntilUtc is { } until && until > now)
+        if (graceUntil is { } until && until > now)
             return CourtClaimResult.InGrace(active.SavedMatchId, until,
                 BuildOccupantLabel(active));
 
         return CourtClaimResult.NeedsChallenge(active.SavedMatchId,
             BuildOccupantLabel(active));
     }
+
+    public async Task<bool> IsStaleAsync(int savedMatchId, CancellationToken ct = default)
+    {
+        await using var db = await _dbFactory.CreateDbContextAsync(ct);
+        var match = await db.SavedMatch.FirstOrDefaultAsync(m => m.SavedMatchId == savedMatchId, ct);
+        if (match is null || match.Complete) return true;
+        var lastSeen = AsUtc(match.LastActivityAt ?? match.CreatedAt);
+        return DateTime.UtcNow - lastSeen >= AbandonAfter;
+    }
+
+    private static DateTime AsUtc(DateTime value) =>
+        value.Kind == DateTimeKind.Utc ? value : DateTime.SpecifyKind(value, DateTimeKind.Utc);
 
     public async Task ExtendGraceAsync(int savedMatchId, CancellationToken ct = default)
     {


### PR DESCRIPTION
## Summary
Follow-ups after live testing of the court-claim flow.

- **Abandon threshold 60 min → 10 min** (`CourtClaimService.AbandonAfter`) so idle courts free up sooner.
- **20 s challenge timeout no longer auto-closes active matches.** After the countdown expires, the dialog calls `IsStaleAsync` and only auto-completes the old match if it truly has had no activity for `AbandonAfter`. If the match is still being scored, the claim is denied and the challenger is prompted to pick another court.
- **Grace-period time display was in the past.** EF Core strips `DateTimeKind` on round-trip, so `ClaimGraceUntilUtc` and `LastActivityAt` came back as `Unspecified` and `ToLocalTime()` was a no-op. Service now pins those columns to `DateTimeKind.Utc` before returning them, so the wizard's "Try again after HH:mm" snackbar renders correctly.

## Test plan
- [ ] Court idle for 10 min → next user claims silently (stale auto-closed)
- [ ] Court active, scorer does not answer within 20 s → challenger is told to pick another court; old match continues
- [ ] Court active, scorer answers Yes → challenger sees grace-until time in the **future** in their local zone
- [ ] Court active, scorer answers No → challenger proceeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)