### PR TITLE
Fix: always validate per-set scores in the bulk rubber dialog

### DIFF
--- a/DropShot/Components/BulkRubberScoreDialog.razor
+++ b/DropShot/Components/BulkRubberScoreDialog.razor
@@ -173,7 +173,9 @@
                 int h = _home[r][i]!.Value, a = _away[r][i]!.Value;
                 if (h == a) { _error = $"{_rubbers[r].Name} – Set {i + 1}: scores are tied."; return; }
 
-                if (!AdminOverride)
+                // Per-set validation always runs in the bulk dialog — score
+                // entry here is the normal match-result flow, so we want the
+                // same guardrails that the single-rubber path uses.
                 {
                     int winner = Math.Max(h, a);
                     int loser = Math.Min(h, a);
@@ -289,13 +291,17 @@
 
                 if (AdminOverride && alreadyFinalised)
                 {
-                    // Admin correcting an already-finalised fixture — update aggregates
-                    // in place; don't touch verification token or fire emails.
+                    // Admin correcting an already-finalised fixture — update
+                    // aggregates in place; don't regenerate the verification
+                    // token and don't resend emails (the outstanding admin
+                    // link needs to keep working).
                     await db.SaveChangesAsync();
                 }
                 else
                 {
                     fx.CompletedAt = DateTime.UtcNow;
+                    // Admins bypass email verification, but all users hit
+                    // the per-set validation at the top of this method.
                     bool requireVerification = !AdminOverride && (fx.Competition?.RequireVerification ?? false);
                     if (requireVerification)
                     {


### PR DESCRIPTION
## Summary

Bulk rubber dialog previously wrapped every per-set range check in \`if (!AdminOverride)\`, so an admin could enter 26-2 (or any out-of-range score) without a single error. That's contrary to what the admin-bypass was supposed to mean — the intent was "admins skip the email-verification workflow", not "admins get no guardrails at all".

- Per-set validation (winner reaches GamesPerSet, WinBy2 margin rules, no tied sets) now runs for every user regardless of role.
- Email verification (\`RequireVerification\` config) still respects \`AdminOverride\` — admins bypass the email flow as before. The explicit "Override Result" path on the competition setup page is still the escape hatch for genuinely irregular scores.

## Test plan

- [ ] As an admin, enter \`26-2\` via bulk dialog → rejected with the correct error.
- [ ] As an admin, enter a valid score \`6-2, 6-4\` → saved and marked Completed (email-verification still bypassed).
- [ ] As a non-admin player on a competition with RequireVerification=true, enter valid bulk scores → fixture moves to AwaitingVerification and admin email fires.
- [ ] \`dotnet build\` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)