### PR TITLE
Group B: per-rubber set scores + verify-before-approve

### DIFF
--- a/DropShot/Components/Pages/Home.razor
+++ b/DropShot/Components/Pages/Home.razor
@@ -348,6 +348,8 @@
                 .Include(f => f.Competition)
                 .Include(f => f.Player1).Include(f => f.Player2)
                 .Include(f => f.Player3).Include(f => f.Player4)
+                .Include(f => f.HomeTeam)
+                .Include(f => f.AwayTeam)
                 .Where(f => f.Status == FixtureStatus.AwaitingVerification
                     && (isAdmin
                         || (f.Competition.HostClubId.HasValue && editableClubIds.Contains(f.Competition.HostClubId.Value))

--- a/DropShot/Components/Pages/TeamMatchScoring.razor
+++ b/DropShot/Components/Pages/TeamMatchScoring.razor
@@ -88,6 +88,7 @@ else
 
 @code {
     [Parameter] public int FixtureId { get; set; }
+    [SupplyParameterFromQuery(Name = "edit")] public int? EditMode { get; set; }
 
     private CompetitionFixture? _fixture;
     private List<Rubber> _rubbers = [];
@@ -98,6 +99,8 @@ else
     private bool _allComplete;
     private string? _resolutionError;
     private bool _isCompetitionAdmin;
+
+    private bool CanEditCompletedRubber => _isCompetitionAdmin && EditMode == 1;
 
     protected override async Task OnInitializedAsync()
     {
@@ -226,13 +229,24 @@ else
                     <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
                         @if (rubber.IsComplete)
                         {
-                            <MudChip T="string" Size="Size.Small" Color="Color.Success">
-                                @* Prefer sets-won; fall back to games-in-last-set for rows *@
-                                @* predating the sets-won column. *@
-                                @(rubber.HomeSetsWon.HasValue && rubber.AwaySetsWon.HasValue
-                                    ? $"{rubber.HomeSetsWon} — {rubber.AwaySetsWon} sets"
-                                    : $"{rubber.HomeGames} — {rubber.AwayGames}")
-                            </MudChip>
+                            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                                <MudChip T="string" Size="Size.Small" Color="Color.Success">
+                                    @(rubber.HomeSetsWon.HasValue && rubber.AwaySetsWon.HasValue
+                                        ? $"{rubber.HomeSetsWon} — {rubber.AwaySetsWon} sets"
+                                        : $"{rubber.HomeGames} — {rubber.AwayGames}")
+                                </MudChip>
+                                @if (rubber.SetScores.Count > 0)
+                                {
+                                    <MudText Typo="Typo.caption" Color="Color.Secondary">
+                                        (@string.Join(", ", rubber.SetScores.Select(s => $"{s.Home}-{s.Away}")))
+                                    </MudText>
+                                }
+                                @if (CanEditCompletedRubber)
+                                {
+                                    <MudIconButton Size="Size.Small" Icon="@Icons.Material.Filled.Edit"
+                                                   OnClick="@(() => EnterRubberScore(rubber))" />
+                                }
+                            </MudStack>
                         }
                         else if (rubber.SavedMatchId.HasValue)
                         {

--- a/DropShot/Components/Pages/VerifyResult.razor
+++ b/DropShot/Components/Pages/VerifyResult.razor
@@ -6,6 +6,7 @@
 @using Microsoft.EntityFrameworkCore
 
 @inject IDbContextFactory<MyDbContext> DbFactory
+@inject IDialogService DialogService
 
 <MudProviders />
 <PageTitle>Verify Result</PageTitle>
@@ -56,7 +57,19 @@
 
                     <MudAlert Severity="Severity.Info" Dense="true" NoIcon="true">
                         <MudText Typo="Typo.subtitle2">Submitted Score</MudText>
-                        <MudText Typo="Typo.h6">@_fixture.ResultSummary</MudText>
+                        @if (_isTeamMatch)
+                        {
+                            <MudText Typo="Typo.h6">
+                                @_aggregateHome – @_aggregateAway @_aggregateUnit
+                            </MudText>
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">
+                                @_secondaryAggregate
+                            </MudText>
+                        }
+                        else
+                        {
+                            <MudText Typo="Typo.h6">@_fixture.ResultSummary</MudText>
+                        }
                         <MudText Typo="Typo.body2">
                             Winner: <strong>@WinnerName()</strong>
                         </MudText>
@@ -72,8 +85,10 @@
                                     <th>Rubber</th>
                                     <th>@_side1</th>
                                     <th>@_side2</th>
-                                    <th style="text-align:center">Score</th>
+                                    <th style="text-align:center">Sets</th>
+                                    <th style="text-align:center">Set scores</th>
                                     <th>Winner</th>
+                                    <th></th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -84,6 +99,9 @@
                                     var rubberScore = r.IsComplete && r.HomeSetsWon.HasValue
                                         ? $"{r.HomeSetsWon}–{r.AwaySetsWon}"
                                         : "—";
+                                    var setScores = r.SetScores.Count > 0
+                                        ? string.Join(", ", r.SetScores.Select(s => $"{s.Home}-{s.Away}"))
+                                        : "—";
                                     var rubberWinner = !r.IsComplete ? "—"
                                         : r.WinnerTeamId == _fixture.HomeTeamId ? _side1
                                         : r.WinnerTeamId == _fixture.AwayTeamId ? _side2
@@ -93,15 +111,20 @@
                                         <td style="font-size:0.8rem">@(string.IsNullOrEmpty(homePair) ? "TBD" : homePair)</td>
                                         <td style="font-size:0.8rem">@(string.IsNullOrEmpty(awayPair) ? "TBD" : awayPair)</td>
                                         <td style="text-align:center;font-weight:bold">@rubberScore</td>
+                                        <td style="text-align:center;font-size:0.8rem">@setScores</td>
                                         <td>@rubberWinner</td>
+                                        <td>
+                                            <MudIconButton Size="Size.Small" Icon="@Icons.Material.Filled.Edit"
+                                                           OnClick="@(() => EditRubberAsync(r))" />
+                                        </td>
                                     </tr>
                                 }
                             </tbody>
                         </MudSimpleTable>
                         <MudAlert Severity="Severity.Info" Dense="true">
-                            Score modification is not available for team matches. To correct rubber scores, use the
-                            <MudLink Href="@($"/team-match/{_fixture.CompetitionFixtureId}")">team match page</MudLink>
-                            after approving.
+                            Edit any rubber above before approving. Once approved the result is
+                            locked — further changes must happen on the
+                            <MudLink Href="@($"/team-match/{_fixture.CompetitionFixtureId}?edit=1")">team match page</MudLink>.
                         </MudAlert>
                     }
 
@@ -204,6 +227,10 @@
     private bool _editing;
     private bool _saving;
     private string? _error;
+    private int _aggregateHome;
+    private int _aggregateAway;
+    private string _aggregateUnit = "rubbers";
+    private string _secondaryAggregate = "";
 
     protected override async Task OnInitializedAsync()
     {
@@ -244,6 +271,8 @@
 
             _side1 = _fixture.HomeTeam?.Name ?? "Home";
             _side2 = _fixture.AwayTeam?.Name ?? "Away";
+
+            RecomputeAggregate();
         }
         else
         {
@@ -264,6 +293,54 @@
         }
 
         _loading = false;
+    }
+
+    private void RecomputeAggregate()
+    {
+        if (_fixture == null || !_fixture.HomeTeamId.HasValue || !_fixture.AwayTeamId.HasValue) return;
+        var mode = _fixture.Competition?.LeagueScoring ?? LeagueScoringMode.WinPoints;
+        (_aggregateHome, _aggregateAway, _aggregateUnit) = RubberResolutionService.ComputeLeagueScore(
+            _rubbers, _fixture.HomeTeamId.Value, _fixture.AwayTeamId.Value, mode);
+
+        // Show the other two metrics as a secondary line for context.
+        var completed = _rubbers.Where(r => r.IsComplete).ToList();
+        int rubbersHome = completed.Count(r => r.WinnerTeamId == _fixture.HomeTeamId);
+        int rubbersAway = completed.Count(r => r.WinnerTeamId == _fixture.AwayTeamId);
+        int setsHome = completed.Sum(r => r.HomeSetsWon ?? 0);
+        int setsAway = completed.Sum(r => r.AwaySetsWon ?? 0);
+        int gamesHome = completed.Sum(r => r.HomeGamesTotal ?? 0);
+        int gamesAway = completed.Sum(r => r.AwayGamesTotal ?? 0);
+
+        _secondaryAggregate = mode switch
+        {
+            LeagueScoringMode.SetsWon  => $"Rubbers: {rubbersHome}–{rubbersAway} · Games: {gamesHome}–{gamesAway}",
+            LeagueScoringMode.GamesWon => $"Rubbers: {rubbersHome}–{rubbersAway} · Sets: {setsHome}–{setsAway}",
+            _                          => $"Sets: {setsHome}–{setsAway} · Games: {gamesHome}–{gamesAway}",
+        };
+    }
+
+    private async Task EditRubberAsync(Rubber rubber)
+    {
+        if (_fixture == null) return;
+        var parameters = new DialogParameters<RubberScoreDialog>
+        {
+            { x => x.Rubber, rubber },
+            { x => x.AdminOverride, true }
+        };
+        var dlg = await DialogService.ShowAsync<RubberScoreDialog>("Edit rubber score", parameters);
+        var res = await dlg.Result;
+        if (res is null || res.Canceled) return;
+
+        // Reload the rubbers so the aggregate + set-scores columns reflect the edit
+        await using var db = DbFactory.CreateDbContext();
+        _rubbers = await db.Rubbers
+            .Include(r => r.HomePlayer1).Include(r => r.HomePlayer2)
+            .Include(r => r.AwayPlayer1).Include(r => r.AwayPlayer2)
+            .Where(r => r.CompetitionFixtureId == _fixture.CompetitionFixtureId)
+            .OrderBy(r => r.Order)
+            .ToListAsync();
+        RecomputeAggregate();
+        StateHasChanged();
     }
 
     private void ParseResultSummary(string? summary)

--- a/DropShot/Components/ResultCard.razor
+++ b/DropShot/Components/ResultCard.razor
@@ -55,12 +55,16 @@
 
     private List<(string P1, string P2)> _sets = [];
 
+    private bool IsTeamMatch => Fixture != null
+        && (Fixture.HomeTeamId.HasValue || Fixture.AwayTeamId.HasValue);
+
     private string Player1Name
     {
         get
         {
             if (Fixture != null)
             {
+                if (IsTeamMatch) return Fixture.HomeTeam?.Name ?? "TBD";
                 return Fixture.Player3 != null
                     ? $"{Fixture.Player1?.DisplayName ?? "TBD"} & {Fixture.Player3?.DisplayName ?? "TBD"}"
                     : Fixture.Player1?.DisplayName ?? "TBD";
@@ -81,6 +85,7 @@
         {
             if (Fixture != null)
             {
+                if (IsTeamMatch) return Fixture.AwayTeam?.Name ?? "TBD";
                 return Fixture.Player4 != null
                     ? $"{Fixture.Player2?.DisplayName ?? "TBD"} & {Fixture.Player4?.DisplayName ?? "TBD"}"
                     : Fixture.Player2?.DisplayName ?? "TBD";

--- a/DropShot/Components/RubberScoreDialog.razor
+++ b/DropShot/Components/RubberScoreDialog.razor
@@ -121,9 +121,16 @@
         _bestOf = newBestOf;
         _home = new int?[_bestOf];
         _away = new int?[_bestOf];
-        // Cap the numeric input a few games beyond the set length — a sensible
-        // ceiling for tie-breaks / extended sets without allowing typos like 26.
         _setMaxInput = _gamesPerSet + 8;
+
+        // Pre-populate from the existing rubber when re-opening to edit.
+        var existing = Rubber.SetScores;
+        for (int i = 0; i < existing.Count && i < _bestOf; i++)
+        {
+            _home[i] = existing[i].Home;
+            _away[i] = existing[i].Away;
+        }
+
         _error = null;
     }
 
@@ -217,6 +224,12 @@
             rub.AwayGamesTotal = awayGames;
             rub.HomeGames = lastHome;
             rub.AwayGames = lastAway;
+
+            var enteredPairs = Enumerable.Range(0, _bestOf)
+                .Where(i => _home[i].HasValue && _away[i].HasValue)
+                .Select(i => new[] { _home[i]!.Value, _away[i]!.Value })
+                .ToList();
+            rub.SetScoresJson = System.Text.Json.JsonSerializer.Serialize(enteredPairs);
             rub.WinnerTeamId = homeSets > awaySets
                 ? rub.Fixture.HomeTeamId
                 : awaySets > homeSets
@@ -248,10 +261,25 @@
                     .FirstOrDefaultAsync(f => f.CompetitionFixtureId == rub.CompetitionFixtureId);
                 if (fx != null)
                 {
+                    bool alreadyFinalised = fx.Status == FixtureStatus.AwaitingVerification
+                        || fx.Status == FixtureStatus.Completed;
+
                     fx.ResultSummary = $"{homeScore}-{awayScore}";
                     fx.WinnerTeamId = homeScore > awayScore ? fx.HomeTeamId
                                     : awayScore > homeScore ? fx.AwayTeamId
                                     : null;
+
+                    // Admin edit of a rubber on an already-finalised fixture: just
+                    // update the aggregates in place. Don't regenerate the verification
+                    // token (that would break the admin's current verify link) and don't
+                    // resend notification emails.
+                    if (AdminOverride && alreadyFinalised)
+                    {
+                        await db.SaveChangesAsync();
+                        MudDialog.Close(DialogResult.Ok(true));
+                        return;
+                    }
+
                     fx.CompletedAt = DateTime.UtcNow;
 
                     bool requireVerification = fx.Competition?.RequireVerification ?? false;

--- a/DropShot/Data/Migrations/20260424203516_AddRubberSetScoresJson.Designer.cs
+++ b/DropShot/Data/Migrations/20260424203516_AddRubberSetScoresJson.Designer.cs
@@ -4,16 +4,19 @@ using DropShot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace DropShot.Migrations
+namespace DropShot.Data.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260424203516_AddRubberSetScoresJson")]
+    partial class AddRubberSetScoresJson
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DropShot/Data/Migrations/20260424203516_AddRubberSetScoresJson.cs
+++ b/DropShot/Data/Migrations/20260424203516_AddRubberSetScoresJson.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropShot.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRubberSetScoresJson : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "SetScoresJson",
+                table: "Rubbers",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SetScoresJson",
+                table: "Rubbers");
+        }
+    }
+}

--- a/DropShot/Models/Rubber.cs
+++ b/DropShot/Models/Rubber.cs
@@ -22,6 +22,13 @@ public class Rubber
     public string HomeRolesJson { get; set; } = "[]";
     public string AwayRolesJson { get; set; } = "[]";
 
+    /// <summary>
+    /// JSON array of per-set scores, e.g. [[6,4],[4,6],[7,5]]. Populated at
+    /// rubber-submit time so the UI can show individual set scores alongside
+    /// the set-count summary.
+    /// </summary>
+    public string? SetScoresJson { get; set; }
+
     public int? HomePlayer1Id { get; set; }
     public int? HomePlayer2Id { get; set; }
     public int? AwayPlayer1Id { get; set; }
@@ -57,5 +64,23 @@ public class Rubber
     {
         get => JsonSerializer.Deserialize<List<string>>(AwayRolesJson) ?? [];
         set => AwayRolesJson = JsonSerializer.Serialize(value);
+    }
+
+    [NotMapped]
+    public IReadOnlyList<(int Home, int Away)> SetScores
+    {
+        get
+        {
+            if (string.IsNullOrWhiteSpace(SetScoresJson)) return [];
+            try
+            {
+                var raw = JsonSerializer.Deserialize<List<int[]>>(SetScoresJson);
+                return raw?.Where(p => p.Length == 2).Select(p => (p[0], p[1])).ToList() ?? [];
+            }
+            catch
+            {
+                return [];
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Covers the pending-approvals and verify-result rework plus the foundational data-model change that Group C builds on.

- **#8** VerifyResult "Submitted Score" now shows a LeagueScoring-aware aggregate (rubbers / sets / games per the competition's setting) with the other two metrics as a secondary caption. Per-rubber rows show the individual set scores alongside the set-count summary.
- **#9** Removed the "can't edit team matches here" block — rubber rows now have an inline Edit icon that opens `RubberScoreDialog` in admin-override mode and recomputes the aggregate after save. The "team match page" link now passes `?edit=1`.
- **#7** `RubberScoreDialog` gracefully handles editing an already-finalised rubber: it updates the aggregate in place but does **not** regenerate the verification token or resend notification emails (which would otherwise invalidate the admin's current verify link).
- **#11** `ResultCard` now detects team-match fixtures and renders team names. `Home.razor`'s pending-reviews query now eager-loads `HomeTeam`/`AwayTeam` so the pending-approvals cards show meaningful context instead of blank player slots.
- **New column** `Rubber.SetScoresJson` (nvarchar) + migration `20260424203516_AddRubberSetScoresJson`. Populated from `RubberScoreDialog.SubmitAsync`. Old rows stay null; the UI falls back to the existing HomeSetsWon/AwaySetsWon display. Exposed via a `NotMapped` `SetScores` property on the model.

Also opportunistically lands the Group C display pieces that naturally fit here:
- Completed rubbers on the team-match page now show `(6-4, 4-6, 7-5)` under the sets chip.
- Admins visiting `/team-match/{id}?edit=1` see an Edit icon on completed rubbers — the post-approval edit path.

## Test plan

- [ ] As a non-admin player, submit a team-match rubber — set scores should persist (check DB).
- [ ] As an admin, open `/verify-result/{token}` for a pending team match: aggregate shows the correct unit per `LeagueScoring`; per-rubber row lists set scores and an Edit icon.
- [ ] Click Edit on a rubber → dialog opens pre-populated → change scores → Save → page aggregate updates without the admin's verify link breaking.
- [ ] Approve result → land on success screen → click "View Competition".
- [ ] Revisit `/team-match/{fixtureId}?edit=1` as an admin after approval — Edit icons appear on completed rubbers and saving updates aggregates in place.
- [ ] Pending-approvals cards on Home show team names (for team matches) and player names (for singles/doubles).
- [ ] `dotnet build` passes.
- [ ] Apply migration: `dotnet ef database update` adds `SetScoresJson nvarchar(max) NULL` to `Rubbers`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)