### PR TITLE
Group E: nav merge, contact page, new-user email

### DIFF
--- a/DropShot/Components/Account/Pages/Register.razor
+++ b/DropShot/Components/Account/Pages/Register.razor
@@ -19,6 +19,7 @@
 @inject EmailService EmailService
 @inject EmailTemplateService EmailTemplateService
 @inject IDbContextFactory<MyDbContext> DbFactory
+@inject DropShot.Services.BackgroundTaskQueue BackgroundTasks
 
 <PageTitle>Register</PageTitle>
 
@@ -250,6 +251,17 @@
 
         await EmailService.SendEmailAsync(Input.Email, "Confirm Your Email",
             EmailTemplateService.ConfirmationEmail(callbackUrl), isHtml: true);
+
+        // Notify site admin — fire-and-forget so a slow SMTP doesn't delay
+        // the user's redirect, and failures don't abort registration.
+        var notifyEmail = Input.Email;
+        var notifyName = Input.DisplayName;
+        var notifyAt = DateTime.UtcNow;
+        BackgroundTasks.Run("new-user-admin-notification", async sp =>
+        {
+            var svc = sp.GetRequiredService<DropShot.Services.AdminEmailService>();
+            await svc.SendNewUserNotificationAsync(notifyEmail, notifyName, notifyAt);
+        });
 
         if (UserManager.Options.SignIn.RequireConfirmedAccount)
         {

--- a/DropShot/Components/Layout/Footer.razor
+++ b/DropShot/Components/Layout/Footer.razor
@@ -23,6 +23,7 @@
                 <MudText Typo="Typo.subtitle2" Class="footer-heading mb-2">Resources</MudText>
                 <div class="footer-links">
                     <MudLink Href="/support" Color="Color.Inherit" Typo="Typo.body2">Support</MudLink>
+                    <MudLink Href="/contact" Color="Color.Inherit" Typo="Typo.body2">Contact</MudLink>
                     <MudLink Href="/student-discount" Color="Color.Inherit" Typo="Typo.body2">Student Discount</MudLink>
                 </div>
             </MudItem>

--- a/DropShot/Components/Layout/NavMenu.razor
+++ b/DropShot/Components/Layout/NavMenu.razor
@@ -30,62 +30,6 @@
                 </div>
             </AuthorizeView>
 
-            <AuthorizeView Roles="Admin,SuperAdmin,ClubAdmin">
-                <div class="nav-item nav-dropdown">
-                    <button class="nav-link nav-dropdown-trigger" onclick="event.stopPropagation()">
-                        <MudIcon Icon="@Icons.Material.Filled.AdminPanelSettings" Class="nav-icon" />
-                        <span class="nav-label-group">
-                            <span class="nav-label">Admin</span>
-                            <span class="nav-sublabel">Scoreboards, users &amp; requests</span>
-                        </span>
-                        <span class="nav-expand-icon">
-                            <MudIcon Icon="@Icons.Material.Filled.ExpandMore" Class="nav-icon" />
-                        </span>
-                    </button>
-                    <div class="nav-dropdown-menu">
-                        <NavLink class="nav-link" href="score">
-                            <MudIcon Icon="@Icons.Material.Filled.Tv" Class="nav-icon" />
-                            <span class="nav-label-group">
-                                <span class="nav-label">Scoreboard View</span>
-                                <span class="nav-sublabel">Display live scores</span>
-                            </span>
-                        </NavLink>
-                        <NavLink class="nav-link" href="score/display-control">
-                            <MudIcon Icon="@Icons.Material.Filled.Settings" Class="nav-icon" />
-                            <span class="nav-label-group">
-                                <span class="nav-label">Display Control</span>
-                                <span class="nav-sublabel">Manage scoreboards</span>
-                            </span>
-                        </NavLink>
-                        <AuthorizeView Roles="Admin,SuperAdmin" Context="adminCtx">
-                            <NavLink class="nav-link" href="admin/users">
-                                <MudIcon Icon="@Icons.Material.Filled.ManageAccounts" Class="nav-icon" />
-                                <span class="nav-label-group">
-                                    <span class="nav-label">Users</span>
-                                    <span class="nav-sublabel">Manage accounts and roles</span>
-                                </span>
-                            </NavLink>
-                            <NavLink class="nav-link" href="admin/site-settings">
-                                <MudIcon Icon="@Icons.Material.Filled.Tune" Class="nav-icon" />
-                                <span class="nav-label-group">
-                                    <span class="nav-label">Site Settings</span>
-                                    <span class="nav-sublabel">Layout and site-wide options</span>
-                                </span>
-                            </NavLink>
-                        </AuthorizeView>
-                        <AuthorizeView Roles="Admin,SuperAdmin,ClubAdmin" Context="linkReqCtx">
-                            <NavLink class="nav-link" href="clubadmin/link-requests">
-                                <MudIcon Icon="@Icons.Material.Filled.GroupAdd" Class="nav-icon" />
-                                <span class="nav-label-group">
-                                    <span class="nav-label">Link Requests</span>
-                                    <span class="nav-sublabel">Approve player links</span>
-                                </span>
-                            </NavLink>
-                        </AuthorizeView>
-                    </div>
-                </div>
-            </AuthorizeView>
-
             <AuthorizeView>
                 <Authorized Context="mainCtx">
                     <div class="nav-item">
@@ -203,6 +147,50 @@
                                     <span class="nav-sublabel">Profile &amp; settings</span>
                                 </span>
                             </a>
+
+                            @* Admin shortcuts — rolled into the user profile dropdown. *@
+                            <AuthorizeView Roles="Admin,SuperAdmin,ClubAdmin" Context="adminCtx">
+                                <hr class="nav-dropdown-divider" />
+                                <NavLink class="nav-link" href="score">
+                                    <MudIcon Icon="@Icons.Material.Filled.Tv" Class="nav-icon" />
+                                    <span class="nav-label-group">
+                                        <span class="nav-label">Scoreboard View</span>
+                                        <span class="nav-sublabel">Display live scores</span>
+                                    </span>
+                                </NavLink>
+                                <NavLink class="nav-link" href="score/display-control">
+                                    <MudIcon Icon="@Icons.Material.Filled.Settings" Class="nav-icon" />
+                                    <span class="nav-label-group">
+                                        <span class="nav-label">Display Control</span>
+                                        <span class="nav-sublabel">Manage scoreboards</span>
+                                    </span>
+                                </NavLink>
+                                <AuthorizeView Roles="Admin,SuperAdmin" Context="saCtx">
+                                    <NavLink class="nav-link" href="admin/users">
+                                        <MudIcon Icon="@Icons.Material.Filled.ManageAccounts" Class="nav-icon" />
+                                        <span class="nav-label-group">
+                                            <span class="nav-label">Users</span>
+                                            <span class="nav-sublabel">Manage accounts and roles</span>
+                                        </span>
+                                    </NavLink>
+                                    <NavLink class="nav-link" href="admin/site-settings">
+                                        <MudIcon Icon="@Icons.Material.Filled.Tune" Class="nav-icon" />
+                                        <span class="nav-label-group">
+                                            <span class="nav-label">Site Settings</span>
+                                            <span class="nav-sublabel">Layout and site-wide options</span>
+                                        </span>
+                                    </NavLink>
+                                </AuthorizeView>
+                                <NavLink class="nav-link" href="clubadmin/link-requests">
+                                    <MudIcon Icon="@Icons.Material.Filled.GroupAdd" Class="nav-icon" />
+                                    <span class="nav-label-group">
+                                        <span class="nav-label">Link Requests</span>
+                                        <span class="nav-sublabel">Approve player links</span>
+                                    </span>
+                                </NavLink>
+                                <hr class="nav-dropdown-divider" />
+                            </AuthorizeView>
+
                             <div class="nav-dropdown-item">
                                 <form action="Account/Logout" method="post">
                                     <AntiforgeryToken />

--- a/DropShot/Components/Layout/NavMenu.razor.css
+++ b/DropShot/Components/Layout/NavMenu.razor.css
@@ -147,6 +147,13 @@
     transform: rotate(180deg);
 }
 
