### PR TITLE
Score entry auto-jump + match-end confirmation

### DIFF
--- a/DropShot/Components/EditScoreDialog.razor
+++ b/DropShot/Components/EditScoreDialog.razor
@@ -11,16 +11,28 @@
 
         <MudText Typo="Typo.subtitle2" Class="mb-2">@UserName</MudText>
         <MudStack Row="true" Spacing="2" Class="mb-3">
-            <MudTextField @bind-Value="UserSets" Label="Sets" Variant="Variant.Outlined" InputMode="InputMode.numeric" UserAttributes="@_numericAttrs" Style="max-width:100px;" />
-            <MudTextField @bind-Value="UserGames" Label="Games" Variant="Variant.Outlined" InputMode="InputMode.numeric" UserAttributes="@_numericAttrs" Style="max-width:100px;" />
-            <MudTextField @bind-Value="UserPoints" Label="Points" Variant="Variant.Outlined" InputMode="InputMode.numeric" UserAttributes="@_numericAttrs" Style="max-width:100px;" />
+            <MudTextField T="int" @ref="_fields[0]" @bind-Value="UserSets" @bind-Value:after="() => JumpToAsync(1)"
+                          Label="Sets" Variant="Variant.Outlined" InputMode="InputMode.numeric"
+                          UserAttributes="@_numericAttrs" AutoFocus="true" Style="max-width:100px;" />
+            <MudTextField T="int" @ref="_fields[1]" @bind-Value="UserGames" @bind-Value:after="() => JumpToAsync(2)"
+                          Label="Games" Variant="Variant.Outlined" InputMode="InputMode.numeric"
+                          UserAttributes="@_numericAttrs" Style="max-width:100px;" />
+            <MudTextField T="int" @ref="_fields[2]" @bind-Value="UserPoints" @bind-Value:after="() => JumpToAsync(3)"
+                          Label="Points" Variant="Variant.Outlined" InputMode="InputMode.numeric"
+                          UserAttributes="@_numericAttrs" Style="max-width:100px;" />
         </MudStack>
 
         <MudText Typo="Typo.subtitle2" Class="mb-2">@OpponentName</MudText>
         <MudStack Row="true" Spacing="2" Class="mb-3">
-            <MudTextField @bind-Value="OppSets" Label="Sets" Variant="Variant.Outlined" InputMode="InputMode.numeric" UserAttributes="@_numericAttrs" Style="max-width:100px;" />
-            <MudTextField @bind-Value="OppGames" Label="Games" Variant="Variant.Outlined" InputMode="InputMode.numeric" UserAttributes="@_numericAttrs" Style="max-width:100px;" />
-            <MudTextField @bind-Value="OppPoints" Label="Points" Variant="Variant.Outlined" InputMode="InputMode.numeric" UserAttributes="@_numericAttrs" Style="max-width:100px;" />
+            <MudTextField T="int" @ref="_fields[3]" @bind-Value="OppSets" @bind-Value:after="() => JumpToAsync(4)"
+                          Label="Sets" Variant="Variant.Outlined" InputMode="InputMode.numeric"
+                          UserAttributes="@_numericAttrs" Style="max-width:100px;" />
+            <MudTextField T="int" @ref="_fields[4]" @bind-Value="OppGames" @bind-Value:after="() => JumpToAsync(5)"
+                          Label="Games" Variant="Variant.Outlined" InputMode="InputMode.numeric"
+                          UserAttributes="@_numericAttrs" Style="max-width:100px;" />
+            <MudTextField T="int" @ref="_fields[5]" @bind-Value="OppPoints"
+                          Label="Points" Variant="Variant.Outlined" InputMode="InputMode.numeric"
+                          UserAttributes="@_numericAttrs" Style="max-width:100px;" />
         </MudStack>
 
         <MudSwitch @bind-Value="IsUserServing" Label="@($"{UserName} is serving")" Color="Color.Primary" />
@@ -45,6 +57,16 @@
     [Parameter] public bool IsUserServing { get; set; }
     [Parameter] public string UserName { get; set; } = "Player 1";
     [Parameter] public string OpponentName { get; set; } = "Player 2";
+
+    private readonly MudTextField<int>?[] _fields = new MudTextField<int>?[6];
+
+    private async Task JumpToAsync(int index)
+    {
+        if (index < 0 || index >= _fields.Length) return;
+        var next = _fields[index];
+        if (next is not null)
+            await next.FocusAsync();
+    }
 
     private void Cancel() => MudDialog.Cancel();
 

