### PR TITLE
Fix MAUI iOS scrolling on list pages

### DIFF
--- a/DropShot.Maui/DropShot.Maui.csproj
+++ b/DropShot.Maui/DropShot.Maui.csproj
@@ -31,7 +31,7 @@
 
         <!-- Versions -->
         <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
-        <ApplicationVersion>3</ApplicationVersion>
+        <ApplicationVersion>4</ApplicationVersion>
 
         <!-- To develop, package, and publish an app to the Microsoft Store, see: https://aka.ms/MauiTemplateUnpackaged -->
         <WindowsPackageType>None</WindowsPackageType>

--- a/DropShot.Maui/wwwroot/css/app.css
+++ b/DropShot.Maui/wwwroot/css/app.css
@@ -4,6 +4,16 @@ html, body {
     overflow: hidden;
 }
 
+/* MudMainContent owns the scroll viewport so the AppBar and Drawer stay
+   pinned while lists (Competitions, Clubs, etc.) scroll inside. Without
+   this the body's overflow:hidden clips overflowing content and it
+   becomes unreachable. */
+.mud-main-content {
+    height: 100vh;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+}
+
 #blazor-error-ui {
     background: lightyellow;
     bottom: 0;


### PR DESCRIPTION
## Summary
On iPhone (and likely Android), tapping into any list-bearing page (Competitions, Clubs, etc.) showed the visible portion but the content below the fold was unreachable - no scroll. Cause: `app.css` sets `html, body { overflow: hidden }` to keep the WebView free of browser scrollbars, but MudBlazor's MudMainContent has no scroll of its own by default and relies on body scroll. Result: content overflows, body clips it, and there's no scrollable region.

## Fix
Make `.mud-main-content` the scroll viewport:
\`\`\`css
.mud-main-content {
    height: 100vh;
    overflow-y: auto;
    -webkit-overflow-scrolling: touch;
}
\`\`\`
The fixed AppBar and Drawer stay pinned while content scrolls inside. `-webkit-overflow-scrolling: touch` enables iOS hardware-accelerated momentum scrolling.

Bumps `<ApplicationVersion>` from 3 to 4 for the next TestFlight upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)