### PR TITLE
Group F: min-days scheduling + orphaned SavedMatch cleanup

### DIFF
--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -312,6 +312,15 @@ else
                         </MudRadioGroup>
                     }
 
+                    <MudText Typo="Typo.subtitle2" Class="mt-3 mb-1">Minimum days between matches</MudText>
+                    <MudText Typo="Typo.caption" Class="mb-2" Style="opacity:0.75">
+                        Auto-scheduling will try to keep each player's matches this many days apart.
+                        Leave blank for no restriction.
+                    </MudText>
+                    <MudNumericField T="int?" @bind-Value="Model.MinDaysBetweenPlayerMatches"
+                                     Label="Days" Min="0" Max="30" Variant="Variant.Outlined"
+                                     Style="max-width: 160px" />
+
                     <MudCheckBox @bind-Value="Model.RequireVerification" Label="Require admin verification of results" Class="mt-2" />
 
                     <MudCheckBox @bind-Value="Model.HasDivisions"
@@ -1710,6 +1719,7 @@ else
         public SetWinMode SetWinMode { get; set; } = SetWinMode.WinBy2;
         public LeagueScoringMode LeagueScoring { get; set; } = LeagueScoringMode.WinPoints;
         public DropShot.Shared.RubberTieBreakMode RubberTieBreak { get; set; } = DropShot.Shared.RubberTieBreakMode.AdminDecides;
+        public int? MinDaysBetweenPlayerMatches { get; set; }
         public bool HasDivisions { get; set; }
         public int? SeededFromCompetitionId { get; set; }
     }
@@ -1925,6 +1935,7 @@ else
                 SetWinMode = comp.SetWinMode,
                 LeagueScoring = comp.LeagueScoring,
                 RubberTieBreak = comp.RubberTieBreak,
+                MinDaysBetweenPlayerMatches = comp.MinDaysBetweenPlayerMatches,
                 HasDivisions = comp.HasDivisions,
                 SeededFromCompetitionId = comp.SeededFromCompetitionId
             };
@@ -2266,6 +2277,7 @@ else
         comp.SetWinMode = Model.SetWinMode;
         comp.LeagueScoring = Model.LeagueScoring;
         comp.RubberTieBreak = Model.RubberTieBreak;
+        comp.MinDaysBetweenPlayerMatches = Model.MinDaysBetweenPlayerMatches;
         comp.HasDivisions = Model.HasDivisions;
         comp.SeededFromCompetitionId = Model.SeededFromCompetitionId;
     }
@@ -2854,6 +2866,7 @@ else
                 SetWinMode          = source.SetWinMode,
                 LeagueScoring       = source.LeagueScoring,
                 RubberTieBreak      = source.RubberTieBreak,
+                MinDaysBetweenPlayerMatches = source.MinDaysBetweenPlayerMatches,
                 TeamSize            = source.TeamSize,
                 RubberTemplateKey   = source.RubberTemplateKey,
                 RequireVerification = source.RequireVerification,
@@ -3936,12 +3949,30 @@ else
 
         await using var db = DbFactory.CreateDbContext();
 
-        // Delete any Rubbers first
         var fixtureIds = _fixtures.Select(f => f.CompetitionFixtureId).ToList();
+
+        // Delete Rubbers first, capturing any SavedMatch links.
         var rubbers = await db.Rubbers.Where(r => fixtureIds.Contains(r.CompetitionFixtureId)).ToListAsync();
+        var rubberSavedMatchIds = rubbers
+            .Where(r => r.SavedMatchId.HasValue)
+            .Select(r => r.SavedMatchId!.Value)
+            .ToList();
         if (rubbers.Count > 0) db.Rubbers.RemoveRange(rubbers);
 
         var all = await db.CompetitionFixtures.Where(f => f.CompetitionId == Id).ToListAsync();
