### PR TITLE
Pin .NET 8 SDK for MAUI builds via scoped global.json

### DIFF
--- a/DropShot.Maui/global.json
+++ b/DropShot.Maui/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.100",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
## Summary
Adds `DropShot.Maui/global.json` pinning the dotnet SDK to 8.0.x (`rollForward: latestFeature`). Scoping the global.json to the MAUI directory means:

- `cd DropShot.Maui && dotnet build` (or any iOS IPA build invoked from inside that directory) uses **.NET 8 SDK + .NET 8 MAUI workloads** — the toolchain that actually supports net8 mobile TFMs.
- `dotnet build DropShot/DropShot.csproj` or solution-wide builds from the repo root keep using **.NET 10** for the web app, Tests, and E2E.

## Why
The .NET 10 SDK can't build the net8 MAUI mobile TFMs at all:

- **NETSDK1202** — workload-EOL gate that hard-rejects `net8.0-android` / `net8.0-ios` / `net8.0-maccatalyst` workloads with no csproj-level override (separate from the TFM-EOL gate that `CheckEolTargetFramework` controls).
- **NETSDK1135** — net10 SDK lacks the .NET 8 MAUI platform manifests, so it falls back to TargetPlatformVersion 1.0/21.0, which is below the project's SupportedOSPlatformVersion settings.

Both vanish when MAUI is built under the .NET 8 SDK + .NET 8 MAUI workloads.

## Required local setup (Mac/iOS dev)
1. Install **.NET 8 SDK** from https://dotnet.microsoft.com/download/dotnet/8.0 (LTS through Nov 2026).
2. `dotnet workload install maui` (with .NET 8 SDK active).
3. Build MAUI from inside its directory: `cd DropShot.Maui && dotnet build -t:Build -f net8.0-ios -c Release /p:ArchiveOnBuild=true`.

## Test plan
- [ ] On Mac after .NET 8 SDK + workloads installed: `cd DropShot.Maui && dotnet --version` reports 8.0.x.
- [ ] On Mac: `cd DropShot.Maui && dotnet clean` runs without NETSDK1202/NETSDK1135.
- [ ] On Mac: iOS IPA build succeeds.
- [ ] From repo root: `dotnet build DropShot/DropShot.csproj -c Release` still uses 10.0.x and succeeds (web app unchanged).
- [ ] Azure deploy workflow still green (no production-path changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)