### PR TITLE
Confirm and allow cancelling club link requests

### DIFF
--- a/DropShot/Components/Pages/Clubs.razor
+++ b/DropShot/Components/Pages/Clubs.razor
@@ -14,6 +14,7 @@
 @inject ClubAuthorizationService AuthzService
 @inject AuthenticationStateProvider AuthStateProvider
 @inject UserManager<ApplicationUser> UserManager
+@inject IDialogService DialogService
 
 <MudProviders />
 
@@ -62,7 +63,12 @@
                     <MudChip T="string" Size="Size.Small" Color="Color.Success" Variant="Variant.Filled">Linked</MudChip>
                     break;
                 case ClubLinkState.Pending:
-                    <MudChip T="string" Size="Size.Small" Color="Color.Warning" Variant="Variant.Outlined">Request Pending</MudChip>
+                    <div style="display: inline-flex; align-items: center; gap: 4px;">
+                        <MudChip T="string" Size="Size.Small" Color="Color.Warning" Variant="Variant.Outlined">Request Pending</MudChip>
+                        <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small" Color="Color.Error"
+                                       aria-label="Cancel link request"
+                                       OnClick="@(() => CancelRequest(context))" />
+                    </div>
                     break;
                 default:
                     <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Primary"
@@ -699,6 +705,15 @@
             return;
         }
 
+        var confirmed = await DialogService.ShowMessageBox(
+            $"Request to link with {club.Name}?",
+            $"This will send a request to the administrators of {club.Name}. " +
+            "If they approve it, you will be added as a player on their roster. " +
+            "You can cancel a pending request from this page at any time before it is approved.",
+            yesText: "Send request", cancelText: "Cancel");
+
+        if (confirmed != true) return;
+
         await using var db = DbFactory.CreateDbContext();
 
         // Guard against a race with approval or an existing pending request.
@@ -723,6 +738,37 @@
 
         _pendingLinkClubIds.Add(club.ClubId);
         Snackbar.Add($"Request sent to {club.Name}.", Severity.Success);
+    }
+
+    private async Task CancelRequest(Club club)
+    {
+        if (string.IsNullOrEmpty(_currentUserId)) return;
+
+        var confirmed = await DialogService.ShowMessageBox(
+            $"Cancel link request to {club.Name}?",
+            "Your pending request will be deleted. You can submit a new one later if you change your mind.",
+            yesText: "Delete request", cancelText: "Keep request");
+
+        if (confirmed != true) return;
+
+        await using var db = DbFactory.CreateDbContext();
+        var pending = await db.ClubLinkRequests
+            .Where(r => r.UserId == _currentUserId && r.ClubId == club.ClubId
+                        && r.Status == ClubLinkRequestStatus.Pending)
+            .ToListAsync();
+
+        if (pending.Count == 0)
+        {
+            _pendingLinkClubIds.Remove(club.ClubId);
+            Snackbar.Add("No pending request found.", Severity.Info);
+            return;
+        }
+
+        db.ClubLinkRequests.RemoveRange(pending);
+        await db.SaveChangesAsync();
+
+        _pendingLinkClubIds.Remove(club.ClubId);
+        Snackbar.Add($"Request to {club.Name} cancelled.", Severity.Success);
     }
 
     private async Task LoadClubs()


### PR DESCRIPTION
## Summary
- Clicking **Request to Link** on `/clubs` now opens a confirmation dialog explaining what will happen — the request goes to the club's administrators, who can approve (adding you to their roster) or reject it, and you can cancel a pending request from this page at any time.
- Adds a **Delete** icon next to the "Request Pending" chip. Clicking it asks for confirmation, then deletes the matching `ClubLinkRequest` row (filtered to the current user, club, and `Pending` status) and updates the row state to show the "Request to Link" button again.

## Why
Sending the request silently with no preview of what would happen made it easy to click by accident, and there was previously no way to undo a request short of asking a club admin to reject it.

## Test plan
- [ ] On a club you're not linked to, click **Request to Link** — confirm the dialog appears with the new copy
- [ ] Cancel the dialog — confirm no request is created
- [ ] Confirm the dialog — confirm "Request Pending" chip + delete icon appear
- [ ] Click the delete icon, cancel the confirmation — confirm the request remains
- [ ] Click the delete icon, confirm — confirm the chip is replaced by **Request to Link** and the `ClubLinkRequests` row is gone from the database
- [ ] As a club admin for a different club, confirm you cannot cancel another user's request (only your own surface in the page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)