### PR TITLE
Better error when a rubber role isn't assigned on the team

### DIFF
--- a/DropShot/Components/Pages/TeamMatchScoring.razor
+++ b/DropShot/Components/Pages/TeamMatchScoring.razor
@@ -27,11 +27,38 @@ else if (_fixture == null)
 else if (_resolutionError != null)
 {
     <MudContainer MaxWidth="MaxWidth.Medium" Class="py-4">
-        <MudAlert Severity="Severity.Error" Class="mb-3">@_resolutionError</MudAlert>
-        <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.ArrowBack"
-                   Href="@($"/competition/{_fixture.CompetitionId}/view")">
-            Back to Competition
-        </MudButton>
+        <MudAlert Severity="Severity.Error" Class="mb-3">
+            <MudText Typo="Typo.body1" Class="mb-2">@_resolutionError</MudText>
+            @if (_isCompetitionAdmin)
+            {
+                <MudText Typo="Typo.body2">
+                    Fix the team roster in the competition setup, then reload this page.
+                    The rubber template requires specific role tags on each team member
+                    (for example MA / MB for a men's doubles). Roles are assigned in the
+                    <strong>Teams</strong> section of the setup page.
+                </MudText>
+            }
+            else
+            {
+                <MudText Typo="Typo.body2">
+                    Ask a competition admin to assign the missing role on the team roster.
+                </MudText>
+            }
+        </MudAlert>
+        <MudStack Row="true" Spacing="2">
+            @if (_isCompetitionAdmin && _fixture != null)
+            {
+                <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                           StartIcon="@Icons.Material.Filled.ManageAccounts"
+                           Href="@($"/competition/{_fixture.CompetitionId}#section-teams")">
+                    Fix team roster
+                </MudButton>
+            }
+            <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.ArrowBack"
+                       Href="@($"/competition/{_fixture!.CompetitionId}/view")">
+                Back to Competition
+            </MudButton>
+        </MudStack>
     </MudContainer>
 }
 else


### PR DESCRIPTION
## Summary

When \`RubberResolutionService.EnsureRubbersAsync\` throws — e.g. because the home team has no player tagged \`MA\` for a men's doubles rubber — the team-match page previously just printed the exception text and offered a "Back to Competition" button. The user has to know that roles are assigned in the Teams section of the setup page, navigate there, find the affected team, and tag the missing role.

- Error page now, for competition admins, adds a short explanation of what the template expects and a primary "Fix team roster" button that deep-links to \`/competition/{id}#section-teams\`.
- Non-admins get a friendlier line telling them to ask a competition admin to assign the missing role.

Not in scope: auto-assigning roles based on player sex, or gating score entry on team validation. Happy to do either as a follow-up if helpful.

## Test plan

- [ ] Open a team-match fixture where a role is missing as an admin → error message is clear, "Fix team roster" button lands on the teams section of the setup page.
- [ ] Open the same fixture as a non-admin player → friendlier message, no "Fix" button.
- [ ] Once the role is assigned and the page reloads, scoring proceeds normally.
- [ ] \`dotnet build\` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)