### PR TITLE
Group A: six small competition/scoring fixes

### DIFF
--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -348,7 +348,7 @@ else
         {
             <DropShot.Components.Competitions.Setup.AdminsSection
                 Admins="_competitionAdmins"
-                NewAdminEmail="_newAdminEmail"
+                NewAdminEmail="@_newAdminEmail"
                 NewAdminEmailChanged="@(v => _newAdminEmail = v)"
                 OnAddAdmin="AddCompetitionAdmin"
                 OnRemoveAdmin="RemoveCompetitionAdmin" />
@@ -396,7 +396,7 @@ else
                     Presets="_rubberPresets"
                     AvailableRoles="_availableRoles"
                     Source="_rubberTemplateSource"
-                    SelectedPresetKey="_selectedRubberPresetKey"
+                    SelectedPresetKey="@_selectedRubberPresetKey"
                     OnApplyPreset="ApplyRubberPreset"
                     OnRevertToDefault="RevertToDefaultTemplate"
                     OnConvertToCustom="ConvertToCustomTemplate"
@@ -740,7 +740,7 @@ else
             }
         </MudTabPanel>
 
-        <MudTabPanel Text="Fixtures">
+        <MudTabPanel Text="Fixtures/Results">
             @if (!Model.HasDivisions)
             {
                 <DropShot.Components.Competitions.Setup.FixturesSection
@@ -780,7 +780,7 @@ else
                 <MudPaper Class="pa-4 mb-4 setup-section" Elevation="0"
                      Style="background: rgba(255,255,255,0.08); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border: 1px solid rgba(255,255,255,0.12); border-radius: 12px; color: white;">
                     <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="mb-3" Wrap="Wrap.Wrap">
-                        <MudText Typo="Typo.h6" Style="flex:1">Fixtures</MudText>
+                        <MudText Typo="Typo.h6" Style="flex:1">Fixtures/Results</MudText>
                         @if (_isSuperAdmin && _stages.Any(s => s.StageType == StageType.RoundRobin))
                         {
                             <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Tertiary"
@@ -3276,10 +3276,7 @@ else
         int teamSize, string itemLabel,
         RubberTemplateRegistry.RoleAssigner? assigner, Random rng)
     {
-        string TeamName(int idx) =>
-            divisionName is null
-                ? $"{itemLabel} {(char)('A' + idx)}"
-                : $"{divisionName} — {itemLabel} {(char)('A' + idx)}";
+        string TeamName(int idx) => $"{itemLabel} {(char)('A' + idx)}";
 
         string BucketPrefix() => divisionName is null ? "" : $"[{divisionName}] ";
 
@@ -3624,7 +3621,13 @@ else
         var loaded = await LoadFixtureForDialogAsync(fixture.CompetitionFixtureId);
         if (loaded == null) return;
 
-        var parameters = new DialogParameters<SubmitScoreDialog> { { x => x.Fixture, loaded } };
+        // This page is only reachable by admins / competition admins, so anyone
+        // who can edit the competition gets the score-validation bypass too.
+        var parameters = new DialogParameters<SubmitScoreDialog>
+        {
+            { x => x.Fixture, loaded },
+            { x => x.AdminOverride, _canEdit }
+        };
         var dialog = await DialogService.ShowAsync<SubmitScoreDialog>("Submit Score", parameters);
         var result = await dialog.Result;
         if (result is not null && !result.Canceled)

--- a/DropShot/Components/Pages/Home.razor
+++ b/DropShot/Components/Pages/Home.razor
@@ -438,7 +438,15 @@
             return;
         }
 
-        var parameters = new DialogParameters<SubmitScoreDialog> { { x => x.Fixture, fixture } };
+        var authState = await AuthStateProvider.GetAuthenticationStateAsync();
+        var isAdmin = await AuthzService.CanEditCompetitionAsync(
+            authState.User, fixture.Competition?.HostClubId, fixture.CompetitionId);
+
+        var parameters = new DialogParameters<SubmitScoreDialog>
+        {
+            { x => x.Fixture, fixture },
+            { x => x.AdminOverride, isAdmin }
+        };
         var dialog = await DialogService.ShowAsync<SubmitScoreDialog>("Submit Score", parameters);
         var result = await dialog.Result;
         if (result is not null && !result.Canceled)

--- a/DropShot/Components/Pages/TeamMatchScoring.razor
+++ b/DropShot/Components/Pages/TeamMatchScoring.razor
@@ -11,6 +11,8 @@
 @inject NavigationManager Navigation
 @inject RubberResolutionService RubberResolver
 @inject IDialogService DialogService
+@inject ClubAuthorizationService AuthzService
+@inject AuthenticationStateProvider AuthStateProvider
 
 <MudProviders />
 
@@ -95,10 +97,19 @@ else
     private string _scoreUnit = "rubbers";
     private bool _allComplete;
     private string? _resolutionError;
+    private bool _isCompetitionAdmin;
 
     protected override async Task OnInitializedAsync()
     {
         await EnsureAndLoad();
+
+        if (_fixture != null)
+        {
+            var authState = await AuthStateProvider.GetAuthenticationStateAsync();
+            _isCompetitionAdmin = await AuthzService.CanEditCompetitionAsync(
+                authState.User, _fixture.Competition?.HostClubId, _fixture.CompetitionId);
+        }
+
         _loading = false;
     }
 
@@ -176,7 +187,11 @@ else
 
     private async Task EnterRubberScore(Rubber rubber)
     {
-        var parameters = new DialogParameters<RubberScoreDialog> { { x => x.Rubber, rubber } };
+        var parameters = new DialogParameters<RubberScoreDialog>
+        {
+            { x => x.Rubber, rubber },
+            { x => x.AdminOverride, _isCompetitionAdmin }
+        };
         var dialog = await DialogService.ShowAsync<RubberScoreDialog>("Enter rubber score", parameters);
         var result = await dialog.Result;
         if (result != null && !result.Canceled)

--- a/DropShot/Components/RubberScoreDialog.razor
+++ b/DropShot/Components/RubberScoreDialog.razor
@@ -52,14 +52,14 @@
                             <td>
                                 <MudNumericField T="int?" Value="_home[idx]"
                                                  ValueChanged="@(v => _home[idx] = v)"
-                                                 Variant="Variant.Outlined" Min="0" Max="20"
+                                                 Variant="Variant.Outlined" Min="0" Max="@_setMaxInput"
                                                  Style="width:80px" />
                             </td>
                             <td style="text-align:center; font-weight:bold">–</td>
                             <td>
                                 <MudNumericField T="int?" Value="_away[idx]"
                                                  ValueChanged="@(v => _away[idx] = v)"
-                                                 Variant="Variant.Outlined" Min="0" Max="20"
+                                                 Variant="Variant.Outlined" Min="0" Max="@_setMaxInput"
                                                  Style="width:80px" />
                             </td>
                         </tr>
@@ -84,6 +84,7 @@
     [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = default!;
 
     [Parameter] public Rubber Rubber { get; set; } = default!;
+    [Parameter] public bool AdminOverride { get; set; }
 
     private Competition? _competition;
     private int _bestOf = 3;
@@ -95,6 +96,7 @@
     private string _awayLabel = "Away";
     private bool _saving;
     private string? _error;
+    private int _setMaxInput = 20;
 
     protected override async Task OnParametersSetAsync()
     {
@@ -119,6 +121,9 @@
         _bestOf = newBestOf;
         _home = new int?[_bestOf];
         _away = new int?[_bestOf];
+        // Cap the numeric input a few games beyond the set length — a sensible
+        // ceiling for tie-breaks / extended sets without allowing typos like 26.
+        _setMaxInput = _gamesPerSet + 8;
         _error = null;
     }
 
@@ -142,6 +147,44 @@
             if (!_home[i].HasValue || !_away[i].HasValue) continue;
             int h = _home[i]!.Value, a = _away[i]!.Value;
             if (h == a) { _error = $"Set {i + 1}: scores are tied."; return; }
+
+            if (!AdminOverride)
+            {
+                int winner = Math.Max(h, a);
+                int loser = Math.Min(h, a);
+                if (_setWinMode == SetWinMode.FirstTo)
+                {
+                    if (winner != _gamesPerSet)
+                    {
+                        _error = $"Set {i + 1}: winner must reach exactly {_gamesPerSet} games (First to mode).";
+                        return;
+                    }
+                    if (loser >= _gamesPerSet)
+                    {
+                        _error = $"Set {i + 1}: loser cannot have {loser} games when target is {_gamesPerSet}.";
+                        return;
+                    }
+                }
+                else
+                {
+                    if (winner < _gamesPerSet)
+                    {
+                        _error = $"Set {i + 1}: winner must have at least {_gamesPerSet} games.";
+                        return;
+                    }
+                    if (winner == _gamesPerSet && loser > _gamesPerSet - 2)
+                    {
+                        _error = $"Set {i + 1}: at {_gamesPerSet} games, opponent can have at most {_gamesPerSet - 2} (Win by 2). Use {_gamesPerSet + 1}-{_gamesPerSet} for a tie-break.";
+                        return;
+                    }
+                    if (winner > _gamesPerSet && Math.Abs(h - a) != 1 && Math.Abs(h - a) != 2)
+                    {
+                        _error = $"Set {i + 1}: above {_gamesPerSet}-all the margin must be 1 (tie-break) or 2 (extended).";
+                        return;
+                    }
+                }
+            }
+
             homeGames += h; awayGames += a;
             if (h > a) homeSets++; else awaySets++;
             lastHome = h; lastAway = a;

--- a/DropShot/Components/SubmitScoreDialog.razor
+++ b/DropShot/Components/SubmitScoreDialog.razor
@@ -241,55 +241,54 @@
             return;
         }
 
-        // Validate each set score against competition rules
-        for (int i = 0; i < _bestOf; i++)
+        // Validate each set score against competition rules. Admins bypass range
+        // validation so they can correct historical / irregular scores.
+        if (!AdminOverride)
         {
-            if (!_score1[i].HasValue || !_score2[i].HasValue) continue;
-            int s1 = _score1[i]!.Value, s2 = _score2[i]!.Value;
-
-            if (s1 == s2)
+            for (int i = 0; i < _bestOf; i++)
             {
-                _error = $"Set {i + 1}: scores are tied — one player must win each set.";
-                return;
-            }
+                if (!_score1[i].HasValue || !_score2[i].HasValue) continue;
+                int s1 = _score1[i]!.Value, s2 = _score2[i]!.Value;
 
-            int winner = Math.Max(s1, s2);
-            int loser = Math.Min(s1, s2);
+                if (s1 == s2)
+                {
+                    _error = $"Set {i + 1}: scores are tied — one player must win each set.";
+                    return;
+                }
 
-            if (_setWinMode == SetWinMode.FirstTo)
-            {
-                // First to: winner must have exactly GamesPerSet, loser must have fewer
-                if (winner != _gamesPerSet)
+                int winner = Math.Max(s1, s2);
+                int loser = Math.Min(s1, s2);
+
+                if (_setWinMode == SetWinMode.FirstTo)
                 {
-                    _error = $"Set {i + 1}: winner must reach exactly {_gamesPerSet} games (First to mode).";
-                    return;
+                    if (winner != _gamesPerSet)
+                    {
+                        _error = $"Set {i + 1}: winner must reach exactly {_gamesPerSet} games (First to mode).";
+                        return;
+                    }
+                    if (loser >= _gamesPerSet)
+                    {
+                        _error = $"Set {i + 1}: loser cannot have {loser} games when target is {_gamesPerSet}.";
+                        return;
+                    }
                 }
-                if (loser >= _gamesPerSet)
+                else
                 {
-                    _error = $"Set {i + 1}: loser cannot have {loser} games when target is {_gamesPerSet}.";
-                    return;
-                }
-            }
-            else
-            {
-                // Win by 2: winner needs at least GamesPerSet games
-                if (winner < _gamesPerSet)
-                {
-                    _error = $"Set {i + 1}: winner must have at least {_gamesPerSet} games.";
-                    return;
-                }
-                // Normal win: exactly GamesPerSet with loser having at most GamesPerSet-2
-                // Or tie-break: GamesPerSet+1 vs GamesPerSet (e.g. 7-6)
-                // Or extended: both above GamesPerSet with exactly 2 game difference
-                if (winner == _gamesPerSet && loser > _gamesPerSet - 2)
-                {
-                    _error = $"Set {i + 1}: at {_gamesPerSet} games, opponent can have at most {_gamesPerSet - 2} (Win by 2 mode). Use {_gamesPerSet + 1}-{_gamesPerSet} for a tie-break.";
-                    return;
-                }
-                if (winner > _gamesPerSet && Math.Abs(s1 - s2) != 1 && Math.Abs(s1 - s2) != 2)
-                {
-                    _error = $"Set {i + 1}: above {_gamesPerSet}-all, the margin must be 1 (tie-break) or 2 (extended).";
-                    return;
+                    if (winner < _gamesPerSet)
+                    {
+                        _error = $"Set {i + 1}: winner must have at least {_gamesPerSet} games.";
+                        return;
+                    }
+                    if (winner == _gamesPerSet && loser > _gamesPerSet - 2)
+                    {
+                        _error = $"Set {i + 1}: at {_gamesPerSet} games, opponent can have at most {_gamesPerSet - 2} (Win by 2 mode). Use {_gamesPerSet + 1}-{_gamesPerSet} for a tie-break.";
+                        return;
+                    }
+                    if (winner > _gamesPerSet && Math.Abs(s1 - s2) != 1 && Math.Abs(s1 - s2) != 2)
+                    {
+                        _error = $"Set {i + 1}: above {_gamesPerSet}-all, the margin must be 1 (tie-break) or 2 (extended).";
+                        return;
+                    }
                 }
             }
         }

--- a/DropShot/Services/CompetitionProgressionService.cs
+++ b/DropShot/Services/CompetitionProgressionService.cs
@@ -162,37 +162,25 @@ public static class CompetitionProgressionService
         CompetitionFixture completedFixture, CompetitionStage stage,
         List<CompetitionStage> allStages)
     {
-        // Collect all fixtures in the same logical "source round"
+        if (!completedFixture.WinnerPlayerId.HasValue) return;
+
+        // Collect all fixtures in the same logical "source round" (ordered by label).
         IQueryable<CompetitionFixture> sourceQuery = db.CompetitionFixtures
             .Where(f => f.CompetitionId == competitionId
                      && f.CompetitionStageId == completedFixture.CompetitionStageId);
 
         if (stage.StageType == StageType.Knockout)
         {
-            // Within a single Knockout stage, round number differentiates QF/SF/Final
             if (!completedFixture.RoundNumber.HasValue) return;
             sourceQuery = sourceQuery.Where(f => f.RoundNumber == completedFixture.RoundNumber);
         }
-        // For explicit QF/SF/Final stages, all fixtures in the stage belong to that round
 
-        var sourceFixtures = await sourceQuery.ToListAsync();
-
-        bool allDone = sourceFixtures.All(f =>
-            f.Status == FixtureStatus.Completed ||
-            f.Status == FixtureStatus.Walkover   ||
-            f.Status == FixtureStatus.Cancelled);
-
-        if (!allDone) return;
-
-        var winners = sourceFixtures
+        var sourceFixtures = await sourceQuery
             .OrderBy(f => f.FixtureLabel)
-            .Where(f => f.WinnerPlayerId.HasValue)
-            .Select(f => f.WinnerPlayerId!.Value)
-            .ToList();
+            .ToListAsync();
 
-        if (!winners.Any()) return;
-
-        // Find the unassigned target fixtures in the next round
+        // Target fixtures in the next round — do not filter on empty slots, since
+        // the sibling's winner may already have populated one of them.
         List<CompetitionFixture> targetFixtures;
 
         if (stage.StageType == StageType.Knockout)
@@ -202,25 +190,22 @@ public static class CompetitionProgressionService
                 .Where(f => f.CompetitionId == competitionId
                          && f.CompetitionStageId == completedFixture.CompetitionStageId
                          && f.RoundNumber == nextRound
-                         && f.Player1Id == null && f.Player2Id == null
                          && f.Status == FixtureStatus.Scheduled)
                 .OrderBy(f => f.FixtureLabel)
                 .ToListAsync();
         }
         else
         {
-            // Move to the next stage in StageOrder
             var nextStage = allStages
                 .Where(s => s.StageOrder > stage.StageOrder)
                 .OrderBy(s => s.StageOrder)
                 .FirstOrDefault();
 
-            if (nextStage is null) return; // This is the final stage — nothing to advance to
+            if (nextStage is null) return;
 
             targetFixtures = await db.CompetitionFixtures
                 .Where(f => f.CompetitionId == competitionId
                          && f.CompetitionStageId == nextStage.CompetitionStageId
-                         && f.Player1Id == null && f.Player2Id == null
                          && f.Status == FixtureStatus.Scheduled)
                 .OrderBy(f => f.FixtureLabel)
                 .ToListAsync();
@@ -228,7 +213,10 @@ public static class CompetitionProgressionService
 
         if (!targetFixtures.Any()) return;
 
-        AssignWinners(targetFixtures, winners);
+        AssignSingleWinner(
+            sourceFixtures, targetFixtures, completedFixture.CompetitionFixtureId,
+            isTeam: false, completedFixture.WinnerPlayerId.Value);
+
         await db.SaveChangesAsync();
     }
 
@@ -343,12 +331,13 @@ public static class CompetitionProgressionService
         CompetitionFixture completedFixture, CompetitionStage stage,
         List<CompetitionStage> allStages)
     {
+        if (!completedFixture.WinnerTeamId.HasValue) return;
+
         var divisions = await db.CompetitionDivisions
             .Where(d => d.CompetitionId == competitionId)
             .OrderBy(d => d.Rank)
             .ToListAsync();
 
-        // Infer which division this fixture belongs to from its label prefix
         var fixtureDiv = InferDivisionFromLabel(completedFixture.FixtureLabel, divisions);
 
         IQueryable<CompetitionFixture> sourceQuery = db.CompetitionFixtures
@@ -361,9 +350,8 @@ public static class CompetitionProgressionService
             sourceQuery = sourceQuery.Where(f => f.RoundNumber == completedFixture.RoundNumber);
         }
 
