### PR TITLE
Group D: configurable rubber tie-break

### DIFF
--- a/DropShot.Shared/Enums.cs
+++ b/DropShot.Shared/Enums.cs
@@ -76,3 +76,20 @@ public enum SetWinMode : byte
     WinBy2 = 0,
     FirstTo = 1
 }
+
+/// <summary>
+/// How to resolve a knockout team-match when the rubbers are tied.
+/// Applied by <c>RubberResolutionService.ResolveTieBreakAsync</c> after
+/// all rubbers are complete and the rubber counts are equal.
+/// </summary>
+public enum RubberTieBreakMode : byte
+{
+    /// <summary>No automatic resolution — the fixture stays unresolved until an admin picks a winner.</summary>
+    AdminDecides = 0,
+    /// <summary>Winner is the team with the greater total games across all rubbers.</summary>
+    MostGamesWon = 1,
+    /// <summary>Winner is the team that won the round-robin fixture between the same two teams.</summary>
+    HeadToHeadRoundRobin = 2,
+    /// <summary>Try MostGamesWon first; if still tied, fall back to HeadToHeadRoundRobin.</summary>
+    MostGamesThenHeadToHead = 3,
+}

--- a/DropShot/Components/BulkRubberScoreDialog.razor
+++ b/DropShot/Components/BulkRubberScoreDialog.razor
@@ -275,9 +275,17 @@
                     || fx.Status == FixtureStatus.Completed;
 
                 fx.ResultSummary = $"{homeScore}-{awayScore}";
-                fx.WinnerTeamId = homeScore > awayScore ? fx.HomeTeamId
-                                : awayScore > homeScore ? fx.AwayTeamId
-                                : null;
+                int? winner = homeScore > awayScore ? fx.HomeTeamId
+                            : awayScore > homeScore ? fx.AwayTeamId
+                            : null;
+
+                if (!winner.HasValue && homeScore == awayScore
+                    && fx.HomeTeamId.HasValue && fx.AwayTeamId.HasValue)
+                {
+                    var mode = fx.Competition?.RubberTieBreak ?? DropShot.Shared.RubberTieBreakMode.AdminDecides;
+                    winner = await RubberResolutionService.ResolveTieBreakAsync(db, fx, allRubbers, mode);
+                }
+                fx.WinnerTeamId = winner;
 
                 if (AdminOverride && alreadyFinalised)
                 {

--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -296,6 +296,22 @@ else
                         </MudStack>
                     </MudRadioGroup>
 
+                    @if (EffectivePersistedFormat() == CompetitionFormat.TeamMatch)
+                    {
+                        <MudText Typo="Typo.subtitle2" Class="mt-3 mb-1">Rubber tie-break</MudText>
+                        <MudText Typo="Typo.caption" Class="mb-2" Style="opacity:0.75">
+                            How to resolve knockout fixtures when rubbers are tied.
+                        </MudText>
+                        <MudRadioGroup @bind-Value="Model.RubberTieBreak">
+                            <MudStack Spacing="1">
+                                <MudRadio Value="DropShot.Shared.RubberTieBreakMode.AdminDecides" Color="Color.Primary">Admin picks the winner</MudRadio>
+                                <MudRadio Value="DropShot.Shared.RubberTieBreakMode.MostGamesWon" Color="Color.Primary">Most games won across all rubbers</MudRadio>
+                                <MudRadio Value="DropShot.Shared.RubberTieBreakMode.HeadToHeadRoundRobin" Color="Color.Primary">Winner of the round-robin meeting</MudRadio>
+                                <MudRadio Value="DropShot.Shared.RubberTieBreakMode.MostGamesThenHeadToHead" Color="Color.Primary">Most games won, then round-robin head-to-head</MudRadio>
+                            </MudStack>
+                        </MudRadioGroup>
+                    }
+
                     <MudCheckBox @bind-Value="Model.RequireVerification" Label="Require admin verification of results" Class="mt-2" />
 
                     <MudCheckBox @bind-Value="Model.HasDivisions"
@@ -1693,6 +1709,7 @@ else
         public int GamesPerSet { get; set; } = 6;
         public SetWinMode SetWinMode { get; set; } = SetWinMode.WinBy2;
         public LeagueScoringMode LeagueScoring { get; set; } = LeagueScoringMode.WinPoints;
+        public DropShot.Shared.RubberTieBreakMode RubberTieBreak { get; set; } = DropShot.Shared.RubberTieBreakMode.AdminDecides;
         public bool HasDivisions { get; set; }
         public int? SeededFromCompetitionId { get; set; }
     }
