### PR TITLE
Score entry: stable initial focus + auto-jump while typing

### DIFF
--- a/DropShot/Components/EditScoreDialog.razor
+++ b/DropShot/Components/EditScoreDialog.razor
@@ -13,26 +13,26 @@
         <MudStack Row="true" Spacing="2" Class="mb-3">
             <MudTextField T="int" @ref="_fields[0]" @bind-Value="UserSets" @bind-Value:after="() => JumpToAsync(1)"
                           Label="Sets" Variant="Variant.Outlined" InputMode="InputMode.numeric"
-                          UserAttributes="@_numericAttrs" AutoFocus="true" Style="max-width:100px;" />
+                          UserAttributes="@_numericAttrs" DebounceInterval="300" Style="max-width:100px;" />
             <MudTextField T="int" @ref="_fields[1]" @bind-Value="UserGames" @bind-Value:after="() => JumpToAsync(2)"
                           Label="Games" Variant="Variant.Outlined" InputMode="InputMode.numeric"
-                          UserAttributes="@_numericAttrs" Style="max-width:100px;" />
+                          UserAttributes="@_numericAttrs" DebounceInterval="300" Style="max-width:100px;" />
             <MudTextField T="int" @ref="_fields[2]" @bind-Value="UserPoints" @bind-Value:after="() => JumpToAsync(3)"
                           Label="Points" Variant="Variant.Outlined" InputMode="InputMode.numeric"
-                          UserAttributes="@_numericAttrs" Style="max-width:100px;" />
+                          UserAttributes="@_numericAttrs" DebounceInterval="300" Style="max-width:100px;" />
         </MudStack>
 
         <MudText Typo="Typo.subtitle2" Class="mb-2">@OpponentName</MudText>
         <MudStack Row="true" Spacing="2" Class="mb-3">
             <MudTextField T="int" @ref="_fields[3]" @bind-Value="OppSets" @bind-Value:after="() => JumpToAsync(4)"
                           Label="Sets" Variant="Variant.Outlined" InputMode="InputMode.numeric"
-                          UserAttributes="@_numericAttrs" Style="max-width:100px;" />
+                          UserAttributes="@_numericAttrs" DebounceInterval="300" Style="max-width:100px;" />
             <MudTextField T="int" @ref="_fields[4]" @bind-Value="OppGames" @bind-Value:after="() => JumpToAsync(5)"
                           Label="Games" Variant="Variant.Outlined" InputMode="InputMode.numeric"
-                          UserAttributes="@_numericAttrs" Style="max-width:100px;" />
+                          UserAttributes="@_numericAttrs" DebounceInterval="300" Style="max-width:100px;" />
             <MudTextField T="int" @ref="_fields[5]" @bind-Value="OppPoints"
                           Label="Points" Variant="Variant.Outlined" InputMode="InputMode.numeric"
-                          UserAttributes="@_numericAttrs" Style="max-width:100px;" />
+                          UserAttributes="@_numericAttrs" DebounceInterval="300" Style="max-width:100px;" />
         </MudStack>
 
         <MudSwitch @bind-Value="IsUserServing" Label="@($"{UserName} is serving")" Color="Color.Primary" />