-        var sourceFixtures = await sourceQuery.ToListAsync();
+        var sourceFixtures = await sourceQuery.OrderBy(f => f.FixtureLabel).ToListAsync();
 
-        // Narrow to this division only so each league advances independently
         if (fixtureDiv is not null)
         {
             var divPrefix = fixtureDiv.Name + " ";
@@ -372,21 +360,6 @@ public static class CompetitionProgressionService
                             f.FixtureLabel.StartsWith(divPrefix, StringComparison.OrdinalIgnoreCase))
                 .ToList();
         }
-
-        bool allDone = sourceFixtures.All(f =>
-            f.Status == FixtureStatus.Completed ||
-            f.Status == FixtureStatus.Walkover   ||
-            f.Status == FixtureStatus.Cancelled);
-
-        if (!allDone) return;
-
-        var winners = sourceFixtures
-            .OrderBy(f => f.FixtureLabel)
-            .Where(f => f.WinnerTeamId.HasValue)
-            .Select(f => f.WinnerTeamId!.Value)
-            .ToList();
-
-        if (!winners.Any()) return;
 
         List<CompetitionFixture> targetFixtures;
 
@@ -397,19 +370,9 @@ public static class CompetitionProgressionService
                 .Where(f => f.CompetitionId == competitionId
                          && f.CompetitionStageId == completedFixture.CompetitionStageId
                          && f.RoundNumber == nextRound
-                         && f.HomeTeamId == null && f.AwayTeamId == null
                          && f.Status == FixtureStatus.Scheduled)
                 .OrderBy(f => f.FixtureLabel)
                 .ToListAsync();
