### PR TITLE
Let Edit Competition and Club Players fill the configured centre section width

### DIFF
--- a/DropShot/Components/Pages/ClubPlayers.razor
+++ b/DropShot/Components/Pages/ClubPlayers.razor
@@ -17,7 +17,7 @@
 
 <div style="position: relative; min-height: 100vh; background-image: url('images/background.png'); background-repeat: no-repeat; background-size: cover; background-position: center; margin: -24px; padding: 0;">
     <div style="position: absolute; inset: 0; background-color: rgba(18, 18, 18, 0.85); pointer-events: none;"></div>
-    <div style="position: relative; z-index: 1; max-width: 1200px; margin: 0 auto; padding: 1rem 0.5rem 2rem;">
+    <div style="position: relative; z-index: 1; padding: 1rem 0.5rem 2rem;">
 
 <MudText Typo="Typo.h4" Class="mb-4" Style="color: white;">Club Players</MudText>
 

--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -36,7 +36,7 @@ else
 
 <div style="position: relative; min-height: 100vh; background-image: url('images/background.png'); background-repeat: no-repeat; background-size: cover; background-position: center; margin: -24px; padding: 0;">
     <div style="position: absolute; inset: 0; background-color: rgba(18, 18, 18, 0.85); pointer-events: none;"></div>
-    <div style="position: relative; z-index: 1; max-width: 1200px; margin: 0 auto; padding: 1rem 0.5rem 2rem;">
+    <div style="position: relative; z-index: 1; padding: 1rem 0.5rem 2rem;">
 
 <MudStack Row="true" AlignItems="AlignItems.Center" Class="mb-4" Spacing="2">
     @if (_nameOverride)


### PR DESCRIPTION
## Summary
- Both pages wrapped their content in an inner div with hardcoded `max-width: 1200px`, overriding the admin-configured `--ds-content-max-width` CSS variable (default 1280px) from `MainLayout.razor.css`.
- Removed the cap on `CompetitionPage.razor` and `ClubPlayers.razor` so they inherit the configured centre-section width from `.content`. Full-bleed background/overlay wrappers are preserved.

## Test plan
- [ ] Open the Edit Competition page and confirm it fills the centre section width
- [ ] Open the Club Players page and confirm it fills the centre section width
- [ ] Adjust the admin Content Max Width setting and confirm both pages track it
- [ ] Confirm the dark background image still extends edge-to-edge on both pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)