### PR TITLE
Add legal pages and hide placeholder footer links

### DIFF
--- a/DropShot/Components/Layout/Footer.razor
+++ b/DropShot/Components/Layout/Footer.razor
@@ -1,34 +1,21 @@
 <footer class="site-footer">
     <MudContainer MaxWidth="MaxWidth.Large">
         <MudGrid Spacing="4">
-            <MudItem xs="6" sm="3">
+            <MudItem xs="6" sm="4">
                 <MudText Typo="Typo.subtitle2" Class="footer-heading mb-2">Product</MudText>
                 <div class="footer-links">
                     <MudLink Href="/features" Color="Color.Inherit" Typo="Typo.body2">Features</MudLink>
-                    <MudLink Href="/whats-new" Color="Color.Inherit" Typo="Typo.body2">What's New</MudLink>
-                    <MudLink Href="/subscription" Color="Color.Inherit" Typo="Typo.body2">Subscription</MudLink>
                 </div>
             </MudItem>
 
-            <MudItem xs="6" sm="3">
-                <MudText Typo="Typo.subtitle2" Class="footer-heading mb-2">Company</MudText>
-                <div class="footer-links">
-                    <MudLink Href="/about" Color="Color.Inherit" Typo="Typo.body2">About</MudLink>
-                    <MudLink Href="/careers" Color="Color.Inherit" Typo="Typo.body2">Careers</MudLink>
-                    <MudLink Href="/press" Color="Color.Inherit" Typo="Typo.body2">Press</MudLink>
-                </div>
-            </MudItem>
-
-            <MudItem xs="6" sm="3">
+            <MudItem xs="6" sm="4">
                 <MudText Typo="Typo.subtitle2" Class="footer-heading mb-2">Resources</MudText>
                 <div class="footer-links">
-                    <MudLink Href="/support" Color="Color.Inherit" Typo="Typo.body2">Support</MudLink>
                     <MudLink Href="/contact" Color="Color.Inherit" Typo="Typo.body2">Contact</MudLink>
-                    <MudLink Href="/student-discount" Color="Color.Inherit" Typo="Typo.body2">Student Discount</MudLink>
                 </div>
             </MudItem>
 
-            <MudItem xs="6" sm="3">
+            <MudItem xs="12" sm="4">
                 <MudText Typo="Typo.subtitle2" Class="footer-heading mb-2">Legal</MudText>
                 <div class="footer-links">
                     <MudLink Href="/privacy" Color="Color.Inherit" Typo="Typo.body2">Privacy</MudLink>

--- a/DropShot/Components/Pages/About.razor
+++ b/DropShot/Components/Pages/About.razor
@@ -1,5 +1,9 @@
 @page "/about"
 
+<HeadContent>
+    <meta name="robots" content="noindex" />
+</HeadContent>
+
 <PageTitle>About - DropShot</PageTitle>
 
 <MudContainer MaxWidth="MaxWidth.Medium" Class="mt-8 mb-8">

--- a/DropShot/Components/Pages/Careers.razor
+++ b/DropShot/Components/Pages/Careers.razor
@@ -1,5 +1,9 @@
 @page "/careers"
 
+<HeadContent>
+    <meta name="robots" content="noindex" />
+</HeadContent>
+
 <PageTitle>Careers - DropShot</PageTitle>
 
 <MudContainer MaxWidth="MaxWidth.Medium" Class="mt-8 mb-8">

--- a/DropShot/Components/Pages/CookiePolicy.razor
+++ b/DropShot/Components/Pages/CookiePolicy.razor
@@ -4,7 +4,71 @@
 
 <MudContainer MaxWidth="MaxWidth.Medium" Class="mt-8 mb-8">
     <MudText Typo="Typo.h4" Align="Align.Center" GutterBottom="true">Cookie Policy</MudText>
