### PR TITLE
Show all players and their clubs on the SuperAdmin players page

### DIFF
--- a/DropShot/Components/Pages/Players.razor
+++ b/DropShot/Components/Pages/Players.razor
@@ -31,6 +31,7 @@
         <MudTh>Date of Birth</MudTh>
         <MudTh>Sex</MudTh>
         <MudTh>Linked Account</MudTh>
+        <MudTh>Clubs</MudTh>
         <AuthorizeView Roles="Admin" Context="auth">
             <MudTh>Actions</MudTh>
         </AuthorizeView>
@@ -50,6 +51,21 @@
             else
             {
                 <MudText Typo="Typo.caption" Style="color: grey;">Not linked</MudText>
+            }
+        </MudTd>
+        <MudTd DataLabel="Clubs">
+            @if (context.ClubNames.Count == 0)
+            {
+                <MudText Typo="Typo.caption" Style="color: grey;">—</MudText>
+            }
+            else
+            {
+                <div style="display: flex; flex-wrap: wrap; gap: 4px;">
+                    @foreach (var name in context.ClubNames)
+                    {
+                        <MudChip T="string" Size="Size.Small">@name</MudChip>
+                    }
+                </div>
             }
         </MudTd>
         <AuthorizeView Roles="Admin" Context="auth">
@@ -182,7 +198,7 @@
 </MudDialog>
 
 @code {
-    private record PlayerRow(Player Player, string? LinkedUserName);
+    private record PlayerRow(Player Player, string? LinkedUserName, IReadOnlyList<string> ClubNames);
 
     private bool _loading = true;
     private List<PlayerRow> _players = [];
@@ -193,7 +209,8 @@
         row.Player.DisplayName.Contains(_searchText, StringComparison.OrdinalIgnoreCase) ||
         (row.Player.FirstName ?? "").Contains(_searchText, StringComparison.OrdinalIgnoreCase) ||
         (row.Player.LastName ?? "").Contains(_searchText, StringComparison.OrdinalIgnoreCase) ||
-        (row.Player.Email ?? "").Contains(_searchText, StringComparison.OrdinalIgnoreCase);
+        (row.Player.Email ?? "").Contains(_searchText, StringComparison.OrdinalIgnoreCase) ||
+        row.ClubNames.Any(n => n.Contains(_searchText, StringComparison.OrdinalIgnoreCase));
 
     private bool _showAddDialog;
     private bool _showEditDialog;
@@ -233,11 +250,18 @@
         await using var dbc = DbFactory.CreateDbContext();
         var players = await dbc.Players
             .Include(p => p.User)
-            .Where(p => !p.IsLight)
+            .Include(p => p.ClubMemberships).ThenInclude(cp => cp.Club)
             .OrderBy(p => p.DisplayName)
             .ToListAsync();
 
-        _players = players.Select(p => new PlayerRow(p, p.User?.UserName)).ToList();
+        _players = players.Select(p => new PlayerRow(
+            p,
+            p.User?.UserName,
+            p.ClubMemberships
+                .Where(cp => cp.Club != null)
+                .Select(cp => cp.Club.Name)
+                .OrderBy(n => n)
+                .ToList())).ToList();
         _loading = false;
     }
 


### PR DESCRIPTION
## Summary
- Drops the `!p.IsLight` filter on `/players` so SuperAdmins see every player in the system, not just full (account-linked) ones.
- Adds a **Clubs** column populated from `Player.ClubMemberships`, rendered as small chips per club.
- Search box now also matches on club name.

## Why
SuperAdmins need full visibility — light players created by club admins via `/players/club` were previously invisible from `/players`, and there was no way to see which clubs a player belongs to from this page.

## Test plan
- [ ] Log in as SuperAdmin and open `/players` — confirm light players (those without linked accounts created via `/players/club`) now appear
- [ ] Confirm the new **Clubs** column lists each player's clubs as chips, with "—" when none
- [ ] Type a club name into the search box and confirm matching players are filtered in
- [ ] Confirm the **Linked Account** column still shows the green chip for full players and "Not linked" for unlinked/light players
- [ ] Confirm Add/Edit/Link/Delete actions still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)