### PR TITLE
Downgrade MAUI to .NET 8 for iOS IPA builds

### DIFF
--- a/DropShot.Maui/DropShot.Maui.csproj
+++ b/DropShot.Maui/DropShot.Maui.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
     <PropertyGroup>
-        <TargetFrameworks>net10.0-android36.0;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
-        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
+        <TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
         <!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
         <!-- <TargetFrameworks>$(TargetFrameworks);net9.0-tizen</TargetFrameworks> -->
 

--- a/DropShot.Shared/DropShot.Shared.csproj
+++ b/DropShot.Shared/DropShot.Shared.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
## Summary
- Switches `DropShot.Maui` `TargetFrameworks` from `net10.0-*` to `net8.0-*` (Android, iOS, MacCatalyst, Windows). Motivation: net10 MAUI / iOS workload tooling can't currently produce an IPA, so the iOS app build path needs net8.
- Multi-targets `DropShot.Shared` as `net8.0;net10.0` so MAUI (net8) can still consume it without forcing the web app, tests, or E2E off net10. Each consumer now picks up the matching TFM.
- No other csproj or workflow changes — `DropShot`, `DropShot.Tests`, `DropShot.E2E`, and `.github/workflows/deploy.yml` stay on net10 / 10.0.x.

## Test plan
- [x] `dotnet build DropShot.Shared/DropShot.Shared.csproj -c Release` — both net8.0 and net10.0 outputs produced, 0 warnings, 0 errors.
- [x] `dotnet build DropShot/DropShot.csproj -c Release` — succeeds against the multi-targeted Shared (consumes the net10 TFM); only pre-existing warnings.
- [ ] `dotnet build DropShot.Maui/DropShot.Maui.csproj -c Release` against the net8 MAUI workload — **not run locally** (requires installed MAUI 8 workloads); the whole point of the change is to enable an IPA build, so verifying that build path is the real acceptance test.
- [ ] Post-merge: confirm the `Deploy Blazor App to Azure` workflow goes green (still on net10, so no expected impact, but worth watching).

🤖 Generated with [Claude Code](https://claude.com/claude-code)