-    <MudText Typo="Typo.subtitle1" Align="Align.Center" Color="Color.Secondary">
-        Coming Soon
+    <MudText Typo="Typo.caption" Align="Align.Center" Color="Color.Secondary" Class="mb-6">
+        Last updated: 28 April 2026
+    </MudText>
+
+    <MudText Typo="Typo.body1" Class="mb-4">
+        This Cookie Policy explains how DropShot uses cookies and similar technologies on our website.
+        It should be read alongside our <MudLink Href="/privacy">Privacy Policy</MudLink>.
+    </MudText>
+
+    <MudText Typo="Typo.h5" Class="mt-6 mb-2">1. What Are Cookies?</MudText>
+    <MudText Typo="Typo.body2" Class="mb-4">
+        Cookies are small text files placed on your device when you visit a website. They allow the
+        site to remember information about your visit, such as your preferred theme or whether you
+        are signed in.
+    </MudText>
+
+    <MudText Typo="Typo.h5" Class="mt-6 mb-2">2. Cookies We Use</MudText>
+
+    <MudText Typo="Typo.h6" Class="mt-4 mb-2">Essential cookies</MudText>
+    <MudText Typo="Typo.body2" Class="mb-2">
+        These are required for the Service to function and cannot be switched off. They include:
+    </MudText>
+    <ul class="mud-typography mud-typography-body2" style="padding-left:1.5rem;">
+        <li><strong>Authentication cookies</strong> — to keep you signed in.</li>
+        <li><strong>Anti-forgery tokens</strong> — to protect forms against cross-site request forgery.</li>
+        <li><strong>ActiveRole cookie</strong> — to remember which role (e.g. ClubAdmin) you are currently using.</li>
+        <li><strong>Theme preference</strong> — stored in <code>localStorage</code> to remember your light/dark mode choice.</li>
+    </ul>
+
+    <MudText Typo="Typo.h6" Class="mt-4 mb-2">Advertising cookies</MudText>
+    <MudText Typo="Typo.body2" Class="mb-4">
+        We use Google AdSense (publisher ID <code>ca-pub-6819827391362636</code>) to display ads on
+        certain pages. Google and its partners may set cookies on your device to measure ad performance
+        and, if you have not opted out, to show personalised ads based on your browsing history.
+        These cookies are governed by Google's policies, not ours. You can review and adjust your
+        preferences at:
+    </MudText>
+    <ul class="mud-typography mud-typography-body2" style="padding-left:1.5rem;">
+        <li><MudLink Href="https://policies.google.com/technologies/ads" Target="_blank" rel="noopener">Google's advertising policy</MudLink></li>
+        <li><MudLink Href="https://www.google.com/settings/ads" Target="_blank" rel="noopener">Google Ads Settings</MudLink> (manage personalised ads)</li>
+        <li><MudLink Href="https://www.aboutads.info" Target="_blank" rel="noopener">www.aboutads.info</MudLink> (US Digital Advertising Alliance opt-out)</li>
+        <li><MudLink Href="https://www.youronlinechoices.eu" Target="_blank" rel="noopener">www.youronlinechoices.eu</MudLink> (EU/UK opt-out)</li>
+    </ul>
+
+    <MudText Typo="Typo.h6" Class="mt-4 mb-2">Payment cookies</MudText>
+    <MudText Typo="Typo.body2" Class="mb-4">
+        If you use our subscription checkout, PayPal may set cookies on your device to process the
+        transaction securely. See <MudLink Href="https://www.paypal.com/uk/legalhub/cookie-full" Target="_blank" rel="noopener">PayPal's Cookie Statement</MudLink>.
+    </MudText>
+
+    <MudText Typo="Typo.h5" Class="mt-6 mb-2">3. Managing Cookies</MudText>
+    <MudText Typo="Typo.body2" Class="mb-4">
+        Most browsers allow you to refuse, accept, or delete cookies via their settings. Note that
+        blocking essential cookies will prevent you from signing in or using parts of the Service.
+        For instructions specific to your browser, see <MudLink Href="https://www.aboutcookies.org" Target="_blank" rel="noopener">www.aboutcookies.org</MudLink>.
+    </MudText>
+
+    <MudText Typo="Typo.h5" Class="mt-6 mb-2">4. Changes to This Policy</MudText>
+    <MudText Typo="Typo.body2" Class="mb-4">
+        We may update this Cookie Policy as our use of cookies changes. The "Last updated" date at the
+        top of this page reflects the most recent revision.
+    </MudText>
+
+    <MudText Typo="Typo.h5" Class="mt-6 mb-2">5. Contact</MudText>
+    <MudText Typo="Typo.body2" Class="mb-4">
+        For questions about cookies, please use our <MudLink Href="/contact">Contact</MudLink> page.
     </MudText>
 </MudContainer>

