### PR TITLE
Declare iOS app as encryption-exempt to skip TestFlight compliance prompt

### DIFF
--- a/DropShot.Maui/Platforms/iOS/Info.plist
+++ b/DropShot.Maui/Platforms/iOS/Info.plist
@@ -28,5 +28,7 @@
     </array>
     <key>XSAppIconAssets</key>
     <string>Assets.xcassets/appicon.appiconset</string>
+    <key>ITSAppUsesNonExemptEncryption</key>
+    <false/>
 </dict>
 </plist>


### PR DESCRIPTION
Adds \`<key>ITSAppUsesNonExemptEncryption</key><false/>\` to \`DropShot.Maui/Platforms/iOS/Info.plist\`.

App Store Connect asks the export-encryption question on every uploaded build by default, gating internal-testing distribution behind a manual click. Declaring \`ITSAppUsesNonExemptEncryption=false\` in Info.plist tells Apple up-front that the app uses only standard OS-provided encryption (HTTPS), which is exempt under US export rules. With the key in place the question is skipped and builds flip straight to "Ready for Testing" after processing.

Effective from the next build uploaded after merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)