### PR TITLE
Warn when auto-scheduling skips unconfirmed participants

### DIFF
--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -4600,6 +4600,18 @@ else
             Snackbar.Add($"{result.FixturesCreated} fixtures scheduled. {result.Unscheduled} could not be scheduled — not enough available slots in the match windows.", Severity.Warning);
         else
             Snackbar.Add($"{result.FixturesCreated} fixtures scheduled.", Severity.Success);
+
+        if (result.UnconfirmedParticipants.Count > 0)
+        {
+            var names = string.Join(", ", result.UnconfirmedParticipants.Take(5));
+            var suffix = result.UnconfirmedParticipants.Count > 5
+                ? $" (+{result.UnconfirmedParticipants.Count - 5} more)"
+                : "";
+            Snackbar.Add(
+                $"{result.UnconfirmedParticipants.Count} participant(s) were not included — they're registered but not yet confirmed as full players: {names}{suffix}.",
+                Severity.Warning,
+                c => c.VisibleStateDuration = 12000);
+        }
     }
 
     private async Task SeedKnockoutFromStandingsAsync()

--- a/DropShot/Services/CompetitionSchedulerService.cs
+++ b/DropShot/Services/CompetitionSchedulerService.cs
@@ -19,7 +19,10 @@ public enum ScheduleDeleteMode
 
 public record ScheduleFixturesRequest(ScheduleDeleteMode DeleteMode = ScheduleDeleteMode.None);
 
-public record ScheduleFixturesResult(int FixturesCreated, int Unscheduled);
+public record ScheduleFixturesResult(
+    int FixturesCreated,
+    int Unscheduled,
+    IReadOnlyList<string> UnconfirmedParticipants);
 
 /// <summary>
 /// Auto-scheduler for round-robin, knockout, semi-final, quarter-final and
@@ -52,7 +55,19 @@ public class CompetitionSchedulerService(IDbContextFactory<MyDbContext> dbFactor
             .AsSplitQuery()
             .AsNoTracking()
             .FirstOrDefaultAsync(c => c.CompetitionID == competitionId);
-        if (comp is null) return new ScheduleFixturesResult(0, 0);
+        if (comp is null) return new ScheduleFixturesResult(0, 0, []);
+
+        // Callers want to know which participants are sitting at Registered
+        // (added but not confirmed) or Substitute — those rows are intentionally
+        // skipped by the scheduler, but it's easy to miss them on a big roster
+        // and end up wondering why a fixture was generated without so-and-so.
+        var unconfirmed = comp.Participants
+            .Where(p => p.Status != ParticipantStatus.FullPlayer
+                     && p.Status != ParticipantStatus.Withdrawn
+                     && p.Status != ParticipantStatus.Disqualified)
+            .Select(p => p.Player?.DisplayName ?? $"Player {p.PlayerId}")
+            .OrderBy(n => n)
+            .ToList();
 
         // ── Delete according to mode ─────────────────────────────────────────
         switch (request.DeleteMode)
@@ -523,7 +538,7 @@ public class CompetitionSchedulerService(IDbContextFactory<MyDbContext> dbFactor
         db.CompetitionFixtures.AddRange(newFixtures);
         await db.SaveChangesAsync();
 
-        return new ScheduleFixturesResult(newFixtures.Count, unscheduled);
+        return new ScheduleFixturesResult(newFixtures.Count, unscheduled, unconfirmed);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

When an admin hits auto-schedule on a competition, participants sitting at \`Registered\` (added but not yet confirmed) or \`Substitute\` are silently excluded — only \`FullPlayer\` status generates fixtures. On a big roster this is easy to miss and leads to surprises like "why isn't Alice in any fixture?" or a downstream rubber-role resolution error because the one male who would have filled \`MA\` hasn't confirmed yet.

- \`ScheduleFixturesResult\` now carries an \`UnconfirmedParticipants\` list populated before the scheduling loop runs.
- \`CompetitionPage.ScheduleFixtures\` shows a second snackbar — warning severity, 12-second visibility — listing up to five names with a "(+X more)" overflow when any are found.

Keeps scope narrow: doesn't gate scheduling, doesn't change the service's fixture-generation logic, just surfaces something that's already happening.

## Test plan

- [ ] Add a participant via admin UI and leave them at status Registered. Auto-schedule → see the warning snackbar naming them.
- [ ] Confirm the same participant (FullPlayer). Re-schedule → warning snackbar no longer appears.
- [ ] With no unconfirmed participants, only the "N fixtures scheduled" success snackbar shows.
- [ ] \`dotnet build\` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)