--- a/DropShot/Components/Pages/Press.razor
+++ b/DropShot/Components/Pages/Press.razor
@@ -1,5 +1,9 @@
 @page "/press"
 
+<HeadContent>
+    <meta name="robots" content="noindex" />
+</HeadContent>
+
 <PageTitle>Press - DropShot</PageTitle>
 
 <MudContainer MaxWidth="MaxWidth.Medium" Class="mt-8 mb-8">

--- a/DropShot/Components/Pages/Privacy.razor
+++ b/DropShot/Components/Pages/Privacy.razor
@@ -1,10 +1,119 @@
 @page "/privacy"
 
-<PageTitle>Privacy - DropShot</PageTitle>
+<PageTitle>Privacy Policy - DropShot</PageTitle>
 
 <MudContainer MaxWidth="MaxWidth.Medium" Class="mt-8 mb-8">
-    <MudText Typo="Typo.h4" Align="Align.Center" GutterBottom="true">Privacy</MudText>
-    <MudText Typo="Typo.subtitle1" Align="Align.Center" Color="Color.Secondary">
-        Coming Soon
+    <MudText Typo="Typo.h4" Align="Align.Center" GutterBottom="true">Privacy Policy</MudText>
+    <MudText Typo="Typo.caption" Align="Align.Center" Color="Color.Secondary" Class="mb-6">
+        Last updated: 28 April 2026
+    </MudText>
+
+    <MudText Typo="Typo.body1" Class="mb-4">
+        This Privacy Policy describes how DropShot ("we", "us", "our") collects, uses, and shares
+        information about you when you use our website and services (the "Service"). DropShot is
+        operated from the United Kingdom and complies with the UK General Data Protection Regulation
+        (UK GDPR) and the Data Protection Act 2018.
+    </MudText>
+
+    <MudText Typo="Typo.h5" Class="mt-6 mb-2">1. Information We Collect</MudText>
+    <MudText Typo="Typo.body2" Class="mb-2">We collect the following categories of personal data:</MudText>
+    <ul class="mud-typography mud-typography-body2" style="padding-left:1.5rem;">
+        <li><strong>Account information:</strong> name, email address, password (hashed), and optional profile photo when you register.</li>
+        <li><strong>Player and competition data:</strong> match results, scores, fixtures, club memberships, and team affiliations you create or are added to.</li>
+        <li><strong>Communications:</strong> messages you send via our contact form or in response to system emails.</li>
+        <li><strong>Payment information:</strong> if you take out a paid subscription, payment is processed by PayPal. We do not store full card details — only a transaction reference and subscription status.</li>
+        <li><strong>Technical data:</strong> IP address, browser type, device type, pages visited, and approximate location, collected via cookies and server logs.</li>
+    </ul>
+
+    <MudText Typo="Typo.h5" Class="mt-6 mb-2">2. How We Use Your Information</MudText>
+    <MudText Typo="Typo.body2" Class="mb-2">We use your personal data to:</MudText>
+    <ul class="mud-typography mud-typography-body2" style="padding-left:1.5rem;">
+        <li>Provide, maintain, and improve the Service;</li>
+        <li>Authenticate you and keep your account secure;</li>
+        <li>Manage competitions, fixtures, and results you participate in;</li>
+        <li>Send transactional emails (e.g. result verifications, fixture reminders, password resets);</li>
+        <li>Process subscription payments and manage entitlements;</li>
+        <li>Display advertising (see "Advertising and Cookies" below);</li>
+        <li>Comply with our legal obligations.</li>
+    </ul>
+
+    <MudText Typo="Typo.h5" Class="mt-6 mb-2">3. Lawful Basis for Processing</MudText>
+    <MudText Typo="Typo.body2" Class="mb-4">
+        We process your data on the following lawful bases under UK GDPR Article 6: (a) <em>contract</em>,
+        where processing is necessary to deliver the Service you've signed up for; (b) <em>legitimate interests</em>,
+        for fraud prevention, service improvement, and limited advertising; (c) <em>consent</em>, where you
+        have opted in (e.g. to non-essential cookies); and (d) <em>legal obligation</em>, where required by law.
+    </MudText>
+
+    <MudText Typo="Typo.h5" Class="mt-6 mb-2">4. Advertising and Cookies</MudText>
+    <MudText Typo="Typo.body2" Class="mb-4">
+        DropShot uses Google AdSense to display advertising on certain pages. Google and its partners
+        may use cookies and similar technologies to serve ads based on your prior visits to this and
+        other websites. You can opt out of personalised advertising by visiting
+        <MudLink Href="https://www.google.com/settings/ads" Target="_blank" rel="noopener">Google Ads Settings</MudLink>
+        or <MudLink Href="https://www.aboutads.info" Target="_blank" rel="noopener">www.aboutads.info</MudLink>.
+        For more detail on the cookies we set, see our
+        <MudLink Href="/cookie-policy">Cookie Policy</MudLink>.
+    </MudText>
+
+    <MudText Typo="Typo.h5" Class="mt-6 mb-2">5. Sharing Your Information</MudText>
+    <MudText Typo="Typo.body2" Class="mb-2">We share personal data only with:</MudText>
+    <ul class="mud-typography mud-typography-body2" style="padding-left:1.5rem;">
+        <li><strong>Service providers</strong> who help us operate the Service, including Microsoft Azure (hosting), Azure Communication Services (transactional email), Google AdSense (advertising), and PayPal (payments);</li>
+        <li><strong>Other users of the Service</strong>, where you have chosen to participate in a public competition, club, or team — your display name, results, and profile photo may be visible to those users;</li>
+        <li><strong>Legal authorities</strong> where we are required by law to do so.</li>
+    </ul>
+    <MudText Typo="Typo.body2" Class="mb-4">
+        We do not sell your personal data.
+    </MudText>
+
+    <MudText Typo="Typo.h5" Class="mt-6 mb-2">6. International Transfers</MudText>
+    <MudText Typo="Typo.body2" Class="mb-4">
+        Some of our service providers (notably Google) are based outside the United Kingdom. Where personal
+        data is transferred outside the UK, we rely on the UK International Data Transfer Agreement, the
+        UK Addendum to the EU Standard Contractual Clauses, or an applicable adequacy decision.
+    </MudText>
+
+    <MudText Typo="Typo.h5" Class="mt-6 mb-2">7. Data Retention</MudText>
+    <MudText Typo="Typo.body2" Class="mb-4">
+        We keep account information for as long as your account is active. If you close your account,
+        we delete or anonymise your personal data within 90 days, except where we are required to keep
+        records for tax, fraud-prevention, or legal reasons. Anonymised match and competition results
+        may be retained indefinitely.
+    </MudText>
+
+    <MudText Typo="Typo.h5" Class="mt-6 mb-2">8. Your Rights</MudText>
+    <MudText Typo="Typo.body2" Class="mb-2">Under UK GDPR you have the right to:</MudText>
+    <ul class="mud-typography mud-typography-body2" style="padding-left:1.5rem;">
+        <li>Request access to the personal data we hold about you;</li>
+        <li>Request correction of inaccurate data;</li>
+        <li>Request erasure of your data;</li>
+        <li>Restrict or object to processing;</li>
+        <li>Data portability;</li>
+        <li>Withdraw consent where we rely on it;</li>
+        <li>Lodge a complaint with the Information Commissioner's Office (<MudLink Href="https://ico.org.uk" Target="_blank" rel="noopener">ico.org.uk</MudLink>).</li>
+    </ul>
+    <MudText Typo="Typo.body2" Class="mb-4">
+        To exercise any of these rights, please use the <MudLink Href="/contact">Contact</MudLink> form.
+    </MudText>
+
+    <MudText Typo="Typo.h5" Class="mt-6 mb-2">9. Children</MudText>
+    <MudText Typo="Typo.body2" Class="mb-4">
+        DropShot is not directed at children under 13. If you become aware that a child under 13 has
+        provided us with personal data without parental consent, please contact us and we will remove
+        that data.
+    </MudText>
+
+    <MudText Typo="Typo.h5" Class="mt-6 mb-2">10. Changes to This Policy</MudText>
+    <MudText Typo="Typo.body2" Class="mb-4">
+        We may update this Privacy Policy from time to time. The "Last updated" date at the top of this
+        page will reflect the most recent revision. Material changes will be notified via the Service
+        or by email.
+    </MudText>
+
+    <MudText Typo="Typo.h5" Class="mt-6 mb-2">11. Contact</MudText>
+    <MudText Typo="Typo.body2" Class="mb-4">
+        Questions about this Privacy Policy or your personal data should be sent via our
+        <MudLink Href="/contact">Contact</MudLink> page.
     </MudText>
 </MudContainer>