@@ -1907,6 +1924,7 @@ else
                 GamesPerSet = comp.GamesPerSet,
                 SetWinMode = comp.SetWinMode,
                 LeagueScoring = comp.LeagueScoring,
+                RubberTieBreak = comp.RubberTieBreak,
                 HasDivisions = comp.HasDivisions,
                 SeededFromCompetitionId = comp.SeededFromCompetitionId
             };
@@ -2247,6 +2265,7 @@ else
         comp.GamesPerSet = Model.GamesPerSet;
         comp.SetWinMode = Model.SetWinMode;
         comp.LeagueScoring = Model.LeagueScoring;
+        comp.RubberTieBreak = Model.RubberTieBreak;
         comp.HasDivisions = Model.HasDivisions;
         comp.SeededFromCompetitionId = Model.SeededFromCompetitionId;
     }
@@ -2834,6 +2853,7 @@ else
                 GamesPerSet         = source.GamesPerSet,
                 SetWinMode          = source.SetWinMode,
                 LeagueScoring       = source.LeagueScoring,
+                RubberTieBreak      = source.RubberTieBreak,
                 TeamSize            = source.TeamSize,
                 RubberTemplateKey   = source.RubberTemplateKey,
                 RequireVerification = source.RequireVerification,

--- a/DropShot/Components/Pages/VerifyResult.razor
+++ b/DropShot/Components/Pages/VerifyResult.razor
@@ -126,6 +126,18 @@
                             locked — further changes must happen on the
                             <MudLink Href="@($"/team-match/{_fixture.CompetitionFixtureId}?edit=1")">team match page</MudLink>.
                         </MudAlert>
+
+                        @if (_allRubbersComplete && !_fixture.WinnerTeamId.HasValue)
+                        {
+                            <MudAlert Severity="Severity.Warning" Dense="true">
+                                Rubbers are tied and the configured tie-break (@(_fixture.Competition?.RubberTieBreak.ToString() ?? "AdminDecides"))
+                                did not pick a winner. Choose which team wins:
+                            </MudAlert>
+                            <MudSelect T="int?" @bind-Value="_manualWinnerTeamId" Label="Winner" Variant="Variant.Outlined" Dense="true">
+                                <MudSelectItem T="int?" Value="@_fixture.HomeTeamId">@_side1</MudSelectItem>
+                                <MudSelectItem T="int?" Value="@_fixture.AwayTeamId">@_side2</MudSelectItem>
+                            </MudSelect>
+                        }
                     }
 
                     @* ── Individual match: allow score editing ── *@
@@ -231,6 +243,8 @@
     private int _aggregateAway;
     private string _aggregateUnit = "rubbers";
     private string _secondaryAggregate = "";
+    private bool _allRubbersComplete;
+    private int? _manualWinnerTeamId;
 
     protected override async Task OnInitializedAsync()
     {
@@ -317,6 +331,8 @@
             LeagueScoringMode.GamesWon => $"Rubbers: {rubbersHome}–{rubbersAway} · Sets: {setsHome}–{setsAway}",
             _                          => $"Sets: {setsHome}–{setsAway} · Games: {gamesHome}–{gamesAway}",
         };
+
+        _allRubbersComplete = _rubbers.Count > 0 && _rubbers.All(r => r.IsComplete);
     }
 
     private async Task EditRubberAsync(Rubber rubber)
@@ -388,6 +404,15 @@
             if (_winnerPlayerId == null) { _error = "Please select a winner."; return; }
         }
 
