### PR TITLE
Block starting a second match while one is in progress

### DIFF
--- a/DropShot/Components/Pages/Home.razor
+++ b/DropShot/Components/Pages/Home.razor
@@ -11,6 +11,7 @@
 @inject AuthenticationStateProvider AuthStateProvider
 @inject IDialogService DialogService
 @inject ClubAuthorizationService AuthzService
+@inject CourtClaimService CourtClaim
 @inject ISnackbar Snackbar
 @inject IJSRuntime JS
 
@@ -166,7 +167,7 @@
         </MudText>
         <MudButton Variant="Variant.Filled" Color="Color.Dark" Size="Size.Large"
                    StartIcon="@Icons.Material.Filled.PlayArrow"
-                   Href="/match" Class="mt-3"
+                   OnClick="StartCasualMatchAsync" Class="mt-3"
                    Style="font-weight: 600; border-radius: 24px; padding: 10px 32px;">
             Start a Match
         </MudButton>
@@ -211,7 +212,7 @@
                                     <MudStack Row="true" Spacing="2">
                                         <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary"
                                                    StartIcon="@Icons.Material.Filled.PlayArrow"
-                                                   OnClick="@(() => Navigation.NavigateTo(FixturePlayUrl(context)))">
+                                                   OnClick="@(() => StartFixtureMatchAsync(context))">
                                             Play
                                         </MudButton>
                                         <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Secondary"
@@ -461,6 +462,54 @@
         (f.HomeTeamId.HasValue || f.AwayTeamId.HasValue)
             ? $"/team-match/{f.CompetitionFixtureId}"
             : $"/match/0?fixtureId={f.CompetitionFixtureId}&autoStart=true";
+
+    private Task StartCasualMatchAsync() => NavigateToMatchWithActiveGuardAsync("/match");
+
+    private Task StartFixtureMatchAsync(CompetitionFixture fixture) =>
+        NavigateToMatchWithActiveGuardAsync(FixturePlayUrl(fixture));
+
+    private async Task NavigateToMatchWithActiveGuardAsync(string targetUrl)
+    {
+        var authState = await AuthStateProvider.GetAuthenticationStateAsync();
+        var userId = authState.User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (!string.IsNullOrEmpty(userId))
+        {
+            var active = await CourtClaim.GetUserActiveMatchAsync(userId);
+            if (active is not null)
+            {
+                var choice = await DialogService.ShowMessageBox(new MessageBoxOptions
+                {
+                    Title = "Match already in progress",
+                    Message = $"You're already scoring {OccupantLabel(active)}. What would you like to do?",
+                    YesText = "Resume match",
+                    NoText = "End and start new",
+                    CancelText = "Cancel"
+                });
+                if (choice is null) return;
+                if (choice == true)
+                {
+                    Navigation.NavigateTo($"/match/{active.SavedMatchId}");
+                    return;
+                }
+                await CourtClaim.EndMatchAsync(active.SavedMatchId);
+            }
+        }
+        Navigation.NavigateTo(targetUrl);
+    }
+
+    private static string OccupantLabel(SavedMatch m)
+    {
+        var a = !string.IsNullOrWhiteSpace(m.Player3)
+            ? $"{m.Player1} & {m.Player2}"
+            : m.Player1 ?? "";
+        var b = !string.IsNullOrWhiteSpace(m.Player3)
+            ? $"{m.Player3} & {m.Player4}"
+            : m.Player2 ?? "";
+        if (string.IsNullOrWhiteSpace(a) && string.IsNullOrWhiteSpace(b))
+            return "a match";
+        if (string.IsNullOrWhiteSpace(b)) return $"a match ({a})";
+        return $"{a} vs {b}";
+    }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {

--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -107,7 +107,7 @@
                             <MudTd>
                                 <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary"
                                            StartIcon="@Icons.Material.Filled.PlayArrow"
-                                           OnClick="@(() => Navigation.NavigateTo($"/match/0?fixtureId={context.CompetitionFixtureId}&autoStart=true", forceLoad: true))">
+                                           OnClick="@(() => StartFixtureMatchAsync(context))">
                                     Play
                                 </MudButton>
                             </MudTd>
@@ -1556,4 +1556,44 @@
         FixtureStatus.Walkover => Color.Info,
         _ => Color.Default
     };
