### PR TITLE
Admin-tunable content max width

### DIFF
--- a/DropShot/Components/Layout/MainLayout.razor
+++ b/DropShot/Components/Layout/MainLayout.razor
@@ -1,6 +1,8 @@
  <meta name="viewport" content="width=device-width, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
 @inherits LayoutComponentBase
+@inject DropShot.Services.SiteSettingsService SiteSettings
 <MudThemeProvider IsDarkMode="true" Theme="_theme" />
+<style>:root { --ds-content-max-width: @(_contentMaxWidthPx)px; }</style>
 @* Popover/Dialog/Snackbar providers are intentionally NOT here.
    Each @rendermode InteractiveServer page injects <MudProviders /> directly
    so the providers share the page's circuit DI scope.  Having them here too
@@ -37,4 +39,11 @@
             Secondary = "#26a69a",
         }
     };
+
+    private int _contentMaxWidthPx = SiteSettingsService.ContentMaxWidthPxDefault;
+
+    protected override async Task OnInitializedAsync()
+    {
+        _contentMaxWidthPx = await SiteSettings.GetContentMaxWidthPxAsync();
+    }
 }

--- a/DropShot/Components/Layout/MainLayout.razor.css
+++ b/DropShot/Components/Layout/MainLayout.razor.css
@@ -14,7 +14,7 @@ main {
 main ::deep .content {
     flex: 1;
     width: 100%;
-    max-width: 1280px;
+    max-width: var(--ds-content-max-width, 1280px);
     margin-left: auto;
     margin-right: auto;
     padding-bottom: 3rem;

--- a/DropShot/Components/Layout/NavMenu.razor
+++ b/DropShot/Components/Layout/NavMenu.razor
@@ -65,6 +65,13 @@
                                     <span class="nav-sublabel">Manage accounts and roles</span>
                                 </span>
                             </NavLink>
+                            <NavLink class="nav-link" href="admin/site-settings">
+                                <MudIcon Icon="@Icons.Material.Filled.Tune" Class="nav-icon" />
+                                <span class="nav-label-group">
+                                    <span class="nav-label">Site Settings</span>
+                                    <span class="nav-sublabel">Layout and site-wide options</span>
+                                </span>
+                            </NavLink>
                         </AuthorizeView>
                         <AuthorizeView Roles="Admin,SuperAdmin,ClubAdmin" Context="linkReqCtx">
                             <NavLink class="nav-link" href="clubadmin/link-requests">

--- a/DropShot/Components/Pages/Admin/SiteSettings.razor
+++ b/DropShot/Components/Pages/Admin/SiteSettings.razor
@@ -1,0 +1,72 @@
+@page "/admin/site-settings"
+@rendermode InteractiveServer
+@attribute [Authorize(Roles = "Admin,SuperAdmin")]
+@using Microsoft.AspNetCore.Authorization
+@using DropShot.Services
+@inject SiteSettingsService Settings
+@inject ISnackbar Snackbar
+
+<MudProviders />
+
+<MudText Typo="Typo.h4" Class="mb-4">Site Settings</MudText>
+
+<MudCard Class="mb-4" MaxWidth="600px">
+    <MudCardHeader>
+        <CardHeaderContent>
+            <MudText Typo="Typo.h6">Layout</MudText>
+            <MudText Typo="Typo.caption" Color="Color.Secondary">
+                Controls the maximum width (in pixels) that page content occupies on desktop.
+                The top navbar and footer always span the full viewport; only the body is constrained.
+            </MudText>
+        </CardHeaderContent>
+    </MudCardHeader>
+    <MudCardContent>
+        <MudNumericField T="int"
+                         @bind-Value="_contentMaxWidthPx"
+                         Label="Content max width (px)"
+                         Min="@SiteSettingsService.ContentMaxWidthPxMin"
+                         Max="@SiteSettingsService.ContentMaxWidthPxMax"
+                         Step="40"
+                         Variant="Variant.Outlined"
+                         HelperText="@($"Allowed range: {SiteSettingsService.ContentMaxWidthPxMin} – {SiteSettingsService.ContentMaxWidthPxMax} px. Default {SiteSettingsService.ContentMaxWidthPxDefault}.")" />
+    </MudCardContent>
+    <MudCardActions>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                   StartIcon="@Icons.Material.Filled.Save"
+                   Disabled="@_saving"
+                   OnClick="SaveAsync">
+            Save
+        </MudButton>
+        <MudText Typo="Typo.caption" Color="Color.Secondary" Class="ms-3 align-self-center">
+            Refresh other tabs to see the change.
+        </MudText>
+    </MudCardActions>
+</MudCard>
+
+@code {
+    private int _contentMaxWidthPx = SiteSettingsService.ContentMaxWidthPxDefault;
+    private bool _saving;
+
+    protected override async Task OnInitializedAsync()
+    {
+        _contentMaxWidthPx = await Settings.GetContentMaxWidthPxAsync();
+    }
+
+    private async Task SaveAsync()
+    {
+        _saving = true;
+        try
+        {
+            await Settings.SetContentMaxWidthPxAsync(_contentMaxWidthPx);
+            Snackbar.Add($"Content max width set to {_contentMaxWidthPx}px.", Severity.Success);
+        }
+        catch (ArgumentOutOfRangeException ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+        finally
+        {
+            _saving = false;
+        }
+    }
+}

--- a/DropShot/Program.cs
+++ b/DropShot/Program.cs
@@ -113,6 +113,7 @@ builder.Services.AddScoped<UserState>();
 builder.Services.AddScoped<TennisScoreService>();
 builder.Services.AddScoped<ClubAuthorizationService>();
 builder.Services.AddSingleton<CourtClaimService>();
+builder.Services.AddSingleton<SiteSettingsService>();
 builder.Services.AddScoped<JwtTokenService>();
 builder.Services.AddSingleton<EmailService>();
 builder.Services.AddSingleton<EmailTemplateService>();

--- a/DropShot/Services/SiteSettingsService.cs
+++ b/DropShot/Services/SiteSettingsService.cs
@@ -1,0 +1,81 @@
+using DropShot.Data;
+using DropShot.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace DropShot.Services;
+
+/// <summary>
+/// Admin-tunable, app-wide settings that live in the AppSettings key/value
+/// table. Values are cached in memory and only re-read on a write.
+/// </summary>
+public sealed class SiteSettingsService
+{
+    public const string ContentMaxWidthPxKey = "ContentMaxWidthPx";
+    public const int ContentMaxWidthPxDefault = 1280;
+    public const int ContentMaxWidthPxMin = 960;
+    public const int ContentMaxWidthPxMax = 2400;
+
+    private readonly IDbContextFactory<MyDbContext> _dbFactory;
+    private readonly SemaphoreSlim _lock = new(1, 1);
+
+    private int? _contentMaxWidthPx;
+
+    public SiteSettingsService(IDbContextFactory<MyDbContext> dbFactory)
+    {
+        _dbFactory = dbFactory;
+    }
+
+    public async Task<int> GetContentMaxWidthPxAsync(CancellationToken ct = default)
+    {
+        if (_contentMaxWidthPx is { } cached) return cached;
+
+        await _lock.WaitAsync(ct);
+        try
+        {
+            if (_contentMaxWidthPx is { } cached2) return cached2;
+
+            await using var db = await _dbFactory.CreateDbContextAsync(ct);
+            var raw = await db.AppSettings
+                .Where(s => s.Setting == ContentMaxWidthPxKey)
+                .Select(s => s.Value)
+                .FirstOrDefaultAsync(ct);
+
+            var value = ParseWidth(raw) ?? ContentMaxWidthPxDefault;
+            _contentMaxWidthPx = value;
+            return value;
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
+    public async Task SetContentMaxWidthPxAsync(int px, CancellationToken ct = default)
+    {
+        if (px < ContentMaxWidthPxMin || px > ContentMaxWidthPxMax)
+            throw new ArgumentOutOfRangeException(nameof(px),
+                $"Content width must be between {ContentMaxWidthPxMin} and {ContentMaxWidthPxMax} px.");
+
+        await using var db = await _dbFactory.CreateDbContextAsync(ct);
+        var row = await db.AppSettings.FirstOrDefaultAsync(s => s.Setting == ContentMaxWidthPxKey, ct);
+        if (row is null)
+        {
+            row = new AppSetting { Setting = ContentMaxWidthPxKey, Value = px.ToString() };
+            db.AppSettings.Add(row);
+        }
+        else
+        {
+            row.Value = px.ToString();
+        }
+        await db.SaveChangesAsync(ct);
+
+        await _lock.WaitAsync(ct);
+        try { _contentMaxWidthPx = px; }
+        finally { _lock.Release(); }
+    }
+
+    private static int? ParseWidth(string? raw) =>
+        int.TryParse(raw, out var n) && n >= ContentMaxWidthPxMin && n <= ContentMaxWidthPxMax
+            ? n
+            : (int?)null;
+}


### PR DESCRIPTION
## Summary
Admins can now change the desktop content max-width at runtime instead of the 1280px cap living in CSS.

- **`SiteSettingsService`** — singleton, caches a `ContentMaxWidthPx` value from the existing `AppSettings` key/value table. Clamped to 960 – 2400 px (default 1280). Exposes `GetContentMaxWidthPxAsync` / `SetContentMaxWidthPxAsync`.
- **`MainLayout`** loads the value on init and emits `<style>:root { --ds-content-max-width: Npx; }</style>`. The scoped `.content` rule was switched to `max-width: var(--ds-content-max-width, 1280px)` so the default still renders if the setting is missing.
- **`/admin/site-settings`** — new `[Authorize(Roles = "Admin,SuperAdmin")]` page with a `MudNumericField`, min/max enforced client- and server-side, save button + toast.
- **Nav menu** gains a "Site Settings" entry alongside the existing Users link for the same roles.

Other tabs pick up the change on refresh (the CSS variable is rendered once per circuit).

## Test plan
- [ ] Admin opens `/admin/site-settings`, changes the value to e.g. 1440, saves → current tab re-renders with wider content
- [ ] Value below 960 or above 2400 is rejected with a toast
- [ ] Scoreboard page still goes edge-to-edge (opt-out via `body.scoreboard-active` is unaffected)
- [ ] Non-admin users get 403 on `/admin/site-settings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)