### PR TITLE
Fix test suite — DI registrations and admin-gated assertions

### DIFF
--- a/DropShot.Tests/Helpers/DropShotTestContext.cs
+++ b/DropShot.Tests/Helpers/DropShotTestContext.cs
@@ -89,15 +89,28 @@ public class DropShotTestContext : BunitContext
         var emailService = Substitute.For<EmailService>(config);
         Services.AddSingleton(emailService);
 
+        var emailTemplateService = new EmailTemplateService(config);
+        Services.AddSingleton(emailTemplateService);
+
         var resultVerification = Substitute.For<ResultVerificationService>(
-            emailService, config, NullLogger<ResultVerificationService>.Instance);
+            emailService, emailTemplateService, config, NullLogger<ResultVerificationService>.Instance);
         Services.AddScoped(_ => resultVerification);
 
         var adminEmailSvc = Substitute.For<AdminEmailService>(
-            emailService, config, NullLogger<AdminEmailService>.Instance);
+            emailService, emailTemplateService, config, NullLogger<AdminEmailService>.Instance);
         Services.AddScoped(_ => adminEmailSvc);
 
         Services.AddScoped(_ => Substitute.For<JwtTokenService>(config, userManager));
+
+        Services.AddScoped(_ => new CourtClaimService(DbFactory));
+
+        Services.AddSingleton<QrLoginService>();
+        Services.AddSingleton<BackgroundTaskQueue>();
+        Services.AddScoped<ICompetitionRubberTemplateProvider, CompetitionRubberTemplateProvider>();
+        Services.AddScoped<RubberResolutionService>();
+        Services.AddScoped<FixtureSimulationService>();
+        Services.AddScoped<CompetitionSchedulerService>();
+        Services.AddScoped<FuzzySearchService>();
 
         // Logging
         Services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));

--- a/DropShot.Tests/Pages/CompetitionPageTests.cs
+++ b/DropShot.Tests/Pages/CompetitionPageTests.cs
@@ -21,7 +21,7 @@ public class CompetitionPageTests
     [Fact]
     public async Task CompetitionPage_Existing_Renders_With_Data()
     {
-        await using var ctx = new DropShotTestContext(authenticated: true);
+        await using var ctx = new DropShotTestContext(authenticated: true, roles: ["Admin"]);
 
         using (var db = ctx.SeedDatabase())
         {

--- a/DropShot.Tests/Pages/CompetitionsTests.cs
+++ b/DropShot.Tests/Pages/CompetitionsTests.cs
@@ -11,7 +11,7 @@ public class CompetitionsTests
     [Fact]
     public async Task Competitions_Renders_Without_Exception()
     {
-        await using var ctx = new DropShotTestContext(authenticated: true);
+        await using var ctx = new DropShotTestContext(authenticated: true, roles: ["Admin"]);
         var cut = ctx.Render<Competitions>();
 
         Assert.Contains("Search competitions", cut.Markup);
@@ -20,7 +20,7 @@ public class CompetitionsTests
     [Fact]
     public async Task Competitions_Shows_Seeded_Data()
     {
-        await using var ctx = new DropShotTestContext(authenticated: true);
+        await using var ctx = new DropShotTestContext(authenticated: true, roles: ["Admin"]);
 
         using (var db = ctx.SeedDatabase())
         {

--- a/DropShot.Tests/Pages/ViewCompetitionTests.cs
+++ b/DropShot.Tests/Pages/ViewCompetitionTests.cs
@@ -11,7 +11,7 @@ public class ViewCompetitionTests
     [Fact]
     public async Task ViewCompetition_Renders_Without_Exception()
     {
-        await using var ctx = new DropShotTestContext(authenticated: true);
+        await using var ctx = new DropShotTestContext(authenticated: true, roles: ["Admin"]);
 
         using (var db = ctx.SeedDatabase())
         {


### PR DESCRIPTION
## Summary
The unit test suite had **21 failing tests out of 28** sitting on `main`, all stemming from drift between `DropShotTestContext` and the app's evolving service graph. This PR brings the suite back to green (28/28).

### Root causes
- **Constructors changed**: `ResultVerificationService` and `AdminEmailService` both gained an `EmailTemplateService` dependency that the test substitutes weren't passing.
- **New page-injected services not registered**: `CourtClaimService` (sealed — can't be substituted, so registered as a real instance), `QrLoginService`, `BackgroundTaskQueue`, `FixtureSimulationService` (+ its `RubberResolutionService` / `ICompetitionRubberTemplateProvider` chain), `CompetitionSchedulerService`, `FuzzySearchService`.
- **Stale assertions**: Four `Competitions*` / `CompetitionPage` / `ViewCompetition` tests asserted on UI strings that are only rendered for admin users — role-gating was added to those pages after the tests were written. Fixed by passing `roles: ["Admin"]` to the test context.

## Test plan
- [x] `dotnet test DropShot.Tests/DropShot.Tests.csproj` — `Failed: 0, Passed: 28`

🤖 Generated with [Claude Code](https://claude.com/claude-code)