### PR TITLE
Move MAUI from .NET 8 to .NET 9

### DIFF
--- a/DropShot.Maui/DropShot.Maui.csproj
+++ b/DropShot.Maui/DropShot.Maui.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0-android34.0;net8.0-ios17.2;net8.0-maccatalyst17.2</TargetFrameworks>
-        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
+        <TargetFrameworks>net9.0-android35.0;net9.0-ios18.0;net9.0-maccatalyst18.0</TargetFrameworks>
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0</TargetFrameworks>
         <CheckEolTargetFramework>false</CheckEolTargetFramework>
-        <MauiVersion Condition="'$(MauiVersion)' == ''">8.0.100</MauiVersion>
+        <MauiVersion Condition="'$(MauiVersion)' == ''">9.0.0</MauiVersion>
         <!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
         <!-- <TargetFrameworks>$(TargetFrameworks);net9.0-tizen</TargetFrameworks> -->
 

--- a/DropShot.Maui/global.json
+++ b/DropShot.Maui/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "9.0.100",
     "rollForward": "latestFeature"
   }
 }

--- a/DropShot.Shared/DropShot.Shared.csproj
+++ b/DropShot.Shared/DropShot.Shared.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
## Summary
Pivots the MAUI toolchain target from net8 to net9 to align with the .NET 9 SDK + MAUI workloads already installed on the Mac dev machine. .NET 9 MAUI supports iOS IPA builds, so this still resolves the original blocker (net10 MAUI iOS does not yet support IPA packaging).

- `DropShot.Maui/DropShot.Maui.csproj` — TFMs `net8.0-*` → `net9.0-*` with the .NET 9 MAUI default platform versions (Android 35.0, iOS/MacCatalyst 18.0). MauiVersion fallback bumped to 9.0.0.
- `DropShot.Maui/global.json` — pin SDK to 9.0.x (`rollForward: latestFeature`).
- `DropShot.Shared/DropShot.Shared.csproj` — multi-target `net8.0;net10.0` → `net9.0;net10.0` so MAUI (net9) can still consume Shared without forcing the web app off net10.

## Verification done locally
- [x] `dotnet build DropShot.Shared/DropShot.Shared.csproj -c Release` — both net9.0 and net10.0 outputs produced, 0 errors, 0 warnings.
- [x] `dotnet build DropShot/DropShot.csproj -c Release` — succeeds (consumes the net10 TFM of Shared); only pre-existing warnings.

## Test plan (Mac)
- [ ] `cd DropShot.Maui && dotnet --version` → reports 9.0.x.
- [ ] `cd DropShot.Maui && dotnet workload install maui` (if not already installed under .NET 9).
- [ ] `cd DropShot.Maui && dotnet clean` runs without NETSDK1202/1135.
- [ ] `dotnet build -t:Build -f net9.0-ios -c Release /p:ArchiveOnBuild=true` produces an IPA.
- [ ] From repo root: `dotnet build DropShot/DropShot.csproj` still uses 10.0.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)