### PR TITLE
Temp: bootstrap SuperAdmin self-promotion button

### DIFF
--- a/DropShot/Components/Pages/Admin/UserManagement.razor
+++ b/DropShot/Components/Pages/Admin/UserManagement.razor
@@ -11,8 +11,26 @@
 @inject IDbContextFactory<MyDbContext> DbFactory
 @inject ISnackbar Snackbar
 @inject IDialogService Dialog
+@inject ILogger<UserManagement> Logger
 
 <MudProviders />
+
+@* ── Bootstrap SuperAdmin (temporary — remove once role is set) ──────── *@
+@if (_showBootstrapBanner)
+{
+    <MudAlert Severity="Severity.Warning" Class="mb-4" Icon="@Icons.Material.Filled.AdminPanelSettings">
+        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="3">
+            <MudText Style="flex:1">
+                No SuperAdmin exists. As the bootstrap user you can promote yourself now.
+            </MudText>
+            <MudButton Variant="Variant.Filled" Color="Color.Warning"
+                       Disabled="@_bootstrapBusy"
+                       OnClick="BootstrapSuperAdminAsync">
+                Grant me SuperAdmin
+            </MudButton>
+        </MudStack>
+    </MudAlert>
+}
 
 @if (_error is not null)
 {
@@ -177,6 +195,9 @@
     private bool _isSuperAdmin;
     private string? _currentUserId;
 
+    private bool _showBootstrapBanner;
+    private bool _bootstrapBusy;
+
     private bool _showAddClubDialog;
     private UserRow? _targetRow;
     private int? _selectedClubId;
@@ -211,6 +232,12 @@
             _currentUserId = currentUser?.Id;
             _isSuperAdmin = currentUser is not null && await UserManager.IsInRoleAsync(currentUser, "SuperAdmin");
             await Load();
+
+            const string bootstrapEmail = "alan.beattie@xma.co.uk";
+            _showBootstrapBanner =
+                !_isSuperAdmin &&
+                currentUser?.Email?.Equals(bootstrapEmail, StringComparison.OrdinalIgnoreCase) == true &&
+                _rows.All(r => !r.IsSuperAdmin);
         }
         catch (Exception ex)
         {
@@ -310,6 +337,51 @@
         Snackbar.Add(
             $"{row.User.UserName} premium {(make ? "enabled" : "disabled")}.",
             make ? Severity.Success : Severity.Warning);
+    }
+
+    // ── Bootstrap SuperAdmin (temporary) ────────────────────────────────────
+
+    private async Task BootstrapSuperAdminAsync()
+    {
+        _bootstrapBusy = true;
+        const string bootstrapEmail = "alan.beattie@xma.co.uk";
+
+        var authState = await AuthenticationState;
+        var currentUser = await UserManager.GetUserAsync(authState.User);
+
+        // Server-side guard: email must match
+        if (currentUser?.Email?.Equals(bootstrapEmail, StringComparison.OrdinalIgnoreCase) != true)
+        {
+            Snackbar.Add("Bootstrap not permitted for this account.", Severity.Error);
+            _bootstrapBusy = false;
+            return;
+        }
+
+        // Server-side guard: no SuperAdmin must already exist
+        var superAdmins = await UserManager.GetUsersInRoleAsync("SuperAdmin");
+        if (superAdmins.Count > 0)
+        {
+            Snackbar.Add("A SuperAdmin already exists — bootstrap not permitted.", Severity.Error);
+            _showBootstrapBanner = false;
+            _bootstrapBusy = false;
+            return;
+        }
+
+        var result = await UserManager.AddToRoleAsync(currentUser, "SuperAdmin");
+        if (!result.Succeeded)
+        {
+            Snackbar.Add(string.Join(" ", result.Errors.Select(e => e.Description)), Severity.Error);
+            _bootstrapBusy = false;
+            return;
+        }
+
+        Logger.LogWarning(
+            "BOOTSTRAP: SuperAdmin role granted to user {UserId} ({Email}) — no prior SuperAdmin existed.",
+            currentUser.Id, currentUser.Email);
+
+        Snackbar.Add("SuperAdmin role granted. Reload the page to see full admin controls.", Severity.Success);
+        _showBootstrapBanner = false;
+        _bootstrapBusy = false;
     }
 
     // ── Club admin assignments ───────────────────────────────────────────────

