### PR TITLE
Round-robin simulator: super-admin button to auto-generate results

### DIFF
--- a/DropShot/Components/Competitions/Setup/FixturesSection.razor
+++ b/DropShot/Components/Competitions/Setup/FixturesSection.razor
@@ -4,6 +4,15 @@
      Style="background: rgba(255,255,255,0.08); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border: 1px solid rgba(255,255,255,0.12); border-radius: 12px; color: white;">
     <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="mb-3">
         <MudText Typo="Typo.h6" Style="flex:1">Fixtures</MudText>
+        @if (IsSuperAdmin && Stages.Any(s => s.StageType == StageType.RoundRobin))
+        {
+            <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Tertiary"
+                       StartIcon="@Icons.Material.Filled.Casino"
+                       Disabled="@SimulateRunning"
+                       OnClick="@(() => ShowSimulateConfirmChanged.InvokeAsync(true))">
+                Simulate Round-Robin
+            </MudButton>
+        }
         @if (Stages.Any(s => s.StageType == StageType.RoundRobin) &&
              Stages.Any(s => s.StageType is StageType.Knockout or StageType.QuarterFinal))
         {
@@ -54,6 +63,21 @@
                 <MudText Typo="Typo.body2">Delete all @Fixtures.Count fixture(s)? This cannot be undone.</MudText>
                 <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Error"
                            OnClick="@(() => OnDeleteAll.InvokeAsync())">Confirm Delete</MudButton>
+            </MudStack>
+        </MudAlert>
+    }
+
+    @if (ShowSimulateConfirm)
+    {
+        <MudAlert Severity="Severity.Info" Class="mb-3" ShowCloseIcon="true"
+                  CloseIconClicked="@(() => ShowSimulateConfirmChanged.InvokeAsync(false))">
+            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                <MudText Typo="Typo.body2">
+                    Generate random valid results for every unfinished round-robin fixture (including all rubbers for team matches)?
+                </MudText>
+                <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Tertiary"
+                           Disabled="@SimulateRunning"
+                           OnClick="@(() => OnSimulate.InvokeAsync())">Simulate</MudButton>
             </MudStack>
         </MudAlert>
     }
@@ -151,11 +175,16 @@
     [Parameter] public EventCallback<bool> ShowDeleteAllConfirmChanged { get; set; }
     [Parameter] public bool ScheduleDeleteExisting { get; set; }
     [Parameter] public EventCallback<bool> ScheduleDeleteExistingChanged { get; set; }
+    [Parameter] public bool IsSuperAdmin { get; set; }
+    [Parameter] public bool ShowSimulateConfirm { get; set; }
+    [Parameter] public EventCallback<bool> ShowSimulateConfirmChanged { get; set; }
+    [Parameter] public bool SimulateRunning { get; set; }
 
     [Parameter] public EventCallback OnOpenScheduleConfirm { get; set; }
     [Parameter] public EventCallback OnOpenAddDialog { get; set; }
     [Parameter] public EventCallback OnSchedule { get; set; }
     [Parameter] public EventCallback OnDeleteAll { get; set; }
+    [Parameter] public EventCallback OnSimulate { get; set; }
     [Parameter] public EventCallback<CompetitionFixture> OnSubmitScore { get; set; }
     [Parameter] public EventCallback<CompetitionFixture> OnOverrideResult { get; set; }
     [Parameter] public EventCallback<CompetitionFixture> OnShowQr { get; set; }

--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -22,6 +22,7 @@
 @inject Microsoft.AspNetCore.Identity.UserManager<DropShot.Data.ApplicationUser> UserManager
 @inject ICompetitionRubberTemplateProvider RubberTemplateProvider
 @inject CompetitionSchedulerService Scheduler
+@inject FixtureSimulationService FixtureSimulator
 
 <MudProviders />
 
