### PR TITLE
Feat: participant roles, competition clone, and self-registration

### DIFF
--- a/DropShot.Shared/Enums.cs
+++ b/DropShot.Shared/Enums.cs
@@ -35,10 +35,11 @@ public enum StageType : byte
 
 public enum ParticipantStatus : byte
 {
-    Registered = 1,
-    Confirmed = 2,
-    Withdrawn = 3,
-    Eliminated = 4
+    Registered   = 1,  // Added by admin but player has not yet confirmed participation
+    FullPlayer   = 2,  // Active full participant (was Confirmed — byte value unchanged)
+    Withdrawn    = 3,
+    Disqualified = 4,
+    Substitute   = 5,  // Available as a substitute, not in a team
 }
 
 public enum FriendStatus : byte

--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -70,6 +70,17 @@ else
         {
             <MudChip T="string" Color="Color.Warning" Variant="Variant.Outlined">Not Started</MudChip>
         }
+        @if (_canEdit && IsEdit)
+        {
+            <MudTooltip Text="Create a new competition based on this one">
+                <MudButton Variant="Variant.Outlined" Color="Color.Secondary"
+                           StartIcon="@Icons.Material.Filled.ContentCopy"
+                           Class="px-4"
+                           OnClick="OpenCloneDialog">
+                    Clone
+                </MudButton>
+            </MudTooltip>
+        }
         <MudButton Variant="Variant.Outlined" Color="Color.Info" StartIcon="@Icons.Material.Filled.Visibility"
                    Class="px-4"
                    OnClick="@(() => Nav.NavigateTo($"/competition/{Id}/view"))">
@@ -436,6 +447,13 @@ else
                                      ValueChanged="AddParticipant" ResetValueOnEmptyText="true"
                                      MaxItems="null"
                                      Variant="Variant.Outlined" Dense="true" Style="max-width:260px" />
+                    <MudSelect T="ParticipantStatus" @bind-Value="_addParticipantStatus"
+                               Label="Add as" Variant="Variant.Outlined" Dense="true"
+                               Style="max-width:160px">
+                        <MudSelectItem Value="@ParticipantStatus.Registered">Registered</MudSelectItem>
+                        <MudSelectItem Value="@ParticipantStatus.FullPlayer">Full Player</MudSelectItem>
+                        <MudSelectItem Value="@ParticipantStatus.Substitute">Substitute</MudSelectItem>
+                    </MudSelect>
                     @if (Model.HostClubId.HasValue)
                     {
                         <MudTooltip Text="Add a new light player to this club and competition">
@@ -512,7 +530,7 @@ else
                                Style="min-width:140px">
                         @foreach (ParticipantStatus s in Enum.GetValues<ParticipantStatus>())
                         {
-                            <MudSelectItem T="ParticipantStatus?" Value="@((ParticipantStatus?)s)">@s</MudSelectItem>
+                            <MudSelectItem T="ParticipantStatus?" Value="@((ParticipantStatus?)s)">@ParticipantStatusLabel(s)</MudSelectItem>
                         }
                     </MudSelect>
                     @if (hasTeamCol)
@@ -587,7 +605,7 @@ else
                                        T="ParticipantStatus">
                                 @foreach (ParticipantStatus s in Enum.GetValues<ParticipantStatus>())
                                 {
-                                    <MudSelectItem Value="@s">@s</MudSelectItem>
+                                    <MudSelectItem Value="@s">@ParticipantStatusLabel(s)</MudSelectItem>
                                 }
                             </MudSelect>
                         </MudTd>
@@ -1376,6 +1394,30 @@ else
 </MudDialog>
 
 @* ── QR Code Dialog ──────────────────────────────────────── *@
+@* ── Clone competition dialog ────────────────────────────────── *@
+<MudDialog @bind-Visible="_showCloneDialog" Options="@(new DialogOptions { MaxWidth = MaxWidth.Small, FullWidth = true, CloseOnEscapeKey = true })">
+    <TitleContent>Clone Competition</TitleContent>
+    <DialogContent>
+        <MudStack Spacing="3">
+            <MudText Typo="Typo.body2" Color="Color.Secondary">
+                Creates a new competition with the same format, scoring, stages, and rubber template.
+                Dates are not copied — set them on the new competition after creation.
+            </MudText>
+            <MudTextField @bind-Value="_cloneName" Label="New competition name"
+                          Variant="Variant.Outlined" Required="true" Immediate="true" />
+            <MudCheckBox @bind-Value="_cloneCopyParticipants" Label="Copy participants (reset to Registered)" Color="Color.Primary" />
+        </MudStack>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@(() => _showCloneDialog = false)">Cancel</MudButton>
+        <MudButton Color="Color.Primary" Variant="Variant.Filled"
+                   Disabled="@(string.IsNullOrWhiteSpace(_cloneName) || _cloneSaving)"
+                   OnClick="CloneCompetitionAsync">
+            @(_cloneSaving ? "Creating…" : "Create")
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
 <MudDialog @bind-Visible="_showQrDialog" Options="@(new DialogOptions { MaxWidth = MaxWidth.Small, FullWidth = true })">
     <TitleContent>Match QR Code</TitleContent>
     <DialogContent>
@@ -1501,6 +1543,15 @@ else
     private byte _divisionRank = 1;
     private bool _addingDivision;
     private int? _inlineEditDivisionId;
+
+    // Add-participant status selector
+    private ParticipantStatus _addParticipantStatus = ParticipantStatus.Registered;
+
+    // Clone competition dialog state
+    private bool _showCloneDialog;
+    private string _cloneName = "";
+    private bool _cloneCopyParticipants;
+    private bool _cloneSaving;
 
     // Seed-from-previous dialog state
     private bool _showSeedDivisionsDialog;
@@ -2499,13 +2550,13 @@ else
             CompetitionId = Id,
             PlayerId = player.PlayerId,
             RegisteredAt = DateTime.UtcNow,
-            Status = ParticipantStatus.Registered
+            Status = _addParticipantStatus
         };
         db.CompetitionParticipants.Add(cp);
         await db.SaveChangesAsync();
         cp.Player = player;
         _participants.Add(cp);
