### PR TITLE
Remove bootstrap SuperAdmin self-promotion code

### DIFF
--- a/DropShot/Components/Pages/Admin/UserManagement.razor
+++ b/DropShot/Components/Pages/Admin/UserManagement.razor
@@ -11,27 +11,6 @@
 @inject IDbContextFactory<MyDbContext> DbFactory
 @inject ISnackbar Snackbar
 @inject IDialogService Dialog
-@inject ILogger<UserManagement> Logger
-
-<MudProviders />
-
-@* ── Bootstrap SuperAdmin (temporary — remove once role is set) ──────── *@
-@if (_showBootstrapBanner)
-{
-    <MudAlert Severity="Severity.Warning" Class="mb-4" Icon="@Icons.Material.Filled.AdminPanelSettings">
-        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="3">
-            <MudText Style="flex:1">
-                No SuperAdmin exists. As the bootstrap user you can promote yourself now.
-            </MudText>
-            <MudButton Variant="Variant.Filled" Color="Color.Warning"
-                       Disabled="@_bootstrapBusy"
-                       OnClick="BootstrapSuperAdminAsync">
-                Grant me SuperAdmin
-            </MudButton>
-        </MudStack>
-    </MudAlert>
-}
-
 @if (_error is not null)
 {
     <MudAlert Severity="Severity.Error" Class="mb-4">@_error</MudAlert>
@@ -195,9 +174,6 @@
     private bool _isSuperAdmin;
     private string? _currentUserId;
 
-    private bool _showBootstrapBanner;
-    private bool _bootstrapBusy;
-
     private bool _showAddClubDialog;
     private UserRow? _targetRow;
     private int? _selectedClubId;
@@ -232,12 +208,6 @@
             _currentUserId = currentUser?.Id;
             _isSuperAdmin = currentUser is not null && await UserManager.IsInRoleAsync(currentUser, "SuperAdmin");
             await Load();
-
-            const string bootstrapEmail = "beattie.edwin@gmail.com";
-            _showBootstrapBanner =
-                !_isSuperAdmin &&
-                currentUser?.Email?.Equals(bootstrapEmail, StringComparison.OrdinalIgnoreCase) == true &&
-                _rows.All(r => !r.IsSuperAdmin);
         }
         catch (Exception ex)
         {
@@ -337,51 +307,6 @@
         Snackbar.Add(
             $"{row.User.UserName} premium {(make ? "enabled" : "disabled")}.",
             make ? Severity.Success : Severity.Warning);
-    }
-
-    // ── Bootstrap SuperAdmin (temporary) ────────────────────────────────────
-
-    private async Task BootstrapSuperAdminAsync()
-    {
-        _bootstrapBusy = true;
-        const string bootstrapEmail = "beattie.edwin@gmail.com";
-
-        var authState = await AuthenticationState;
-        var currentUser = await UserManager.GetUserAsync(authState.User);
-
-        // Server-side guard: email must match
-        if (currentUser?.Email?.Equals(bootstrapEmail, StringComparison.OrdinalIgnoreCase) != true)
-        {
-            Snackbar.Add("Bootstrap not permitted for this account.", Severity.Error);
-            _bootstrapBusy = false;
-            return;
-        }
-
-        // Server-side guard: no SuperAdmin must already exist
-        var superAdmins = await UserManager.GetUsersInRoleAsync("SuperAdmin");
-        if (superAdmins.Count > 0)
-        {
-            Snackbar.Add("A SuperAdmin already exists — bootstrap not permitted.", Severity.Error);
-            _showBootstrapBanner = false;
-            _bootstrapBusy = false;
-            return;
-        }
-
-        var result = await UserManager.AddToRoleAsync(currentUser, "SuperAdmin");
-        if (!result.Succeeded)
-        {
-            Snackbar.Add(string.Join(" ", result.Errors.Select(e => e.Description)), Severity.Error);
-            _bootstrapBusy = false;
-            return;
-        }
-
-        Logger.LogWarning(
-            "BOOTSTRAP: SuperAdmin role granted to user {UserId} ({Email}) — no prior SuperAdmin existed.",
-            currentUser.Id, currentUser.Email);
-
-        Snackbar.Add("SuperAdmin role granted. Reload the page to see full admin controls.", Severity.Success);
-        _showBootstrapBanner = false;
-        _bootstrapBusy = false;
     }
 
     // ── Club admin assignments ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Role is confirmed set. Removes everything added in PRs #422 and #423:

- Bootstrap warning banner and button from `/admin/users`
- `_showBootstrapBanner` / `_bootstrapBusy` state fields
- Bootstrap email constant and banner visibility check in `OnInitializedAsync`
- `BootstrapSuperAdminAsync()` method (both guards, role grant, audit log)
- `@inject ILogger<UserManagement> Logger` (added solely for the bootstrap log)

No other behaviour changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)