@@ -727,6 +728,7 @@ else
                     Fixtures="_fixtures"
                     Stages="_stages"
                     CanEdit="_canEdit"
+                    IsSuperAdmin="_isSuperAdmin"
                     FixturePlayers="FixturePlayers"
                     FixtureCourtLabel="FixtureCourtLabel"
                     FixtureResultDisplay="FixtureResultDisplay"
@@ -739,10 +741,14 @@ else
                     ShowDeleteAllConfirmChanged="@(v => _showDeleteAllFixturesConfirm = v)"
                     ScheduleDeleteExisting="_scheduleDeleteExisting"
                     ScheduleDeleteExistingChanged="@(v => _scheduleDeleteExisting = v)"
+                    ShowSimulateConfirm="_showSimulateConfirm"
+                    ShowSimulateConfirmChanged="@(v => _showSimulateConfirm = v)"
+                    SimulateRunning="_simulateRunning"
                     OnOpenScheduleConfirm="OpenScheduleConfirm"
                     OnOpenAddDialog="OpenAddFixtureDialog"
                     OnSchedule="ScheduleFixtures"
                     OnDeleteAll="DeleteAllFixtures"
+                    OnSimulate="SimulateRoundRobinAsync"
                     OnSubmitScore="OpenSubmitScoreAsync"
                     OnOverrideResult="OpenOverrideResultAsync"
                     OnShowQr="ShowQrCode"
@@ -756,6 +762,15 @@ else
                      Style="background: rgba(255,255,255,0.08); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border: 1px solid rgba(255,255,255,0.12); border-radius: 12px; color: white;">
                     <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="mb-3" Wrap="Wrap.Wrap">
                         <MudText Typo="Typo.h6" Style="flex:1">Fixtures</MudText>
+                        @if (_isSuperAdmin && _stages.Any(s => s.StageType == StageType.RoundRobin))
+                        {
+                            <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Tertiary"
+                                       StartIcon="@Icons.Material.Filled.Casino"
+                                       Disabled="@_simulateRunning"
+                                       OnClick="@(() => _showSimulateConfirm = true)">
+                                Simulate Round-Robin
+                            </MudButton>
+                        }
                         @if (_stages.Any(s => s.StageType == StageType.RoundRobin) &&
                              _stages.Any(s => s.StageType is StageType.Knockout or StageType.QuarterFinal))
                         {
@@ -804,6 +819,21 @@ else
                                 <MudText Typo="Typo.body2">Delete all @_fixtures.Count fixture(s)? This cannot be undone.</MudText>
                                 <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Error"
                                            OnClick="DeleteAllFixtures">Confirm Delete</MudButton>
+                            </MudStack>
+                        </MudAlert>
+                    }
+
+                    @if (_showSimulateConfirm)
+                    {
+                        <MudAlert Severity="Severity.Info" Class="mb-3" ShowCloseIcon="true"
+                                  CloseIconClicked="@(() => _showSimulateConfirm = false)">
+                            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                                <MudText Typo="Typo.body2">
+                                    Generate random valid results for every unfinished round-robin fixture (including all rubbers for team matches)?
+                                </MudText>
+                                <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Tertiary"
+                                           Disabled="@_simulateRunning"
+                                           OnClick="SimulateRoundRobinAsync">Simulate</MudButton>
                             </MudStack>
                         </MudAlert>
                     }
@@ -1387,6 +1417,9 @@ else
     private bool _canEdit;
     private bool _canCreateUserComp;
     private bool _authChecked;
+    private bool _isSuperAdmin;
+    private bool _showSimulateConfirm;
+    private bool _simulateRunning;
 
     // When true, the host-club select is rendered but locked to the caller's
     // active ClubAdmin club — forces a club competition. Set during Create only.
@@ -1795,6 +1828,7 @@ else
                 Nav.NavigateTo("/", replace: true);
                 return;
             }
