### PR TITLE
Drop Shared to net9 only so .NET 9 SDK can evaluate it

### DIFF
--- a/DropShot.Shared/DropShot.Shared.csproj
+++ b/DropShot.Shared/DropShot.Shared.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
## Summary
The .NET 9 SDK on the Mac (9.0.306) trips **NETSDK1045** ("does not support targeting .NET 10.0") whenever it has to evaluate any project with `net10.0` in its TFM list — including the recent `net9.0;net10.0` multi-target on DropShot.Shared. Filtering the MAUI ProjectReference to a single inner build doesn't help, because the SDK still parses the full `TargetFrameworks` list during project evaluation.

Simpler fix: drop Shared to **net9.0 single-target**.

## Why this is safe
.NET forward-compatibility: a net10 project can reference a net9 library. So:
- DropShot.Maui (net9) — consumes Shared on net9, native fit.
- DropShot (net10) — consumes Shared's net9 build via forward-compat.
- DropShot.Tests (net10), DropShot.E2E (net10) — same as DropShot.

Verified locally: `dotnet build DropShot/DropShot.csproj -c Release` succeeds against the net10 SDK with Shared on net9 only (only pre-existing warnings, 0 errors).

## What this unblocks
On Mac, `dotnet --version` (and subsequent `dotnet workload`/`dotnet build` invocations) inside DropShot.Maui/ no longer fail with NETSDK1045 just from walking the project graph.

## Test plan
- [x] `dotnet build DropShot/DropShot.csproj -c Release` (net10 SDK consuming net9 Shared) — green.
- [ ] On Mac: `cd DropShot.Maui && dotnet --version` → 9.0.306 (no NETSDK1045).
- [ ] On Mac: `dotnet workload install maui` succeeds under .NET 9.
- [ ] iOS IPA build succeeds.
- [ ] Azure deploy workflow still green post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)