-        Snackbar.Add($"{player.DisplayName} added.", Severity.Success);
+        Snackbar.Add($"{player.DisplayName} added as {ParticipantStatusLabel(_addParticipantStatus)}.", Severity.Success);
         if (_participantAutocomplete != null)
             await _participantAutocomplete.ClearAsync();
     }
@@ -2566,7 +2617,7 @@ else
         {
             var candidates = _participants
                 .Where(p => p.TeamId == team.CompetitionTeamId
-                         && (p.Status == ParticipantStatus.Registered || p.Status == ParticipantStatus.Confirmed))
+                         && p.Status == ParticipantStatus.FullPlayer)
                 .ToList();
             if (candidates.Count == 0) { skipped++; continue; }
 
@@ -2713,6 +2764,131 @@ else
         _divisions.Remove(d);
     }
 
+    // ── Clone competition ───────────────────────────────────────────────────
+
+    private void OpenCloneDialog()
+    {
+        _cloneName = $"{Model.CompetitionName} — New Season";
+        _cloneCopyParticipants = false;
+        _cloneSaving = false;
+        _showCloneDialog = true;
+    }
+
+    private async Task CloneCompetitionAsync()
+    {
+        if (string.IsNullOrWhiteSpace(_cloneName)) return;
+        _cloneSaving = true;
+        try
+        {
+            await using var db = DbFactory.CreateDbContext();
+            var source = await db.Competition
+                .Include(c => c.Stages)
+                .Include(c => c.RubberTemplate!).ThenInclude(rt => rt.Rubbers)
+                .FirstOrDefaultAsync(c => c.CompetitionID == Id);
+            if (source == null) return;
+
+            var newComp = new Competition
+            {
+                CompetitionName     = _cloneName.Trim(),
+                CompetitionFormat   = source.CompetitionFormat,
+                HostClubId          = source.HostClubId,
+                CreatorUserId       = source.HostClubId == null ? source.CreatorUserId : null,
+                MaxParticipants     = source.MaxParticipants,
+                MaxAge              = source.MaxAge,
+                MinAge              = source.MinAge,
+                EligibleSex         = source.EligibleSex,
+                RulesSetId          = source.RulesSetId,
+                EventId             = source.EventId,
+                HasDivisions        = source.HasDivisions,
+                BestOf              = source.BestOf,
+                MatchFormat         = source.MatchFormat,
+                NumberOfSets        = source.NumberOfSets,
+                GamesPerSet         = source.GamesPerSet,
+                SetWinMode          = source.SetWinMode,
+                LeagueScoring       = source.LeagueScoring,
+                TeamSize            = source.TeamSize,
+                RubberTemplateKey   = source.RubberTemplateKey,
+                RequireVerification = source.RequireVerification,
+                IsRestricted        = source.IsRestricted,
+                SeededFromCompetitionId = Id,
+            };
+            db.Competition.Add(newComp);
+            await db.SaveChangesAsync(); // generates CompetitionID
+
+            // Copy stages
+            foreach (var stage in source.Stages.OrderBy(s => s.StageOrder))
+            {
+                db.CompetitionStages.Add(new CompetitionStage
+                {
+                    CompetitionId = newComp.CompetitionID,
+                    Name          = stage.Name,
+                    StageOrder    = stage.StageOrder,
+                    StageType     = stage.StageType,
+                });
+            }
+
+            // Copy custom rubber template rubbers (if any)
+            if (source.RubberTemplate?.Rubbers.Count > 0)
+            {
+                var newTemplate = new CompetitionRubberTemplate { CompetitionId = newComp.CompetitionID };
+                db.CompetitionRubberTemplates.Add(newTemplate);
+                await db.SaveChangesAsync(); // generates template ID
+                foreach (var r in source.RubberTemplate.Rubbers.OrderBy(r => r.Order))
+                {
+                    db.RubberTemplateRubbers.Add(new RubberTemplateRubber
+                    {
+                        CompetitionRubberTemplateId = newTemplate.CompetitionRubberTemplateId,
+                        Order        = r.Order,
+                        Name         = r.Name,
+                        CourtNumber  = r.CourtNumber,
+                        HomeRolesJson = r.HomeRolesJson,
+                        AwayRolesJson = r.AwayRolesJson,
+                    });
+                }
+            }
+
+            // Copy active participants (reset status to Registered)
+            if (_cloneCopyParticipants)
+            {
+                var toClone = await db.CompetitionParticipants
+                    .Where(p => p.CompetitionId == Id
+                        && p.Status != ParticipantStatus.Withdrawn
+                        && p.Status != ParticipantStatus.Disqualified)
+                    .ToListAsync();
+                foreach (var p in toClone)
+                {
+                    db.CompetitionParticipants.Add(new CompetitionParticipant
+                    {
+                        CompetitionId = newComp.CompetitionID,
+                        PlayerId      = p.PlayerId,
+                        RegisteredAt  = DateTime.UtcNow,
+                        Status        = ParticipantStatus.Registered,
+                    });
+                }
+            }
+
+            await db.SaveChangesAsync();
+            _showCloneDialog = false;
+            Nav.NavigateTo($"/competition/{newComp.CompetitionID}");
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Failed to clone competition: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _cloneSaving = false;
+        }
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private static string ParticipantStatusLabel(ParticipantStatus s) => s switch
+    {
+        ParticipantStatus.FullPlayer => "Full Player",
+        _ => s.ToString()
+    };
+
     private void OpenSeedDivisionsDialog()
     {
         _seedSourceCompetitionId = _seedSourceCandidates.FirstOrDefault()?.CompetitionID;
@@ -2829,7 +3005,7 @@ else
     {
         var members = _participants
             .Where(p => p.TeamId == team.CompetitionTeamId
-                && (p.Status == ParticipantStatus.Registered || p.Status == ParticipantStatus.Confirmed))
+                && p.Status == ParticipantStatus.FullPlayer)
             .ToList();
 
         var errors = new List<string>();
@@ -2985,12 +3161,20 @@ else
         _generatedPreview = [];
 
         var active = _participants
-            .Where(p => p.Status is ParticipantStatus.Registered or ParticipantStatus.Confirmed)
+            .Where(p => p.Status == ParticipantStatus.FullPlayer)
             .ToList();
+
+        // Warn about participants who will be skipped
+        var skippedRegistered = _participants.Count(p => p.Status == ParticipantStatus.Registered);
+        var skippedDisqualified = _participants.Count(p => p.Status == ParticipantStatus.Disqualified);
+        if (skippedRegistered > 0)
+            _generateWarnings.Add($"{skippedRegistered} participant(s) with status 'Registered' will be skipped — only Full Players are included in team generation. Confirm their participation first.");
+        if (skippedDisqualified > 0)
+            _generateWarnings.Add($"{skippedDisqualified} disqualified participant(s) will be skipped.");
 
         if (active.Count == 0)
         {
-            _generateWarnings.Add("No active participants to generate from.");
+            _generateWarnings.Add("No Full Players to generate from.");
             return;
         }
 
@@ -4297,7 +4481,7 @@ else
             .ToHashSet();
 
         var activePlayers = _participants
-            .Where(p => p.Status == ParticipantStatus.Registered || p.Status == ParticipantStatus.Confirmed)
+            .Where(p => p.Status == ParticipantStatus.FullPlayer)
             .Select(p => p.PlayerId)
             .ToList();
 

--- a/DropShot/Components/Pages/ViewCompetition.razor
+++ b/DropShot/Components/Pages/ViewCompetition.razor
@@ -31,7 +31,36 @@ else if (!_competition.IsStarted && !_canEdit)
 }
 else if (!_canView)
 {
-    <MudAlert Severity="Severity.Warning" Class="mb-4">You can only view this competition if you are registered to play in it.</MudAlert>
+    @if (!string.IsNullOrEmpty(_currentUserId) && !(_competition!.IsRestricted))
+    {
+        @* Logged-in player who is not yet registered — offer self-registration *@
+        <MudCard Class="mb-4" Elevation="2">
+            <MudCardContent>
+                <MudText Typo="Typo.h6" Class="mb-2">Join @_competition.CompetitionName</MudText>
+                @if (!string.IsNullOrEmpty(_selfRegisterError))
+                {
+                    <MudAlert Severity="Severity.Error" Class="mb-3">@_selfRegisterError</MudAlert>
+                }
+                <MudText Typo="Typo.body2" Class="mb-3">How would you like to participate?</MudText>
+                <MudStack Row="true" Spacing="2" Wrap="Wrap.Wrap">
+                    <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                               Disabled="_selfRegisterSaving"
+                               OnClick="@(() => SelfRegisterAsync(ParticipantStatus.FullPlayer))">
+                        Register as Full Player
+                    </MudButton>
+                    <MudButton Variant="Variant.Outlined" Color="Color.Primary"
+                               Disabled="_selfRegisterSaving"
+                               OnClick="@(() => SelfRegisterAsync(ParticipantStatus.Substitute))">
+                        Register as Substitute
+                    </MudButton>
+                </MudStack>
+            </MudCardContent>
+        </MudCard>
+    }
+    else
+    {
+        <MudAlert Severity="Severity.Warning" Class="mb-4">You can only view this competition if you are registered to play in it.</MudAlert>
+    }
 }
 else
 {
@@ -84,6 +113,35 @@ else
             </MudItem>
         }
     </MudGrid>
+
+    @* ── Confirm participation banner (for Registered-only players) ── *@
+    @if (!_canEdit && _myParticipant?.Status == ParticipantStatus.Registered)
+    {
+        <MudAlert Severity="Severity.Info" Class="mb-4">
+            <MudStack Spacing="2">
+                <MudText Typo="Typo.body2">
+                    You are registered for this competition but have not yet confirmed your participation.
+                    Please indicate how you would like to take part:
+                </MudText>
+                @if (!string.IsNullOrEmpty(_selfRegisterError))
+                {
+                    <MudAlert Severity="Severity.Error" Dense="true">@_selfRegisterError</MudAlert>
+                }
+                <MudStack Row="true" Spacing="2" Wrap="Wrap.Wrap">
+                    <MudButton Variant="Variant.Filled" Color="Color.Primary" Size="Size.Small"
+                               Disabled="_selfRegisterSaving"
+                               OnClick="@(() => ConfirmParticipationAsync(ParticipantStatus.FullPlayer))">
+                        Enter as Full Player
+                    </MudButton>
+                    <MudButton Variant="Variant.Outlined" Color="Color.Primary" Size="Size.Small"
+                               Disabled="_selfRegisterSaving"
+                               OnClick="@(() => ConfirmParticipationAsync(ParticipantStatus.Substitute))">
+                        Enter as Substitute
+                    </MudButton>
+                </MudStack>
+            </MudStack>
+        </MudAlert>
+    }
 
     <MudDivider Class="mb-4" />
 
@@ -341,13 +399,39 @@ else
                                     <MudTd DataLabel="Mobile">@(context.Player?.MobileNumber ?? "—")</MudTd>
                                     <MudTd DataLabel="Status">
                                         <MudChip T="string" Size="Size.Small" Color="@ParticipantColor(context.Status)">
-                                            @context.Status
+                                            @ParticipantStatusLabel(context.Status)
                                         </MudChip>
                                     </MudTd>
                                 </RowTemplate>
                                 <NoRecordsContent><MudText Typo="Typo.caption">No players in this team.</MudText></NoRecordsContent>
                             </MudTable>
                         }
