### PR TITLE
Phase 5: move Admin/SiteSettings into DropShot.UI

### DIFF
--- a/DropShot.Maui/Components/Pages/Admin/SiteSettings.razor
+++ b/DropShot.Maui/Components/Pages/Admin/SiteSettings.razor
@@ -1,8 +1,5 @@
 @page "/admin/site-settings"
-@rendermode InteractiveServer
 @attribute [Authorize(Roles = "Admin,SuperAdmin")]
 @using Microsoft.AspNetCore.Authorization
-
-<MudProviders />
 
 <DropShot.UI.Components.Pages.Admin.SiteSettings />

--- a/DropShot.Maui/Services/HttpSiteSettingsService.cs
+++ b/DropShot.Maui/Services/HttpSiteSettingsService.cs
@@ -1,11 +1,23 @@
+using System.Net.Http.Json;
+using DropShot.Shared.Dtos;
 using DropShot.UI.Services;
 
 namespace DropShot.Maui.Services;
 
 /// <summary>
-/// Phase 3 placeholder. Populated in phase 5 alongside the
-/// <c>GET/PUT /api/site-settings</c> endpoints.
+/// MAUI HTTP implementation of <see cref="ISiteSettingsService"/>. Hits the
+/// new <c>GET/PUT /api/site-settings</c> endpoints (phase 5).
 /// </summary>
-public sealed class HttpSiteSettingsService : ISiteSettingsService
+public sealed class HttpSiteSettingsService(HttpClient http) : ISiteSettingsService
 {
+    public async Task<SiteSettingsDto> GetSettingsAsync(CancellationToken ct = default) =>
+        await http.GetFromJsonAsync<SiteSettingsDto>("api/site-settings", ct)
+            ?? new SiteSettingsDto(SiteSettingsDto.ContentMaxWidthPxDefault);
+
+    public async Task SetContentMaxWidthPxAsync(int px, CancellationToken ct = default)
+    {
+        var resp = await http.PutAsJsonAsync(
+            "api/site-settings", new UpdateContentMaxWidthRequest(px), ct);
+        resp.EnsureSuccessStatusCode();
+    }
 }

--- a/DropShot.Shared/Dtos/SiteSettingsDtos.cs
+++ b/DropShot.Shared/Dtos/SiteSettingsDtos.cs
@@ -1,0 +1,14 @@
+namespace DropShot.Shared.Dtos;
+
+/// <summary>
+/// Admin-tunable, app-wide settings. Currently exposes only the body content
+/// max-width (top navbar + footer always span the full viewport).
+/// </summary>
+public record SiteSettingsDto(int ContentMaxWidthPx)
+{
+    public const int ContentMaxWidthPxDefault = 1280;
+    public const int ContentMaxWidthPxMin = 960;
+    public const int ContentMaxWidthPxMax = 2400;
+}
+
+public record UpdateContentMaxWidthRequest(int ContentMaxWidthPx);

--- a/DropShot.UI/Components/Pages/Admin/SiteSettings.razor
+++ b/DropShot.UI/Components/Pages/Admin/SiteSettings.razor
@@ -1,0 +1,68 @@
+@inject ISiteSettingsService Settings
+@inject ISnackbar Snackbar
+
+@* Routing + auth + MudProviders supplied by host shims. *@
+
+<MudText Typo="Typo.h4" Class="mb-4">Site Settings</MudText>
+
+<MudCard Class="mb-4" Style="max-width:600px">
+    <MudCardHeader>
+        <CardHeaderContent>
+            <MudText Typo="Typo.h6">Layout</MudText>
+            <MudText Typo="Typo.caption" Color="Color.Secondary">
+                Controls the maximum width (in pixels) that page content occupies on desktop.
+                The top navbar and footer always span the full viewport; only the body is constrained.
+            </MudText>
+        </CardHeaderContent>
+    </MudCardHeader>
+    <MudCardContent>
+        <MudNumericField T="int"
+                         @bind-Value="_contentMaxWidthPx"
+                         Label="Content max width (px)"
+                         Min="@SiteSettingsDto.ContentMaxWidthPxMin"
+                         Max="@SiteSettingsDto.ContentMaxWidthPxMax"
+                         Step="40"
+                         Variant="Variant.Outlined"
+                         HelperText="@($"Allowed range: {SiteSettingsDto.ContentMaxWidthPxMin} – {SiteSettingsDto.ContentMaxWidthPxMax} px. Default {SiteSettingsDto.ContentMaxWidthPxDefault}.")" />
+    </MudCardContent>
+    <MudCardActions>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                   StartIcon="@Icons.Material.Filled.Save"
+                   Disabled="@_saving"
+                   OnClick="SaveAsync">
+            Save
+        </MudButton>
+        <MudText Typo="Typo.caption" Color="Color.Secondary" Class="ms-3 align-self-center">
+            Refresh other tabs to see the change.
+        </MudText>
+    </MudCardActions>
+</MudCard>
+
+@code {
+    private int _contentMaxWidthPx = SiteSettingsDto.ContentMaxWidthPxDefault;
+    private bool _saving;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var dto = await Settings.GetSettingsAsync();
+        _contentMaxWidthPx = dto.ContentMaxWidthPx;
+    }
+
+    private async Task SaveAsync()
+    {
+        _saving = true;
+        try
+        {
+            await Settings.SetContentMaxWidthPxAsync(_contentMaxWidthPx);
+            Snackbar.Add($"Content max width set to {_contentMaxWidthPx}px.", Severity.Success);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+        finally
+        {
+            _saving = false;
+        }
+    }
+}