+.nav-dropdown-divider {
+    border: none;
+    height: 1px;
+    background: rgba(255, 255, 255, 0.12);
+    margin: 0.35rem 0;
+}
+
 .nav-dropdown-menu ::deep .nav-link,
 .nav-dropdown-menu > .nav-link,
 .nav-dropdown-menu a.nav-link,
@@ -268,6 +275,8 @@
 
 /* ══════════════════════════════════════════════════════════════════════
    Medium screens – tighten spacing
+   Labels stay visible; we shrink the font / gap / sublabel instead of
+   hiding labels (which used to leave users with unlabelled icons).
    ══════════════════════════════════════════════════════════════════════ */
 @media (min-width: 641px) and (max-width: 1024px) {
     .nav-item ::deep .nav-link,
@@ -275,11 +284,24 @@
     .nav-dropdown-trigger {
         padding: 0 0.5rem;
         gap: 0.3rem;
-        font-size: 0.85rem;
+        font-size: 0.8rem;
     }
 
     .nav-label {
+        display: inline;
+        font-size: 0.8rem;
+    }
+
+    /* Hide the small grey descriptor on tight screens — label alone is enough. */
+    .nav-primary .nav-sublabel,
+    .nav-utils .nav-sublabel {
         display: none;
+    }
+
+    /* Shrink icons a touch so the label has room. */
+    .nav-primary .nav-icon,
+    .nav-utils .nav-icon {
+        font-size: 1.1rem;
     }
 }
 

