### PR TITLE
Send rubber-completion emails in the background

### DIFF
--- a/DropShot/Components/RubberScoreDialog.razor
+++ b/DropShot/Components/RubberScoreDialog.razor
@@ -6,6 +6,7 @@
 @inject IDbContextFactory<MyDbContext> DbFactory
 @inject ISnackbar Snackbar
 @inject ResultVerificationService ResultVerificationService
+@inject BackgroundTaskQueue BackgroundTasks
 
 <MudDialog>
     <TitleContent>Enter rubber score</TitleContent>
@@ -211,22 +212,35 @@
                     fx.CompletedAt = DateTime.UtcNow;
 
                     bool requireVerification = fx.Competition?.RequireVerification ?? false;
+                    // Fire emails in the background so the dialog closes immediately
+                    // — SMTP latency was blocking the return after the last rubber.
+                    // Bracket progression stays awaited because the UI depends on it.
                     if (requireVerification)
                     {
                         fx.Status = FixtureStatus.AwaitingVerification;
                         fx.VerificationToken = Guid.NewGuid();
                         await db.SaveChangesAsync();
 
-                        var adminEmails = await ResultVerificationService.GetAdminEmailsForCompetitionAsync(fx.CompetitionId, db);
-                        await ResultVerificationService.SendAdminVerificationEmailsForTeamMatchAsync(fx, allRubbers, adminEmails);
+                        var compId = fx.CompetitionId;
+                        BackgroundTasks.Run("team-match-verification-emails", async sp =>
+                        {
+                            var svc = sp.GetRequiredService<ResultVerificationService>();
+                            var dbf = sp.GetRequiredService<IDbContextFactory<MyDbContext>>();
+                            await using var bgDb = dbf.CreateDbContext();
+                            var adminEmails = await svc.GetAdminEmailsForCompetitionAsync(compId, bgDb);
+                            await svc.SendAdminVerificationEmailsForTeamMatchAsync(fx, allRubbers, adminEmails);
+                        });
                     }
                     else
                     {
                         fx.Status = FixtureStatus.Completed;
                         await db.SaveChangesAsync();
-                        await Task.WhenAll(
-                            ResultVerificationService.SendResultNotificationForTeamMatchAsync(fx, allRubbers),
-                            CompetitionProgressionService.TryAdvanceAsync(db, fx.CompetitionId, fx.CompetitionFixtureId));
+                        BackgroundTasks.Run("team-match-result-notification", async sp =>
+                        {
+                            var svc = sp.GetRequiredService<ResultVerificationService>();
+                            await svc.SendResultNotificationForTeamMatchAsync(fx, allRubbers);
+                        });
+                        await CompetitionProgressionService.TryAdvanceAsync(db, fx.CompetitionId, fx.CompetitionFixtureId);
                     }
                 }
             }


### PR DESCRIPTION
## Summary
[PR #433](https://github.com/kingbeazer/DropShot/pull/433) backgrounded the email sends for the live-scoring (`TennisScore.razor`) and manual singles/doubles (`SubmitScoreDialog.razor`) paths, but missed `RubberScoreDialog.razor` — added in [#432](https://github.com/kingbeazer/DropShot/pull/432) after the audit branch forked. Submitting the final rubber via that dialog still awaited the admin verification email inline, so the delay returned on team matches.

This routes the same two email sends (`SendAdminVerificationEmailsForTeamMatchAsync` in the verification path, `SendResultNotificationForTeamMatchAsync` in the straight-complete path) through `BackgroundTaskQueue`, matching the `TennisScore.razor` team-match completion logic. Bracket progression stays awaited.

## Test plan
- [ ] Score the final rubber of a team match with `RequireVerification=true` via the rubber dialog → dialog closes immediately; admin verification email arrives shortly after
- [ ] Same with `RequireVerification=false` → dialog closes immediately; player notification email arrives; bracket advances before the UI returns

🤖 Generated with [Claude Code](https://claude.com/claude-code)