--- a/DropShot/Components/Pages/StudentDiscount.razor
+++ b/DropShot/Components/Pages/StudentDiscount.razor
@@ -1,5 +1,9 @@
 @page "/student-discount"
 
+<HeadContent>
+    <meta name="robots" content="noindex" />
+</HeadContent>
+
 <PageTitle>Student Discount - DropShot</PageTitle>
 
 <MudContainer MaxWidth="MaxWidth.Medium" Class="mt-8 mb-8">

--- a/DropShot/Components/Pages/Subscription.razor
+++ b/DropShot/Components/Pages/Subscription.razor
@@ -1,5 +1,9 @@
 @page "/subscription"
 
+<HeadContent>
+    <meta name="robots" content="noindex" />
+</HeadContent>
+
 <PageTitle>Subscription - DropShot</PageTitle>
 
 <MudContainer MaxWidth="MaxWidth.Medium" Class="mt-8 mb-8">

--- a/DropShot/Components/Pages/Support.razor
+++ b/DropShot/Components/Pages/Support.razor
@@ -1,5 +1,9 @@
 @page "/support"
 
+<HeadContent>
+    <meta name="robots" content="noindex" />
+</HeadContent>
+
 <PageTitle>Support - DropShot</PageTitle>
 
 <MudContainer MaxWidth="MaxWidth.Medium" Class="mt-8 mb-8">