--- a/DropShot/Components/SubmitScoreDialog.razor
+++ b/DropShot/Components/SubmitScoreDialog.razor
@@ -52,6 +52,7 @@
                                                Variant="Variant.Outlined"
                                                InputMode="InputMode.numeric"
                                                UserAttributes="@_numericAttrs"
+                                               AutoFocus="@(idx == 0)"
                                                Style="width:65px" />
                             </td>
                             <td style="text-align:center; padding:0 4px; font-weight:bold">–</td>

--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -356,19 +356,31 @@
         <div class="match-complete-score">
             @string.Join("  ", _state.SetScores.Select(s => $"{s.UserGames}-{s.OpponentGames}"))
         </div>
-        <div class="match-complete-countdown">
-            @if (_competitionFixture != null)
-            {
-                <span>Returning to @(_competitionFixture.Competition?.CompetitionName ?? "competition") in @_countdownSeconds…</span>
-            }
-            else
-            {
-                <span>New match in @_countdownSeconds…</span>
-            }
-        </div>
-        <MudButton Style="margin-top: 12px;" Variant="Variant.Filled" Color="Color.Primary" Size="Size.Medium"
-                   StartIcon="@Icons.Material.Filled.SkipNext"
-                   OnClick="@NavigateAfterMatch">Skip</MudButton>
+        @if (_countdownHandle != null)
+        {
+            <div class="match-complete-countdown">
+                @if (_competitionFixture != null)
+                {
+                    <span>Returning to @(_competitionFixture.Competition?.CompetitionName ?? "competition") in @_countdownSeconds…</span>
+                }
+                else
+                {
+                    <span>New match in @_countdownSeconds…</span>
+                }
+            </div>
+        }
+        <MudStack Row="true" Spacing="2" Justify="Justify.Center" Style="margin-top: 16px;">
+            <MudButton Variant="Variant.Outlined" Color="Color.Warning" Size="Size.Large"
+                       StartIcon="@Icons.Material.Filled.Undo"
+                       OnClick="UndoLastPoint">
+                Undo Last Point
+            </MudButton>
+            <MudButton Variant="Variant.Filled" Color="Color.Primary" Size="Size.Large"
+                       StartIcon="@Icons.Material.Filled.CheckCircle"
+                       OnClick="@NavigateAfterMatch">
+                End Match
+            </MudButton>
+        </MudStack>
     </div>
 }
 
@@ -1339,7 +1351,9 @@
         {
             _winner = ScoreService.EndMatch(_state, CurrentMatch, Label_Switch1) ?? string.Empty;
             StopTimer();
-            StartMatchEndCountdown();
+            // Do NOT auto-navigate — show the match-complete overlay with
+            // End Match / Undo Last Point buttons so an accidental double
+            // tap at match point can still be reversed.
         }
         await SaveHistory();
     }
@@ -1362,7 +1376,8 @@
         {
             _winner = ScoreService.EndMatch(_state, CurrentMatch, Label_Switch1) ?? string.Empty;
             StopTimer();
-            StartMatchEndCountdown();
+            // See UserWinsPoint: let the user confirm or undo rather than
+            // auto-starting the post-match navigation countdown.
         }
         await SaveHistory();
     }


### PR DESCRIPTION
## Summary
Two related UX tweaks on the scoring flow.

**Manual score entry (EditScoreDialog / SubmitScoreDialog)**
- First numeric cell now autofocuses on open (`AutoFocus="true"`).
- EditScoreDialog wasn't auto-jumping between cells; it now uses `@ref`s plus `@bind-Value:after` to shift focus to the next cell as soon as the current one picks up a value. Submit dialog's existing auto-jump is unchanged.
- Both dialogs already set `InputMode="numeric"` + `pattern="[0-9]*"`, which surfaces the mobile numeric keypad.

**Match-end confirmation (TennisScore)**
- When the winning point closes the match we no longer start the 5 s auto-navigation countdown. The match-complete overlay now shows an **End Match** button plus **Undo Last Point** so an accidental double-tap at match point can be reversed via the existing `UndoLastPoint` helper.
- Explicit End-Match actions (from the end-match dialog's "save" branch) keep their countdown — the user already confirmed intent there. The countdown text only renders while the timer is actually running.

## Test plan
- [ ] Open the in-match Edit Score dialog — first field focused, typing a digit shifts focus to the next cell
- [ ] Open the Submit Score dialog — first set-score cell focused; tabbing still works
- [ ] Score the winning point — overlay appears with End Match + Undo Last Point; no auto-navigation
- [ ] "Undo Last Point" re-enables scoring at the prior state
- [ ] Explicit End Match via the settings drawer still auto-returns after the countdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)