-
-            if (fixtureDiv is not null)
-            {
-                var divPrefix = fixtureDiv.Name + " ";
-                targetFixtures = targetFixtures
-                    .Where(f => f.FixtureLabel != null &&
-                                f.FixtureLabel.StartsWith(divPrefix, StringComparison.OrdinalIgnoreCase))
-                    .ToList();
-            }
         }
         else
         {
@@ -423,24 +386,26 @@ public static class CompetitionProgressionService
             targetFixtures = await db.CompetitionFixtures
                 .Where(f => f.CompetitionId == competitionId
                          && f.CompetitionStageId == nextStage.CompetitionStageId
-                         && f.HomeTeamId == null && f.AwayTeamId == null
                          && f.Status == FixtureStatus.Scheduled)
                 .OrderBy(f => f.FixtureLabel)
                 .ToListAsync();
+        }
 
-            if (fixtureDiv is not null)
-            {
-                var divPrefix = fixtureDiv.Name + " ";
-                targetFixtures = targetFixtures
-                    .Where(f => f.FixtureLabel != null &&
-                                f.FixtureLabel.StartsWith(divPrefix, StringComparison.OrdinalIgnoreCase))
-                    .ToList();
-            }
+        if (fixtureDiv is not null)
+        {
+            var divPrefix = fixtureDiv.Name + " ";
+            targetFixtures = targetFixtures
+                .Where(f => f.FixtureLabel != null &&
+                            f.FixtureLabel.StartsWith(divPrefix, StringComparison.OrdinalIgnoreCase))
+                .ToList();
         }
 
         if (!targetFixtures.Any()) return;
 