+
+        // Collect all SavedMatch IDs linked either directly on a fixture or via one of its rubbers,
+        // so they get cleaned up too and don't re-appear as orphaned casual matches on players' feeds.
+        var directSavedMatchIds = all.Where(f => f.SavedMatchId.HasValue).Select(f => f.SavedMatchId!.Value);
+        var savedMatchIds = directSavedMatchIds.Concat(rubberSavedMatchIds).Distinct().ToList();
+        if (savedMatchIds.Count > 0)
+        {
+            var savedMatches = await db.SavedMatch
+                .Where(m => savedMatchIds.Contains(m.SavedMatchId))
+                .ToListAsync();
+            if (savedMatches.Count > 0) db.SavedMatch.RemoveRange(savedMatches);
+        }
+
         db.CompetitionFixtures.RemoveRange(all);
         await db.SaveChangesAsync();
 

--- a/DropShot/Controllers/CompetitionsController.cs
+++ b/DropShot/Controllers/CompetitionsController.cs
@@ -665,8 +665,26 @@ public class CompetitionsController(
         if (comp is null) return NotFound();
         if (!await authzService.CanEditCompetitionAsync(User, comp.HostClubId)) return Forbid();
 
-        var fixture = await db.CompetitionFixtures.FindAsync(fixtureId);
+        var fixture = await db.CompetitionFixtures
+            .Include(f => f.Rubbers)
+            .FirstOrDefaultAsync(f => f.CompetitionFixtureId == fixtureId);
         if (fixture is null || fixture.CompetitionId != id) return NotFound();
+
+        // Remove the linked SavedMatch so it doesn't re-appear as an
+        // "unlinked" casual match on the player's recent-results feed.
+        if (fixture.SavedMatchId.HasValue)
+        {
+            var savedMatch = await db.SavedMatch.FindAsync(fixture.SavedMatchId.Value);
+            if (savedMatch != null) db.SavedMatch.Remove(savedMatch);
+        }
+        // Remove any SavedMatches linked through the fixture's rubbers.
+        foreach (var rubber in fixture.Rubbers.Where(r => r.SavedMatchId.HasValue))
+        {
+            var rubberMatch = await db.SavedMatch.FindAsync(rubber.SavedMatchId!.Value);
+            if (rubberMatch != null) db.SavedMatch.Remove(rubberMatch);
+        }
+        if (fixture.Rubbers.Any()) db.Rubbers.RemoveRange(fixture.Rubbers);
+
         db.CompetitionFixtures.Remove(fixture);
         await db.SaveChangesAsync();
         return NoContent();

--- a/DropShot/Data/Migrations/20260424211229_AddMinDaysBetweenPlayerMatches.Designer.cs
+++ b/DropShot/Data/Migrations/20260424211229_AddMinDaysBetweenPlayerMatches.Designer.cs
@@ -4,16 +4,19 @@ using DropShot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace DropShot.Migrations
+namespace DropShot.Data.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260424211229_AddMinDaysBetweenPlayerMatches")]
+    partial class AddMinDaysBetweenPlayerMatches
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DropShot/Data/Migrations/20260424211229_AddMinDaysBetweenPlayerMatches.cs
+++ b/DropShot/Data/Migrations/20260424211229_AddMinDaysBetweenPlayerMatches.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropShot.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMinDaysBetweenPlayerMatches : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "MinDaysBetweenPlayerMatches",
+                table: "Competition",
+                type: "int",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MinDaysBetweenPlayerMatches",
+                table: "Competition");
+        }
+    }
+}

--- a/DropShot/Models/Competition.cs
+++ b/DropShot/Models/Competition.cs
@@ -80,6 +80,12 @@
         public DropShot.Shared.RubberTieBreakMode RubberTieBreak { get; set; } = DropShot.Shared.RubberTieBreakMode.AdminDecides;
 
         /// <summary>
+        /// Minimum number of days that must elapse between any two matches for the
+        /// same player during auto-scheduling. Null or 0 means no constraint.
+        /// </summary>
+        public int? MinDaysBetweenPlayerMatches { get; set; }
+
+        /// <summary>
         /// When true, this competition is split into ranked divisions via
         /// <see cref="Divisions"/>. Teams only play other teams in the same
         /// division, and league tables render per-division.

