### PR TITLE
Fix: replace remaining ParticipantStatus.Confirmed with FullPlayer

### DIFF
--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -3532,7 +3532,7 @@ else
         if (comp == null) return true;
 
         var participantIds = _participants
-            .Where(p => p.Status == ParticipantStatus.Registered || p.Status == ParticipantStatus.Confirmed)
+            .Where(p => p.Status == ParticipantStatus.FullPlayer)
             .Select(p => p.PlayerId).ToHashSet();
         var missing = playerIds.Where(pid => !participantIds.Contains(pid)).ToList();
         if (missing.Count > 0)

--- a/DropShot/Controllers/CompetitionsController.cs
+++ b/DropShot/Controllers/CompetitionsController.cs
@@ -431,8 +431,7 @@ public class CompetitionsController(
 
         var members = await db.CompetitionParticipants
             .Where(cp => cp.CompetitionId == id && cp.TeamId == teamId
-                && (cp.Status == DropShot.Models.ParticipantStatus.Registered
-                    || cp.Status == DropShot.Models.ParticipantStatus.Confirmed))
+                && cp.Status == DropShot.Models.ParticipantStatus.FullPlayer)
             .Include(cp => cp.Player)
             .ToListAsync();
 
@@ -592,8 +591,7 @@ public class CompetitionsController(
 
         var confirmedParticipantIds = await db.CompetitionParticipants
             .Where(cp => cp.CompetitionId == id && playerIds.Contains(cp.PlayerId)
-                && (cp.Status == DropShot.Models.ParticipantStatus.Registered
-                    || cp.Status == DropShot.Models.ParticipantStatus.Confirmed))
+                && cp.Status == DropShot.Models.ParticipantStatus.FullPlayer)
             .Select(cp => cp.PlayerId)
             .ToListAsync();
         var missingParticipant = playerIds.Except(confirmedParticipantIds).ToList();


### PR DESCRIPTION
## Summary

- Three `ParticipantStatus.Confirmed` references in `CompetitionsController` (team composition validation and participant ID check) and `CompetitionPage` (eligibility filter) were introduced by unrelated commits that landed in `main` after our feature branch was created
- They slipped through the squash merge of #435 and broke the CI Release build
- All three are now updated to `FullPlayer` (consistent with the rest of the codebase)

## Test plan

- [ ] CI Release build passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)