### PR TITLE
Phase 4 batch B.3: move ClubPlayers.razor into DropShot.UI

### DIFF
--- a/DropShot.Maui/Components/Layout/NavMenu.razor
+++ b/DropShot.Maui/Components/Layout/NavMenu.razor
@@ -11,6 +11,11 @@
     <MudNavLink Href="/rulessets" Icon="@Icons.Material.Filled.Gavel">
         Rules Sets
     </MudNavLink>
+    <AuthorizeView Roles="ClubAdmin,Admin,SuperAdmin">
+        <MudNavLink Href="/players/club" Icon="@Icons.Material.Filled.Groups">
+            Club Players
+        </MudNavLink>
+    </AuthorizeView>
     <AuthorizeView Roles="SuperAdmin">
         <MudNavLink Href="/players" Icon="@Icons.Material.Filled.People">
             Players

--- a/DropShot.Maui/Components/Pages/ClubPlayers.razor
+++ b/DropShot.Maui/Components/Pages/ClubPlayers.razor
@@ -1,8 +1,5 @@
 @page "/players/club"
-@rendermode InteractiveServer
 @attribute [Authorize(Roles = "ClubAdmin,Admin,SuperAdmin")]
 @using Microsoft.AspNetCore.Authorization
-
-<MudProviders />
 
 <DropShot.UI.Components.Pages.ClubPlayers />

--- a/DropShot.Maui/Services/HttpPlayerService.cs
+++ b/DropShot.Maui/Services/HttpPlayerService.cs
@@ -42,4 +42,37 @@ public sealed class HttpPlayerService(HttpClient http) : IPlayerService
         var resp = await http.DeleteAsync($"api/players/{playerId}", ct);
         resp.EnsureSuccessStatusCode();
     }
+
+    public async Task<List<ClubPlayerDto>> GetClubPlayersAsync(int clubId, CancellationToken ct = default) =>
+        await http.GetFromJsonAsync<List<ClubPlayerDto>>($"api/clubs/{clubId}/players", ct) ?? [];
+
+    public async Task<List<PlayerDto>> SearchPlayersForClubLinkAsync(int clubId, string term, CancellationToken ct = default) =>
+        await http.GetFromJsonAsync<List<PlayerDto>>(
+            $"api/clubs/{clubId}/players/search?term={Uri.EscapeDataString(term)}", ct) ?? [];
+
+    public async Task<PlayerDto> CreateLightPlayerAsync(int clubId, CreateLightPlayerRequest request, CancellationToken ct = default)
+    {
+        var resp = await http.PostAsJsonAsync($"api/clubs/{clubId}/players/light", request, ct);
+        resp.EnsureSuccessStatusCode();
+        return (await resp.Content.ReadFromJsonAsync<PlayerDto>(cancellationToken: ct))!;
+    }
+
+    public async Task<PlayerDto> UpdateLightPlayerAsync(int clubId, int playerId, UpdateLightPlayerRequest request, CancellationToken ct = default)
+    {
+        var resp = await http.PutAsJsonAsync($"api/clubs/{clubId}/players/light/{playerId}", request, ct);
+        resp.EnsureSuccessStatusCode();
+        return (await resp.Content.ReadFromJsonAsync<PlayerDto>(cancellationToken: ct))!;
+    }
+
+    public async Task RemovePlayerFromClubAsync(int clubId, int playerId, CancellationToken ct = default)
+    {
+        var resp = await http.DeleteAsync($"api/clubs/{clubId}/players/{playerId}", ct);
+        resp.EnsureSuccessStatusCode();
+    }
+
+    public async Task LinkExistingPlayerToClubAsync(int clubId, int playerId, CancellationToken ct = default)
+    {
+        var resp = await http.PostAsync($"api/clubs/{clubId}/players/{playerId}/link", null, ct);
+        resp.EnsureSuccessStatusCode();
+    }
 }

--- a/DropShot.Shared/Dtos/PlayerDtos.cs
+++ b/DropShot.Shared/Dtos/PlayerDtos.cs
@@ -37,6 +37,42 @@ public record UpdatePlayerRequest(
     string? MobileNumber);
 
 /// <summary>