--- a/DropShot/Components/Pages/Terms.razor
+++ b/DropShot/Components/Pages/Terms.razor
@@ -1,10 +1,123 @@
 @page "/terms"
 
-<PageTitle>Terms - DropShot</PageTitle>
+<PageTitle>Terms of Service - DropShot</PageTitle>
 
 <MudContainer MaxWidth="MaxWidth.Medium" Class="mt-8 mb-8">
-    <MudText Typo="Typo.h4" Align="Align.Center" GutterBottom="true">Terms</MudText>
-    <MudText Typo="Typo.subtitle1" Align="Align.Center" Color="Color.Secondary">
-        Coming Soon
+    <MudText Typo="Typo.h4" Align="Align.Center" GutterBottom="true">Terms of Service</MudText>
+    <MudText Typo="Typo.caption" Align="Align.Center" Color="Color.Secondary" Class="mb-6">
+        Last updated: 28 April 2026
+    </MudText>
+
+    <MudText Typo="Typo.body1" Class="mb-4">
+        These Terms of Service ("Terms") govern your use of DropShot (the "Service"). By creating an
+        account or otherwise using the Service, you agree to be bound by these Terms. If you do not
+        agree, do not use the Service.
+    </MudText>
+
+    <MudText Typo="Typo.h5" Class="mt-6 mb-2">1. Eligibility</MudText>
+    <MudText Typo="Typo.body2" Class="mb-4">
+        You must be at least 13 years old to create an account. If you are under 18, you confirm that
+        you have your parent or guardian's permission to use the Service.
+    </MudText>
+
+    <MudText Typo="Typo.h5" Class="mt-6 mb-2">2. Your Account</MudText>
+    <MudText Typo="Typo.body2" Class="mb-4">
+        You are responsible for keeping your login credentials secure and for all activity that occurs
+        under your account. Notify us immediately via the <MudLink Href="/contact">Contact</MudLink>
+        page if you believe your account has been compromised. You may close your account at any time
+        via your account settings.
+    </MudText>
+
+    <MudText Typo="Typo.h5" Class="mt-6 mb-2">3. Acceptable Use</MudText>
+    <MudText Typo="Typo.body2" Class="mb-2">When using the Service, you agree not to:</MudText>
+    <ul class="mud-typography mud-typography-body2" style="padding-left:1.5rem;">
+        <li>Submit false or misleading match results, scores, or player information;</li>
+        <li>Impersonate another person or misrepresent your affiliation with a club or team;</li>
+        <li>Attempt to access accounts, data, or areas of the Service you are not authorised to access;</li>
+        <li>Use the Service to harass, abuse, or harm other users;</li>
+        <li>Upload malicious code or attempt to disrupt the Service;</li>
+        <li>Scrape, crawl, or copy substantial portions of the Service without our written permission;</li>
+        <li>Use the Service in violation of any applicable law.</li>
+    </ul>
+    <MudText Typo="Typo.body2" Class="mb-4">
+        We may suspend or terminate accounts that breach these rules.
+    </MudText>
+
+    <MudText Typo="Typo.h5" Class="mt-6 mb-2">4. User Content</MudText>
+    <MudText Typo="Typo.body2" Class="mb-4">
+        You retain ownership of the content you submit (such as your profile, team names, and match
+        results). By submitting content, you grant DropShot a non-exclusive, worldwide, royalty-free
+        licence to host, store, display, and use that content for the purpose of operating and
+        improving the Service. You are responsible for ensuring you have the right to submit any
+        content you upload.
+    </MudText>
+
+    <MudText Typo="Typo.h5" Class="mt-6 mb-2">5. Subscriptions and Payments</MudText>
+    <MudText Typo="Typo.body2" Class="mb-4">
+        DropShot is offered with a free tier and a paid Premium subscription. Premium subscriptions
+        are billed via PayPal on the schedule shown at checkout. Subscriptions renew automatically
+        unless cancelled before the renewal date. You can cancel at any time from your account
+        settings; cancellation takes effect at the end of your current billing period. Except where
+        required by law, fees already paid are non-refundable.
+    </MudText>
+
+    <MudText Typo="Typo.h5" Class="mt-6 mb-2">6. Intellectual Property</MudText>
+    <MudText Typo="Typo.body2" Class="mb-4">
+        The Service, including its software, design, logos, and branding, is owned by DropShot and
+        protected by intellectual-property laws. These Terms do not grant you any right in our
+        intellectual property except the limited right to use the Service in accordance with these
+        Terms.
+    </MudText>
+
+    <MudText Typo="Typo.h5" Class="mt-6 mb-2">7. Third-Party Services</MudText>
+    <MudText Typo="Typo.body2" Class="mb-4">
+        The Service integrates with third-party services including Google AdSense (advertising),
+        PayPal (payments), and Microsoft Azure (hosting and email). Your use of those services is
+        governed by their own terms and privacy policies.
+    </MudText>
+
+    <MudText Typo="Typo.h5" Class="mt-6 mb-2">8. Disclaimer of Warranties</MudText>
+    <MudText Typo="Typo.body2" Class="mb-4">
+        The Service is provided "as is" and "as available" without warranties of any kind, whether
+        express or implied, except as required by law. We do not warrant that the Service will be
+        uninterrupted, error-free, or that data will be preserved without loss.
+    </MudText>
+
+    <MudText Typo="Typo.h5" Class="mt-6 mb-2">9. Limitation of Liability</MudText>
+    <MudText Typo="Typo.body2" Class="mb-4">
+        To the maximum extent permitted by law, DropShot will not be liable for any indirect,
+        incidental, consequential, or special damages arising out of your use of the Service. Nothing
+        in these Terms limits or excludes any liability that cannot be limited or excluded under
+        applicable law (including liability for death or personal injury caused by negligence, or for
+        fraud).
+    </MudText>
+
+    <MudText Typo="Typo.h5" Class="mt-6 mb-2">10. Termination</MudText>
+    <MudText Typo="Typo.body2" Class="mb-4">
+        We may suspend or terminate your access to the Service at any time, with or without notice,
+        if we reasonably believe you have breached these Terms. On termination, your right to use the
+        Service ceases immediately. Sections that by their nature should survive termination (e.g.
+        intellectual property, disclaimers, limitation of liability) will continue to apply.
+    </MudText>
+
+    <MudText Typo="Typo.h5" Class="mt-6 mb-2">11. Changes to These Terms</MudText>
+    <MudText Typo="Typo.body2" Class="mb-4">
+        We may update these Terms from time to time. The "Last updated" date at the top of this page
+        will reflect the most recent revision. Material changes will be notified via the Service or
+        by email. Continued use of the Service after changes take effect constitutes acceptance of
+        the updated Terms.
+    </MudText>
+
+    <MudText Typo="Typo.h5" Class="mt-6 mb-2">12. Governing Law</MudText>
+    <MudText Typo="Typo.body2" Class="mb-4">
+        These Terms are governed by the laws of England and Wales. The courts of England and Wales
+        will have exclusive jurisdiction over any dispute arising out of or relating to these Terms,
+        except where consumer-protection law gives you the right to bring proceedings in your country
+        of residence.
+    </MudText>
+
+    <MudText Typo="Typo.h5" Class="mt-6 mb-2">13. Contact</MudText>
+    <MudText Typo="Typo.body2" Class="mb-4">
+        Questions about these Terms can be sent via our <MudLink Href="/contact">Contact</MudLink> page.
     </MudText>
 </MudContainer>

