### PR TITLE
Fix iOS safe-area: push MAUI top bar below the status bar

### DIFF
--- a/DropShot.Maui/DropShot.Maui.csproj
+++ b/DropShot.Maui/DropShot.Maui.csproj
@@ -31,7 +31,7 @@
 
         <!-- Versions -->
         <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
-        <ApplicationVersion>2</ApplicationVersion>
+        <ApplicationVersion>3</ApplicationVersion>
 
         <!-- To develop, package, and publish an app to the Microsoft Store, see: https://aka.ms/MauiTemplateUnpackaged -->
         <WindowsPackageType>None</WindowsPackageType>

--- a/DropShot.Maui/wwwroot/css/app.css
+++ b/DropShot.Maui/wwwroot/css/app.css
@@ -38,4 +38,20 @@ html, body {
         width: 100%;
         z-index: 1000;
     }
+
+    /* Push MudBlazor AppBar and Drawer below the iOS status bar so the
+       hamburger menu and logout button aren't hidden under the system
+       clock / battery / signal indicators. The .status-bar-safe-area
+       above provides the primary-coloured backdrop. */
+    .mud-appbar {
+        top: env(safe-area-inset-top) !important;
+    }
+
+    .mud-main-content {
+        padding-top: calc(64px + env(safe-area-inset-top)) !important;
+    }
+
+    .mud-drawer-fixed {
+        top: env(safe-area-inset-top) !important;
+    }
 }


### PR DESCRIPTION
## Summary
On iPhone the MudBlazor AppBar rendered at `top: 0` and overlapped the iOS system status bar (clock, signal, battery). The hamburger menu and logout button sat under the clock and were unreachable.

## Fix
Add iOS-only CSS overrides in `wwwroot/css/app.css` that push the AppBar and the fixed Drawer down by `env(safe-area-inset-top)` and extend MudMainContent's top padding to match. The existing `.status-bar-safe-area` div continues to fill the inset area with the primary palette colour as the backdrop.

Targeted via `@supports (-webkit-touch-callout: none)` so Android and Windows builds are untouched (their safe-area inset is 0 anyway, so the rules would be no-ops, but scoping keeps them out of the cascade).

Bumps `<ApplicationVersion>` from 2 to 3 for the next TestFlight upload.

## Test plan
- [ ] Pull and republish on Mac, upload via Transporter.
- [ ] On iPhone: hamburger menu and logout icon are tappable and not hidden under the clock.
- [ ] Status bar area shows the primary colour (matches the rest of the AppBar visually).

🤖 Generated with [Claude Code](https://claude.com/claude-code)