+/// Row in the ClubPlayers grid (per-club roster). IsClubOwned is true when the
+/// player is a light placeholder created specifically for this club —
+/// determines whether the row exposes the edit / cascade-delete affordances.
+/// </summary>
+public record ClubPlayerDto(
+    int PlayerId,
+    string DisplayName,
+    string? FirstName,
+    string? LastName,
+    string? Email,
+    string? MobileNumber,
+    PlayerSex? Sex,
+    DateOnly? DateOfBirth,
+    string? ProfileImagePath,
+    bool IsLight,
+    bool IsClubOwned);
+
+public record CreateLightPlayerRequest(
+    string DisplayName,
+    string? FirstName,
+    string? LastName,
+    string? Email,
+    string? MobileNumber,
+    DateOnly? DateOfBirth,
+    PlayerSex? Sex);
+
+public record UpdateLightPlayerRequest(
+    string DisplayName,
+    string? FirstName,
+    string? LastName,
+    string? Email,
+    string? MobileNumber,
+    DateOnly? DateOfBirth,
+    PlayerSex? Sex);
+
+/// <summary>
 /// Row in the SuperAdmin Players grid. Joins each player with the linked
 /// ASP.NET account user-name (when present) and the names of the clubs they
 /// belong to.

--- a/DropShot.UI/Components/Pages/ClubPlayers.razor
+++ b/DropShot.UI/Components/Pages/ClubPlayers.razor
@@ -1,0 +1,342 @@
+@inject IPlayerService PlayerService
+@inject IClubService ClubService
+@inject ICurrentUser CurrentUser
+@inject ISnackbar Snackbar
+
+@* Routing + auth + MudProviders supplied by host shims. *@
+
+<div style="position: relative; min-height: 100vh; background-image: url('images/background.png'); background-repeat: no-repeat; background-size: cover; background-position: center; margin: -24px; padding: 0;">
+    <div style="position: absolute; inset: 0; background-color: rgba(18, 18, 18, 0.85); pointer-events: none;"></div>
+    <div style="position: relative; z-index: 1; padding: 1rem 0.5rem 2rem;">
+
+<MudText Typo="Typo.h4" Class="mb-4" Style="color: white;">Club Players</MudText>
+
+@if (_activeClubId is null)
+{
+    <MudAlert Severity="Severity.Warning">
+        No club is currently selected. You may not be an administrator of any club.
+    </MudAlert>
+}
+else
+{
+    <MudText Typo="Typo.subtitle1" Class="mb-3" Style="color: rgba(255,255,255,0.85);">Managing: <strong>@_clubName</strong></MudText>
+
+    <MudStack Row="true" Spacing="2" Class="mb-4">
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Filled.PersonAdd"
+                   OnClick="OpenCreateDialog">
+            Add Light Player
+        </MudButton>
+        <MudButton Variant="Variant.Outlined" Color="Color.Primary" StartIcon="@Icons.Material.Filled.Search"
+                   OnClick="OpenAddExistingDialog">
+            Add Existing Player
+        </MudButton>
+    </MudStack>
+
+    <MudTextField @bind-Value="_searchText" Placeholder="Search club players..."
+                  Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search"
+                  Immediate="true" Class="mb-4" />
+
+    <MudTable Items="@_players" Hover="true" Breakpoint="Breakpoint.Sm" Loading="@_loading"
+              Filter="@(row => FilterPlayers(row))">
+        <HeaderContent>
+            <MudTh>Player</MudTh>
+            <MudTh>First Name</MudTh>
+            <MudTh>Last Name</MudTh>
+            <MudTh>Age</MudTh>
+            <MudTh>Category</MudTh>
+            <MudTh>Email</MudTh>
+            <MudTh>Mobile</MudTh>
+            <MudTh Style="width: 100px;">Actions</MudTh>
+        </HeaderContent>
+        <RowTemplate>
+            <MudTd DataLabel="Player">
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                    @if (!context.IsLight)
+                    {
+                        @if (!string.IsNullOrEmpty(context.ProfileImagePath))
+                        {
+                            <MudAvatar Size="Size.Small" Style="width:24px; height:24px;">
+                                <MudImage Src="@context.ProfileImagePath" />
+                            </MudAvatar>
+                        }
+                        else
+                        {
+                            <MudAvatar Size="Size.Small" Style="width:24px; height:24px; background: var(--mud-palette-primary);">
+                                <MudIcon Icon="@Icons.Material.Filled.Face" Size="Size.Small" Style="font-size:16px;" />
+                            </MudAvatar>
+                        }
+                    }
+                    else
+                    {
+                        <MudIcon Icon="@Icons.Material.Filled.PersonOutline" Color="Color.Default" Size="Size.Small" />
+                    }
+                    <MudText>@context.DisplayName</MudText>
+                </MudStack>
+            </MudTd>
+            <MudTd DataLabel="First Name">@(context.FirstName ?? "—")</MudTd>
+            <MudTd DataLabel="Last Name">@(context.LastName ?? "—")</MudTd>
+            <MudTd DataLabel="Age">@(AgeFor(context.DateOfBirth)?.ToString() ?? "—")</MudTd>
+            <MudTd DataLabel="Category">@(context.Sex?.ToString() ?? "—")</MudTd>
+            <MudTd DataLabel="Email">@(context.Email ?? "—")</MudTd>
+            <MudTd DataLabel="Mobile">@(context.MobileNumber ?? "—")</MudTd>
+            <MudTd DataLabel="Actions">
+                <MudStack Row="true" Spacing="0">
+                    @if (context.IsLight && context.IsClubOwned)
+                    {
+                        <MudTooltip Text="Edit">
+                            <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="Size.Small"
+                                           OnClick="@(() => OpenEditDialog(context))" />
+                        </MudTooltip>
+                    }
+                    else
+                    {
+                        <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="Size.Small"
+                                       Style="visibility: hidden;" />
+                    }
+                    <MudTooltip Text="Remove from club">
+                        <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small" Color="Color.Error"
+                                       OnClick="@(() => RemoveFromClub(context))" />
+                    </MudTooltip>
+                </MudStack>
+            </MudTd>
+        </RowTemplate>
+        <NoRecordsContent>
+            <MudText>No players yet. Add a player to get started.</MudText>
+        </NoRecordsContent>
+    </MudTable>
+}
+
+<MudDialog @bind-Visible="_showPlayerDialog">
+    <TitleContent>@(_editingPlayerId.HasValue ? "Edit Player" : "Add Light Player")</TitleContent>
+    <DialogContent>
+        <MudGrid Spacing="2">
+            <MudItem xs="12">
+                <MudTextField @bind-Value="_form.DisplayName" Label="Display Name" Variant="Variant.Outlined"
+                              Required="true" Immediate="true" />
+            </MudItem>
+            <MudItem xs="6">
+                <MudTextField @bind-Value="_form.FirstName" Label="First Name" Variant="Variant.Outlined" />
+            </MudItem>
+            <MudItem xs="6">
+                <MudTextField @bind-Value="_form.LastName" Label="Last Name" Variant="Variant.Outlined" />
+            </MudItem>
+            <MudItem xs="12">
+                <MudTextField @bind-Value="_form.Email" Label="Email address" Variant="Variant.Outlined"
+                              InputType="InputType.Email" />
+            </MudItem>
+            <MudItem xs="12">
+                <MudTextField @bind-Value="_form.MobileNumber" Label="Mobile number" Variant="Variant.Outlined"
+                              InputType="InputType.Telephone" />
+            </MudItem>
+            <MudItem xs="12">
+                <MudDatePicker @bind-Date="_form.DateOfBirth" Label="Date of birth *" Variant="Variant.Outlined"
+                               DateFormat="dd/MM/yyyy" Editable="true" />
+            </MudItem>
+            <MudItem xs="12">
+                <MudText Typo="Typo.body2" Class="mb-1">Competition category</MudText>
+                <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mb-2">Determines which events they're eligible to enter</MudText>
+                <MudRadioGroup T="PlayerSex?" @bind-Value="_form.CompetitionCategory">
+                    <MudRadio T="PlayerSex?" Value="@PlayerSex.Male" Color="Color.Primary">Male events</MudRadio>
+                    <MudRadio T="PlayerSex?" Value="@PlayerSex.Female" Color="Color.Primary">Female events</MudRadio>
+                </MudRadioGroup>
+            </MudItem>
+        </MudGrid>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@(() => _showPlayerDialog = false)">Cancel</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                   Disabled="@(string.IsNullOrWhiteSpace(_form.DisplayName) || !_form.DateOfBirth.HasValue)"
+                   OnClick="SavePlayer">
+            @(_editingPlayerId.HasValue ? "Save" : "Add")
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
+<MudDialog @bind-Visible="_showAddExistingDialog">
+    <TitleContent>Add Existing Player to Club</TitleContent>
+    <DialogContent>
+        <MudTextField @bind-Value="_existingSearch" Placeholder="Search by name..."
+                      Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search"
+                      Immediate="true" TextChanged="OnExistingSearchChanged" Class="mb-2" />
+        @if (_existingResults.Count > 0)
+        {
+            <MudList T="PlayerDto" Dense="true">
+                @foreach (var p in _existingResults)
+                {
+                    <MudListItem T="PlayerDto" OnClick="@(() => AddExistingPlayer(p))">
+                        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                            @if (!string.IsNullOrEmpty(p.ProfileImagePath))
+                            {
+                                <MudAvatar Size="Size.Small" Style="width:24px; height:24px;">
+                                    <MudImage Src="@p.ProfileImagePath" />
+                                </MudAvatar>
+                            }
+                            else
+                            {
+                                <MudAvatar Size="Size.Small" Style="width:24px; height:24px; background: var(--mud-palette-primary);">
+                                    <MudIcon Icon="@Icons.Material.Filled.Face" Size="Size.Small" Style="font-size:16px;" />
+                                </MudAvatar>
+                            }
+                            <MudText>@p.DisplayName</MudText>
+                        </MudStack>
+                    </MudListItem>
+                }
+            </MudList>
+        }
+        else if (!string.IsNullOrWhiteSpace(_existingSearch))
+        {
+            <MudText Typo="Typo.caption" Color="Color.Secondary">No matching players.</MudText>
+        }
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@(() => _showAddExistingDialog = false)">Close</MudButton>
+    </DialogActions>
+</MudDialog>
+
+</div></div>
+
+@code {
+    private bool _loading = true;
+    private List<ClubPlayerDto> _players = [];
+    private string _searchText = "";
+    private int? _activeClubId;
+    private string _clubName = "";
+
+    private bool _showPlayerDialog;
+    private int? _editingPlayerId;
+    private PlayerForm _form = new();
+
+    private bool _showAddExistingDialog;
+    private string _existingSearch = "";
+    private List<PlayerDto> _existingResults = [];
+
+    private sealed class PlayerForm
+    {
+        public string DisplayName { get; set; } = "";
+        public string? FirstName { get; set; }
+        public string? LastName { get; set; }
+        public string? Email { get; set; }
+        public string? MobileNumber { get; set; }
+        public PlayerSex? CompetitionCategory { get; set; }
+        public DateTime? DateOfBirth { get; set; }
+    }
+
+    private bool FilterPlayers(ClubPlayerDto row) =>
+        string.IsNullOrWhiteSpace(_searchText) ||
+        row.DisplayName.Contains(_searchText, StringComparison.OrdinalIgnoreCase) ||
+        (row.FirstName ?? "").Contains(_searchText, StringComparison.OrdinalIgnoreCase) ||
+        (row.LastName ?? "").Contains(_searchText, StringComparison.OrdinalIgnoreCase);
+
+    private static int? AgeFor(DateOnly? dob)
+    {
+        if (!dob.HasValue) return null;
+        var today = DateOnly.FromDateTime(DateTime.Today);
+        var age = today.Year - dob.Value.Year;
+        if (dob.Value > today.AddYears(-age)) age--;
+        return age;
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        _activeClubId = CurrentUser.ActiveClubId;
+        if (_activeClubId is not null)
+        {
+            var club = await ClubService.GetClubAsync(_activeClubId.Value);
+            _clubName = club?.Name ?? "";
+        }
+        await LoadPlayers();
+    }
+
+    private async Task LoadPlayers()
+    {
+        _loading = true;
+        if (_activeClubId is null) { _players = []; _loading = false; return; }
+        _players = await PlayerService.GetClubPlayersAsync(_activeClubId.Value);
+        _loading = false;
+    }
+
+    private void OpenCreateDialog()
+    {
+        _editingPlayerId = null;
+        _form = new PlayerForm();
+        _showPlayerDialog = true;
+    }
+
+    private void OpenEditDialog(ClubPlayerDto row)
+    {
+        _editingPlayerId = row.PlayerId;
+        _form = new PlayerForm
+        {
+            DisplayName = row.DisplayName,
+            FirstName = row.FirstName,
+            LastName = row.LastName,
+            Email = row.Email,
+            MobileNumber = row.MobileNumber,
+            CompetitionCategory = row.Sex,
+            DateOfBirth = row.DateOfBirth?.ToDateTime(TimeOnly.MinValue)
+        };
+        _showPlayerDialog = true;
+    }
+
+    private async Task SavePlayer()
+    {
+        if (_activeClubId is null || string.IsNullOrWhiteSpace(_form.DisplayName)) return;
+
+        var dob = _form.DateOfBirth.HasValue ? DateOnly.FromDateTime(_form.DateOfBirth.Value) : (DateOnly?)null;
+
+        if (_editingPlayerId.HasValue)
+        {
+            await PlayerService.UpdateLightPlayerAsync(_activeClubId.Value, _editingPlayerId.Value,
+                new UpdateLightPlayerRequest(
+                    _form.DisplayName.Trim(), _form.FirstName, _form.LastName,
+                    _form.Email, _form.MobileNumber, dob, _form.CompetitionCategory));
+            Snackbar.Add("Player updated.", Severity.Success);
+        }
+        else
+        {
+            await PlayerService.CreateLightPlayerAsync(_activeClubId.Value,
+                new CreateLightPlayerRequest(
+                    _form.DisplayName.Trim(), _form.FirstName, _form.LastName,
+                    _form.Email, _form.MobileNumber, dob, _form.CompetitionCategory));
+            Snackbar.Add("Player added to club.", Severity.Success);
+        }
+
+        _showPlayerDialog = false;
+        await LoadPlayers();
+    }
+
+    private void OpenAddExistingDialog()
+    {
+        _existingSearch = "";
+        _existingResults = [];
+        _showAddExistingDialog = true;
+    }
+
+    private async Task OnExistingSearchChanged(string value)
+    {
+        _existingSearch = value;
+        if (string.IsNullOrWhiteSpace(value) || _activeClubId is null)
+        {
+            _existingResults = [];
+            return;
+        }
+        _existingResults = await PlayerService.SearchPlayersForClubLinkAsync(_activeClubId.Value, value);
+    }
+
+    private async Task AddExistingPlayer(PlayerDto p)
+    {
+        if (_activeClubId is null) return;
+        await PlayerService.LinkExistingPlayerToClubAsync(_activeClubId.Value, p.PlayerId);
+        Snackbar.Add($"{p.DisplayName} added to club.", Severity.Success);
+        _showAddExistingDialog = false;
+        await LoadPlayers();
+    }
+
+    private async Task RemoveFromClub(ClubPlayerDto row)
+    {
+        if (_activeClubId is null) return;
+        await PlayerService.RemovePlayerFromClubAsync(_activeClubId.Value, row.PlayerId);
+        Snackbar.Add("Player removed from club.", Severity.Info);
+        await LoadPlayers();
+    }
+}