+                    }
+
+                    @* ── Substitutes for this division ── *@
+                    @{
+                        var divSubs = _participants
+                            .Where(p => p.Status == ParticipantStatus.Substitute
+                                && (p.CompetitionDivisionId == divKey
+                                    || (p.TeamId.HasValue && divTeams.Any(t => t.CompetitionTeamId == p.TeamId.Value))))
+                            .OrderBy(p => p.Player?.DisplayName)
+                            .ToList();
+                    }
+                    @if (divSubs.Count > 0)
+                    {
+                        <MudDivider Class="my-3" />
+                        <MudText Typo="Typo.subtitle1" Class="mt-1 mb-2">Substitutes</MudText>
+                        <MudTable Items="@divSubs" Dense="true" Hover="true" Breakpoint="Breakpoint.Sm" Class="mb-2 mobile-stack-table">
+                            <HeaderContent>
+                                <MudTh Style="width:auto">Player</MudTh>
+                                <MudTh Style="width:180px">Mobile</MudTh>
+                            </HeaderContent>
+                            <RowTemplate>
+                                <MudTd DataLabel="Player">@context.Player?.DisplayName</MudTd>
+                                <MudTd DataLabel="Mobile">@(context.Player?.MobileNumber ?? "—")</MudTd>
+                            </RowTemplate>
+                            <NoRecordsContent><MudText Typo="Typo.caption">No substitutes.</MudText></NoRecordsContent>
+                        </MudTable>
                     }
                 </MudExpansionPanel>
         }