-        AssignTeamWinners(targetFixtures, winners);
+        AssignSingleWinner(
+            sourceFixtures, targetFixtures, completedFixture.CompetitionFixtureId,
+            isTeam: true, completedFixture.WinnerTeamId.Value);
+
         await db.SaveChangesAsync();
     }
 
@@ -498,6 +463,83 @@ public static class CompetitionProgressionService
             .OrderByDescending(d => d.Name!.Length)   // longest name first — avoids prefix collisions
             .FirstOrDefault(d =>
                 label.StartsWith(d.Name! + " ", StringComparison.OrdinalIgnoreCase));
+    }
+
+    // ── Per-fixture helper: place one winner into its target slot ───────────
+    //
+    // Standard bracket pairing: source fixtures ordered by label, target
+    // fixtures ordered by label. Target[i] = winner-of-Source[i] vs
+    // winner-of-Source[2n-1-i] (n = target count). So:
+    //   source index < n → target[idx].Player1/HomeTeam
+    //   source index >= n → target[2n-1-idx].Player2/AwayTeam
+    //
+    // For non-standard ratios (e.g. 3 sources into 2 targets on a bye round),
+    // fall back to filling the first empty slot in order — matches the legacy
+    // batch behaviour's "not enough winners" case.
+
+    internal static void AssignSingleWinner(
+        List<CompetitionFixture> sourceFixtures,
+        List<CompetitionFixture> targetFixtures,
+        int completedFixtureId,
+        bool isTeam,
+        int winnerId)
+    {
+        int sourceIdx = sourceFixtures.FindIndex(f => f.CompetitionFixtureId == completedFixtureId);
+        if (sourceIdx < 0) return;
+
+        int n = targetFixtures.Count;
+        if (n == 0) return;
+
+        bool standardBracket = sourceFixtures.Count == 2 * n;
+
+        if (standardBracket)
+        {
+            bool isSlot1 = sourceIdx < n;
+            int targetIdx = isSlot1 ? sourceIdx : (2 * n - 1 - sourceIdx);
+            if (targetIdx < 0 || targetIdx >= n) return;
+            SetSlot(targetFixtures[targetIdx], isTeam, isSlot1, winnerId);
+        }
+        else
+        {
+            // Fallback: first empty slot in bracket order (Player1/HomeTeam then
+            // Player2/AwayTeam across targets).
+            foreach (var t in targetFixtures)
+            {
+                if (isTeam)
+                {
+                    if (!t.HomeTeamId.HasValue) { t.HomeTeamId = winnerId; return; }
+                }
+                else
+                {
+                    if (!t.Player1Id.HasValue) { t.Player1Id = winnerId; return; }
+                }
+            }
+            foreach (var t in targetFixtures)
+            {
+                if (isTeam)
+                {
+                    if (!t.AwayTeamId.HasValue) { t.AwayTeamId = winnerId; return; }
+                }
+                else
+                {
+                    if (!t.Player2Id.HasValue) { t.Player2Id = winnerId; return; }
+                }
+            }
+        }
+    }
+
+    private static void SetSlot(CompetitionFixture target, bool isTeam, bool isSlot1, int winnerId)
+    {
+        if (isTeam)
+        {
+            if (isSlot1) target.HomeTeamId = winnerId;
+            else target.AwayTeamId = winnerId;
+        }
+        else
+        {
+            if (isSlot1) target.Player1Id = winnerId;
+            else target.Player2Id = winnerId;
+        }
     }
 
     // ── Team helper: assign teams to knockout fixtures ──────────────────────