--- a/DropShot.UI/Services/IPlayerService.cs
+++ b/DropShot.UI/Services/IPlayerService.cs
@@ -28,4 +28,25 @@ public interface IPlayerService
     Task<PlayerDto> CreatePlayerAsync(CreatePlayerRequest request, CancellationToken ct = default);
     Task<PlayerDto> UpdatePlayerAsync(int playerId, UpdatePlayerRequest request, CancellationToken ct = default);
     Task DeletePlayerAsync(int playerId, CancellationToken ct = default);
+
+    /// <summary>Roster for a specific club (joins ClubPlayer + Player + linked account image).</summary>
+    Task<List<ClubPlayerDto>> GetClubPlayersAsync(int clubId, CancellationToken ct = default);
+
+    /// <summary>Search non-light players who aren't already in the given club. Caps at 10 results.</summary>
+    Task<List<PlayerDto>> SearchPlayersForClubLinkAsync(int clubId, string term, CancellationToken ct = default);
+
+    /// <summary>Insert a light placeholder player for the club; returns the new player.</summary>
+    Task<PlayerDto> CreateLightPlayerAsync(int clubId, CreateLightPlayerRequest request, CancellationToken ct = default);
+
+    /// <summary>Update a light, club-owned player. Throws if the player is non-light or owned by another club.</summary>
+    Task<PlayerDto> UpdateLightPlayerAsync(int clubId, int playerId, UpdateLightPlayerRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Remove the player's membership from the club. If the player is light and
+    /// club-owned (CreatedByClubId == clubId), the Player record is also deleted.
+    /// </summary>
+    Task RemovePlayerFromClubAsync(int clubId, int playerId, CancellationToken ct = default);
+
+    /// <summary>Add an existing (non-light) player to the club's roster.</summary>
+    Task LinkExistingPlayerToClubAsync(int clubId, int playerId, CancellationToken ct = default);
 }