@@ -503,7 +587,7 @@ else
                         <MudTd DataLabel="Mobile">@(context.Player?.MobileNumber ?? "—")</MudTd>
                         <MudTd DataLabel="Status">
                             <MudChip T="string" Size="Size.Small" Color="@ParticipantColor(context.Status)">
-                                @context.Status
+                                @ParticipantStatusLabel(context.Status)
                             </MudChip>
                         </MudTd>
                     </RowTemplate>
@@ -543,7 +627,7 @@ else
                         <MudTd DataLabel="Mobile">@(context.Player?.MobileNumber ?? "—")</MudTd>
                         <MudTd DataLabel="Status">
                             <MudChip T="string" Size="Size.Small" Color="@ParticipantColor(context.Status)">
-                                @context.Status
+                                @ParticipantStatusLabel(context.Status)
                             </MudChip>
                         </MudTd>
                     </RowTemplate>
@@ -629,6 +713,12 @@ else
     private List<DivisionFixtureGroup> _fixturesByDivision = [];
     private List<(CompetitionDivision? Division, List<CompetitionTeam> Teams)> _teamsByDivision = [];
 
+    // Self-registration / participation confirmation state
+    private CompetitionParticipant? _myParticipant;
+    private string? _currentUserId;
+    private bool _selfRegisterSaving;
+    private string? _selfRegisterError;
+
     protected override async Task OnParametersSetAsync()
     {
         _loading = true;
@@ -685,6 +775,10 @@ else
             _participants = _competition.Participants
                 .OrderBy(p => p.Player?.DisplayName)
                 .ToList();
+
+            // Track current user's participant record for self-registration / status-upgrade flows
+            _currentUserId = authState.User.FindFirstValue(ClaimTypes.NameIdentifier);
+            _myParticipant = _participants.FirstOrDefault(p => p.Player?.UserId == _currentUserId);
 
             _teams = _competition.Teams
                 .OrderBy(t => t.Name)
@@ -1022,11 +1116,94 @@ else
 
     private static Color ParticipantColor(ParticipantStatus s) => s switch
     {
-        ParticipantStatus.Confirmed => Color.Success,
-        ParticipantStatus.Registered => Color.Info,
-        ParticipantStatus.Withdrawn => Color.Warning,
+        ParticipantStatus.FullPlayer   => Color.Success,
+        ParticipantStatus.Substitute   => Color.Info,
+        ParticipantStatus.Registered   => Color.Default,
+        ParticipantStatus.Withdrawn    => Color.Warning,
         ParticipantStatus.Disqualified => Color.Error,
         _ => Color.Default
     };
+
+    private static string ParticipantStatusLabel(ParticipantStatus s) => s switch
+    {
+        ParticipantStatus.FullPlayer => "Full Player",
+        _ => s.ToString()
+    };
+
+    private async Task SelfRegisterAsync(ParticipantStatus status)
+    {
+        if (string.IsNullOrEmpty(_currentUserId) || _competition == null) return;
+        _selfRegisterSaving = true;
+        _selfRegisterError = null;
+        StateHasChanged();
+        try
+        {
+            await using var db = await DbFactory.CreateDbContextAsync();
+            var player = await db.Players.FirstOrDefaultAsync(p => p.UserId == _currentUserId);
+            if (player == null)
+            {
+                _selfRegisterError = "Could not find your player record.";
+                return;
+            }
+            var existing = await db.CompetitionParticipants
+                .AnyAsync(cp => cp.CompetitionId == _competition.CompetitionID && cp.PlayerId == player.PlayerId);
+            if (existing)
+            {
+                _selfRegisterError = "You are already registered for this competition.";
+                return;
+            }
+            db.CompetitionParticipants.Add(new CompetitionParticipant
+            {
+                CompetitionId = _competition.CompetitionID,
+                PlayerId = player.PlayerId,
+                Status = status,
+                RegisteredAt = DateTime.UtcNow
+            });
+            await db.SaveChangesAsync();
+            Nav.NavigateTo(Nav.Uri, forceLoad: true);
+        }
+        catch (Exception ex)
+        {
+            _selfRegisterError = $"Registration failed: {ex.Message}";
+        }
+        finally
+        {
+            _selfRegisterSaving = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task ConfirmParticipationAsync(ParticipantStatus status)
+    {
+        if (string.IsNullOrEmpty(_currentUserId) || _competition == null || _myParticipant == null) return;
+        _selfRegisterSaving = true;
+        _selfRegisterError = null;
+        StateHasChanged();
+        try
+        {
+            await using var db = await DbFactory.CreateDbContextAsync();
+            var participant = await db.CompetitionParticipants
+                .FirstOrDefaultAsync(cp => cp.CompetitionId == _competition.CompetitionID
+                    && cp.PlayerId == _myParticipant.PlayerId);
+            if (participant == null)
+            {
+                _selfRegisterError = "Could not find your participant record.";
+                return;
+            }
+            participant.Status = status;
+            await db.SaveChangesAsync();
+            _myParticipant.Status = status;
+            StateHasChanged();
+        }
+        catch (Exception ex)
+        {
+            _selfRegisterError = $"Failed to update status: {ex.Message}";
+        }
+        finally
+        {
+            _selfRegisterSaving = false;
+            StateHasChanged();
+        }
+    }
 
 }

--- a/DropShot/Components/RubberScoreDialog.razor
+++ b/DropShot/Components/RubberScoreDialog.razor
@@ -230,6 +230,19 @@
                     }
                 }
             }