--- a/DropShot.UI/Services/ISiteSettingsService.cs
+++ b/DropShot.UI/Services/ISiteSettingsService.cs
@@ -1,10 +1,12 @@
+using DropShot.Shared.Dtos;
+
 namespace DropShot.UI.Services;
 
 /// <summary>
-/// Site-settings domain abstraction. Marker interface at phase 3 — populated in
-/// phase 5 when Admin/SiteSettings moves into <c>DropShot.UI</c>. New endpoints
-/// (<c>GET/PUT /api/site-settings</c>) land alongside the page move.
+/// Admin-tunable site settings. Backs the Admin/SiteSettings page (phase 5).
 /// </summary>
 public interface ISiteSettingsService
 {
+    Task<SiteSettingsDto> GetSettingsAsync(CancellationToken ct = default);
+    Task SetContentMaxWidthPxAsync(int px, CancellationToken ct = default);
 }

--- a/DropShot/Controllers/SiteSettingsController.cs
+++ b/DropShot/Controllers/SiteSettingsController.cs
@@ -1,0 +1,40 @@
+using DropShot.Shared.Dtos;
+using DropShot.UI.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DropShot.Controllers;
+
+/// <summary>
+/// Site-wide settings tunable by Admin / SuperAdmin. Backs Admin/SiteSettings
+/// (phase 5). Reads are <see cref="AllowAnonymous"/> because the only setting
+/// today (content max width) drives the host layout for every visitor.
+/// </summary>
+[ApiController]
+[Route("api/site-settings")]
+[Authorize(AuthenticationSchemes = "Bearer")]
+public class SiteSettingsController(ISiteSettingsService settings) : ControllerBase
+{
+    [HttpGet]
+    [AllowAnonymous]
+    public async Task<ActionResult<SiteSettingsDto>> Get(CancellationToken ct)
+    {
+        return await settings.GetSettingsAsync(ct);
+    }
+
+    [HttpPut]
+    [Authorize(Roles = "Admin,SuperAdmin")]
+    public async Task<IActionResult> Update(
+        [FromBody] UpdateContentMaxWidthRequest req, CancellationToken ct)
+    {
+        try
+        {
+            await settings.SetContentMaxWidthPxAsync(req.ContentMaxWidthPx, ct);
+            return NoContent();
+        }
+        catch (ArgumentOutOfRangeException ex)
+        {
+            return BadRequest(new { message = ex.Message });
+        }
+    }
+}

--- a/DropShot/Services/WebSiteSettingsService.cs
+++ b/DropShot/Services/WebSiteSettingsService.cs
@@ -1,11 +1,18 @@
+using DropShot.Shared.Dtos;
 using DropShot.UI.Services;
 
 namespace DropShot.Services;
 
 /// <summary>
-/// Phase 3 placeholder. Populated in phase 5 when Admin/SiteSettings moves into
-/// <c>DropShot.UI</c>; will wrap the existing <c>SiteSettingsService</c>.
+/// Web implementation of <see cref="ISiteSettingsService"/>. Thin adapter over
+/// the existing in-process <see cref="SiteSettingsService"/> (which holds the
+/// AppSettings cache + EF read/write).
 /// </summary>
-public sealed class WebSiteSettingsService : ISiteSettingsService
+public sealed class WebSiteSettingsService(SiteSettingsService inner) : ISiteSettingsService
 {
+    public async Task<SiteSettingsDto> GetSettingsAsync(CancellationToken ct = default) =>
+        new(await inner.GetContentMaxWidthPxAsync(ct));
+
+    public Task SetContentMaxWidthPxAsync(int px, CancellationToken ct = default) =>
+        inner.SetContentMaxWidthPxAsync(px, ct);
 }


### PR DESCRIPTION
## Summary

Phase 5 first PR — kicks off admin / write-heavy migrations after batch B (#472–#477) shipped phase 4.

Smallest available phase-5 page: a single MudNumericField for the body content max-width.

- \`ISiteSettingsService\` (phase-3 marker stub) fleshed out with \`GetSettingsAsync\` + \`SetContentMaxWidthPxAsync\`.
- \`WebSiteSettingsService\` wraps the existing in-process \`SiteSettingsService\` (which holds the AppSettings cache).
- \`HttpSiteSettingsService\` hits the new \`GET /api/site-settings\` (\`AllowAnonymous\` — drives layout for every visitor) and \`PUT /api/site-settings\` (Admin/SuperAdmin).
- \`SiteSettingsDto\` carries the layout constants (\`ContentMaxWidthPxMin/Max/Default\`) so both hosts render identically without referencing the web-only static fields on \`SiteSettingsService\`.
- Page moves to \`DropShot.UI/Components/Pages/Admin/\` plus matching MAUI shim under \`/admin/site-settings\`.

## Test plan

- [x] \`dotnet build DropShot.sln\` — 0 errors, 6 warnings (one fewer than pre-change).
- [x] \`dotnet test DropShot.Tests\` — 28/28 pass.
- [ ] Web smoke: \`/admin/site-settings\` saves a width change; reload confirms persistence.
- [ ] MAUI Windows smoke: same flow against \`PUT /api/site-settings\` (admin user).

🤖 Generated with [Claude Code](https://claude.com/claude-code)