+
+    private async Task StartFixtureMatchAsync(CompetitionFixture fixture)
+    {
+        var targetUrl = $"/match/0?fixtureId={fixture.CompetitionFixtureId}&autoStart=true";
+        var authState = await AuthStateProvider.GetAuthenticationStateAsync();
+        var userId = authState.User.FindFirstValue(ClaimTypes.NameIdentifier);
+        int? excluding = _savedMatchId > 0 ? _savedMatchId : null;
+        if (!string.IsNullOrEmpty(userId))
+        {
+            var active = await CourtClaim.GetUserActiveMatchAsync(userId, excluding);
+            if (active is not null)
+            {
+                var choice = await DialogService.ShowMessageBox(new MessageBoxOptions
+                {
+                    Title = "Match already in progress",
+                    Message = $"You're already scoring {ActiveMatchLabel(active)}. What would you like to do?",
+                    YesText = "Resume match",
+                    NoText = "End and start new",
+                    CancelText = "Cancel"
+                });
+                if (choice is null) return;
+                if (choice == true)
+                {
+                    Navigation.NavigateTo($"/match/{active.SavedMatchId}", forceLoad: true);
+                    return;
+                }
+                await CourtClaim.EndMatchAsync(active.SavedMatchId);
+            }
+        }
+        Navigation.NavigateTo(targetUrl, forceLoad: true);
+    }
+
+    private static string ActiveMatchLabel(SavedMatch m)
+    {
+        var a = !string.IsNullOrWhiteSpace(m.Player3) ? $"{m.Player1} & {m.Player2}" : m.Player1 ?? "";
+        var b = !string.IsNullOrWhiteSpace(m.Player3) ? $"{m.Player3} & {m.Player4}" : m.Player2 ?? "";
+        if (string.IsNullOrWhiteSpace(a) && string.IsNullOrWhiteSpace(b)) return "a match";
+        if (string.IsNullOrWhiteSpace(b)) return $"a match ({a})";
+        return $"{a} vs {b}";
+    }
 }

--- a/DropShot/Services/CourtClaimService.cs
+++ b/DropShot/Services/CourtClaimService.cs
@@ -68,6 +68,21 @@ public sealed class CourtClaimService
         return DateTime.UtcNow - lastSeen >= AbandonAfter;
     }
 
+    /// <summary>
+    /// Finds the most recent incomplete SavedMatch owned by this user so the
+    /// "Play" buttons can offer to resume or end it before starting a new one.
+    /// </summary>
+    public async Task<SavedMatch?> GetUserActiveMatchAsync(
+        string userId, int? excludingSavedMatchId = null, CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(userId)) return null;
+        await using var db = await _dbFactory.CreateDbContextAsync(ct);
+        var q = db.SavedMatch.Where(m => m.UserId == userId && !m.Complete);
+        if (excludingSavedMatchId.HasValue)
+            q = q.Where(m => m.SavedMatchId != excludingSavedMatchId.Value);
+        return await q.OrderByDescending(m => m.CreatedAt).FirstOrDefaultAsync(ct);
+    }
+
     private static DateTime AsUtc(DateTime value) =>
         value.Kind == DateTimeKind.Utc ? value : DateTime.SpecifyKind(value, DateTimeKind.Utc);
 


### PR DESCRIPTION
## Summary
Prevents a user from accidentally starting a new match while they still have an incomplete one. Clicking a \"Play\" button now checks for an active `SavedMatch` owned by the caller and, if one exists, prompts with a three-option message box:

- **Resume match** → navigate to `/match/{existing}` so they land in their in-progress match.
- **End and start new** → mark the existing `SavedMatch` complete via `CourtClaimService.EndMatchAsync`, then proceed to the new URL.
- **Cancel** → stay put.

Wired into:
- `Home.razor`: the \"Start a Match\" casual button and the \"Play\" button inside the *Your Upcoming Matches* list.
- `TennisScore.razor`: the \"Play\" button in the setup-screen upcoming-matches card (which uses `forceLoad` navigation).

`CourtClaimService` gained a `GetUserActiveMatchAsync(userId, excludingSavedMatchId)` helper; `excludingSavedMatchId` lets `TennisScore` ignore the match it's already scoring.

## Test plan
- [ ] Start a match (leave it incomplete), return to home, click the \"Start a Match\" casual button → dialog appears with the active match name
- [ ] \"Resume match\" → you land back in the existing match
- [ ] \"End and start new\" → existing match shows complete in DB, new match setup opens
- [ ] \"Cancel\" → nothing changes
- [ ] Same from a competition fixture \"Play\" button on the Home page
- [ ] From the TennisScore setup screen's upcoming-fixtures list → same prompt behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)