+            else
+            {
+                // Rubbers are in progress but not all done yet — mark fixture InProgress
+                // now that the first score has been entered. We deliberately did not do
+                // this in EnsureRubbersAsync (which runs when the page loads) so the
+                // fixture stays Scheduled until an actual score is recorded.
+                var fx = await db.CompetitionFixtures.FindAsync(rub.CompetitionFixtureId);
+                if (fx != null && fx.Status == FixtureStatus.Scheduled)
+                {
+                    fx.Status = FixtureStatus.InProgress;
+                    await db.SaveChangesAsync();
+                }
+            }
 
             MudDialog.Close(DialogResult.Ok(true));
         }

--- a/DropShot/Components/RubberScoreDialog.razor
+++ b/DropShot/Components/RubberScoreDialog.razor
@@ -199,8 +199,8 @@
                     allRubbers, rub.Fixture.HomeTeamId.Value, rub.Fixture.AwayTeamId.Value);
                 var fx = await db.CompetitionFixtures
                     .Include(f => f.Competition)
-                    .Include(f => f.HomeTeam)
-                    .Include(f => f.AwayTeam)
+                    .Include(f => f.HomeTeam).ThenInclude(t => t.Division)
+                    .Include(f => f.AwayTeam).ThenInclude(t => t.Division)
                     .FirstOrDefaultAsync(f => f.CompetitionFixtureId == rub.CompetitionFixtureId);
                 if (fx != null)
                 {

--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -1312,8 +1312,8 @@
                         allRubbers, rub.Fixture.HomeTeamId.Value, rub.Fixture.AwayTeamId.Value);
                     var fx = await dbc4.CompetitionFixtures
                         .Include(f => f.Competition)
-                        .Include(f => f.HomeTeam)
-                        .Include(f => f.AwayTeam)
+                        .Include(f => f.HomeTeam).ThenInclude(t => t.Division)
+                        .Include(f => f.AwayTeam).ThenInclude(t => t.Division)
                         .FirstOrDefaultAsync(f => f.CompetitionFixtureId == rub.CompetitionFixtureId);
                     if (fx != null)
                     {

--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -1343,6 +1343,19 @@
                         }
                     }
                 }
+                else
+                {
+                    // Rubbers are in progress but not all done — mark fixture InProgress
+                    // now that the first rubber has been scored. Status is deliberately
+                    // NOT set in EnsureRubbersAsync (which runs on page load) so the
+                    // fixture stays Scheduled until an actual score is recorded.
+                    var fx = await dbc4.CompetitionFixtures.FindAsync(rub.CompetitionFixtureId);
+                    if (fx != null && fx.Status == FixtureStatus.Scheduled)
+                    {
+                        fx.Status = FixtureStatus.InProgress;
+                        await dbc4.SaveChangesAsync();
+                    }
+                }
             }
         }
     }

--- a/DropShot/Controllers/CompetitionsController.cs
+++ b/DropShot/Controllers/CompetitionsController.cs
@@ -872,8 +872,7 @@ public class CompetitionsController(
 
         var members = await db.CompetitionParticipants
             .Where(cp => cp.CompetitionId == id && cp.TeamId == teamId
-                && (cp.Status == DropShot.Models.ParticipantStatus.Registered
-                    || cp.Status == DropShot.Models.ParticipantStatus.Confirmed))
+                && cp.Status == DropShot.Models.ParticipantStatus.FullPlayer)
             .Include(cp => cp.Player)
             .ToListAsync();
 

--- a/DropShot/Models/CompetitionParticipant.cs
+++ b/DropShot/Models/CompetitionParticipant.cs
@@ -2,10 +2,11 @@ namespace DropShot.Models;
 
 public enum ParticipantStatus : byte
 {
-    Registered = 1,
-    Confirmed = 2,
-    Withdrawn = 3,
-    Disqualified = 4
+    Registered   = 1,  // Added by admin but player has not yet confirmed participation
+    FullPlayer   = 2,  // Active full participant (was Confirmed — byte value unchanged)
+    Withdrawn    = 3,
+    Disqualified = 4,
+    Substitute   = 5,  // Available as a substitute, not in a team
 }
 
 public class CompetitionParticipant

--- a/DropShot/Services/CompetitionProgressionService.cs
+++ b/DropShot/Services/CompetitionProgressionService.cs
@@ -104,7 +104,7 @@ public static class CompetitionProgressionService
         // Compute RR standings
         var activePids = await db.CompetitionParticipants
             .Where(p => p.CompetitionId == competitionId
-                     && (p.Status == ParticipantStatus.Registered || p.Status == ParticipantStatus.Confirmed))
+                     && p.Status == ParticipantStatus.FullPlayer)
             .Select(p => p.PlayerId)
             .ToListAsync();
 