+        // Team match: if rubbers are tied and there's no resolved winner, the
+        // admin must pick one before approving.
+        if (_isTeamMatch && _allRubbersComplete && !_fixture!.WinnerTeamId.HasValue
+            && !_manualWinnerTeamId.HasValue)
+        {
+            _error = "Rubbers are tied — please pick a winner before approving.";
+            return;
+        }
+
         _saving = true;
         try
         {
@@ -395,6 +420,12 @@
             var fx = await db.CompetitionFixtures
                 .FirstOrDefaultAsync(f => f.CompetitionFixtureId == _fixture!.CompetitionFixtureId);
             if (fx == null) { _error = "Fixture not found."; return; }
+
+            // Apply manual tie-break pick.
+            if (_isTeamMatch && !fx.WinnerTeamId.HasValue && _manualWinnerTeamId.HasValue)
+            {
+                fx.WinnerTeamId = _manualWinnerTeamId;
+            }
 
             if (!_isTeamMatch && _editing)
             {

--- a/DropShot/Components/RubberScoreDialog.razor
+++ b/DropShot/Components/RubberScoreDialog.razor
@@ -265,9 +265,18 @@
                         || fx.Status == FixtureStatus.Completed;
 
                     fx.ResultSummary = $"{homeScore}-{awayScore}";
-                    fx.WinnerTeamId = homeScore > awayScore ? fx.HomeTeamId
-                                    : awayScore > homeScore ? fx.AwayTeamId
-                                    : null;
+                    int? winner = homeScore > awayScore ? fx.HomeTeamId
+                                : awayScore > homeScore ? fx.AwayTeamId
+                                : null;
+
+                    // Rubbers tied — try the configured tie-break fallback.
+                    if (!winner.HasValue && homeScore == awayScore
+                        && fx.HomeTeamId.HasValue && fx.AwayTeamId.HasValue)
+                    {
+                        var mode = fx.Competition?.RubberTieBreak ?? DropShot.Shared.RubberTieBreakMode.AdminDecides;
+                        winner = await RubberResolutionService.ResolveTieBreakAsync(db, fx, allRubbers, mode);
+                    }
+                    fx.WinnerTeamId = winner;
 
                     // Admin edit of a rubber on an already-finalised fixture: just
                     // update the aggregates in place. Don't regenerate the verification

--- a/DropShot/Data/Migrations/20260424205512_AddRubberTieBreakMode.Designer.cs
+++ b/DropShot/Data/Migrations/20260424205512_AddRubberTieBreakMode.Designer.cs
@@ -4,16 +4,19 @@ using DropShot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace DropShot.Migrations
+namespace DropShot.Data.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260424205512_AddRubberTieBreakMode")]
+    partial class AddRubberTieBreakMode
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DropShot/Data/Migrations/20260424205512_AddRubberTieBreakMode.cs
+++ b/DropShot/Data/Migrations/20260424205512_AddRubberTieBreakMode.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropShot.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRubberTieBreakMode : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<byte>(
+                name: "RubberTieBreak",
+                table: "Competition",
+                type: "tinyint",
+                nullable: false,
+                defaultValue: (byte)0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RubberTieBreak",
+                table: "Competition");
+        }
+    }
+}

--- a/DropShot/Models/Competition.cs
+++ b/DropShot/Models/Competition.cs
@@ -74,6 +74,12 @@
         public LeagueScoringMode LeagueScoring { get; set; } = LeagueScoringMode.WinPoints;
 
         /// <summary>
+        /// How to resolve a knockout team-match when the rubbers are tied.
+        /// Only applies to TeamMatch competitions. See <see cref="DropShot.Shared.RubberTieBreakMode"/>.
+        /// </summary>
+        public DropShot.Shared.RubberTieBreakMode RubberTieBreak { get; set; } = DropShot.Shared.RubberTieBreakMode.AdminDecides;
+
+        /// <summary>
         /// When true, this competition is split into ranked divisions via
         /// <see cref="Divisions"/>. Teams only play other teams in the same
         /// division, and league tables render per-division.

--- a/DropShot/Services/RubberResolutionService.cs
+++ b/DropShot/Services/RubberResolutionService.cs
@@ -2,6 +2,7 @@ using DropShot.Data;
 using DropShot.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using RubberTieBreakMode = DropShot.Shared.RubberTieBreakMode;
 
 namespace DropShot.Services;
 
@@ -77,6 +78,65 @@ public class RubberResolutionService(
             else if (r.WinnerTeamId == awayTeamId) away++;
         }
         return (home, away);
