### PR TITLE
Prepare DropShot.UI for phase 4 batch B (ICurrentUser.ActiveClubId, CompetitionDetailDto deepening, FixtureResultCard)

### DIFF
--- a/DropShot.Maui/Services/MauiCurrentUser.cs
+++ b/DropShot.Maui/Services/MauiCurrentUser.cs
@@ -53,6 +53,10 @@ public sealed class MauiCurrentUser : ICurrentUser, IDisposable
     public string? ActiveRole => _auth.Session is null ? null : _auth.ActiveRole;
     public IReadOnlyCollection<string> GrantedRoles => _auth.GrantedRoles;
     public IReadOnlyCollection<int> AdminClubIds => _auth.AdminClubIds;
+
+    public int? ActiveClubId =>
+        _auth.AdminClubIds.Count == 1 ? _auth.AdminClubIds.First() : null;
+
     public bool IsAuthenticated => _auth.Session is not null;
     public bool IsAdmin => _auth.IsAdmin;
     public bool IsClubAdmin => _auth.IsClubAdmin;

--- a/DropShot.Shared/Dtos/CompetitionDtos.cs
+++ b/DropShot.Shared/Dtos/CompetitionDtos.cs
@@ -45,7 +45,10 @@ public record CompetitionDetailDto(
     bool IsRestricted = false,
     List<int>? AllowedPlayerIds = null,
     bool HasDivisions = false,
-    List<CompetitionDivisionDto>? Divisions = null);
+    List<CompetitionDivisionDto>? Divisions = null,
+    List<CompetitionFixtureDto>? Fixtures = null,
+    List<CompetitionTeamDto>? Teams = null,
+    List<CourtPairDto>? CourtPairs = null);
 
 public record CompetitionStageDto(
     int CompetitionStageId,
@@ -93,7 +96,8 @@ public record CompetitionFixtureDto(
     string? AwayTeamName = null,
     int? WinnerTeamId = null,
     int? CourtPairId = null,
-    string? CourtPairName = null);
+    string? CourtPairName = null,
+    IReadOnlyList<RubberDto>? Rubbers = null);
 
 public record CompetitionTeamDto(
     int CompetitionTeamId,

--- a/DropShot.UI/Components/Shared/FixtureResultCard.razor
+++ b/DropShot.UI/Components/Shared/FixtureResultCard.razor
@@ -1,0 +1,126 @@
+@* DTO-typed counterpart to DropShot/Components/ResultCard.razor. The web file stays
+   for Home.razor's casual-match overload (phase 7); shared pages use this one. *@
+
+<div class="@CardClass">
+    @if (!Compact && Fixture is not null)
+    {
+        <div class="rc-header">
+            @if (!string.IsNullOrEmpty(Fixture.FixtureLabel))
+            {
+                <span class="rc-label">@Fixture.FixtureLabel</span>
+            }
+            @if (Fixture.ScheduledAt.HasValue)
+            {
+                <span class="rc-date">@Fixture.ScheduledAt.Value.ToString("dd MMM yyyy")</span>
+            }
+        </div>
+    }
+
+    <div class="rc-player-row @(_p1Winner ? "rc-winner" : "")">
+        <div class="rc-name">@Player1Name</div>
+        <div class="rc-sets">
+            @foreach (var set in _sets)
+            {
+                <span class="rc-set-score">@set.P1</span>
+            }
+        </div>
+    </div>
+
+    @if (!Compact)
+    {
+        <div class="rc-separator">v</div>
+    }
+
+    <div class="rc-player-row @(_p2Winner ? "rc-winner" : "")">
+        <div class="rc-name">@Player2Name</div>
+        <div class="rc-sets">
+            @foreach (var set in _sets)
+            {
+                <span class="rc-set-score">@set.P2</span>
+            }
+        </div>
+    </div>
+</div>
+
+@code {
+    [Parameter] public CompetitionFixtureDto? Fixture { get; set; }
+    [Parameter] public bool Compact { get; set; }
+
+    private string CardClass => Compact ? "result-card result-card-compact" : "result-card";
+
+    private List<(string P1, string P2)> _sets = [];
+    private bool _p1Winner;
+    private bool _p2Winner;
+
+    private bool IsTeamMatch => Fixture is not null
+        && (Fixture.HomeTeamId.HasValue || Fixture.AwayTeamId.HasValue);
+
+    private string Player1Name
+    {
+        get
+        {
+            if (Fixture is null) return "TBD";
+            if (IsTeamMatch) return Fixture.HomeTeamName ?? "TBD";
+            return Fixture.Player3Id is not null
+                ? $"{Fixture.Player1Name ?? "TBD"} & {Fixture.Player3Name ?? "TBD"}"
+                : Fixture.Player1Name ?? "TBD";
+        }
+    }
+
+    private string Player2Name
+    {
+        get
+        {
+            if (Fixture is null) return "TBD";
+            if (IsTeamMatch) return Fixture.AwayTeamName ?? "TBD";
+            return Fixture.Player4Id is not null
+                ? $"{Fixture.Player2Name ?? "TBD"} & {Fixture.Player4Name ?? "TBD"}"
+                : Fixture.Player2Name ?? "TBD";
+        }
+    }
+
+    protected override void OnParametersSet()
+    {
+        if (Fixture is null)
+        {
+            _sets = [];
+            _p1Winner = _p2Winner = false;
+            return;
+        }
+
+        _sets = ParseResultSummary(Fixture.ResultSummary);
+        _p1Winner = Fixture.WinnerPlayerId.HasValue && Fixture.WinnerPlayerId == Fixture.Player1Id;
+        _p2Winner = Fixture.WinnerPlayerId.HasValue && Fixture.WinnerPlayerId == Fixture.Player2Id;
+        if (!_p1Winner && !_p2Winner)
+            (_p1Winner, _p2Winner) = DeriveWinnerFromSets(_sets);
+    }
+
+    private static (bool p1, bool p2) DeriveWinnerFromSets(List<(string P1, string P2)> sets)
+    {
+        int p1Sets = 0, p2Sets = 0;
+        foreach (var s in sets)
+        {
+            if (int.TryParse(s.P1, out var a) && int.TryParse(s.P2, out var b))
+            {
+                if (a > b) p1Sets++;
+                else if (b > a) p2Sets++;
+            }
+        }
+        if (p1Sets > p2Sets) return (true, false);
+        if (p2Sets > p1Sets) return (false, true);
+        return (false, false);
+    }
+
+    private static List<(string P1, string P2)> ParseResultSummary(string? summary)
+    {
+        if (string.IsNullOrWhiteSpace(summary)) return [];
+        var result = new List<(string, string)>();
+        foreach (var part in summary.Split(',', StringSplitOptions.TrimEntries))
+        {
+            var scores = part.Split(['-', '–'], 2);
+            if (scores.Length == 2)
+                result.Add((scores[0].Trim(), scores[1].Trim()));
+        }
+        return result;
+    }
+}

--- a/DropShot.UI/Services/Auth/ICurrentUser.cs
+++ b/DropShot.UI/Services/Auth/ICurrentUser.cs
@@ -13,6 +13,14 @@ public interface ICurrentUser
     string? ActiveRole { get; }
     IReadOnlyCollection<string> GrantedRoles { get; }
     IReadOnlyCollection<int> AdminClubIds { get; }
+
+    /// <summary>
+    /// The club the user is currently "acting as administrator" for.
+    /// Web: reads the ActiveClubId cookie; MAUI: the sole admin club if exactly one exists.
+    /// Null when the user administrates no clubs, or (on MAUI) administrates more than one.
+    /// </summary>
+    int? ActiveClubId { get; }
+
     bool IsAuthenticated { get; }
     bool IsAdmin { get; }
     bool IsClubAdmin { get; }

--- a/DropShot/Services/WebCompetitionService.cs
+++ b/DropShot/Services/WebCompetitionService.cs
@@ -45,6 +45,8 @@ public sealed class WebCompetitionService(
     {
         await using var db = await dbFactory.CreateDbContextAsync(ct);
         var c = await db.Competition
+            .AsSplitQuery()
+            .AsNoTracking()
             .Include(x => x.HostClub)
             .Include(x => x.Rules)
             .Include(x => x.Event)
@@ -54,6 +56,21 @@ public sealed class WebCompetitionService(
             .Include(x => x.Participants).ThenInclude(p => p.Division)
             .Include(x => x.Divisions)
             .Include(x => x.AllowedPlayers)
+            .Include(x => x.Fixtures).ThenInclude(f => f.Stage)
+            .Include(x => x.Fixtures).ThenInclude(f => f.Court)
+            .Include(x => x.Fixtures).ThenInclude(f => f.CourtPair).ThenInclude(cp => cp!.Court1)
+            .Include(x => x.Fixtures).ThenInclude(f => f.CourtPair).ThenInclude(cp => cp!.Court2)
+            .Include(x => x.Fixtures).ThenInclude(f => f.Player1)
+            .Include(x => x.Fixtures).ThenInclude(f => f.Player2)
+            .Include(x => x.Fixtures).ThenInclude(f => f.Player3)
+            .Include(x => x.Fixtures).ThenInclude(f => f.Player4)
+            .Include(x => x.Fixtures).ThenInclude(f => f.HomeTeam)
+            .Include(x => x.Fixtures).ThenInclude(f => f.AwayTeam)
+            .Include(x => x.Fixtures).ThenInclude(f => f.Rubbers).ThenInclude(r => r.HomePlayer1)
+            .Include(x => x.Fixtures).ThenInclude(f => f.Rubbers).ThenInclude(r => r.HomePlayer2)
+            .Include(x => x.Fixtures).ThenInclude(f => f.Rubbers).ThenInclude(r => r.AwayPlayer1)
+            .Include(x => x.Fixtures).ThenInclude(f => f.Rubbers).ThenInclude(r => r.AwayPlayer2)
+            .Include(x => x.Teams).ThenInclude(t => t.Captain)
             .FirstOrDefaultAsync(x => x.CompetitionID == id, ct);
 
         if (c is null) return null;
@@ -61,6 +78,14 @@ public sealed class WebCompetitionService(
         var user = httpContextAccessor.HttpContext?.User ?? new ClaimsPrincipal();
         if (!await authzService.CanViewCompetitionAsync(user, id))
             return null;
+
+        var courtPairs = await db.CourtPairs
+            .AsNoTracking()
+            .Where(cp => cp.CompetitionId == id)
+            .Include(cp => cp.Court1)
+            .Include(cp => cp.Court2)
+            .OrderBy(cp => cp.Name)
+            .ToListAsync(ct);
 
         return new CompetitionDetailDto(
             c.CompetitionID, c.CompetitionName,
@@ -89,8 +114,49 @@ public sealed class WebCompetitionService(
             c.HasDivisions,
             c.Divisions.OrderBy(d => d.Rank)
                 .Select(d => new CompetitionDivisionDto(d.CompetitionDivisionId, d.CompetitionId, d.Rank, d.Name))
-                .ToList());
+                .ToList(),
+            c.Fixtures
+                .OrderBy(f => f.RoundNumber).ThenBy(f => f.ScheduledAt)
+                .Select(ToFixtureDto)
+                .ToList(),
+            c.Teams
+                .Select(t => new CompetitionTeamDto(
+                    t.CompetitionTeamId, t.CompetitionId, t.Name,
+                    t.CaptainPlayerId, t.Captain?.DisplayName))
+                .ToList(),
+            courtPairs.Select(cp => new CourtPairDto(
+                cp.CourtPairId, cp.CompetitionId,
+                cp.Court1Id, cp.Court1.Name,
+                cp.Court2Id, cp.Court2.Name,
+                cp.Name)).ToList());
     }
+
+    private static CompetitionFixtureDto ToFixtureDto(DropShot.Models.CompetitionFixture f) => new(
+        f.CompetitionFixtureId, f.CompetitionId,
+        f.CompetitionStageId, f.Stage?.Name,
+        f.CourtId, f.Court?.Name,
+        f.ScheduledAt, (DropShot.Shared.FixtureStatus)f.Status,
+        f.FixtureLabel, f.RoundNumber,
+        f.Player1Id, f.Player1?.DisplayName,
+        f.Player2Id, f.Player2?.DisplayName,
+        f.Player3Id, f.Player3?.DisplayName,
+        f.Player4Id, f.Player4?.DisplayName,
+        f.ResultSummary, f.WinnerPlayerId,
+        f.HomeTeamId, f.HomeTeam?.Name,
+        f.AwayTeamId, f.AwayTeam?.Name,
+        f.WinnerTeamId, f.CourtPairId, f.CourtPair?.Name,
+        f.Rubbers
+            .OrderBy(r => r.Order)
+            .Select(r => new RubberDto(
+                r.RubberId, r.CompetitionFixtureId, r.Order, r.Name, r.CourtNumber,
+                r.HomeRoles, r.AwayRoles,
+                r.HomePlayer1Id, r.HomePlayer1?.DisplayName,
+                r.HomePlayer2Id, r.HomePlayer2?.DisplayName,
+                r.AwayPlayer1Id, r.AwayPlayer1?.DisplayName,
+                r.AwayPlayer2Id, r.AwayPlayer2?.DisplayName,
+                r.HomeGames, r.AwayGames, r.WinnerTeamId,
+                r.IsComplete, r.SavedMatchId))
+            .ToList());
 
     private static CompetitionDto ToDto(Competition c) => new(
         c.CompetitionID, c.CompetitionName,

--- a/DropShot/Services/WebCurrentUser.cs
+++ b/DropShot/Services/WebCurrentUser.cs
@@ -2,6 +2,7 @@ using System.Security.Claims;
 using DropShot.Data;
 using DropShot.UI.Services.Auth;
 using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 
@@ -18,6 +19,7 @@ public sealed class WebCurrentUser : ICurrentUser, IDisposable
     private readonly AuthenticationStateProvider _authState;
     private readonly UserManager<ApplicationUser> _userManager;
     private readonly IDbContextFactory<MyDbContext> _dbFactory;
+    private readonly IHttpContextAccessor _httpContextAccessor;
 
     private string? _userId;
     private string? _userName;
@@ -32,11 +34,13 @@ public sealed class WebCurrentUser : ICurrentUser, IDisposable
     public WebCurrentUser(
         AuthenticationStateProvider authState,
         UserManager<ApplicationUser> userManager,
-        IDbContextFactory<MyDbContext> dbFactory)
+        IDbContextFactory<MyDbContext> dbFactory,
+        IHttpContextAccessor httpContextAccessor)
     {
         _authState = authState;
         _userManager = userManager;
         _dbFactory = dbFactory;
+        _httpContextAccessor = httpContextAccessor;
         _authState.AuthenticationStateChanged += OnAuthStateChanged;
         _ = RefreshAsync();
     }
@@ -99,6 +103,21 @@ public sealed class WebCurrentUser : ICurrentUser, IDisposable
     public string? ActiveRole => _activeRole;
     public IReadOnlyCollection<string> GrantedRoles => _grantedRoles;
     public IReadOnlyCollection<int> AdminClubIds => _adminClubIds;
+
+    public int? ActiveClubId
+    {
+        get
+        {
+            if (_adminClubIds.Count == 0) return null;
+            if (int.TryParse(_httpContextAccessor.HttpContext?.Request.Cookies["ActiveClubId"], out var cookieClubId)
+                && _adminClubIds.Contains(cookieClubId))
+            {
+                return cookieClubId;
+            }
+            return _adminClubIds[0];
+        }
+    }
+
     public bool IsAuthenticated => _isAuthenticated;
     public bool IsAdmin => _activeRole is "Admin" or "SuperAdmin";
     public bool IsClubAdmin => _activeRole == "ClubAdmin";


### PR DESCRIPTION
## Summary

Cross-cutting prerequisites for moving Clubs / ClubPlayers / Players / ViewCompetition into `DropShot.UI`. **No page moves in this PR** — sets the table for the four follow-up PRs (B.1 Players, B.2 ViewCompetition, B.3 ClubPlayers, B.4 Clubs).

- **`ICurrentUser.ActiveClubId`** lifts `ActiveClubResolver`'s `IHttpContextAccessor` dependency into the auth abstraction so ClubPlayers can run on MAUI.
  - Web: reads the `ActiveClubId` cookie, falls back to the first admin club.
  - MAUI: exposes the sole admin club when the user admins exactly one (multi-admin requires a future active-club switcher).
- **`CompetitionDetailDto` + `CompetitionFixtureDto`** grow optional collections (`Fixtures`, `Teams`, `CourtPairs`, and per-fixture `Rubbers`). `WebCompetitionService.GetCompetitionAsync` materialises them with the same split-query/no-tracking include graph that `ViewCompetition.razor` uses inline today. Every new parameter is positional-optional with a null default — existing two construction sites (this service + `CompetitionsController.Get`) compile unchanged.
- **`FixtureResultCard.razor`** is a new DTO-typed shared component. The original `DropShot/Components/ResultCard.razor` stays put for `Home.razor`'s casual-match overload (entity-typed `SavedMatch` + `Match` JSON parsing) until phase 7 retires that page; cross-host pages going forward use `FixtureResultCard`. Avoids a Razor name collision in the web project where both `DropShot.Components` and `DropShot.UI.Components.Shared` are imported.

Plan: [continue-the-dropshot-ui-extraction-squishy-swing.md](C:\Users\Alan.Beattie\.claude\plans\continue-the-dropshot-ui-extraction-squishy-swing.md). Phase context: [PR #471](https://github.com/kingbeazer/DropShot/pull/471) merged phases 0–3 + phase 4 batch A.

## Test plan

- [x] `dotnet build DropShot.sln` — 0 errors, 7 pre-existing warnings unchanged.
- [x] `dotnet test DropShot.Tests` — 28/28 pass.
- [ ] Manual: `/competitions/{id}/view` renders identically on web (no behavioural change to ViewCompetition; it still calls EF directly until B.2).
- [ ] Manual: web role-switch + active-club cookie propagates to `WebCurrentUser.ActiveClubId` getter (verified inadvertently when ClubPlayers moves in B.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)