### PR TITLE
Use proper casing for MAUI ApplicationTitle: DS Tennis

### DIFF
--- a/DropShot.Maui/DropShot.Maui.csproj
+++ b/DropShot.Maui/DropShot.Maui.csproj
@@ -24,7 +24,7 @@
         <Nullable>enable</Nullable>
 
         <!-- Display name -->
-        <ApplicationTitle>ds tennis</ApplicationTitle>
+        <ApplicationTitle>DS Tennis</ApplicationTitle>
 
         <!-- App Identifier -->
         <ApplicationId>tennis.ds.dropshot</ApplicationId>


### PR DESCRIPTION
Capitalises the home-screen label from `ds tennis` to `DS Tennis`.