### PR TITLE
Feat: team match verification emails with rubber-by-rubber score display

### DIFF
--- a/DropShot/Components/Pages/VerifyResult.razor
+++ b/DropShot/Components/Pages/VerifyResult.razor
@@ -62,56 +62,103 @@
                         </MudText>
                     </MudAlert>
 
-                    <MudSwitch @bind-Value="_editing" Label="Modify score" Color="Color.Warning" />
-
-                    @if (_editing)
+                    @* ── Team match: show rubber-by-rubber breakdown ── *@
+                    @if (_isTeamMatch && _rubbers.Count > 0)
                     {
-                        <MudAlert Severity="Severity.Warning" Dense="true">
-                            The original submission will be preserved for audit purposes.
-                        </MudAlert>
-
-                        <MudText Typo="Typo.subtitle2">Updated Set Scores</MudText>
-                        <MudSimpleTable Dense="true" Style="max-width:300px">
+                        <MudText Typo="Typo.subtitle2">Rubber Results</MudText>
+                        <MudSimpleTable Dense="true">
                             <thead>
                                 <tr>
-                                    <th style="width:50px"></th>
-                                    <th style="text-align:center; font-size:0.8rem">@_side1</th>
-                                    <th style="width:20px"></th>
-                                    <th style="text-align:center; font-size:0.8rem">@_side2</th>
+                                    <th>Rubber</th>
+                                    <th>@_side1</th>
+                                    <th>@_side2</th>
+                                    <th style="text-align:center">Score</th>
+                                    <th>Winner</th>
                                 </tr>
                             </thead>
                             <tbody>
-                                @for (int i = 0; i < _bestOf; i++)
+                                @foreach (var r in _rubbers.OrderBy(r => r.Order))
                                 {
-                                    int idx = i;
+                                    var homePair = string.Join(" & ", new[] { r.HomePlayer1?.DisplayName, r.HomePlayer2?.DisplayName }.Where(n => !string.IsNullOrEmpty(n)));
+                                    var awayPair = string.Join(" & ", new[] { r.AwayPlayer1?.DisplayName, r.AwayPlayer2?.DisplayName }.Where(n => !string.IsNullOrEmpty(n)));
+                                    var rubberScore = r.IsComplete && r.HomeSetsWon.HasValue
+                                        ? $"{r.HomeSetsWon}–{r.AwaySetsWon}"
+                                        : "—";
+                                    var rubberWinner = !r.IsComplete ? "—"
+                                        : r.WinnerTeamId == _fixture.HomeTeamId ? _side1
+                                        : r.WinnerTeamId == _fixture.AwayTeamId ? _side2
+                                        : "Draw";
                                     <tr>
-                                        <td style="color:#888; font-size:0.8rem; padding-right:8px">Set @(idx + 1)</td>
-                                        <td>
-                                            <MudNumericField T="int?" @bind-Value="_score1[idx]"
-                                                            Min="0" Max="13" Variant="Variant.Outlined"
-                                                            Style="width:65px" HideSpinButtons="true" />
-                                        </td>
-                                        <td style="text-align:center; padding:0 4px; font-weight:bold">-</td>
-                                        <td>
-                                            <MudNumericField T="int?" @bind-Value="_score2[idx]"
-                                                            Min="0" Max="13" Variant="Variant.Outlined"
-                                                            Style="width:65px" HideSpinButtons="true" />
-                                        </td>
+                                        <td>@r.Name</td>
+                                        <td style="font-size:0.8rem">@(string.IsNullOrEmpty(homePair) ? "TBD" : homePair)</td>
+                                        <td style="font-size:0.8rem">@(string.IsNullOrEmpty(awayPair) ? "TBD" : awayPair)</td>
+                                        <td style="text-align:center;font-weight:bold">@rubberScore</td>
+                                        <td>@rubberWinner</td>
                                     </tr>
                                 }
                             </tbody>
                         </MudSimpleTable>
+                        <MudAlert Severity="Severity.Info" Dense="true">
+                            Score modification is not available for team matches. To correct rubber scores, use the
+                            <MudLink Href="@($"/team-match/{_fixture.CompetitionFixtureId}")">team match page</MudLink>
+                            after approving.
+                        </MudAlert>
+                    }
 