--- a/DropShot/Controllers/PlayersController.cs
+++ b/DropShot/Controllers/PlayersController.cs
@@ -129,3 +129,73 @@ public class PlayersController(
         p.ContactPreferences, p.ProfileImagePath, p.UserId, p.MobileNumber,
         p.IsLight, p.CreatedByUserId);
 }
+
+/// <summary>
+/// Per-club player roster endpoints. Backs ClubPlayers.razor (phase 4 batch B.3).
+/// All routes require an active ClubAdmin / Admin / SuperAdmin role with edit
+/// rights on the club (delegated to <see cref="ClubAuthorizationService"/>).
+/// </summary>
+[ApiController]
+[Route("api/clubs/{clubId:int}/players")]
+[Authorize(AuthenticationSchemes = "Bearer", Roles = "ClubAdmin,Admin,SuperAdmin")]
+public class ClubPlayersController(
+    IPlayerService playerService,
+    DropShot.Services.ClubAuthorizationService authzService) : ControllerBase
+{
+    [HttpGet]
+    public async Task<ActionResult<List<ClubPlayerDto>>> GetClubPlayers(int clubId, CancellationToken ct)
+    {
+        if (!await authzService.CanEditClubAsync(User, clubId)) return Forbid();
+        return await playerService.GetClubPlayersAsync(clubId, ct);
+    }
+
+    [HttpGet("search")]
+    public async Task<ActionResult<List<PlayerDto>>> SearchForLink(
+        int clubId, [FromQuery] string term, CancellationToken ct)
+    {
+        if (!await authzService.CanEditClubAsync(User, clubId)) return Forbid();
+        return await playerService.SearchPlayersForClubLinkAsync(clubId, term, ct);
+    }
+
+    [HttpPost("light")]
+    public async Task<ActionResult<PlayerDto>> CreateLight(
+        int clubId, [FromBody] CreateLightPlayerRequest req, CancellationToken ct)
+    {
+        if (!await authzService.CanEditClubAsync(User, clubId)) return Forbid();
+        if (string.IsNullOrWhiteSpace(req.DisplayName))
+            return BadRequest(new { message = "DisplayName is required." });
+        var dto = await playerService.CreateLightPlayerAsync(clubId, req, ct);
+        return CreatedAtAction(nameof(GetClubPlayers), new { clubId }, dto);
+    }
+
+    [HttpPut("light/{playerId:int}")]
+    public async Task<ActionResult<PlayerDto>> UpdateLight(
+        int clubId, int playerId, [FromBody] UpdateLightPlayerRequest req, CancellationToken ct)
+    {
+        if (!await authzService.CanEditClubAsync(User, clubId)) return Forbid();
+        if (string.IsNullOrWhiteSpace(req.DisplayName))
+            return BadRequest(new { message = "DisplayName is required." });
+        try
+        {
+            return await playerService.UpdateLightPlayerAsync(clubId, playerId, req, ct);
+        }
+        catch (KeyNotFoundException) { return NotFound(); }
+        catch (InvalidOperationException) { return Forbid(); }
+    }
+
+    [HttpPost("{playerId:int}/link")]
+    public async Task<IActionResult> LinkExisting(int clubId, int playerId, CancellationToken ct)
+    {
+        if (!await authzService.CanEditClubAsync(User, clubId)) return Forbid();
+        await playerService.LinkExistingPlayerToClubAsync(clubId, playerId, ct);
+        return NoContent();
+    }
+
+    [HttpDelete("{playerId:int}")]
+    public async Task<IActionResult> RemoveFromClub(int clubId, int playerId, CancellationToken ct)
+    {
+        if (!await authzService.CanEditClubAsync(User, clubId)) return Forbid();
+        await playerService.RemovePlayerFromClubAsync(clubId, playerId, ct);
+        return NoContent();
+    }
+}

