### PR TITLE
Global tiling background image, dark overlay, and consistent padding

### DIFF
--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -68,7 +68,7 @@
 @if (loaded && CurrentMatch == null && !_showCoinToss && !_showServerSelect)
 {
     <section class="bg-tennis overlay-dark" style="min-height: 100vh; align-items: flex-start;">
-    <div style="max-width: var(--ds-content-max-width, 1280px); margin: 0 auto; padding: 1rem 0.5rem 2rem; width: 100%; position: relative; z-index: 1;">
+    <div style="max-width: var(--ds-content-max-width, 1280px); margin: 0 auto; padding: 1rem 1.5rem 2rem; width: 100%; position: relative; z-index: 1;">
         <MatchSetupWizard OnSetupComplete="HandleSetupComplete"
                           PresetPlayer1="@_value" PresetPlayer2="@_value2"
                           PresetPlayer3="@_value3" PresetPlayer4="@_value4"

--- a/DropShot/Components/TennisScore.razor.css
+++ b/DropShot/Components/TennisScore.razor.css
@@ -60,8 +60,8 @@
     --overlay-color: 18, 18, 18;
     --overlay-alpha: 0.85;
     --bg-fallback: #121212;
-    --bg-size: cover;
-    --bg-position: center center;
+    --bg-size: auto;
+    --bg-position: left top;
     --content-max-width: 72rem;
     --content-padding: clamp(1.25rem, 3vw, 3rem);
     --text-color: #ffffff;
@@ -69,7 +69,7 @@
     flex: 1;
     background-color: var(--bg-fallback);
     background-image: var(--bg-image);
-    background-repeat: no-repeat;
+    background-repeat: repeat;
     background-size: var(--bg-size);
     background-position: var(--bg-position);
     overflow: hidden;

--- a/DropShot/wwwroot/app.css
+++ b/DropShot/wwwroot/app.css
@@ -2,6 +2,10 @@ html, body {
     font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
     touch-action: manipulation;
     background-color: #121212;
+    background-image:
+        linear-gradient(rgba(18, 18, 18, 0.85), rgba(18, 18, 18, 0.85)),
+        url('images/background.png');
+    background-repeat: repeat;
     color: #e0e0e0;
 }
 


### PR DESCRIPTION
## Summary
- **All pages**: `html/body` in `app.css` now renders the tennis court background image tiling across the full page, with the same `rgba(18,18,18,0.85)` dark overlay applied as a CSS multi-layer background — no stretching
- **Scoring page**: `.bg-tennis` updated from `cover`/`no-repeat` to `auto`/`repeat` so it tiles consistently with the rest of the app (the per-section overlay pseudo-element is unchanged)
- **Match setup padding**: inner div horizontal padding corrected from `0.5rem` → `1.5rem` to match the `px-4` padding all other content pages use

## Test plan
- [ ] Check several pages (Home, Competition, Admin) — all should show the tiling background with dark overlay
- [ ] Visit the match page pre-start — setup wizard and upcoming matches card should have consistent side padding
- [ ] Visit the scoring page mid-match — background should tile rather than stretch, overlay unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)