-                        <MudSelect T="int?" @bind-Value="_winnerPlayerId" Label="Winner" Variant="Variant.Outlined">
-                            @if (_fixture.Player1Id.HasValue)
-                            {
-                                <MudSelectItem T="int?" Value="@_fixture.Player1Id">@_side1</MudSelectItem>
-                            }
-                            @if (_fixture.Player2Id.HasValue)
-                            {
-                                <MudSelectItem T="int?" Value="@_fixture.Player2Id">@_side2</MudSelectItem>
-                            }
-                        </MudSelect>
+                    @* ── Individual match: allow score editing ── *@
+                    @if (!_isTeamMatch)
+                    {
+                        <MudSwitch @bind-Value="_editing" Label="Modify score" Color="Color.Warning" />
+
+                        @if (_editing)
+                        {
+                            <MudAlert Severity="Severity.Warning" Dense="true">
+                                The original submission will be preserved for audit purposes.
+                            </MudAlert>
+
+                            <MudText Typo="Typo.subtitle2">Updated Set Scores</MudText>
+                            <MudSimpleTable Dense="true" Style="max-width:300px">
+                                <thead>
+                                    <tr>
+                                        <th style="width:50px"></th>
+                                        <th style="text-align:center; font-size:0.8rem">@_side1</th>
+                                        <th style="width:20px"></th>
+                                        <th style="text-align:center; font-size:0.8rem">@_side2</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @for (int i = 0; i < _bestOf; i++)
+                                    {
+                                        int idx = i;
+                                        <tr>
+                                            <td style="color:#888; font-size:0.8rem; padding-right:8px">Set @(idx + 1)</td>
+                                            <td>
+                                                <MudNumericField T="int?" @bind-Value="_score1[idx]"
+                                                                Min="0" Max="13" Variant="Variant.Outlined"
+                                                                Style="width:65px" HideSpinButtons="true" />
+                                            </td>
+                                            <td style="text-align:center; padding:0 4px; font-weight:bold">-</td>
+                                            <td>
+                                                <MudNumericField T="int?" @bind-Value="_score2[idx]"
+                                                                Min="0" Max="13" Variant="Variant.Outlined"
+                                                                Style="width:65px" HideSpinButtons="true" />
+                                            </td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </MudSimpleTable>
+
+                            <MudSelect T="int?" @bind-Value="_winnerPlayerId" Label="Winner" Variant="Variant.Outlined">
+                                @if (_fixture.Player1Id.HasValue)
+                                {
+                                    <MudSelectItem T="int?" Value="@_fixture.Player1Id">@_side1</MudSelectItem>
+                                }
+                                @if (_fixture.Player2Id.HasValue)
+                                {
+                                    <MudSelectItem T="int?" Value="@_fixture.Player2Id">@_side2</MudSelectItem>
+                                }
+                            </MudSelect>
+                        }
                     }
 
                     @if (!string.IsNullOrEmpty(_error))
@@ -146,6 +193,8 @@
     private int? _competitionId;
 
     private CompetitionFixture? _fixture;
+    private List<Rubber> _rubbers = [];
+    private bool _isTeamMatch;
     private string _side1 = "";
     private string _side2 = "";
     private int _bestOf = 3;
@@ -169,6 +218,8 @@
 
         _fixture = await db.CompetitionFixtures
             .Include(f => f.Competition)
+            .Include(f => f.HomeTeam)
+            .Include(f => f.AwayTeam)
             .Include(f => f.Player1).Include(f => f.Player2)
             .Include(f => f.Player3).Include(f => f.Player4)
             .FirstOrDefaultAsync(f => f.VerificationToken == token && f.Status == FixtureStatus.AwaitingVerification);
@@ -180,20 +231,37 @@
             return;
         }
 
-        var comp = _fixture.Competition;
-        _bestOf = comp?.MatchFormat == MatchFormatType.FixedSets
-            ? Math.Max(1, comp.NumberOfSets)
-            : Math.Max(1, comp?.BestOf ?? 3);
-        _score1 = new int?[_bestOf];
-        _score2 = new int?[_bestOf];
+        _isTeamMatch = _fixture.HomeTeamId.HasValue || _fixture.AwayTeamId.HasValue;
 