--- a/DropShot/Services/WebPlayerService.cs
+++ b/DropShot/Services/WebPlayerService.cs
@@ -149,6 +149,121 @@ public sealed class WebPlayerService(
         await db.SaveChangesAsync(ct);
     }
 
+    public async Task<List<ClubPlayerDto>> GetClubPlayersAsync(int clubId, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var rows = await db.ClubPlayers
+            .Where(cp => cp.ClubId == clubId)
+            .Join(db.Players, cp => cp.PlayerId, p => p.PlayerId,
+                (cp, p) => new
+                {
+                    p.PlayerId, p.DisplayName, p.FirstName, p.LastName,
+                    p.IsLight, p.CreatedByClubId, p.Email, p.MobileNumber,
+                    p.Sex, p.ProfileImagePath, p.DateOfBirth,
+                    UserImage = p.User != null ? p.User.ProfileImagePath : null
+                })
+            .OrderBy(x => x.DisplayName)
+            .ToListAsync(ct);
+
+        return rows.Select(x => new ClubPlayerDto(
+            x.PlayerId, x.DisplayName, x.FirstName, x.LastName,
+            x.Email, x.MobileNumber, (DropShot.Shared.PlayerSex?)x.Sex,
+            x.DateOfBirth, x.UserImage ?? x.ProfileImagePath,
+            x.IsLight, x.CreatedByClubId == clubId)).ToList();
+    }
+
+    public async Task<List<PlayerDto>> SearchPlayersForClubLinkAsync(int clubId, string term, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(term)) return [];
+
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var alreadyInClub = await db.ClubPlayers
+            .Where(cp => cp.ClubId == clubId)
+            .Select(cp => cp.PlayerId)
+            .ToListAsync(ct);
+
+        var matches = await db.Players
+            .Where(p => !alreadyInClub.Contains(p.PlayerId)
+                && !p.IsLight
+                && p.DisplayName.Contains(term))
+            .OrderBy(p => p.DisplayName)
+            .Take(10)
+            .ToListAsync(ct);
+
+        return matches.Select(ToDto).ToList();
+    }
+
+    public async Task<PlayerDto> CreateLightPlayerAsync(int clubId, CreateLightPlayerRequest request, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var player = new Player
+        {
+            DisplayName = request.DisplayName.Trim(),
+            FirstName = NullIfEmpty(request.FirstName),
+            LastName = NullIfEmpty(request.LastName),
+            Email = NullIfEmpty(request.Email),
+            MobileNumber = NullIfEmpty(request.MobileNumber),
+            DateOfBirth = request.DateOfBirth,
+            Sex = (DropShot.Models.PlayerSex?)request.Sex,
+            IsLight = true,
+            CreatedByClubId = clubId,
+            CreatedByUserId = currentUser.UserId
+        };
+        db.Players.Add(player);
+        await db.SaveChangesAsync(ct);
+
+        db.ClubPlayers.Add(new ClubPlayer { ClubId = clubId, PlayerId = player.PlayerId });
+        await db.SaveChangesAsync(ct);
+
+        return ToDto(player);
+    }
+
+    public async Task<PlayerDto> UpdateLightPlayerAsync(int clubId, int playerId, UpdateLightPlayerRequest request, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var p = await db.Players.FindAsync([playerId], ct)
+            ?? throw new KeyNotFoundException($"Player {playerId} not found.");
+
+        if (!p.IsLight || p.CreatedByClubId != clubId)
+            throw new InvalidOperationException("Only light players owned by this club can be edited.");
+
+        p.DisplayName = request.DisplayName.Trim();
+        p.FirstName = NullIfEmpty(request.FirstName);
+        p.LastName = NullIfEmpty(request.LastName);
+        p.Email = NullIfEmpty(request.Email);
+        p.MobileNumber = NullIfEmpty(request.MobileNumber);
+        p.DateOfBirth = request.DateOfBirth;
+        p.Sex = (DropShot.Models.PlayerSex?)request.Sex;
+        await db.SaveChangesAsync(ct);
+        return ToDto(p);
+    }
+
+    public async Task RemovePlayerFromClubAsync(int clubId, int playerId, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var cp = await db.ClubPlayers.FindAsync([clubId, playerId], ct);
+        if (cp is null) return;
+
+        db.ClubPlayers.Remove(cp);
+
+        var player = await db.Players.FindAsync([playerId], ct);
+        if (player is { IsLight: true } && player.CreatedByClubId == clubId)
+        {
+            db.Players.Remove(player);
+        }
+
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task LinkExistingPlayerToClubAsync(int clubId, int playerId, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var exists = await db.ClubPlayers.AnyAsync(cp => cp.ClubId == clubId && cp.PlayerId == playerId, ct);
+        if (exists) return;
+        db.ClubPlayers.Add(new ClubPlayer { ClubId = clubId, PlayerId = playerId });
+        await db.SaveChangesAsync(ct);
+    }
+
     private static string? NullIfEmpty(string? s) =>
         string.IsNullOrWhiteSpace(s) ? null : s.Trim();
 


### PR DESCRIPTION
## Summary

Phase 4 batch B.3. Brings the per-club roster admin page to MAUI.

**Stacks on [#474](https://github.com/kingbeazer/DropShot/pull/474) (B.2 ViewCompetition)** which stacks on [#473](https://github.com/kingbeazer/DropShot/pull/473) → [#472](https://github.com/kingbeazer/DropShot/pull/472). Merge order: #472 → #473 → #474 → this.

**New service surface (IPlayerService)**

- \`GetClubPlayersAsync(clubId)\` — joined ClubPlayer + Player + linked-account image.
- \`SearchPlayersForClubLinkAsync(clubId, term)\` — autocomplete for "Add Existing", caps at 10.
- \`CreateLightPlayerAsync(clubId, request)\` — INSERT Player(IsLight=true, CreatedByClubId=clubId) + ClubPlayer link.
- \`UpdateLightPlayerAsync(clubId, playerId, request)\` — guards \`IsLight && CreatedByClubId == clubId\` server-side.
- \`RemovePlayerFromClubAsync(clubId, playerId)\` — cascades the Player delete when the player is light + club-owned (this was page-side logic before; moving it to the service layer means MAUI gets the same behaviour).
- \`LinkExistingPlayerToClubAsync(clubId, playerId)\` — INSERT ClubPlayer if not already linked.

**New API surface**

\`ClubPlayersController\` (new) under \`/api/clubs/{clubId}/players\`, all routes \`[Authorize(Roles = "ClubAdmin,Admin,SuperAdmin")]\` and additionally gated by \`ClubAuthorizationService.CanEditClubAsync\`. Six endpoints: \`GET\`, \`GET search\`, \`POST light\`, \`PUT light/{playerId}\`, \`POST {playerId}/link\`, \`DELETE {playerId}\`.

**New DTOs**

- \`ClubPlayerDto\` — display fields + \`IsLight\` + \`IsClubOwned\` (server resolves from \`CreatedByClubId == clubId\`).
- \`CreateLightPlayerRequest\` / \`UpdateLightPlayerRequest\`.

**Page move**

- Drops \`IDbContextFactory\` + \`AuthenticationStateProvider\` + \`IHttpContextAccessor\` injection.
- \`_activeClubId\` now reads \`ICurrentUser.ActiveClubId\` (the whole point of P0.1's \`ActiveClubResolver\` lift).
- Club name comes from \`IClubService.GetClubAsync(activeClubId)\`.
- All write paths funnel through the new \`IPlayerService\` methods.

MAUI NavMenu gains a "Club Players" link wrapped in \`AuthorizeView Roles="ClubAdmin,Admin,SuperAdmin"\` to match the page's role gate.

## Test plan

- [x] \`dotnet build DropShot.sln\` — 0 errors, 7 pre-existing warnings unchanged.
- [x] \`dotnet test DropShot.Tests\` — 28/28 pass.
- [ ] Web smoke: ClubAdmin loads \`/players/club\`, sees roster; create light player, edit, remove (cascade), add existing.
- [ ] Web smoke: SuperAdmin without an active club cookie → "no club selected" warning renders.
- [ ] MAUI Windows smoke: ClubAdmin who admins exactly one club sees roster end-to-end against the API.
- [ ] MAUI Windows smoke: ClubAdmin who admins multiple clubs sees the warning (active-club switcher is future work).
- [ ] iOS rebuild recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)