--- a/DropShot/Components/Pages/Contact.razor
+++ b/DropShot/Components/Pages/Contact.razor
@@ -1,0 +1,157 @@
+@page "/contact"
+@rendermode InteractiveServer
+@using System.ComponentModel.DataAnnotations
+@using DropShot.Services
+@using Microsoft.AspNetCore.Http
+
+@inject EmailService EmailService
+@inject EmailTemplateService EmailTemplateService
+@inject ContactRateLimiter RateLimiter
+@inject IConfiguration Configuration
+@inject IHttpContextAccessor HttpContextAccessor
+@inject ILogger<Contact> Logger
+
+<MudProviders />
+<PageTitle>Contact DropShot</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Small" Class="mt-8">
+    <MudCard>
+        <MudCardContent>
+            <MudText Typo="Typo.h5" Class="mb-2">Get in touch</MudText>
+            <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mb-4">
+                We would love to hear from you. All emails will be responded to and we would love
+                your feedback and suggestions for improvements or to hear about any issues you're
+                having with the site or improvements or anything.
+            </MudText>
+
+            @if (_sent)
+            {
+                <MudAlert Severity="Severity.Success">
+                    Thanks — your message has been received. We'll get back to you shortly.
+                </MudAlert>
+            }
+            else
+            {
+                <EditForm Model="_input" OnValidSubmit="SubmitAsync" FormName="contact">
+                    <DataAnnotationsValidator />
+                    <MudStack Spacing="3">
+                        <MudTextField @bind-Value="_input.Name" Label="Your name"
+                                      Required="true" Variant="Variant.Outlined" />
+                        <MudTextField @bind-Value="_input.Email" Label="Email"
+                                      InputType="InputType.Email" Required="true" Variant="Variant.Outlined" />
+                        <MudTextField @bind-Value="_input.Subject" Label="Subject"
+                                      Required="true" Variant="Variant.Outlined" />
+                        <MudTextField @bind-Value="_input.Message" Label="Message"
+                                      Required="true" Lines="6" Variant="Variant.Outlined" />
+
+                        @* Honeypot: real users can't see this field; bots fill it in and get dropped. *@
+                        <div style="position:absolute; left:-9999px; top:auto; width:1px; height:1px; overflow:hidden;" aria-hidden="true">
+                            <label>Website (leave blank)
+                                <input type="text" tabindex="-1" autocomplete="off"
+                                       @bind="_input.Website" />
+                            </label>
+                        </div>
+
+                        @if (!string.IsNullOrEmpty(_error))
+                        {
+                            <MudAlert Severity="Severity.Error">@_error</MudAlert>
+                        }
+
+                        <MudButton ButtonType="ButtonType.Submit" Color="Color.Primary"
+                                   Variant="Variant.Filled" Disabled="_sending">
+                            @(_sending ? "Sending…" : "Send message")
+                        </MudButton>
+                    </MudStack>
+                </EditForm>
+            }
+        </MudCardContent>
+    </MudCard>
+</MudContainer>
+
+@code {
+    private ContactInput _input = new();
+    private bool _sending;
+    private bool _sent;
+    private string? _error;
+    private DateTime _loadedAt;
+
+    protected override void OnInitialized()
+    {
+        _loadedAt = DateTime.UtcNow;
+    }
+
+    private async Task SubmitAsync()
+    {
+        _error = null;
+
+        // Layer 1: honeypot. Any value here means a bot. Silently succeed so the
+        // bot doesn't retry.
+        if (!string.IsNullOrWhiteSpace(_input.Website))
+        {
+            Logger.LogInformation("Contact form: honeypot triggered (IP {Ip}).", RequestIp());
+            _sent = true;
+            return;
+        }
+
+        // Layer 2: time-trap. Humans can't read + type a message in 3s.
+        if ((DateTime.UtcNow - _loadedAt) < TimeSpan.FromSeconds(3))
+        {
+            Logger.LogInformation("Contact form: time-trap triggered (IP {Ip}).", RequestIp());
+            _sent = true;
+            return;
+        }
+
+        // Layer 3: rate-limit per IP and per email.
+        var ip = RequestIp();
+        if (!RateLimiter.TryRecord($"ip:{ip}") ||
+            !RateLimiter.TryRecord($"email:{_input.Email}"))
+        {
+            _error = "You've sent a few messages recently — please wait a few minutes and try again.";
+            return;
+        }
+
+        _sending = true;
+        try
+        {
+            var adminAddress = Configuration["App:AdminNotificationEmail"] ?? "admin@ds.tennis";
+            var body = $"""
+                <p><strong>From:</strong> {System.Net.WebUtility.HtmlEncode(_input.Name)} &lt;{System.Net.WebUtility.HtmlEncode(_input.Email)}&gt;</p>
+                <p><strong>Subject:</strong> {System.Net.WebUtility.HtmlEncode(_input.Subject)}</p>
+                <hr />
+                <p>{System.Net.WebUtility.HtmlEncode(_input.Message).Replace("\n", "<br />")}</p>
+                """;
+
+            await EmailService.SendEmailAsync(
+                adminAddress,
+                $"[DropShot contact] {_input.Subject}",
+                EmailTemplateService.AdminCustomEmail(body),
+                isHtml: true);
+
+            _sent = true;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Contact form send failed for {Email}", _input.Email);
+            _error = "Sorry — something went wrong sending your message. Please try again.";
+        }
+        finally
+        {
+            _sending = false;
+        }
+    }
+
+    private string RequestIp()
+    {
+        var ctx = HttpContextAccessor.HttpContext;
+        return ctx?.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+    }
+
+    public class ContactInput
+    {
+        [Required] public string Name { get; set; } = "";
+        [Required, EmailAddress] public string Email { get; set; } = "";
+        [Required] public string Subject { get; set; } = "";
+        [Required] public string Message { get; set; } = "";
+        public string? Website { get; set; }
+    }
+}

