### PR TITLE
Fix: defer InProgress status to first rubber score entry

### DIFF
--- a/DropShot/Components/RubberScoreDialog.razor
+++ b/DropShot/Components/RubberScoreDialog.razor
@@ -230,6 +230,19 @@
                     }
                 }
             }
+            else
+            {
+                // Rubbers are in progress but not all done yet — mark fixture InProgress
+                // now that the first score has been entered. We deliberately did not do
+                // this in EnsureRubbersAsync (which runs when the page loads) so the
+                // fixture stays Scheduled until an actual score is recorded.
+                var fx = await db.CompetitionFixtures.FindAsync(rub.CompetitionFixtureId);
+                if (fx != null && fx.Status == FixtureStatus.Scheduled)
+                {
+                    fx.Status = FixtureStatus.InProgress;
+                    await db.SaveChangesAsync();
+                }
+            }
 
             MudDialog.Close(DialogResult.Ok(true));
         }

--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -1343,6 +1343,19 @@
                         }
                     }
                 }
+                else
+                {
+                    // Rubbers are in progress but not all done — mark fixture InProgress
+                    // now that the first rubber has been scored. Status is deliberately
+                    // NOT set in EnsureRubbersAsync (which runs on page load) so the
+                    // fixture stays Scheduled until an actual score is recorded.
+                    var fx = await dbc4.CompetitionFixtures.FindAsync(rub.CompetitionFixtureId);
+                    if (fx != null && fx.Status == FixtureStatus.Scheduled)
+                    {
+                        fx.Status = FixtureStatus.InProgress;
+                        await dbc4.SaveChangesAsync();
+                    }
+                }
             }
         }
     }

--- a/DropShot/Services/RubberResolutionService.cs
+++ b/DropShot/Services/RubberResolutionService.cs
@@ -58,9 +58,9 @@ public class RubberResolutionService(ICompetitionRubberTemplateProvider template
             db.Rubbers.Add(rubber);
         }
 
-        if (fixture.Status == FixtureStatus.Scheduled)
-            fixture.Status = FixtureStatus.InProgress;
-
+        // Do NOT advance status here — rubber rows are created lazily when the
+        // team-match page first loads, which is before any score is entered.
+        // Status is set to InProgress only when a rubber score is actually saved.
         await db.SaveChangesAsync();
     }
 


### PR DESCRIPTION
## Summary
- Removed the `InProgress` status change from `EnsureRubbersAsync` — this was firing on every page load before any score was entered
- `RubberScoreDialog` now sets `InProgress` in its `else` clause (triggered when not all rubbers are complete after saving a score)
- `TennisScore.razor` does the same after each rubber is finalised during live play
- Fixtures with rubbers will now stay `Scheduled` until the first actual rubber score is recorded

## Test plan
- [ ] Open a team-match page for a scheduled fixture — fixture should remain **Scheduled** in the fixtures list
- [ ] Enter a score for the first rubber — fixture should now show **In Progress**
- [ ] Complete all rubbers — fixture should move to **Completed** (or **Awaiting Verification** if required)
- [ ] Repeat via the live-scoring path (TennisScore) to confirm same behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)