### PR TITLE
Set MAUI app display name to ds tennis

### DIFF
--- a/DropShot.Maui/DropShot.Maui.csproj
+++ b/DropShot.Maui/DropShot.Maui.csproj
@@ -24,7 +24,7 @@
         <Nullable>enable</Nullable>
 
         <!-- Display name -->
-        <ApplicationTitle>DropShot.Maui</ApplicationTitle>
+        <ApplicationTitle>ds tennis</ApplicationTitle>
 
         <!-- App Identifier -->
         <ApplicationId>tennis.ds.dropshot</ApplicationId>


### PR DESCRIPTION
Changes `<ApplicationTitle>` from the placeholder `DropShot.Maui` to `ds tennis`. This is the label shown under the app icon on iOS home screen and in the app switcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)