--- a/DropShot/Program.cs
+++ b/DropShot/Program.cs
@@ -120,6 +120,8 @@ builder.Services.AddSingleton<EmailTemplateService>();
 builder.Services.AddSingleton<BackgroundTaskQueue>();
 builder.Services.AddScoped<ResultVerificationService>();
 builder.Services.AddScoped<AdminEmailService>();
+builder.Services.AddMemoryCache();
+builder.Services.AddSingleton<ContactRateLimiter>();
 builder.Services.AddScoped<FuzzySearchService>();
 builder.Services.AddScoped<ICompetitionRubberTemplateProvider, CompetitionRubberTemplateProvider>();
 builder.Services.AddScoped<RubberResolutionService>();

--- a/DropShot/Services/AdminEmailService.cs
+++ b/DropShot/Services/AdminEmailService.cs
@@ -81,6 +81,35 @@ public class AdminEmailService(
     // ── Club link requests ────────────────────────────────────────────────────
 
     /// <summary>
+    /// Notifies the site-wide admin address that a new user has just registered.
+    /// Destination address is read from <c>App:AdminNotificationEmail</c>
+    /// (defaults to <c>admin@ds.tennis</c>). Fire-and-forget — failures are
+    /// logged but don't block the registration flow.
+    /// </summary>
+    public async Task SendNewUserNotificationAsync(
+        string userEmail, string? displayName, DateTime registeredAtUtc)
+    {
+        var adminAddress = config["App:AdminNotificationEmail"];
+        if (string.IsNullOrWhiteSpace(adminAddress)) return;
+
+        var body = $"""
+            <p>A new user has just registered on DropShot.</p>
+            <ul>
+                <li><strong>Email:</strong> {System.Net.WebUtility.HtmlEncode(userEmail)}</li>
+                <li><strong>Display name:</strong> {System.Net.WebUtility.HtmlEncode(displayName ?? "(not set)")}</li>
+                <li><strong>Registered at (UTC):</strong> {registeredAtUtc:yyyy-MM-dd HH:mm:ss}</li>
+            </ul>
+            """;
+
+        await SendSafe(
+            adminAddress,
+            "New DropShot user registered",
+            emailTemplateService.AdminCustomEmail(body),
+            "new user notification",
+            isHtml: true);
+    }
+
+    /// <summary>
     /// Notifies club admins that a new link request has been submitted.
     /// </summary>
     public async Task SendClubLinkRequestReceivedAsync(

--- a/DropShot/Services/ContactRateLimiter.cs
+++ b/DropShot/Services/ContactRateLimiter.cs
@@ -1,0 +1,34 @@
+using Microsoft.Extensions.Caching.Memory;
+
+namespace DropShot.Services;
+
+/// <summary>
+/// Lightweight in-memory sliding-window limiter for the public /contact form.
+/// Three submissions per 15 minutes per key (either IP or email) is enough to
+/// stop casual abuse without punishing legitimate resubmits.
+/// </summary>
+public class ContactRateLimiter(IMemoryCache cache)
+{
+    private static readonly TimeSpan Window = TimeSpan.FromMinutes(15);
+    private const int MaxPerWindow = 3;
+
+    /// <summary>
+    /// Records an attempt for the given key. Returns true if the attempt is
+    /// within the allowed window, false if the caller has exceeded the limit.
+    /// </summary>
+    public bool TryRecord(string key)
+    {
+        if (string.IsNullOrWhiteSpace(key)) return true;
+
+        var cacheKey = $"contact-rl:{key.ToLowerInvariant()}";
+        var stamps = cache.Get<List<DateTime>>(cacheKey) ?? [];
+        var cutoff = DateTime.UtcNow - Window;
+        stamps = stamps.Where(t => t >= cutoff).ToList();
+
+        if (stamps.Count >= MaxPerWindow) return false;
+
+        stamps.Add(DateTime.UtcNow);
+        cache.Set(cacheKey, stamps, Window);
+        return true;
+    }
+}

--- a/DropShot/appsettings.json
+++ b/DropShot/appsettings.json
@@ -14,7 +14,8 @@
     "AllowedOrigins": ["https://localhost:7000", "https://localhost:5001"]
   },
   "App": {
-    "BaseUrl": "https://localhost:7000"
+    "BaseUrl": "https://localhost:7000",
+    "AdminNotificationEmail": "admin@ds.tennis"
   },
   "Jwt": {
     "Key": "CHANGE-THIS-TO-A-LONG-RANDOM-SECRET-KEY-IN-PRODUCTION",


### PR DESCRIPTION
## Summary

Four UX / communication issues landing together — they're small but touch several places and it's cleaner to bundle them.

- **#12** — Admin-tasks dropdown merged into the user-profile dropdown. The admin icon is gone from the main nav; its five entries (Scoreboard View / Display Control / Users / Site Settings / Link Requests) now live inside the account menu, each still wrapped in its own `AuthorizeView` role block. A new `.nav-dropdown-divider` style separates the account items from the admin items.
- **#13** — Desktop nav between 641–1024px no longer hides labels. Labels stay visible with a slightly smaller font; the grey sublabel and icon shrink instead. Narrow-desktop users can now actually tell what every item is.
- **#15** — New user registration fires a fire-and-forget admin notification via `BackgroundTaskQueue` → `AdminEmailService.SendNewUserNotificationAsync`. Destination read from `App:AdminNotificationEmail` in appsettings (default `admin@ds.tennis`).
- **#16** — New `/contact` page with the requested blurb text and four fields (Name, Email, Subject, Message). Three anti-spam layers, no CAPTCHA:
  - Honeypot `website` input positioned off-screen — if filled, we silently "succeed" and drop the message.
  - 3-second time-trap — submissions inside 3s of page-load are silently dropped.
  - `ContactRateLimiter` backed by `IMemoryCache`: 3 submissions per 15 min per IP and per email.
  - Successful submit emails `App:AdminNotificationEmail` via `EmailService.SendEmailAsync`.
- Footer gets a `Contact` link under Resources.

## Test plan

- [ ] As an admin / club admin / super admin, confirm the admin-panel dropdown icon is gone from the main nav and the five admin items appear inside the account menu on the right (each respects its role check).
- [ ] Resize browser to 640/768/900/1024/1200 — labels are legible at every width.
- [ ] Register a new test user → confirmation email arrives AND admin notification to `admin@ds.tennis` arrives (check SMTP log).
- [ ] Visit `/contact`, submit a normal message → admin email arrives.
- [ ] Submit within 3s of load → no email sent, form shows success (silent drop).
- [ ] Fill the hidden `website` input via DOM tools → no email sent, form shows success.
- [ ] Submit 4 times in a row → 4th rejected with the rate-limit message.
- [ ] `dotnet build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)