+    }
+
+    /// <summary>
+    /// Resolve a rubber tie (equal rubbers won) using the competition's configured
+    /// tie-break mode. Returns the winning team id, or null if the mode is
+    /// <see cref="RubberTieBreakMode.AdminDecides"/> or the configured fallback is
+    /// itself tied.
+    /// </summary>
+    public static async Task<int?> ResolveTieBreakAsync(
+        MyDbContext db, CompetitionFixture fixture, List<Rubber> rubbers,
+        RubberTieBreakMode mode)
+    {
+        if (!fixture.HomeTeamId.HasValue || !fixture.AwayTeamId.HasValue) return null;
+        int home = fixture.HomeTeamId.Value;
+        int away = fixture.AwayTeamId.Value;
+
+        int? byGames = ResolveByGames(rubbers, home, away);
+        int? byH2H = null;
+
+        switch (mode)
+        {
+            case RubberTieBreakMode.MostGamesWon:
+                return byGames;
+            case RubberTieBreakMode.HeadToHeadRoundRobin:
+                byH2H = await ResolveByRoundRobinH2HAsync(db, fixture.CompetitionId, home, away);
+                return byH2H;
+            case RubberTieBreakMode.MostGamesThenHeadToHead:
+                if (byGames.HasValue) return byGames;
+                byH2H = await ResolveByRoundRobinH2HAsync(db, fixture.CompetitionId, home, away);
+                return byH2H;
+            default:
+                return null;
+        }
+    }
+
+    private static int? ResolveByGames(List<Rubber> rubbers, int home, int away)
+    {
+        int hGames = rubbers.Where(r => r.IsComplete).Sum(r => r.HomeGamesTotal ?? 0);
+        int aGames = rubbers.Where(r => r.IsComplete).Sum(r => r.AwayGamesTotal ?? 0);
+        if (hGames > aGames) return home;
+        if (aGames > hGames) return away;
+        return null;
+    }
+
+    private static async Task<int?> ResolveByRoundRobinH2HAsync(
+        MyDbContext db, int competitionId, int home, int away)
+    {
+        var rrFixture = await db.CompetitionFixtures
+            .Include(f => f.Stage)
+            .Where(f => f.CompetitionId == competitionId
+                     && f.Stage != null && f.Stage.StageType == StageType.RoundRobin
+                     && ((f.HomeTeamId == home && f.AwayTeamId == away) ||
+                         (f.HomeTeamId == away && f.AwayTeamId == home))
+                     && f.Status == FixtureStatus.Completed
+                     && f.WinnerTeamId.HasValue)
+            .OrderByDescending(f => f.CompletedAt)
+            .FirstOrDefaultAsync();
+
+        return rrFixture?.WinnerTeamId;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Knockout team-matches that finish with rubbers tied now resolve via a configurable per-competition setting, rather than stalling.

- **#3** New `Competition.RubberTieBreak` column (EF migration `AddRubberTieBreakMode`) with four modes on `DropShot.Shared.RubberTieBreakMode`:
  - `AdminDecides` (default) — no auto-resolution, admin picks.
  - `MostGamesWon` — sum games across all rubbers; more games wins.
  - `HeadToHeadRoundRobin` — winner of the RR fixture between the same two teams.
  - `MostGamesThenHeadToHead` — games first, H2H as secondary tiebreak.
- `RubberResolutionService.ResolveTieBreakAsync` implements each mode. Both `RubberScoreDialog` and `BulkRubberScoreDialog` call it from their fixture-finalisation path: if all rubbers complete and rubber counts are equal, the resolver picks a winner (or leaves `WinnerTeamId` null for admin resolution).
- `VerifyResult.razor` detects the unresolved-tie case and surfaces a "Rubbers are tied — choose a winner" picker. `ApproveAsync` refuses to proceed until an admin picks one.
- Competition-setup form exposes the setting (TeamMatch only) via a radio group below LeagueScoring. The clone path carries it over.

## Test plan

- [ ] Apply migration: adds `RubberTieBreak tinyint NOT NULL DEFAULT 0` to `Competitions`.
- [ ] Create a TeamMatch competition with each mode and play a knockout with rubber counts forced tied (e.g. 2-2). Verify:
  - AdminDecides → fixture stays with WinnerTeamId null; VerifyResult shows the picker.
  - MostGamesWon → winner is the team with more total games across rubbers.
  - HeadToHeadRoundRobin → winner is the RR fixture's winner between the same two teams.
  - MostGamesThenHeadToHead → games preferred, falls back to H2H if games are also tied.
- [ ] Setup page: tie-break radio group only shows when format is TeamMatch; toggling persists and reloads correctly.
- [ ] Cloning a TeamMatch competition preserves the setting.
- [ ] `dotnet build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)