-        var s1Parts = new[] { _fixture.Player1?.DisplayName, _fixture.Player3?.DisplayName }.Where(n => n != null).ToList();
-        var s2Parts = new[] { _fixture.Player2?.DisplayName, _fixture.Player4?.DisplayName }.Where(n => n != null).ToList();
-        _side1 = s1Parts.Any() ? string.Join(" & ", s1Parts) : "Player 1";
-        _side2 = s2Parts.Any() ? string.Join(" & ", s2Parts) : "Player 2";
+        if (_isTeamMatch)
+        {
+            _rubbers = await db.Rubbers
+                .Include(r => r.HomePlayer1).Include(r => r.HomePlayer2)
+                .Include(r => r.AwayPlayer1).Include(r => r.AwayPlayer2)
+                .Where(r => r.CompetitionFixtureId == _fixture.CompetitionFixtureId)
+                .OrderBy(r => r.Order)
+                .ToListAsync();
 
-        _winnerPlayerId = _fixture.WinnerPlayerId;
-        ParseResultSummary(_fixture.ResultSummary);
+            _side1 = _fixture.HomeTeam?.Name ?? "Home";
+            _side2 = _fixture.AwayTeam?.Name ?? "Away";
+        }
+        else
+        {
+            var comp = _fixture.Competition;
+            _bestOf = comp?.MatchFormat == MatchFormatType.FixedSets
+                ? Math.Max(1, comp.NumberOfSets)
+                : Math.Max(1, comp?.BestOf ?? 3);
+            _score1 = new int?[_bestOf];
+            _score2 = new int?[_bestOf];
+
+            var s1Parts = new[] { _fixture.Player1?.DisplayName, _fixture.Player3?.DisplayName }.Where(n => n != null).ToList();
+            var s2Parts = new[] { _fixture.Player2?.DisplayName, _fixture.Player4?.DisplayName }.Where(n => n != null).ToList();
+            _side1 = s1Parts.Any() ? string.Join(" & ", s1Parts) : "Player 1";
+            _side2 = s2Parts.Any() ? string.Join(" & ", s2Parts) : "Player 2";
+
+            _winnerPlayerId = _fixture.WinnerPlayerId;
+            ParseResultSummary(_fixture.ResultSummary);
+        }
 
         _loading = false;
     }