--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -68,7 +68,7 @@
 @if (loaded && CurrentMatch == null && !_showCoinToss && !_showServerSelect)
 {
     <section class="bg-tennis overlay-dark" style="min-height: 100vh; align-items: flex-start;">
-    <div style="max-width: var(--ds-content-max-width, 1280px); margin: 0 auto; padding: 1rem 0.5rem 2rem; width: 100%; position: relative; z-index: 1;">
+    <div style="max-width: var(--ds-content-max-width, 1280px); margin: 0 auto; padding: 1rem 1.5rem 2rem; width: 100%; position: relative; z-index: 1;">
         <MatchSetupWizard OnSetupComplete="HandleSetupComplete"
                           PresetPlayer1="@_value" PresetPlayer2="@_value2"
                           PresetPlayer3="@_value3" PresetPlayer4="@_value4"

--- a/DropShot/Components/TennisScore.razor.css
+++ b/DropShot/Components/TennisScore.razor.css
@@ -60,8 +60,8 @@
     --overlay-color: 18, 18, 18;
     --overlay-alpha: 0.85;
     --bg-fallback: #121212;
-    --bg-size: cover;
-    --bg-position: center center;
+    --bg-size: auto;
+    --bg-position: left top;
     --content-max-width: 72rem;
     --content-padding: clamp(1.25rem, 3vw, 3rem);
     --text-color: #ffffff;
@@ -69,7 +69,7 @@
     flex: 1;
     background-color: var(--bg-fallback);
     background-image: var(--bg-image);
-    background-repeat: no-repeat;
+    background-repeat: repeat;
     background-size: var(--bg-size);
     background-position: var(--bg-position);
     overflow: hidden;

--- a/DropShot/wwwroot/app.css
+++ b/DropShot/wwwroot/app.css
@@ -2,6 +2,10 @@ html, body {
     font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
     touch-action: manipulation;
     background-color: #121212;
+    background-image:
+        linear-gradient(rgba(18, 18, 18, 0.85), rgba(18, 18, 18, 0.85)),
+        url('images/background.png');
+    background-repeat: repeat;
     color: #e0e0e0;
 }
 


### PR DESCRIPTION
## Summary

- Adds a yellow warning banner to `/admin/users` with a **"Grant me SuperAdmin"** button
- Banner only appears when the signed-in user is `alan.beattie@xma.co.uk` AND no SuperAdmin exists in the system
- Both guards are re-validated server-side in `BootstrapSuperAdminAsync` before the role is granted — the check can't be bypassed via UI manipulation
- Logs at `Warning` level with a `BOOTSTRAP:` prefix for the audit trail
- Banner disappears immediately after the role is granted

## Safeguards

| Guard | Where enforced |
|---|---|
| Email must be `alan.beattie@xma.co.uk` | UI (banner visibility) + server-side method |
| No SuperAdmin must already exist | UI (banner visibility) + server-side method via `UserManager.GetUsersInRoleAsync` |
| Standard Identity result check | `AddToRoleAsync` result validated before success path |

## Test plan

- [ ] Log in as `alan.beattie@xma.co.uk` (Admin role, no SuperAdmin exists) → banner appears at top of `/admin/users`
- [ ] Click **Grant me SuperAdmin** → success snackbar, banner disappears
- [ ] Reload page → SuperAdmin toggle columns now visible, banner gone
- [ ] Log out and back in; verify SuperAdmin role is active
- [ ] Confirm: a second user visiting the page sees no banner
- [ ] Confirm: once SuperAdmin exists, button refuses with an error if somehow invoked directly

## Removal

Remove this in a follow-up PR once the role is confirmed. The only changes are in `UserManagement.razor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)