### PR TITLE
Bump MAUI ApplicationVersion to 2

### DIFF
--- a/DropShot.Maui/DropShot.Maui.csproj
+++ b/DropShot.Maui/DropShot.Maui.csproj
@@ -31,7 +31,7 @@
 
         <!-- Versions -->
         <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
-        <ApplicationVersion>1</ApplicationVersion>
+        <ApplicationVersion>2</ApplicationVersion>
 
         <!-- To develop, package, and publish an app to the Microsoft Store, see: https://aka.ms/MauiTemplateUnpackaged -->
         <WindowsPackageType>None</WindowsPackageType>


### PR DESCRIPTION
## Summary
Bumps `<ApplicationVersion>` from 1 to 2 in DropShot.Maui.csproj. Build 1 has already been delivered to App Store Connect; the next IPA upload (with the new logo + corrected API base URL) needs a strictly higher build number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)