### PR TITLE
Set MAUI bundle identifier to tennis.ds.dropshot

### DIFF
--- a/DropShot.Maui/DropShot.Maui.csproj
+++ b/DropShot.Maui/DropShot.Maui.csproj
@@ -27,7 +27,7 @@
         <ApplicationTitle>DropShot.Maui</ApplicationTitle>
 
         <!-- App Identifier -->
-        <ApplicationId>com.companyname.dropshot.maui</ApplicationId>
+        <ApplicationId>tennis.ds.dropshot</ApplicationId>
 
         <!-- Versions -->
         <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>


### PR DESCRIPTION
## Summary
Replaces the MAUI template placeholder `com.companyname.dropshot.maui` with `tennis.ds.dropshot` (reverse-DNS of the ds.tennis domain). Apple won't let `com.companyname.*` be registered as an App ID, so this has to change before an iOS provisioning profile can be created.

## Test plan
- [ ] Register App ID `tennis.ds.dropshot` at https://developer.apple.com/account/resources/identifiers/list
- [ ] Create App Store provisioning profile bound to that App ID + the Apple Distribution cert
- [ ] `dotnet publish -f net9.0-ios18.0 -c Release -r ios-arm64 /p:ArchiveOnBuild=true /p:CodesignKey=... /p:CodesignProvision=...` produces a signed .ipa

🤖 Generated with [Claude Code](https://claude.com/claude-code)