### PR TITLE
Show Clubs nav link to all authenticated users

### DIFF
--- a/DropShot/Components/Layout/NavMenu.razor
+++ b/DropShot/Components/Layout/NavMenu.razor
@@ -79,13 +79,13 @@
                 </div>
             </AuthorizeView>
 
-            <AuthorizeView Roles="Admin,SuperAdmin">
+            <AuthorizeView>
                 <div class="nav-item">
                     <NavLink class="nav-link" href="clubs">
                         <MudIcon Icon="@Icons.Material.Filled.Business" Class="nav-icon" />
                         <span class="nav-label-group">
                             <span class="nav-label">Clubs</span>
-                            <span class="nav-sublabel">Manage tennis clubs</span>
+                            <span class="nav-sublabel">Browse tennis clubs</span>
                         </span>
                     </NavLink>
                 </div>


### PR DESCRIPTION
## Summary
- The Clubs nav item was gated to `Admin,SuperAdmin`, but `/clubs` itself only requires `[Authorize]` and offers a "Request to Link" workflow specifically for users who aren't admins of the club.
- Drops the role gate so any authenticated user can see and reach the Clubs page.
- Updates the sublabel from "Manage tennis clubs" to "Browse tennis clubs" — non-admins can't manage, so the previous wording was misleading.

## Test plan
- [ ] Sign in as a user with no admin roles — confirm the Clubs nav item is now visible
- [ ] Open the Clubs page from the nav and confirm the "Request to Link" button works for clubs the user isn't already linked to
- [ ] Sign in as Admin/SuperAdmin — confirm the nav item still appears and the existing management actions still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)