@@ -44,7 +44,11 @@
 </MudDialog>
 
 @code {
-    private static readonly Dictionary<string, object> _numericAttrs = new() { { "pattern", "[0-9]*" } };
+    private static readonly Dictionary<string, object> _numericAttrs = new()
+    {
+        { "pattern", "[0-9]*" },
+        { "inputmode", "numeric" }
+    };
 
     [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = null!;
 
@@ -59,13 +63,31 @@
     [Parameter] public string OpponentName { get; set; } = "Player 2";
 
     private readonly MudTextField<int>?[] _fields = new MudTextField<int>?[6];
+    private bool _initialFocusApplied;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        // MudBlazor populates @ref assignments on the *second* render pass, so
+        // we need to wait until at least one of them is non-null before asking
+        // it to take focus. Doing this here (instead of relying on AutoFocus)
+        // also survives the dialog's interactive-mode re-render, which was
+        // taking focus away as soon as the component mounted.
+        if (_initialFocusApplied) return;
+        if (_fields[0] is { } first)
+        {
+            _initialFocusApplied = true;
+            await first.FocusAsync();
+            await first.SelectAsync();
+        }
+    }
 
     private async Task JumpToAsync(int index)
     {
         if (index < 0 || index >= _fields.Length) return;
         var next = _fields[index];
-        if (next is not null)
-            await next.FocusAsync();
+        if (next is null) return;
+        await next.FocusAsync();
+        await next.SelectAsync();
     }
 
     private void Cancel() => MudDialog.Cancel();

--- a/DropShot/Components/SubmitScoreDialog.razor
+++ b/DropShot/Components/SubmitScoreDialog.razor
@@ -52,7 +52,7 @@
                                                Variant="Variant.Outlined"
                                                InputMode="InputMode.numeric"
                                                UserAttributes="@_numericAttrs"
-                                               AutoFocus="@(idx == 0)"
+                                               DebounceInterval="300"
                                                Style="width:65px" />
                             </td>
                             <td style="text-align:center; padding:0 4px; font-weight:bold">–</td>
@@ -63,6 +63,7 @@
                                                Variant="Variant.Outlined"
                                                InputMode="InputMode.numeric"
                                                UserAttributes="@_numericAttrs"
+                                               DebounceInterval="300"
                                                Style="width:65px" />
                             </td>
                         </tr>
@@ -113,6 +114,22 @@
     private string? _error;
     private string _side1 = "";
     private string _side2 = "";
+
+    private bool _initialFocusApplied;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        // MudTextField's @ref is wired up on the second render pass. Apply
+        // focus here (instead of AutoFocus) so the dialog's interactive-mode
+        // re-render can't steal the caret back from the first cell.
+        if (_initialFocusApplied) return;
+        if (_f1.Length > 0 && _f1[0] is { } first)
+        {
+            _initialFocusApplied = true;
+            await first.FocusAsync();
+            await first.SelectAsync();
+        }
+    }
 
     protected override void OnParametersSet()
     {
@@ -183,8 +200,11 @@
 
         AutoDetectWinner();
 
-        if (v.HasValue && nextIdx < _bestOf && nextFields[nextIdx] != null)
-            await nextFields[nextIdx].FocusAsync();
+        if (v.HasValue && nextIdx < _bestOf && nextFields[nextIdx] is { } next)
+        {
+            await next.FocusAsync();
+            await next.SelectAsync();
+        }
     }
 
     private void AutoDetectWinner()


### PR DESCRIPTION
## Summary
Follow-ups on the score-entry UX tweaks shipped in #415.

- **Initial focus was getting stolen.** `AutoFocus="true"` fired during the dialog's initial render, but the interactive-mode re-render that follows in a Blazor Server circuit was taking focus back. Both `EditScoreDialog` and `SubmitScoreDialog` now apply focus explicitly in `OnAfterRenderAsync` once the `@ref` has populated, and also call `SelectAsync` so the cell's contents are pre-selected (handy for the default `0`).
- **Auto-jump didn't fire while typing.** Without `DebounceInterval`, MudTextField only raises its change handler on blur, so the next-cell focus move only kicked in after the user tabbed off. Set `DebounceInterval="300"` on every numeric cell so `ValueChanged` / `@bind-Value:after` fire as the user types. The 300 ms window also lets two-digit scores (e.g. 10-8 super tie-break) batch into a single jump.
- The auto-jump now selects the next cell's contents too, so the auto-filled losing-side value can be overtyped.

## Test plan
- [ ] Open the Edit Score dialog — focus lands in the first cell and stays there
- [ ] Open the Submit Score dialog from the home-page review queue — same
- [ ] Type a single digit → focus moves to the next cell, its contents selected
- [ ] Type two digits within ~300ms → both land in the same cell before the jump fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)