--- a/DropShot/Services/CompetitionSchedulerService.cs
+++ b/DropShot/Services/CompetitionSchedulerService.cs
@@ -206,7 +206,9 @@ public class CompetitionSchedulerService(IDbContextFactory<MyDbContext> dbFactor
         var courtBusyAt  = new Dictionary<DateTime, HashSet<int>>();
         var playerBusyAt = new Dictionary<DateTime, HashSet<int>>();
         var teamBusyAt   = new Dictionary<DateTime, HashSet<int>>();
+        var playerSlotTimes = new Dictionary<int, List<DateTime>>();
         DateTime? earliestAllowedTime = null;
+        int minDaysBetweenPlayerMatches = Math.Max(0, comp.MinDaysBetweenPlayerMatches ?? 0);
 
         (DateTime time, int? courtId)? PickSlot(List<int> playerIds, List<int> teamIds, int? requestedDivisionId)
         {
@@ -229,6 +231,21 @@ public class CompetitionSchedulerService(IDbContextFactory<MyDbContext> dbFactor
                         && (cBusy.Contains(pairCourts.Court1Id) || cBusy.Contains(pairCourts.Court2Id)))
                         conflict = true;
                 }
+
+                // Min-days-between-matches constraint per player.
+                if (!conflict && minDaysBetweenPlayerMatches > 0 && playerIds.Count > 0)
+                {
+                    foreach (var pid in playerIds)
+                    {
+                        if (!playerSlotTimes.TryGetValue(pid, out var times)) continue;
+                        if (times.Any(t => Math.Abs((slot.time.Date - t.Date).TotalDays) < minDaysBetweenPlayerMatches))
+                        {
+                            conflict = true;
+                            break;
+                        }
+                    }
+                }
+
                 if (conflict) continue;
 
                 usedSlots.Add((slot.time, slot.courtId));
@@ -237,6 +254,12 @@ public class CompetitionSchedulerService(IDbContextFactory<MyDbContext> dbFactor
                     if (!playerBusyAt.TryGetValue(slot.time, out var pSet))
                         playerBusyAt[slot.time] = pSet = [];
                     foreach (var pid in playerIds) pSet.Add(pid);
+                    foreach (var pid in playerIds)
+                    {
+                        if (!playerSlotTimes.TryGetValue(pid, out var times))
+                            playerSlotTimes[pid] = times = [];
+                        times.Add(slot.time);
+                    }
                 }
                 if (teamIds.Count > 0)
                 {


### PR DESCRIPTION
## Summary

Final batch of the 17-issue backlog.

- **#17** New `Competition.MinDaysBetweenPlayerMatches` column (nullable int, EF migration `AddMinDaysBetweenPlayerMatches`). Exposed via a small numeric field on the competition-setup form below the rubber tie-break setting. `CompetitionSchedulerService.PickSlot` tracks each player's already-picked slot times in a dictionary and rejects any candidate slot whose date is closer than the configured minimum — applied during both auto-schedule and re-schedule.
- **#18** `DeleteFixture` and the "Delete All Fixtures" path now also delete the `SavedMatch` rows that were linked to the removed fixtures (either directly via `fixture.SavedMatchId` or indirectly via a rubber's `rubber.SavedMatchId`). Without this those SavedMatches were left orphaned and reappeared on the player's Home recent-results feed as unlinked casual matches.

## Test plan

- [ ] Apply migration: adds `MinDaysBetweenPlayerMatches int NULL` to `Competitions`.
- [ ] Create a competition with `MinDaysBetweenPlayerMatches = 3` and enough match windows to cover the RR schedule tightly. Auto-schedule and verify no player has two fixtures within 3 days of each other.
- [ ] Set the value to null/blank on an existing competition → scheduler ignores the constraint (old behaviour).
- [ ] Create a fixture, play a live match, check it appears on Home → recent results.
- [ ] Delete that fixture via the admin UI → the recent-results row disappears.
- [ ] Click "Delete All Fixtures" on a competition with completed matches → SavedMatch rows for those fixtures are also removed, so they don't re-appear as casual matches.
- [ ] `dotnet build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)