--- a/DropShot/Components/Pages/WhatsNew.razor
+++ b/DropShot/Components/Pages/WhatsNew.razor
@@ -1,5 +1,9 @@
 @page "/whats-new"
 
+<HeadContent>
+    <meta name="robots" content="noindex" />
+</HeadContent>
+
 <PageTitle>What's New - DropShot</PageTitle>
 
 <MudContainer MaxWidth="MaxWidth.Medium" Class="mt-8 mb-8">

--- a/DropShot/wwwroot/robots.txt
+++ b/DropShot/wwwroot/robots.txt
@@ -5,4 +5,11 @@ Disallow: /verify-result/
 Disallow: /invite/
 Disallow: /Error
 Disallow: /score/display-control
+Disallow: /whats-new
+Disallow: /subscription
+Disallow: /about
+Disallow: /careers
+Disallow: /press
+Disallow: /support
+Disallow: /student-discount
 Allow: /


### PR DESCRIPTION
## Summary
Closes the remaining AdSense \"Low value content\" exposure surface from publicly-linked stub pages and supplies the legal content AdSense requires.

- **Legal pages (real content):** Replace \"Coming Soon\" stubs at `/privacy`, `/cookie-policy`, and `/terms` with UK GDPR-aligned content. Privacy covers data collected, lawful bases, AdSense disclosure, sub-processors (Azure / Google / PayPal), retention, your rights and ICO complaint route. Cookies covers essential / advertising / payment categories with publisher ID and opt-out links. Terms covers eligibility, acceptable use, content licence, subscription/PayPal billing, IP, third-party services, liability and England & Wales governing law. All three reference `/contact` for inquiries (no personal email exposed).
- **Noindex the rest:** Add `<meta name=\"robots\" content=\"noindex\">` to `/whats-new`, `/subscription`, `/about`, `/careers`, `/press`, `/support`, `/student-discount` until they have real content.
- **Hide footer links** to those 7 placeholders so users (and crawlers) only follow links to pages with real content. Footer now shows three columns: Product (Features), Resources (Contact), Legal (Privacy / Cookie Policy / Terms).
- **Belt-and-braces:** Add the 7 placeholder paths to `robots.txt`.

> Note: the legal pages are reasonable templates, not legal advice — recommend a solicitor review before relying on the liability / refund / dispute clauses for paying customers.

## Test plan
- [x] `dotnet build` succeeds (no new warnings)
- [ ] Visit `/privacy`, `/cookie-policy`, `/terms` — view-source contains the real content
- [ ] Visit `/about`, `/careers`, `/press`, `/support`, `/whats-new`, `/subscription`, `/student-discount` — view-source contains `<meta name=\"robots\" content=\"noindex\">`
- [ ] Footer shows only Features / Contact / Privacy / Cookie Policy / Terms
- [ ] `/robots.txt` lists the 7 new disallow entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)