+            _isSuperAdmin = AuthzService.IsSuperAdmin(authState.User);
             _isStarted = comp.IsStarted;
             _nameOverride = true; // Existing competition — preserve its name
 
@@ -3593,6 +3627,36 @@ else
 
         _fixtures.Clear();
         Snackbar.Add($"{all.Count} fixture(s) deleted.", Severity.Warning);
+    }
+
+    private async Task SimulateRoundRobinAsync()
+    {
+        if (_simulateRunning) return;
+        _showSimulateConfirm = false;
+        _simulateRunning = true;
+        try
+        {
+            await using var db = DbFactory.CreateDbContext();
+            var outcome = await FixtureSimulator.SimulateRoundRobinAsync(db, Id);
+
+            if (outcome.FixturesSimulated > 0)
+                Snackbar.Add($"Simulated {outcome.FixturesSimulated} round-robin fixture(s).", Severity.Success);
+            else
+                Snackbar.Add("No eligible round-robin fixtures to simulate.", Severity.Info);
+
+            foreach (var err in outcome.Errors)
+                Snackbar.Add(err, Severity.Warning);
+
+            await OnParametersSetAsync();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Simulation failed: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _simulateRunning = false;
+        }
     }
 
     private async Task AddMatchWindow()

--- a/DropShot/Program.cs
+++ b/DropShot/Program.cs
@@ -122,6 +122,7 @@ builder.Services.AddScoped<AdminEmailService>();
 builder.Services.AddScoped<FuzzySearchService>();
 builder.Services.AddScoped<ICompetitionRubberTemplateProvider, CompetitionRubberTemplateProvider>();
 builder.Services.AddScoped<RubberResolutionService>();
+builder.Services.AddScoped<FixtureSimulationService>();
 builder.Services.AddScoped<CompetitionSchedulerService>();
 builder.Services.AddSingleton<QrLoginService>();
 builder.Services.AddHostedService<QrSessionCleanupService>();

