### PR TITLE
Match setup page: stretch content to full center-section width

### DIFF
--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -68,7 +68,7 @@
 @if (loaded && CurrentMatch == null && !_showCoinToss && !_showServerSelect)
 {
     <section class="bg-tennis overlay-dark" style="min-height: 100vh; align-items: flex-start;">
-    <div style="max-width: 800px; margin: 0 auto; padding: 1rem 0.5rem 2rem; width: 100%; position: relative; z-index: 1;">
+    <div style="max-width: var(--content-max-width); margin: 0 auto; padding: 1rem 0.5rem 2rem; width: 100%; position: relative; z-index: 1;">
         <MatchSetupWizard OnSetupComplete="HandleSetupComplete"
                           PresetPlayer1="@_value" PresetPlayer2="@_value2"
                           PresetPlayer3="@_value3" PresetPlayer4="@_value4"


### PR DESCRIPTION
## Summary
- Replaces hardcoded `max-width: 800px` on the pre-match setup container with `var(--content-max-width)` (72rem), which is already defined on the `.bg-tennis` section
- The "Start a Match" wizard and "Your Upcoming Matches" card now stretch to use the full available width of the center content section

## Test plan
- [ ] Visit the match page before starting a match and confirm the setup wizard and upcoming matches card are wider
- [ ] Verify no visual regressions on the active match scoreboard view

🤖 Generated with [Claude Code](https://claude.com/claude-code)