### PR TITLE
Fix bootstrap email address

### DIFF
--- a/DropShot/Components/Pages/Admin/UserManagement.razor
+++ b/DropShot/Components/Pages/Admin/UserManagement.razor
@@ -233,7 +233,7 @@
             _isSuperAdmin = currentUser is not null && await UserManager.IsInRoleAsync(currentUser, "SuperAdmin");
             await Load();
 
-            const string bootstrapEmail = "alan.beattie@xma.co.uk";
+            const string bootstrapEmail = "beattie.edwin@gmail.com";
             _showBootstrapBanner =
                 !_isSuperAdmin &&
                 currentUser?.Email?.Equals(bootstrapEmail, StringComparison.OrdinalIgnoreCase) == true &&
@@ -344,7 +344,7 @@
     private async Task BootstrapSuperAdminAsync()
     {
         _bootstrapBusy = true;
-        const string bootstrapEmail = "alan.beattie@xma.co.uk";
+        const string bootstrapEmail = "beattie.edwin@gmail.com";
 
         var authState = await AuthenticationState;
         var currentUser = await UserManager.GetUserAsync(authState.User);


### PR DESCRIPTION
## Summary

- Corrects the hardcoded bootstrap email in the SuperAdmin self-promote button from `alan.beattie@xma.co.uk` to `beattie.edwin@gmail.com` (the actual DropShot account)
- Both occurrences updated: the banner visibility check in `OnInitializedAsync` and the server-side guard in `BootstrapSuperAdminAsync`
- All other safeguards unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)