--- a/DropShot/Services/FixtureSimulationService.cs
+++ b/DropShot/Services/FixtureSimulationService.cs
@@ -1,0 +1,177 @@
+using DropShot.Data;
+using DropShot.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace DropShot.Services;
+
+/// <summary>
+/// Generates plausible random results for round-robin fixtures. Intended as a
+/// super-admin test utility — respects competition match-format rules so the
+/// saved scores pass the same validation the score-entry dialogs enforce.
+/// </summary>
+public class FixtureSimulationService(RubberResolutionService rubberResolver)
+{
+    private static readonly Random _rng = new();
+
+    public record Outcome(int FixturesSimulated, int FixturesSkipped, List<string> Errors);
+
+    public async Task<Outcome> SimulateRoundRobinAsync(MyDbContext db, int competitionId)
+    {
+        var fixtures = await db.CompetitionFixtures
+            .Include(f => f.Competition)
+            .Include(f => f.Stage)
+            .Where(f => f.CompetitionId == competitionId
+                        && f.Stage != null
+                        && f.Stage!.StageType == StageType.RoundRobin
+                        && f.Status != FixtureStatus.Completed
+                        && f.Status != FixtureStatus.Cancelled
+                        && f.Status != FixtureStatus.Walkover
+                        && f.Status != FixtureStatus.AwaitingVerification)
+            .ToListAsync();
+
+        int done = 0, skipped = 0;
+        var errors = new List<string>();
+
+        foreach (var fx in fixtures)
+        {
+            try
+            {
+                if (fx.HomeTeamId.HasValue && fx.AwayTeamId.HasValue)
+                {
+                    await SimulateTeamFixtureAsync(db, fx);
+                    done++;
+                }
+                else if (fx.Player1Id.HasValue && fx.Player2Id.HasValue)
+                {
+                    await SimulatePlayerFixtureAsync(db, fx);
+                    done++;
+                }
+                else
+                {
+                    skipped++;
+                }
+            }
+            catch (RubberResolutionException ex)
+            {
+                skipped++;
+                errors.Add($"Fixture {fx.CompetitionFixtureId}: {ex.Message}");
+            }
+        }
+
+        return new Outcome(done, skipped, errors);
+    }
+
+    private async Task SimulateTeamFixtureAsync(MyDbContext db, CompetitionFixture fx)
+    {
+        await rubberResolver.EnsureRubbersAsync(db, fx.CompetitionFixtureId);
+
+        var rubbers = await db.Rubbers
+            .Where(r => r.CompetitionFixtureId == fx.CompetitionFixtureId)
+            .ToListAsync();
+
+        foreach (var rub in rubbers.Where(r => !r.IsComplete))
+            FillRubber(rub, fx);
+
+        await db.SaveChangesAsync();
+
+        var allRubbers = await db.Rubbers
+            .Where(r => r.CompetitionFixtureId == fx.CompetitionFixtureId)
+            .ToListAsync();
+
+        if (!RubberResolutionService.AllComplete(allRubbers)) return;
+
+        var (homeScore, awayScore) = RubberResolutionService.ComputeScore(
+            allRubbers, fx.HomeTeamId!.Value, fx.AwayTeamId!.Value);
+
+        fx.Status = FixtureStatus.Completed;
+        fx.CompletedAt = DateTime.UtcNow;
+        fx.ResultSummary = $"{homeScore}-{awayScore}";
+        fx.WinnerTeamId = homeScore > awayScore ? fx.HomeTeamId
+                         : awayScore > homeScore ? fx.AwayTeamId
+                         : null;
+        fx.VerificationToken = null;
+        await db.SaveChangesAsync();
+
+        await CompetitionProgressionService.TryAdvanceAsync(db, fx.CompetitionId, fx.CompetitionFixtureId);
+    }
+
+    private static async Task SimulatePlayerFixtureAsync(MyDbContext db, CompetitionFixture fx)
+    {
+        var comp = fx.Competition!;
+        var (bestOf, gamesPerSet, setWinMode, isFixedSets) = GetFormat(comp);
+
+        var sets = GenerateMatchSets(bestOf, gamesPerSet, setWinMode, isFixedSets);
+        int side1Sets = sets.Count(s => s.Side1 > s.Side2);
+        int side2Sets = sets.Count(s => s.Side2 > s.Side1);
+
+        fx.ResultSummary = string.Join(" ", sets.Select(s => $"{s.Side1}\u2013{s.Side2}"));
+        fx.WinnerPlayerId = side1Sets > side2Sets ? fx.Player1Id
+                           : side2Sets > side1Sets ? fx.Player2Id
+                           : null;
+        fx.Status = FixtureStatus.Completed;
+        fx.CompletedAt = DateTime.UtcNow;
+        fx.VerificationToken = null;
+
+        await db.SaveChangesAsync();
+        await CompetitionProgressionService.TryAdvanceAsync(db, fx.CompetitionId, fx.CompetitionFixtureId);
+    }
+
+    private static void FillRubber(Rubber rub, CompetitionFixture fx)
+    {
+        var (bestOf, gamesPerSet, setWinMode, isFixedSets) = GetFormat(fx.Competition!);
+        var sets = GenerateMatchSets(bestOf, gamesPerSet, setWinMode, isFixedSets);
+
+        int homeSets = sets.Count(s => s.Side1 > s.Side2);
+        int awaySets = sets.Count(s => s.Side2 > s.Side1);
+        int homeGames = sets.Sum(s => s.Side1);
+        int awayGames = sets.Sum(s => s.Side2);
+        var last = sets[^1];
+
+        rub.IsComplete = true;
+        rub.HomeSetsWon = homeSets;
+        rub.AwaySetsWon = awaySets;
+        rub.HomeGamesTotal = homeGames;
+        rub.AwayGamesTotal = awayGames;
+        rub.HomeGames = last.Side1;
+        rub.AwayGames = last.Side2;
+        rub.WinnerTeamId = homeSets > awaySets ? fx.HomeTeamId
+                          : awaySets > homeSets ? fx.AwayTeamId
+                          : null;
+        rub.SavedMatchId = null;
+    }
+
+    private static (int bestOf, int gamesPerSet, SetWinMode mode, bool isFixedSets) GetFormat(Competition comp)
+    {
+        bool isFixedSets = comp.MatchFormat == MatchFormatType.FixedSets;
+        int bestOf = isFixedSets ? Math.Max(1, comp.NumberOfSets) : Math.Max(1, comp.BestOf);
+        return (bestOf, Math.Max(1, comp.GamesPerSet), comp.SetWinMode, isFixedSets);
+    }
+
+    private record SetScore(int Side1, int Side2);
+
+    private static List<SetScore> GenerateMatchSets(int bestOf, int gamesPerSet, SetWinMode mode, bool isFixedSets)
+    {
+        var sets = new List<SetScore>();
+        int target = bestOf / 2 + 1;
+        int s1 = 0, s2 = 0;
+        for (int i = 0; i < bestOf; i++)
+        {
+            if (!isFixedSets && (s1 >= target || s2 >= target)) break;
+            bool side1Wins = _rng.Next(2) == 0;
+            var (winG, loseG) = RandomSetScore(gamesPerSet, mode);
+            if (side1Wins) { sets.Add(new SetScore(winG, loseG)); s1++; }
+            else           { sets.Add(new SetScore(loseG, winG)); s2++; }
+        }
+        return sets;
+    }
+
+    private static (int winner, int loser) RandomSetScore(int gamesPerSet, SetWinMode mode)
+    {
+        // A safe valid score for both WinBy2 and FirstTo: winner reaches exactly
+        // gamesPerSet with loser at most gamesPerSet-2. Matches the strictest
+        // branch of the score-entry validators.
+        int maxLoser = Math.Max(0, gamesPerSet - 2);
+        int loser = _rng.Next(0, maxLoser + 1);
+        return (gamesPerSet, loser);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a `FixtureSimulationService` that generates random, rules-valid results for every unfinished round-robin fixture in a competition, including per-rubber scores for team matches. Set scores respect `MatchFormat` / `BestOf` / `NumberOfSets` / `GamesPerSet` / `SetWinMode` so the saved values pass the same validation the score-entry dialogs enforce.
- Surfaces a "Simulate Round-Robin" button at the top of the fixtures list (both flat and divisional paths). The button is visible only when the signed-in user has the `SuperAdmin` role **and** at least one stage is a `RoundRobin`.
- Reuses `RubberResolutionService.EnsureRubbersAsync` to materialise rubbers on demand, `RubberResolutionService.ComputeScore` to derive the fixture result, and `CompetitionProgressionService.TryAdvanceAsync` so simulated results cascade into knockout stages.

## Why
During manual testing it's tedious to click through every round-robin fixture to reach the knockout stage. This gives super admins a one-click way to fast-forward a competition into a state worth testing against.

## Test plan
- [ ] Sign in as a non–super-admin (ClubAdmin/Admin): button does not appear on a competition with a round-robin stage.
- [ ] Sign in as a SuperAdmin, competition has no round-robin stage: button does not appear.
- [ ] Sign in as a SuperAdmin, competition has a round-robin stage: button appears, confirm alert shows, clicking Simulate generates results for every unfinished round-robin fixture; already-completed fixtures are left alone.
- [ ] Player (Singles/Doubles) round-robin: fixtures move to Completed with a plausible `ResultSummary` and `WinnerPlayerId`.
- [ ] TeamMatch round-robin: every rubber is created and completed with valid set scores, then the fixture shows the aggregated team score.
- [ ] Combined RR + Knockout competition: after simulation, the knockout bracket has its placeholders seeded (progression service runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)