### PR TITLE
Send match-completion emails in the background

### DIFF
--- a/DropShot/Components/SubmitScoreDialog.razor
+++ b/DropShot/Components/SubmitScoreDialog.razor
@@ -5,6 +5,7 @@
 
 @inject IDbContextFactory<MyDbContext> DbFactory
 @inject ResultVerificationService ResultVerificationService
+@inject BackgroundTaskQueue BackgroundTasks
 @inject ISnackbar Snackbar
 
 <MudDialog>
@@ -362,24 +363,40 @@
                 fx.Player4      = Fixture.Player4;
                 fx.FixtureLabel = Fixture.FixtureLabel;
 
-                try
+                // Fire notification + verification emails in the background so the
+                // dialog closes immediately — SMTP latency was blocking the UI.
+                // Bracket progression (in the non-verification path) stays awaited
+                // because the caller's view depends on the advanced state.
+                var competitionId = Fixture.CompetitionId;
+                var fixtureId = Fixture.CompetitionFixtureId;
+                if (requireVerification)
                 {
-                    if (requireVerification)
+                    BackgroundTasks.Run("fixture-verification-emails", async sp =>
                     {
-                        var adminEmailsTask = ResultVerificationService.GetAdminEmailsForCompetitionAsync(Fixture.CompetitionId, db);
-                        await Task.WhenAll(ResultVerificationService.SendResultNotificationAsync(fx), adminEmailsTask);
-                        await ResultVerificationService.SendAdminVerificationEmailsAsync(fx, adminEmailsTask.Result);
-                    }
-                    else
-                    {
+                        var svc = sp.GetRequiredService<ResultVerificationService>();
+                        var dbf = sp.GetRequiredService<IDbContextFactory<MyDbContext>>();
+                        await using var bgDb = dbf.CreateDbContext();
+                        var adminEmails = await svc.GetAdminEmailsForCompetitionAsync(competitionId, bgDb);
                         await Task.WhenAll(
-                            ResultVerificationService.SendResultNotificationAsync(fx),
-                            CompetitionProgressionService.TryAdvanceAsync(db, Fixture.CompetitionId, Fixture.CompetitionFixtureId));
-                    }
+                            svc.SendResultNotificationAsync(fx),
+                            svc.SendAdminVerificationEmailsAsync(fx, adminEmails));
+                    });
                 }
-                catch (Exception)
+                else
                 {
-                    Snackbar.Add("Score saved, but notifications or bracket progression failed. An admin may need to follow up.", Severity.Warning);
+                    BackgroundTasks.Run("fixture-result-notification", async sp =>
+                    {
+                        var svc = sp.GetRequiredService<ResultVerificationService>();
+                        await svc.SendResultNotificationAsync(fx);
+                    });
+                    try
+                    {
+                        await CompetitionProgressionService.TryAdvanceAsync(db, Fixture.CompetitionId, Fixture.CompetitionFixtureId);
+                    }
+                    catch (Exception)
+                    {
+                        Snackbar.Add("Score saved, but bracket progression failed. An admin may need to follow up.", Severity.Warning);
+                    }
                 }
             }
 

--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -24,6 +24,7 @@
 @inject CourtClaimService CourtClaim
 @inject ISnackbar Snackbar
 @inject ResultVerificationService ResultVerificationService
+@inject BackgroundTaskQueue BackgroundTasks
 @inject AuthenticationStateProvider AuthStateProvider
 @inject IJSRuntime JS
 
@@ -1334,22 +1335,35 @@
                         fx.CompletedAt = DateTime.UtcNow;
 
                         bool requireVerification = fx.Competition?.RequireVerification ?? false;