--- a/DropShot/Services/CompetitionSchedulerService.cs
+++ b/DropShot/Services/CompetitionSchedulerService.cs
@@ -111,7 +111,7 @@ public class CompetitionSchedulerService(IDbContextFactory<MyDbContext> dbFactor
             .ToHashSet();
 
         var activePlayers = comp.Participants
-            .Where(p => p.Status is ParticipantStatus.Registered or ParticipantStatus.Confirmed)
+            .Where(p => p.Status == ParticipantStatus.FullPlayer)
             .Select(p => p.PlayerId)
             .ToList();
 
@@ -307,7 +307,7 @@ public class CompetitionSchedulerService(IDbContextFactory<MyDbContext> dbFactor
                         ? comp.Teams.Count(t => t.CompetitionDivisionId == d.CompetitionDivisionId)
                         : comp.Participants.Count(p =>
                             p.CompetitionDivisionId == d.CompetitionDivisionId &&
-                            (p.Status == ParticipantStatus.Registered || p.Status == ParticipantStatus.Confirmed));
+                            p.Status == ParticipantStatus.FullPlayer);
                     yield return (d.Name, d.CompetitionDivisionId, bucketN);
                 }
             }
@@ -355,7 +355,7 @@ public class CompetitionSchedulerService(IDbContextFactory<MyDbContext> dbFactor
                     if (isTeamComp && comp.Teams.Count >= 2)
                     {
                         var allMembers = comp.Participants
-                            .Where(p => p.TeamId != null && (p.Status is ParticipantStatus.Registered or ParticipantStatus.Confirmed))
+                            .Where(p => p.TeamId != null && p.Status == ParticipantStatus.FullPlayer)
                             .ToList();
 
                         IEnumerable<IGrouping<int?, CompetitionTeam>> teamGroups = comp.HasDivisions

--- a/DropShot/Services/EmailTemplateService.cs
+++ b/DropShot/Services/EmailTemplateService.cs
@@ -215,74 +215,104 @@ public class EmailTemplateService
 
     /// <param name="rubbers">Each tuple: (rubberName, homePlayersLabel, awayPlayersLabel, scoreText, homeWon)</param>
     public string MatchResultEmailForTeamMatch(
-        string fixtureTitle, string homeName, string awayName, string? winnerName,
+        string competitionName, string? divisionName,
+        string homeName, string awayName, string? winnerName,
+        int totalHomeSets, int totalAwaySets,
         IEnumerable<(string Name, string HomePlayers, string AwayPlayers, string Score, bool? HomeWon)> rubbers)
     {
+        var winnerBlock = winnerName != null
+            ? $@"<p style=""margin:12px 0 16px 0;font-size:15px;"">
+    <strong style=""color:#1b5e20;"">Winner: {Encode(winnerName)} &#9733;</strong>
+</p>"
+            : "";
+
         var body = $@"
 <h2 style=""margin:0 0 16px 0;font-size:22px;color:#1b5e20;"">Match Result</h2>
 <p style=""margin:0 0 12px 0;"">The result for your team match has been recorded:</p>
-{InfoBox($@"<strong>{Encode(fixtureTitle)}</strong>")}
-{RubberScoreCard(homeName, awayName, winnerName, rubbers)}
+{MatchHeader(competitionName, divisionName, homeName, awayName)}
+{RubberScoreCard(homeName, awayName, totalHomeSets, totalAwaySets, rubbers)}
+{winnerBlock}
 <p style=""margin:16px 0 0 0;font-size:13px;color:#888888;"">This is an automated notification from DropShot.</p>";
 
-        return WrapInBaseLayout($"Match Result: {fixtureTitle}", body, $"Result recorded: {homeName} vs {awayName}");
+        return WrapInBaseLayout($"Match Result: {competitionName}", body, $"Result recorded: {homeName} vs {awayName}");
     }
 
     /// <param name="rubbers">Each tuple: (rubberName, homePlayersLabel, awayPlayersLabel, scoreText, homeWon)</param>
     public string AdminVerificationEmailForTeamMatch(
-        string fixtureTitle, string homeName, string awayName, string? winnerName,
+        string competitionName, string? divisionName,
+        string homeName, string awayName, string? winnerName,
         string verifyUrl,
+        int totalHomeSets, int totalAwaySets,
         IEnumerable<(string Name, string HomePlayers, string AwayPlayers, string Score, bool? HomeWon)> rubbers)
     {
+        var winnerBlock = winnerName != null
+            ? $@"<p style=""margin:12px 0 8px 0;font-size:15px;"">
+    <strong style=""color:#1b5e20;"">Winner: {Encode(winnerName)} &#9733;</strong>
+</p>"
+            : "";
+
         var body = $@"
 <h2 style=""margin:0 0 16px 0;font-size:22px;color:#1b5e20;"">Result Verification Required</h2>
 <p style=""margin:0 0 12px 0;"">A team match result has been submitted and requires your verification:</p>
-{InfoBox($@"<strong>{Encode(fixtureTitle)}</strong>")}
-{RubberScoreCard(homeName, awayName, winnerName, rubbers)}
+{MatchHeader(competitionName, divisionName, homeName, awayName)}
+{RubberScoreCard(homeName, awayName, totalHomeSets, totalAwaySets, rubbers)}
+{winnerBlock}
 {ActionButton("Verify Result", verifyUrl)}
 <p style=""margin:16px 0 0 0;font-size:13px;color:#888888;"">Please review and verify this result at your earliest convenience.</p>";
 
-        return WrapInBaseLayout($"Verify Result: {fixtureTitle}", body, $"Result verification needed: {homeName} vs {awayName}");
+        return WrapInBaseLayout($"Verify Result: {competitionName}", body, $"Result verification needed: {homeName} vs {awayName}");
+    }
+
+    private string MatchHeader(string competitionName, string? divisionName, string homeName, string awayName)
+    {
+        var divLine = divisionName != null
+            ? $@"<p style=""margin:0 0 4px 0;font-size:13px;color:#888888;"">{Encode(divisionName)}</p>"
+            : "";
+        return $@"<div style=""margin:0 0 16px 0;"">
+    <p style=""margin:0 0 4px 0;font-size:14px;font-weight:600;color:#333333;"">{Encode(competitionName)}</p>
+    {divLine}
+    <p style=""margin:0;font-size:15px;""><strong>{Encode(homeName)}</strong>&nbsp;vs&nbsp;<strong>{Encode(awayName)}</strong></p>
+</div>";
     }
 
     private string RubberScoreCard(
-        string homeName, string awayName, string? winnerName,
+        string homeName, string awayName,
+        int totalHomeSets, int totalAwaySets,
         IEnumerable<(string Name, string HomePlayers, string AwayPlayers, string Score, bool? HomeWon)> rubbers)
     {
-        var homeStyle = winnerName == homeName ? "color:#1b5e20;font-weight:bold;" : "";
-        var awayStyle = winnerName == awayName ? "color:#1b5e20;font-weight:bold;" : "";
-
         var rows = "";
-        foreach (var (name, homePlayers, awayPlayers, score, homeWon) in rubbers)
+        foreach (var (name, homePlayers, awayPlayers, score, _) in rubbers)
         {
-            var winCol = homeWon == true  ? $@"<td style=""padding:6px 10px;font-size:13px;color:#1b5e20;font-weight:bold;"">{Encode(homeName)} &#9733;</td>"
-                       : homeWon == false ? $@"<td style=""padding:6px 10px;font-size:13px;color:#1b5e20;font-weight:bold;"">{Encode(awayName)} &#9733;</td>"
-                       :                    $@"<td style=""padding:6px 10px;font-size:13px;color:#888;"">Draw</td>";
             rows += $@"
     <tr style=""border-bottom:1px solid #f0f0f0;"">
         <td style=""padding:6px 10px;font-size:13px;font-weight:600;"">{Encode(name)}</td>
         <td style=""padding:6px 10px;font-size:13px;color:#555;"">{Encode(homePlayers)}</td>
         <td style=""padding:6px 10px;font-size:13px;color:#555;"">{Encode(awayPlayers)}</td>
         <td style=""padding:6px 10px;font-size:14px;font-weight:bold;text-align:center;"">{Encode(score)}</td>
-        {winCol}
     </tr>";
         }
 
-        return $@"<p style=""margin:12px 0 4px 0;font-size:14px;"">
-    <span style=""{homeStyle}"">{Encode(homeName)}{(winnerName == homeName ? " &#9733;" : "")}</span>
-    &nbsp;vs&nbsp;
-    <span style=""{awayStyle}"">{Encode(awayName)}{(winnerName == awayName ? " &#9733;" : "")}</span>
-</p>
-<table role=""presentation"" cellpadding=""0"" cellspacing=""0"" border=""0"" width=""100%""
-       style=""margin:12px 0 16px 0;border-collapse:collapse;font-family:Arial,sans-serif;"">
-    <tr style=""border-bottom:2px solid #e0e0e0;background:#f5f5f5;"">
-        <th style=""padding:6px 10px;text-align:left;font-size:12px;color:#888;"">Rubber</th>
-        <th style=""padding:6px 10px;text-align:left;font-size:12px;color:#888;"">{Encode(homeName)}</th>
-        <th style=""padding:6px 10px;text-align:left;font-size:12px;color:#888;"">{Encode(awayName)}</th>
-        <th style=""padding:6px 10px;text-align:center;font-size:12px;color:#888;"">Sets</th>
-        <th style=""padding:6px 10px;text-align:left;font-size:12px;color:#888;"">Winner</th>
-    </tr>
-    {rows}
+        return $@"<table role=""presentation"" cellpadding=""0"" cellspacing=""0"" border=""0"" width=""100%""
+       style=""margin:0 0 8px 0;border-collapse:collapse;font-family:Arial,sans-serif;"">
+    <thead>
+        <tr style=""border-bottom:2px solid #e0e0e0;background:#f5f5f5;"">
+            <th style=""padding:6px 10px;text-align:left;font-size:12px;color:#888;"">Rubber</th>
+            <th style=""padding:6px 10px;text-align:left;font-size:12px;color:#888;"">{Encode(homeName)}</th>
+            <th style=""padding:6px 10px;text-align:left;font-size:12px;color:#888;"">{Encode(awayName)}</th>
+            <th style=""padding:6px 10px;text-align:center;font-size:12px;color:#888;"">Sets</th>
+        </tr>
+    </thead>
+    <tbody>
+        {rows}
+    </tbody>
+    <tfoot>
+        <tr style=""border-top:2px solid #e0e0e0;background:#f5f5f5;"">
+            <td style=""padding:8px 10px;font-size:13px;font-weight:bold;color:#555;"">Total sets</td>
+            <td style=""padding:8px 10px;font-size:15px;font-weight:bold;"">{totalHomeSets}</td>
+            <td style=""padding:8px 10px;font-size:15px;font-weight:bold;"">{totalAwaySets}</td>
+            <td></td>
+        </tr>
+    </tfoot>
 </table>";
     }
 

--- a/DropShot/Services/ResultVerificationService.cs
+++ b/DropShot/Services/ResultVerificationService.cs
@@ -48,14 +48,19 @@ public class ResultVerificationService(EmailService emailService, EmailTemplateS
     /// </summary>
     public async Task SendResultNotificationForTeamMatchAsync(CompetitionFixture fixture, IEnumerable<Rubber> rubbers)
     {
-        var title = FixtureTitle(fixture);
+        var competitionName = fixture.Competition?.CompetitionName ?? "Competition";
+        var divisionName = fixture.HomeTeam?.Division?.Name ?? fixture.AwayTeam?.Division?.Name;
         var (home, away) = SideNames(fixture);
         var winnerName = WinnerName(fixture);
         var subject = $"Match result: {home} vs {away}";
-        var rubberData = BuildRubberEmailData(rubbers, fixture);
-        var html = emailTemplateService.MatchResultEmailForTeamMatch(title, home, away, winnerName, rubberData);
+        var rubberList = rubbers.ToList();
+        var rubberData = BuildRubberEmailData(rubberList, fixture);
+        var (totalHomeSets, totalAwaySets) = ComputeRubberTotals(rubberList);
+        var html = emailTemplateService.MatchResultEmailForTeamMatch(
+            competitionName, divisionName, home, away, winnerName,
+            totalHomeSets, totalAwaySets, rubberData);
 
-        var playerEmails = rubbers
+        var playerEmails = rubberList
             .SelectMany(r => new[] { r.HomePlayer1, r.HomePlayer2, r.AwayPlayer1, r.AwayPlayer2 })
             .Where(p => p?.Email != null)
             .Select(p => p!.Email!)
@@ -74,16 +79,32 @@ public class ResultVerificationService(EmailService emailService, EmailTemplateS
     {
         if (fixture.VerificationToken == null) return;
 
-        var title = FixtureTitle(fixture);
+        var competitionName = fixture.Competition?.CompetitionName ?? "Competition";
+        var divisionName = fixture.HomeTeam?.Division?.Name ?? fixture.AwayTeam?.Division?.Name;
         var (home, away) = SideNames(fixture);
         var winnerName = WinnerName(fixture);
         var verifyUrl = $"{BaseUrl}/verify-result/{fixture.VerificationToken}";
         var subject = $"Result verification required: {home} vs {away}";
-        var rubberData = BuildRubberEmailData(rubbers, fixture);
-        var html = emailTemplateService.AdminVerificationEmailForTeamMatch(title, home, away, winnerName, verifyUrl, rubberData);
+        var rubberList = rubbers.ToList();
+        var rubberData = BuildRubberEmailData(rubberList, fixture);
+        var (totalHomeSets, totalAwaySets) = ComputeRubberTotals(rubberList);
+        var html = emailTemplateService.AdminVerificationEmailForTeamMatch(
+            competitionName, divisionName, home, away, winnerName, verifyUrl,
+            totalHomeSets, totalAwaySets, rubberData);
 
         await Task.WhenAll(adminEmails.Select(email =>
             SendSafe(email, subject, html, "team match admin verification", isHtml: true)));
+    }
+
+    private static (int totalHomeSets, int totalAwaySets) ComputeRubberTotals(IEnumerable<Rubber> rubbers)
+    {
+        int h = 0, a = 0;
+        foreach (var r in rubbers.Where(x => x.IsComplete))
+        {
+            h += r.HomeSetsWon ?? 0;
+            a += r.AwaySetsWon ?? 0;
+        }
+        return (h, a);
     }
 
     private static IEnumerable<(string Name, string HomePlayers, string AwayPlayers, string Score, bool? HomeWon)>

--- a/DropShot/Services/RubberResolutionService.cs
+++ b/DropShot/Services/RubberResolutionService.cs
@@ -58,9 +58,9 @@ public class RubberResolutionService(ICompetitionRubberTemplateProvider template
             db.Rubbers.Add(rubber);
         }
 
-        if (fixture.Status == FixtureStatus.Scheduled)
-            fixture.Status = FixtureStatus.InProgress;
-
+        // Do NOT advance status here — rubber rows are created lazily when the
+        // team-match page first loads, which is before any score is entered.
+        // Status is set to InProgress only when a rubber score is actually saved.
         await db.SaveChangesAsync();
     }
 

--- a/DropShot/Services/RubberResolutionService.cs
+++ b/DropShot/Services/RubberResolutionService.cs
@@ -112,7 +112,7 @@ public class RubberResolutionService(ICompetitionRubberTemplateProvider template
     {
         return await db.CompetitionParticipants
             .Where(cp => cp.CompetitionId == competitionId && cp.TeamId == teamId
-                && (cp.Status == ParticipantStatus.Registered || cp.Status == ParticipantStatus.Confirmed))
+                && cp.Status == ParticipantStatus.FullPlayer)
             .Include(cp => cp.Player)
             .ToListAsync();
     }


### PR DESCRIPTION
## Summary

- **Rename `Confirmed` → `FullPlayer`** (byte value 2 unchanged — no DB migration needed)
- **New `Substitute` status** (byte 5) for players available as cover but not in a team
- **Clone competition button** on the existing competition admin page — copies format, scoring, stages, and rubber template into a new competition; optionally copies participants (reset to Registered status)
- **Admin `Add as` selector** when adding a participant: choose Registered, Full Player, or Substitute
- **Self-registration**: players can join any non-restricted competition directly as Full Player or Substitute
- **Registered → active upgrade**: a banner prompts Registered players to confirm themselves as Full Player or Substitute
- **Team generation guard**: skips Registered and Disqualified participants with a visible warning count before generating
- **Substitutes section** per division in ViewCompetition, shown below the teams list
- All service-layer `ParticipantStatus.Confirmed` references updated to `FullPlayer`

## Test plan

- [ ] Add a participant as Registered, Full Player, and Substitute from the admin panel — verify correct status chip colours
- [ ] Log in as a non-participant and self-register on an open competition as Full Player and as Substitute
- [ ] Log in as a Registered player and use the upgrade banner to become Full Player / Substitute
- [ ] Generate teams with a mix of Registered, Full Player, and Disqualified participants — confirm warning counts appear and only Full Players are teamed
- [ ] Clone an existing competition — verify the cloned competition has the same stages/rubbers; clone with and without copying participants
- [ ] Confirm substitutes appear in the per-division section on ViewCompetition

🤖 Generated with [Claude Code](https://claude.com/claude-code)