### PR TITLE
Match setup page: use admin-tunable --ds-content-max-width variable

### DIFF
--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -68,7 +68,7 @@
 @if (loaded && CurrentMatch == null && !_showCoinToss && !_showServerSelect)
 {
     <section class="bg-tennis overlay-dark" style="min-height: 100vh; align-items: flex-start;">
-    <div style="max-width: var(--content-max-width); margin: 0 auto; padding: 1rem 0.5rem 2rem; width: 100%; position: relative; z-index: 1;">
+    <div style="max-width: var(--ds-content-max-width, 1280px); margin: 0 auto; padding: 1rem 0.5rem 2rem; width: 100%; position: relative; z-index: 1;">
         <MatchSetupWizard OnSetupComplete="HandleSetupComplete"
                           PresetPlayer1="@_value" PresetPlayer2="@_value2"
                           PresetPlayer3="@_value3" PresetPlayer4="@_value4"


### PR DESCRIPTION
## Summary
- Fixes #419 which used `--content-max-width` (a local 72rem value scoped to `.bg-tennis`) instead of the correct global variable
- `--ds-content-max-width` is the admin-configurable root CSS variable introduced in #413, set by `MainLayout` from `SiteSettingsService`
- The pre-match setup container now respects whatever width the admin has configured at `/admin/site-settings`

## Test plan
- [ ] Visit the match page before starting a match — setup wizard and upcoming matches card should fill the center content area
- [ ] Change content max width in `/admin/site-settings` and confirm the match setup page reflects it

🤖 Generated with [Claude Code](https://claude.com/claude-code)