@@ -216,6 +284,14 @@
 
     private string WinnerName()
     {
+        // Team match — winner identified by WinnerTeamId
+        if (_fixture?.WinnerTeamId.HasValue == true)
+        {
+            if (_fixture.WinnerTeamId == _fixture.HomeTeamId) return _side1;
+            if (_fixture.WinnerTeamId == _fixture.AwayTeamId) return _side2;
+            return "Draw";
+        }
+        // Individual match — winner identified by WinnerPlayerId
         if (_fixture?.WinnerPlayerId == _fixture?.Player1Id) return _side1;
         if (_fixture?.WinnerPlayerId == _fixture?.Player2Id) return _side2;
         return "Unknown";
@@ -225,7 +301,7 @@
     {
         _error = null;
 
-        if (_editing)
+        if (!_isTeamMatch && _editing)
         {
             var enteredSets = Enumerable.Range(0, _bestOf)
                 .Where(i => _score1[i].HasValue || _score2[i].HasValue)
@@ -243,7 +319,7 @@
                 .FirstOrDefaultAsync(f => f.CompetitionFixtureId == _fixture!.CompetitionFixtureId);
             if (fx == null) { _error = "Fixture not found."; return; }
 
-            if (_editing)
+            if (!_isTeamMatch && _editing)
             {
                 var newSummary = string.Join(" ", Enumerable.Range(0, _bestOf)
                     .Where(i => _score1[i].HasValue || _score2[i].HasValue)

--- a/DropShot/Components/RubberScoreDialog.razor
+++ b/DropShot/Components/RubberScoreDialog.razor
@@ -5,6 +5,7 @@
 
 @inject IDbContextFactory<MyDbContext> DbFactory
 @inject ISnackbar Snackbar
+@inject ResultVerificationService ResultVerificationService
 
 <MudDialog>
     <TitleContent>Enter rubber score</TitleContent>
@@ -186,6 +187,8 @@
             // If every rubber in this fixture is now complete, finalize the fixture
             // result — same pathway as the live-scoring match-end handler.
             var allRubbers = await db.Rubbers
+                .Include(r => r.HomePlayer1).Include(r => r.HomePlayer2)
+                .Include(r => r.AwayPlayer1).Include(r => r.AwayPlayer2)
                 .Where(r => r.CompetitionFixtureId == rub.CompetitionFixtureId)
                 .ToListAsync();
 
@@ -194,17 +197,37 @@
             {
                 var (homeScore, awayScore) = RubberResolutionService.ComputeScore(
                     allRubbers, rub.Fixture.HomeTeamId.Value, rub.Fixture.AwayTeamId.Value);
-                var fx = await db.CompetitionFixtures.FindAsync(rub.CompetitionFixtureId);
+                var fx = await db.CompetitionFixtures
+                    .Include(f => f.Competition)
+                    .Include(f => f.HomeTeam)
+                    .Include(f => f.AwayTeam)
+                    .FirstOrDefaultAsync(f => f.CompetitionFixtureId == rub.CompetitionFixtureId);
                 if (fx != null)
                 {
-                    fx.Status = FixtureStatus.Completed;
-                    fx.CompletedAt = DateTime.UtcNow;
                     fx.ResultSummary = $"{homeScore}-{awayScore}";
                     fx.WinnerTeamId = homeScore > awayScore ? fx.HomeTeamId
                                     : awayScore > homeScore ? fx.AwayTeamId
                                     : null;
-                    await db.SaveChangesAsync();
-                    await CompetitionProgressionService.TryAdvanceAsync(db, fx.CompetitionId, fx.CompetitionFixtureId);
+                    fx.CompletedAt = DateTime.UtcNow;
+
+                    bool requireVerification = fx.Competition?.RequireVerification ?? false;
+                    if (requireVerification)
+                    {
+                        fx.Status = FixtureStatus.AwaitingVerification;
+                        fx.VerificationToken = Guid.NewGuid();
+                        await db.SaveChangesAsync();
+
+                        var adminEmails = await ResultVerificationService.GetAdminEmailsForCompetitionAsync(fx.CompetitionId, db);
+                        await ResultVerificationService.SendAdminVerificationEmailsForTeamMatchAsync(fx, allRubbers, adminEmails);
+                    }
+                    else
+                    {
+                        fx.Status = FixtureStatus.Completed;
+                        await db.SaveChangesAsync();
+                        await Task.WhenAll(
+                            ResultVerificationService.SendResultNotificationForTeamMatchAsync(fx, allRubbers),
+                            CompetitionProgressionService.TryAdvanceAsync(db, fx.CompetitionId, fx.CompetitionFixtureId));
+                    }
                 }
             }
 

--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -23,6 +23,7 @@
 @inject TennisScoreService ScoreService
 @inject CourtClaimService CourtClaim
 @inject ISnackbar Snackbar
+@inject ResultVerificationService ResultVerificationService
 @inject AuthenticationStateProvider AuthStateProvider
 @inject IJSRuntime JS
 
@@ -1300,6 +1301,8 @@
 
                 // Check if all rubbers for the parent fixture are now complete
                 var allRubbers = await dbc4.Rubbers
+                    .Include(r => r.HomePlayer1).Include(r => r.HomePlayer2)
+                    .Include(r => r.AwayPlayer1).Include(r => r.AwayPlayer2)
                     .Where(r => r.CompetitionFixtureId == rub.CompetitionFixtureId)
                     .ToListAsync();
 
@@ -1307,17 +1310,37 @@
                 {
                     var (homeScore, awayScore) = RubberResolutionService.ComputeScore(
                         allRubbers, rub.Fixture.HomeTeamId.Value, rub.Fixture.AwayTeamId.Value);
-                    var fx = await dbc4.CompetitionFixtures.FindAsync(rub.CompetitionFixtureId);
+                    var fx = await dbc4.CompetitionFixtures
+                        .Include(f => f.Competition)
+                        .Include(f => f.HomeTeam)
+                        .Include(f => f.AwayTeam)
+                        .FirstOrDefaultAsync(f => f.CompetitionFixtureId == rub.CompetitionFixtureId);
                     if (fx != null)
                     {
-                        fx.Status = FixtureStatus.Completed;
-                        fx.CompletedAt = DateTime.UtcNow;
                         fx.ResultSummary = $"{homeScore}-{awayScore}";
                         fx.WinnerTeamId = homeScore > awayScore ? fx.HomeTeamId
                                         : awayScore > homeScore ? fx.AwayTeamId
                                         : null; // draw
-                        await dbc4.SaveChangesAsync();
-                        await CompetitionProgressionService.TryAdvanceAsync(dbc4, fx.CompetitionId, fx.CompetitionFixtureId);
+                        fx.CompletedAt = DateTime.UtcNow;
+
+                        bool requireVerification = fx.Competition?.RequireVerification ?? false;
+                        if (requireVerification)
+                        {
+                            fx.Status = FixtureStatus.AwaitingVerification;
+                            fx.VerificationToken = Guid.NewGuid();
+                            await dbc4.SaveChangesAsync();
+
+                            var adminEmails = await ResultVerificationService.GetAdminEmailsForCompetitionAsync(fx.CompetitionId, dbc4);
+                            await ResultVerificationService.SendAdminVerificationEmailsForTeamMatchAsync(fx, allRubbers, adminEmails);
+                        }
+                        else
+                        {
+                            fx.Status = FixtureStatus.Completed;
+                            await dbc4.SaveChangesAsync();
+                            await Task.WhenAll(
+                                ResultVerificationService.SendResultNotificationForTeamMatchAsync(fx, allRubbers),
+                                CompetitionProgressionService.TryAdvanceAsync(dbc4, fx.CompetitionId, fx.CompetitionFixtureId));
+                        }
                     }
                 }
             }

--- a/DropShot/Services/EmailTemplateService.cs
+++ b/DropShot/Services/EmailTemplateService.cs
@@ -211,6 +211,81 @@ public class EmailTemplateService
         return WrapInBaseLayout($"Verify Result: {fixtureTitle}", body, $"Result verification needed: {side1Name} vs {side2Name}");
     }
 
+    // ── Team match emails (rubber-by-rubber layout) ──────────────────────────
+
+    /// <param name="rubbers">Each tuple: (rubberName, homePlayersLabel, awayPlayersLabel, scoreText, homeWon)</param>
+    public string MatchResultEmailForTeamMatch(
+        string fixtureTitle, string homeName, string awayName, string? winnerName,
+        IEnumerable<(string Name, string HomePlayers, string AwayPlayers, string Score, bool? HomeWon)> rubbers)
+    {
+        var body = $@"
+<h2 style=""margin:0 0 16px 0;font-size:22px;color:#1b5e20;"">Match Result</h2>
+<p style=""margin:0 0 12px 0;"">The result for your team match has been recorded:</p>
+{InfoBox($@"<strong>{Encode(fixtureTitle)}</strong>")}
+{RubberScoreCard(homeName, awayName, winnerName, rubbers)}
+<p style=""margin:16px 0 0 0;font-size:13px;color:#888888;"">This is an automated notification from DropShot.</p>";
+
+        return WrapInBaseLayout($"Match Result: {fixtureTitle}", body, $"Result recorded: {homeName} vs {awayName}");
+    }
+
+    /// <param name="rubbers">Each tuple: (rubberName, homePlayersLabel, awayPlayersLabel, scoreText, homeWon)</param>
+    public string AdminVerificationEmailForTeamMatch(
+        string fixtureTitle, string homeName, string awayName, string? winnerName,
+        string verifyUrl,
+        IEnumerable<(string Name, string HomePlayers, string AwayPlayers, string Score, bool? HomeWon)> rubbers)
+    {
+        var body = $@"
+<h2 style=""margin:0 0 16px 0;font-size:22px;color:#1b5e20;"">Result Verification Required</h2>
+<p style=""margin:0 0 12px 0;"">A team match result has been submitted and requires your verification:</p>
+{InfoBox($@"<strong>{Encode(fixtureTitle)}</strong>")}
+{RubberScoreCard(homeName, awayName, winnerName, rubbers)}
+{ActionButton("Verify Result", verifyUrl)}
+<p style=""margin:16px 0 0 0;font-size:13px;color:#888888;"">Please review and verify this result at your earliest convenience.</p>";
+
+        return WrapInBaseLayout($"Verify Result: {fixtureTitle}", body, $"Result verification needed: {homeName} vs {awayName}");
+    }
+
+    private string RubberScoreCard(
+        string homeName, string awayName, string? winnerName,
+        IEnumerable<(string Name, string HomePlayers, string AwayPlayers, string Score, bool? HomeWon)> rubbers)
+    {
+        var homeStyle = winnerName == homeName ? "color:#1b5e20;font-weight:bold;" : "";
+        var awayStyle = winnerName == awayName ? "color:#1b5e20;font-weight:bold;" : "";
+
+        var rows = "";
+        foreach (var (name, homePlayers, awayPlayers, score, homeWon) in rubbers)
+        {
+            var winCol = homeWon == true  ? $@"<td style=""padding:6px 10px;font-size:13px;color:#1b5e20;font-weight:bold;"">{Encode(homeName)} &#9733;</td>"
+                       : homeWon == false ? $@"<td style=""padding:6px 10px;font-size:13px;color:#1b5e20;font-weight:bold;"">{Encode(awayName)} &#9733;</td>"
+                       :                    $@"<td style=""padding:6px 10px;font-size:13px;color:#888;"">Draw</td>";
+            rows += $@"
+    <tr style=""border-bottom:1px solid #f0f0f0;"">
+        <td style=""padding:6px 10px;font-size:13px;font-weight:600;"">{Encode(name)}</td>
+        <td style=""padding:6px 10px;font-size:13px;color:#555;"">{Encode(homePlayers)}</td>
+        <td style=""padding:6px 10px;font-size:13px;color:#555;"">{Encode(awayPlayers)}</td>
+        <td style=""padding:6px 10px;font-size:14px;font-weight:bold;text-align:center;"">{Encode(score)}</td>
+        {winCol}
+    </tr>";
+        }
+
+        return $@"<p style=""margin:12px 0 4px 0;font-size:14px;"">
+    <span style=""{homeStyle}"">{Encode(homeName)}{(winnerName == homeName ? " &#9733;" : "")}</span>
+    &nbsp;vs&nbsp;
+    <span style=""{awayStyle}"">{Encode(awayName)}{(winnerName == awayName ? " &#9733;" : "")}</span>
+</p>
+<table role=""presentation"" cellpadding=""0"" cellspacing=""0"" border=""0"" width=""100%""
+       style=""margin:12px 0 16px 0;border-collapse:collapse;font-family:Arial,sans-serif;"">
+    <tr style=""border-bottom:2px solid #e0e0e0;background:#f5f5f5;"">
+        <th style=""padding:6px 10px;text-align:left;font-size:12px;color:#888;"">Rubber</th>
+        <th style=""padding:6px 10px;text-align:left;font-size:12px;color:#888;"">{Encode(homeName)}</th>
+        <th style=""padding:6px 10px;text-align:left;font-size:12px;color:#888;"">{Encode(awayName)}</th>
+        <th style=""padding:6px 10px;text-align:center;font-size:12px;color:#888;"">Sets</th>
+        <th style=""padding:6px 10px;text-align:left;font-size:12px;color:#888;"">Winner</th>
+    </tr>
+    {rows}
+</table>";
+    }
+
     private string ScoreCard(string side1Name, string side2Name, string resultSummary, string? winnerName)
     {
         // Handle both "6-4 3-6" and "6–4, 3–6" formats

--- a/DropShot/Services/FixtureSimulationService.cs
+++ b/DropShot/Services/FixtureSimulationService.cs
@@ -83,6 +83,8 @@ public class FixtureSimulationService(RubberResolutionService rubberResolver)
         var (homeScore, awayScore) = RubberResolutionService.ComputeScore(
             allRubbers, fx.HomeTeamId!.Value, fx.AwayTeamId!.Value);
 
+        // Simulation is a super-admin test tool — always completes immediately,
+        // bypassing RequireVerification regardless of the competition setting.
         fx.Status = FixtureStatus.Completed;
         fx.CompletedAt = DateTime.UtcNow;
         fx.ResultSummary = $"{homeScore}-{awayScore}";
@@ -108,6 +110,8 @@ public class FixtureSimulationService(RubberResolutionService rubberResolver)
         fx.WinnerPlayerId = side1Sets > side2Sets ? fx.Player1Id
                            : side2Sets > side1Sets ? fx.Player2Id
                            : null;
+        // Simulation is a super-admin test tool — always completes immediately,
+        // bypassing RequireVerification regardless of the competition setting.
         fx.Status = FixtureStatus.Completed;
         fx.CompletedAt = DateTime.UtcNow;
         fx.VerificationToken = null;

--- a/DropShot/Services/ResultVerificationService.cs
+++ b/DropShot/Services/ResultVerificationService.cs
@@ -40,6 +40,95 @@ public class ResultVerificationService(EmailService emailService, EmailTemplateS
         await Task.WhenAll(adminEmails.Select(email => SendSafe(email, subject, html, "admin verification", isHtml: true)));
     }
 
+    // ── Team match (rubber-based) notifications ──────────────────────────────
+
+    /// <summary>
+    /// Sends a result notification to every player who participated in the team
+    /// match (home and away players across all rubbers).
+    /// </summary>
+    public async Task SendResultNotificationForTeamMatchAsync(CompetitionFixture fixture, IEnumerable<Rubber> rubbers)
+    {
+        var title = FixtureTitle(fixture);
+        var (home, away) = SideNames(fixture);
+        var winnerName = WinnerName(fixture);
+        var subject = $"Match result: {home} vs {away}";
+        var rubberData = BuildRubberEmailData(rubbers, fixture);
+        var html = emailTemplateService.MatchResultEmailForTeamMatch(title, home, away, winnerName, rubberData);
+
+        var playerEmails = rubbers
+            .SelectMany(r => new[] { r.HomePlayer1, r.HomePlayer2, r.AwayPlayer1, r.AwayPlayer2 })
+            .Where(p => p?.Email != null)
+            .Select(p => p!.Email!)
+            .Distinct()
+            .Select(email => SendSafe(email, subject, html, "team match result notification", isHtml: true));
+
+        await Task.WhenAll(playerEmails);
+    }
+
+    /// <summary>
+    /// Sends an admin verification email for a team match. The fixture must already
+    /// have a VerificationToken set.
+    /// </summary>
+    public async Task SendAdminVerificationEmailsForTeamMatchAsync(
+        CompetitionFixture fixture, IEnumerable<Rubber> rubbers, IEnumerable<string> adminEmails)
+    {
+        if (fixture.VerificationToken == null) return;
+
+        var title = FixtureTitle(fixture);
+        var (home, away) = SideNames(fixture);
+        var winnerName = WinnerName(fixture);
+        var verifyUrl = $"{BaseUrl}/verify-result/{fixture.VerificationToken}";
+        var subject = $"Result verification required: {home} vs {away}";
+        var rubberData = BuildRubberEmailData(rubbers, fixture);
+        var html = emailTemplateService.AdminVerificationEmailForTeamMatch(title, home, away, winnerName, verifyUrl, rubberData);
+
+        await Task.WhenAll(adminEmails.Select(email =>
+            SendSafe(email, subject, html, "team match admin verification", isHtml: true)));
+    }
+
+    private static IEnumerable<(string Name, string HomePlayers, string AwayPlayers, string Score, bool? HomeWon)>
+        BuildRubberEmailData(IEnumerable<Rubber> rubbers, CompetitionFixture fixture)
+    {
+        foreach (var r in rubbers.OrderBy(x => x.Order))
+        {
+            var homeParts = new[] { r.HomePlayer1?.DisplayName, r.HomePlayer2?.DisplayName }
+                .Where(n => !string.IsNullOrEmpty(n));
+            var awayParts = new[] { r.AwayPlayer1?.DisplayName, r.AwayPlayer2?.DisplayName }
+                .Where(n => !string.IsNullOrEmpty(n));
+
+            string score;
+            bool? homeWon = null;
+            if (r.IsComplete && r.HomeSetsWon.HasValue && r.AwaySetsWon.HasValue)
+            {
+                score = $"{r.HomeSetsWon}–{r.AwaySetsWon} sets";
+                homeWon = r.WinnerTeamId == fixture.HomeTeamId ? true
+                        : r.WinnerTeamId == fixture.AwayTeamId ? false
+                        : (bool?)null;
+            }
+            else if (r.IsComplete && r.HomeGames.HasValue && r.AwayGames.HasValue)
+            {
+                score = $"{r.HomeGames}–{r.AwayGames}";
+                homeWon = r.WinnerTeamId == fixture.HomeTeamId ? true
+                        : r.WinnerTeamId == fixture.AwayTeamId ? false
+                        : (bool?)null;
+            }
+            else
+            {
+                score = "Not played";
+            }
+
+            yield return (
+                r.Name,
+                homeParts.Any() ? string.Join(" & ", homeParts) : "TBD",
+                awayParts.Any() ? string.Join(" & ", awayParts) : "TBD",
+                score,
+                homeWon
+            );
+        }
+    }
+
+    // ── Shared ───────────────────────────────────────────────────────────────
+
     public async Task<List<string>> GetAdminEmailsForCompetitionAsync(int competitionId, MyDbContext db)
     {
         return await db.ClubAdministrators


### PR DESCRIPTION
## Summary

- Team match fixtures (those scored via rubbers) did not honour the competition's **Require Verification** setting — they always completed immediately with no admin email
- `VerifyResult` page showed only individual-match set scores and used `WinnerPlayerId` (always null for team fixtures), so team match verification was broken end-to-end
- The round-robin simulation (SuperAdmin tool) already bypassed verification correctly — added explicit comments to document this

## Changes

### Email templates (`EmailTemplateService`)
- Added `MatchResultEmailForTeamMatch` — result notification showing a rubber-by-rubber table (rubber name, home players, away players, set score, winner)
- Added `AdminVerificationEmailForTeamMatch` — same rubber table with a "Verify Result" action button
- New `RubberScoreCard` HTML helper renders the rubber table

### Verification service (`ResultVerificationService`)
- `SendResultNotificationForTeamMatchAsync` — notifies all rubber players (home + away across all rubbers)
- `SendAdminVerificationEmailsForTeamMatchAsync` — sends rubber-aware verification email to competition admins
- `BuildRubberEmailData` — converts `Rubber` records into the email tuple format

### RubberScoreDialog & TennisScore (both finalization paths)
- After all rubbers complete, check `competition.RequireVerification`
- **If true**: set `AwaitingVerification` + `VerificationToken`, send admin verification email
- **If false**: set `Completed`, send player result notification, advance progression
- Rubbers are now loaded with player includes so email can show player names

### VerifyResult page
- Loads `HomeTeam`/`AwayTeam` and the fixture's rubbers when it's a team match
- Shows rubber breakdown table (rubber name, players, set score, winner per row)
- `WinnerName()` now resolves via `WinnerTeamId` for team fixtures
- Score-edit toggle hidden for team matches (info message links to the team-match page for corrections)

## Test plan
- [ ] Complete all rubbers in a team match for a competition with **Require Verification ON**
  - [ ] Fixture status → AwaitingVerification
  - [ ] Admin receives email with rubber table and Verify link
  - [ ] Verify link opens page showing rubber breakdown and Approve button
  - [ ] Approve → status → Completed, progression advances
- [ ] Same with **Require Verification OFF**
  - [ ] Fixture status → Completed immediately
  - [ ] Players receive result email with rubber table
- [ ] Simulate Round Robin on a competition with Require Verification ON
  - [ ] Simulated fixtures → Completed immediately (no verification email)

🤖 Generated with [Claude Code](https://claude.com/claude-code)