### PR TITLE
Fix MAUI API base URL for Debug and Release

### DIFF
--- a/DropShot.Maui/MauiProgram.cs
+++ b/DropShot.Maui/MauiProgram.cs
@@ -7,8 +7,12 @@ namespace DropShot.Maui;
 
 public static class MauiProgram
 {
-    /// <summary>Base URL of the DropShot API. Update before publishing.</summary>
-    public const string ApiBaseUrl = "https://localhost:7001/";
+    /// <summary>Base URL of the DropShot API. Debug points to local dev server, Release points to production.</summary>
+#if DEBUG
+    public const string ApiBaseUrl = "https://localhost:7243/";
+#else
+    public const string ApiBaseUrl = "https://ds.tennis/";
+#endif
 
     public static MauiApp CreateMauiApp()
     {


### PR DESCRIPTION
## Summary
The hardcoded `ApiBaseUrl = "https://localhost:7001/"` in DropShot.Maui/MauiProgram.cs was wrong on both sides:

- **VS desktop debug** — local DropShot web API listens on `https://localhost:7243` per `DropShot/Properties/launchSettings.json`, not 7001. Every debug login hit a dead port.
- **TestFlight on iPhone** — `localhost` on the iPhone resolves to the iPhone itself; the production-installed app could never reach the API.

Both failure modes surface in the UI as "invalid password" because `AuthService.LoginAsync` swallows network errors into the same `return false` path as a real auth rejection.

## Fix
Replace the constant with a `#if DEBUG` block:

- **Debug:** `https://localhost:7243/` (matches the local HTTPS profile)
- **Release:** `https://ds.tennis/` (production)

## Follow-up worth considering (not in this PR)
The error UX in `AuthService.LoginAsync` and Login.razor surfaces network errors and 401s identically. Even with the URL fixed, a backend outage will still look like "wrong password" to users. Worth a separate cleanup later: have Login.razor display `AuthService.LastError` when set, instead of a fixed "Invalid email or password" string.

## Test plan
- [ ] In VS on Windows: F5 the MAUI Windows target with the DropShot web project also running locally; login with a valid account succeeds.
- [ ] New TestFlight build installed on iPhone: login against ds.tennis succeeds.
- [ ] Wrong password still gives a failure (sanity check; the URL change doesn't relax auth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)