+                        // Fire emails in the background so the scorer isn't left
+                        // staring at SMTP latency after the last rubber. Bracket
+                        // progression stays awaited — it drives the UI.
                         if (requireVerification)
                         {
                             fx.Status = FixtureStatus.AwaitingVerification;
                             fx.VerificationToken = Guid.NewGuid();
                             await dbc4.SaveChangesAsync();
 
-                            var adminEmails = await ResultVerificationService.GetAdminEmailsForCompetitionAsync(fx.CompetitionId, dbc4);
-                            await ResultVerificationService.SendAdminVerificationEmailsForTeamMatchAsync(fx, allRubbers, adminEmails);
+                            var compId = fx.CompetitionId;
+                            BackgroundTasks.Run("team-match-verification-emails", async sp =>
+                            {
+                                var svc = sp.GetRequiredService<ResultVerificationService>();
+                                var dbf = sp.GetRequiredService<IDbContextFactory<MyDbContext>>();
+                                await using var bgDb = dbf.CreateDbContext();
+                                var adminEmails = await svc.GetAdminEmailsForCompetitionAsync(compId, bgDb);
+                                await svc.SendAdminVerificationEmailsForTeamMatchAsync(fx, allRubbers, adminEmails);
+                            });
                         }
                         else
                         {
                             fx.Status = FixtureStatus.Completed;
                             await dbc4.SaveChangesAsync();
-                            await Task.WhenAll(
-                                ResultVerificationService.SendResultNotificationForTeamMatchAsync(fx, allRubbers),
-                                CompetitionProgressionService.TryAdvanceAsync(dbc4, fx.CompetitionId, fx.CompetitionFixtureId));
+                            BackgroundTasks.Run("team-match-result-notification", async sp =>
+                            {
+                                var svc = sp.GetRequiredService<ResultVerificationService>();
+                                await svc.SendResultNotificationForTeamMatchAsync(fx, allRubbers);
+                            });
+                            await CompetitionProgressionService.TryAdvanceAsync(dbc4, fx.CompetitionId, fx.CompetitionFixtureId);
                         }
                     }
                 }

--- a/DropShot/Components/_Imports.razor
+++ b/DropShot/Components/_Imports.razor
@@ -6,6 +6,7 @@
 @using Microsoft.AspNetCore.Components.Web
 @using static Microsoft.AspNetCore.Components.Web.RenderMode
 @using Microsoft.AspNetCore.Components.Web.Virtualization
+@using Microsoft.Extensions.DependencyInjection
 @using Microsoft.JSInterop
 @using DropShot
 @using DropShot.Components

--- a/DropShot/Program.cs
+++ b/DropShot/Program.cs
@@ -117,6 +117,7 @@ builder.Services.AddSingleton<SiteSettingsService>();
 builder.Services.AddScoped<JwtTokenService>();
 builder.Services.AddSingleton<EmailService>();
 builder.Services.AddSingleton<EmailTemplateService>();
+builder.Services.AddSingleton<BackgroundTaskQueue>();
 builder.Services.AddScoped<ResultVerificationService>();
 builder.Services.AddScoped<AdminEmailService>();
 builder.Services.AddScoped<FuzzySearchService>();

--- a/DropShot/Services/BackgroundTaskQueue.cs
+++ b/DropShot/Services/BackgroundTaskQueue.cs
@@ -1,0 +1,33 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DropShot.Services;
+
+/// <summary>
+/// Fire-and-forget runner for work that shouldn't block the caller's response —
+/// primarily outbound email. Each task runs inside a fresh DI scope so it doesn't
+/// depend on the caller's (possibly soon-disposed) scope, and exceptions are
+/// logged rather than surfaced as unobserved-task-exception crashes.
+///
+/// Intended for "best effort" side-effects. Don't use this for work the user is
+/// about to observe (e.g. bracket progression) — those should stay awaited.
+/// </summary>
+public class BackgroundTaskQueue(
+    IServiceScopeFactory scopeFactory,
+    ILogger<BackgroundTaskQueue> logger)
+{
+    public void Run(string description, Func<IServiceProvider, Task> work)
+    {
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                using var scope = scopeFactory.CreateScope();
+                await work(scope.ServiceProvider);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Background task '{Description}' failed", description);
+            }
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- Admin-verification and result-notification emails were awaited inline after the fixture save, so SMTP latency kept the dialog / scoring page open.
- New `BackgroundTaskQueue` singleton runs each email task in a fresh DI scope and logs failures.
- Both `SubmitScoreDialog.razor` and the team-match completion path in `TennisScore.razor` now enqueue emails instead of awaiting them.
- `CompetitionProgressionService.TryAdvanceAsync` stays awaited — the caller's view depends on the advanced state.

## Test plan
- [ ] Score a competition fixture with `RequireVerification=true` → dialog closes immediately; admin receives the verification email shortly after
- [ ] Score a fixture with `RequireVerification=false` → dialog closes immediately; players receive the result notification; bracket advances before the UI returns
- [ ] Complete the final rubber of a team match with `RequireVerification=true` → scoring page returns without delay; admin email arrives
- [ ] Simulate an SMTP failure (misconfigure host temporarily) → UI still returns cleanly; error logged via `BackgroundTaskQueue`

🤖 Generated with [Claude Code](https://claude.com/claude-code)