### PR DESCRIPTION
## Summary

First batch from the 17-issue backlog — quick, low-risk UI and service fixes that don't need a migration.

- **#4** Fixed Razor bindings that were rendering the literal strings `_newAdminEmail` and `_selectedRubberPresetKey` in the competition-setup form (missing `@` prefix).
- **#5** Auto-generated team names no longer include the division prefix — now just `Team A`, `Team B`, etc.
- **#10** Renamed the `Fixtures` tab/heading on the setup page to `Fixtures/Results`.
- **#6** Rubber score dialog now applies the same per-set range validation as the singles dialog (blocks typos like `26-2`) and caps the numeric field at `GamesPerSet+8`.
- **#2** `AdminOverride` plumbed through both score dialogs — when true, range/tie validation is skipped. Callers on Home, TeamMatchScoring, and CompetitionPage now pass `AdminOverride=true` when the current user can edit the competition (SuperAdmin / Admin / ClubAdmin-of-host / CompetitionAdmin / Creator, via `ClubAuthorizationService.CanEditCompetitionAsync`).
- **#1** (revised per user direction) Knockout progression rewritten to push the winner of a single match into its specific next-round slot as soon as that match finishes, instead of waiting for every sibling in the round. Standard bracket pairing: source `i` → `target[i].Player1` for `i<n`, else `target[2n-1-i].Player2`. Falls back to first-empty-slot fill for non-standard ratios.

## Test plan

- [ ] Open a competition's setup — admin-email textbox and rubber-preset dropdown are both blank on first open
- [ ] Generate teams with a division — team names are `Team A` / `Team B` (no division prefix)
- [ ] On the setup page, the tab reads `Fixtures/Results`
- [ ] As a non-admin player, submitting `26-2` on a rubber is rejected with a validation error
- [ ] As an admin / competition admin, submitting `26-2` on either dialog is accepted (bypass)
- [ ] Play a knockout semi-final — as soon as it completes, the final shows the winner in one slot and `TBD` in the other
- [ ] `dotnet build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)