### PR TITLE
Phase 5: move MyPlayers.razor + add /api/players/mine + invitation endpoints

### DIFF
--- a/DropShot.Maui/Components/Pages/MyPlayers.razor
+++ b/DropShot.Maui/Components/Pages/MyPlayers.razor
@@ -1,8 +1,5 @@
 @page "/players/mine"
-@rendermode InteractiveServer
 @attribute [Authorize]
 @using Microsoft.AspNetCore.Authorization
-
-<MudProviders />
 
 <DropShot.UI.Components.Pages.MyPlayers />

--- a/DropShot.Maui/Services/HttpInvitationService.cs
+++ b/DropShot.Maui/Services/HttpInvitationService.cs
@@ -1,11 +1,30 @@
+using System.Net.Http.Json;
+using DropShot.Shared.Dtos;
 using DropShot.UI.Services;
 
 namespace DropShot.Maui.Services;
 
 /// <summary>
-/// Phase 3 placeholder. Populated in phases 4–5 alongside Invite, MobileAuth,
-/// VerifyResult, and the <c>/api/invitations</c> endpoint family.
+/// MAUI HTTP implementation of <see cref="IInvitationService"/>. Phase 5 —
+/// light-player invite flow. Server builds the fully-qualified URL using
+/// <c>App:BaseUrl</c>, so MAUI just renders what the API returns.
 /// </summary>
-public sealed class HttpInvitationService : IInvitationService
+public sealed class HttpInvitationService(HttpClient http) : IInvitationService
 {
+    public async Task<LightPlayerInvitationDto> CreateOrReuseLightPlayerInvitationAsync(
+        int lightPlayerId, CancellationToken ct = default)
+    {
+        var resp = await http.PostAsync(
+            $"api/invitations/light-player/{lightPlayerId}", null, ct);
+        resp.EnsureSuccessStatusCode();
+        return (await resp.Content.ReadFromJsonAsync<LightPlayerInvitationDto>(cancellationToken: ct))!;
+    }
+
+    public async Task SendInvitationEmailAsync(Guid token, string email, CancellationToken ct = default)
+    {
+        var resp = await http.PostAsJsonAsync(
+            $"api/invitations/{token}/send-email",
+            new SendInvitationEmailRequest(email), ct);
+        resp.EnsureSuccessStatusCode();
+    }
 }

--- a/DropShot.Maui/Services/HttpPlayerService.cs
+++ b/DropShot.Maui/Services/HttpPlayerService.cs
@@ -75,4 +75,38 @@ public sealed class HttpPlayerService(HttpClient http) : IPlayerService
         var resp = await http.PostAsync($"api/clubs/{clubId}/players/{playerId}/link", null, ct);
         resp.EnsureSuccessStatusCode();
     }
+
+    public async Task<List<MyPlayerRowDto>> GetMyPlayersAsync(CancellationToken ct = default) =>
+        await http.GetFromJsonAsync<List<MyPlayerRowDto>>("api/players/mine", ct) ?? [];
+
+    public async Task<PlayerDto> CreateMyLightPlayerAsync(CreateMyLightPlayerRequest request, CancellationToken ct = default)
+    {
+        var resp = await http.PostAsJsonAsync("api/players/mine", request, ct);
+        resp.EnsureSuccessStatusCode();
+        return (await resp.Content.ReadFromJsonAsync<PlayerDto>(cancellationToken: ct))!;
+    }
+
+    public async Task<PlayerDto> UpdateMyLightPlayerAsync(int playerId, UpdateMyLightPlayerRequest request, CancellationToken ct = default)
+    {
+        var resp = await http.PutAsJsonAsync($"api/players/mine/{playerId}", request, ct);
+        resp.EnsureSuccessStatusCode();
+        return (await resp.Content.ReadFromJsonAsync<PlayerDto>(cancellationToken: ct))!;
+    }
+
+    public async Task DeleteMyLightPlayerAsync(int playerId, CancellationToken ct = default)
+    {
+        var resp = await http.DeleteAsync($"api/players/mine/{playerId}", ct);
+        resp.EnsureSuccessStatusCode();
+    }
+
+    public async Task LinkLightToVerifiedAsync(int lightPlayerId, int verifiedPlayerId, CancellationToken ct = default)
+    {
+        var resp = await http.PostAsync(
+            $"api/players/mine/{lightPlayerId}/link-to/{verifiedPlayerId}", null, ct);
+        resp.EnsureSuccessStatusCode();
+    }
+
+    public async Task<List<SimilarPlayerDto>> SearchSimilarVerifiedPlayersAsync(string term, int max, CancellationToken ct = default) =>
+        await http.GetFromJsonAsync<List<SimilarPlayerDto>>(
+            $"api/players/search-similar?term={Uri.EscapeDataString(term)}&max={max}", ct) ?? [];
 }

--- a/DropShot.Shared/Dtos/PlayerDtos.cs
+++ b/DropShot.Shared/Dtos/PlayerDtos.cs
@@ -73,6 +73,61 @@ public record UpdateLightPlayerRequest(
     PlayerSex? Sex);
 
 /// <summary>
+/// Row in the My Players grid. Combines light players owned by the current
+/// user and verified players the user has bookmarked. <c>HasMatchHistory</c>
+/// is computed server-side so the page can hide the delete button on light
+/// players whose matches need migrating first.
+/// </summary>
+public record MyPlayerRowDto(
+    int PlayerId,
+    string DisplayName,
+    string? FirstName,
+    string? LastName,
+    bool IsLight,
+    string? Email,
+    string? MobileNumber,
+    PlayerSex? Sex,
+    string? ProfileImagePath,
+    bool HasMatchHistory);
+
+public record CreateMyLightPlayerRequest(
+    string DisplayName,
+    string? FirstName,
+    string? LastName,
+    string? Email,
+    string? MobileNumber,
+    PlayerSex? Sex);
+
+public record UpdateMyLightPlayerRequest(
+    string DisplayName,
+    string? FirstName,
+    string? LastName,
+    string? Email,
+    string? MobileNumber,
+    PlayerSex? Sex);
+
+/// <summary>
+/// Suggested "similar" verified player surfaced while typing a display name.
+/// Web ranks via <c>FuzzySearchService</c>; MAUI hits the same endpoint.
+/// </summary>
+public record SimilarPlayerDto(
+    int PlayerId,
+    string DisplayName,
+    string? FirstName,
+    string? LastName);
+
+/// <summary>
+/// Light-player invitation handle returned by
+/// <c>IInvitationService.CreateOrReuseLightPlayerInvitationAsync</c>.
+/// The full URL is built server-side so MAUI doesn't need to know the host.
+/// </summary>
+public record LightPlayerInvitationDto(
+    Guid Token,
+    string InviteUrl);
+
+public record SendInvitationEmailRequest(string Email);
+
+/// <summary>
 /// Row in the SuperAdmin Players grid. Joins each player with the linked
 /// ASP.NET account user-name (when present) and the names of the clubs they
 /// belong to.

--- a/DropShot.UI/Components/Pages/MyPlayers.razor
+++ b/DropShot.UI/Components/Pages/MyPlayers.razor
@@ -1,0 +1,546 @@
+@inject IPlayerService PlayerService
+@inject IInvitationService InvitationService
+@inject ICurrentUser CurrentUser
+@inject ISnackbar Snackbar
+@inject IDialogService DialogService
+@inject IJSRuntime JS
+
+@* Routing + auth + MudProviders supplied by host shims. Fuzzy-ranked
+   suggestions previously used the JS-backed FuzzySearchService; the cross-host
+   port substitutes a server-side LIKE search via ICurrentUser →
+   IPlayerService.SearchSimilarVerifiedPlayersAsync. Fuzzy ranking can return
+   in a later phase as a server-side port. *@
+
+<MudText Typo="Typo.h4" Class="mb-4">My Players</MudText>
+
+<MudButton Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Filled.PersonAdd"
+           OnClick="OpenCreateDialog" Class="mb-4">
+    Add Player
+</MudButton>
+
+<MudTextField @bind-Value="_searchText" Placeholder="Search my players..."
+              Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search"
+              Immediate="true" Class="mb-4" />
+
+<MudTable Items="@_players" Hover="true" Breakpoint="Breakpoint.Sm" Loading="@_loading"
+          Filter="@(row => FilterPlayers(row))">
+    <HeaderContent>
+        <MudTh>Player</MudTh>
+        <MudTh>First Name</MudTh>
+        <MudTh>Last Name</MudTh>
+        <MudTh>Actions</MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd DataLabel="Player">
+            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                @if (!context.IsLight)
+                {
+                    @if (!string.IsNullOrEmpty(context.ProfileImagePath))
+                    {
+                        <MudAvatar Size="Size.Small" Style="width:24px; height:24px;">
+                            <MudImage Src="@context.ProfileImagePath" />
+                        </MudAvatar>
+                    }
+                    else
+                    {
+                        <MudAvatar Size="Size.Small" Style="width:24px; height:24px; background: var(--mud-palette-primary);">
+                            <MudIcon Icon="@Icons.Material.Filled.Face" Size="Size.Small" Style="font-size:16px;" />
+                        </MudAvatar>
+                    }
+                }
+                else
+                {
+                    <MudIcon Icon="@Icons.Material.Filled.PersonOutline" Color="Color.Default" Size="Size.Small" />
+                }
+                <MudText>@context.DisplayName</MudText>
+            </MudStack>
+        </MudTd>
+        <MudTd DataLabel="First Name">@(context.FirstName ?? "—")</MudTd>
+        <MudTd DataLabel="Last Name">@(context.LastName ?? "—")</MudTd>
+        <MudTd DataLabel="Actions">
+            @if (context.IsLight)
+            {
+                <MudTooltip Text="Edit">
+                    <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="Size.Small"
+                                   OnClick="@(() => OpenEditDialog(context))" />
+                </MudTooltip>
+                <MudTooltip Text="Invite to join">
+                    <MudIconButton Icon="@Icons.Material.Filled.PersonAddAlt1" Size="Size.Small" Color="Color.Info"
+                                   OnClick="@(() => OpenInviteDialog(context))" />
+                </MudTooltip>
+                @if (context.HasMatchHistory)
+                {
+                    <MudTooltip Text="Has match history — link to a verified player to transfer records">
+                        <MudIconButton Icon="@Icons.Material.Filled.Link" Size="Size.Small" Color="Color.Warning"
+                                       OnClick="@(() => OpenLinkDialog(context))" />
+                    </MudTooltip>
+                }
+                else
+                {
+                    <MudTooltip Text="Delete">
+                        <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small" Color="Color.Error"
+                                       OnClick="@(() => DeleteLightPlayer(context))" />
+                    </MudTooltip>
+                }
+            }
+        </MudTd>
+    </RowTemplate>
+    <NoRecordsContent>
+        <MudText>No players yet. Add a player to get started.</MudText>
+    </NoRecordsContent>
+</MudTable>
+
+<MudDialog @bind-Visible="_showPlayerDialog">
+    <TitleContent>@(_editingPlayerId.HasValue ? "Edit Player" : "Add Player")</TitleContent>
+    <DialogContent>
+        <MudGrid Spacing="2">
+            <MudItem xs="12">
+                <MudTextField @bind-Value="_form.DisplayName" Label="Display Name" Variant="Variant.Outlined"
+                              Required="true" Immediate="true" TextChanged="OnDisplayNameChanged" />
+            </MudItem>
+            <MudItem xs="6">
+                <MudTextField @bind-Value="_form.FirstName" Label="First Name" Variant="Variant.Outlined"
+                              Immediate="true" />
+            </MudItem>
+            <MudItem xs="6">
+                <MudTextField @bind-Value="_form.LastName" Label="Last Name" Variant="Variant.Outlined"
+                              Immediate="true" />
+            </MudItem>
+            <MudItem xs="12">
+                <MudTextField @bind-Value="_form.Email" Label="Email address" Variant="Variant.Outlined"
+                              InputType="InputType.Email" />
+            </MudItem>
+            <MudItem xs="12">
+                <MudTextField @bind-Value="_form.MobileNumber" Label="Mobile number" Variant="Variant.Outlined"
+                              InputType="InputType.Telephone" />
+            </MudItem>
+            <MudItem xs="12">
+                <MudText Typo="Typo.body2" Class="mb-1">Competition category</MudText>
+                <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mb-2">Determines which events they're eligible to enter</MudText>
+                <MudRadioGroup T="PlayerSex?" @bind-Value="_form.CompetitionCategory">
+                    <MudRadio T="PlayerSex?" Value="@PlayerSex.Male" Color="Color.Primary">Male events</MudRadio>
+                    <MudRadio T="PlayerSex?" Value="@PlayerSex.Female" Color="Color.Primary">Female events</MudRadio>
+                </MudRadioGroup>
+            </MudItem>
+        </MudGrid>
+
+        @if (_suggestions.Count > 0)
+        {
+            <MudText Typo="Typo.subtitle2" Class="mt-3 mb-1">Similar verified players:</MudText>
+            <MudList T="SimilarPlayerDto" Dense="true">
+                @foreach (var s in _suggestions)
+                {
+                    <MudListItem T="SimilarPlayerDto">
+                        <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
+                            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                                <MudIcon Icon="@Icons.Material.Filled.Verified" Color="Color.Success" Size="Size.Small" />
+                                <MudText>@s.DisplayName</MudText>
+                                @if (!string.IsNullOrEmpty(s.FirstName) || !string.IsNullOrEmpty(s.LastName))
+                                {
+                                    <MudText Typo="Typo.caption" Color="Color.Secondary">
+                                        (@(string.Join(" ", new[] { s.FirstName, s.LastName }.Where(x => !string.IsNullOrEmpty(x)))))
+                                    </MudText>
+                                }
+                            </MudStack>
+                            @if (_editingPlayerId.HasValue)
+                            {
+                                <MudButton Size="Size.Small" Variant="Variant.Text" Color="Color.Info"
+                                           OnClick="@(() => LinkToVerified(s))">
+                                    Link
+                                </MudButton>
+                            }
+                        </MudStack>
+                    </MudListItem>
+                }
+            </MudList>
+        }
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@(() => _showPlayerDialog = false)">Cancel</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                   Disabled="@string.IsNullOrWhiteSpace(_form.DisplayName)"
+                   OnClick="SaveLightPlayer">
+            @(_editingPlayerId.HasValue ? "Save" : "Add")
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
+<MudDialog @bind-Visible="_showLinkDialog">
+    <TitleContent>Link "@_linkingPlayer?.DisplayName" to a Verified Player</TitleContent>
+    <DialogContent>
+        <MudText Typo="Typo.body2" Class="mb-3">
+            Linking will transfer match history to the verified player and remove the light player record.
+        </MudText>
+
+        <MudTextField @bind-Value="_linkSearch" Label="Search verified players" Variant="Variant.Outlined"
+                      Immediate="true" TextChanged="OnLinkSearchChanged"
+                      Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search" Class="mb-2" />
+
+        @if (_linkSuggestions.Count > 0)
+        {
+            <MudList T="SimilarPlayerDto" Dense="true">
+                @foreach (var s in _linkSuggestions)
+                {
+                    <MudListItem T="SimilarPlayerDto" OnClick="@(() => _selectedLinkPlayer = s)"
+                                 Class="@(_selectedLinkPlayer?.PlayerId == s.PlayerId ? "mud-selected-item" : "")">
+                        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                            <MudIcon Icon="@Icons.Material.Filled.Verified" Color="Color.Success" Size="Size.Small" />
+                            <MudText>@s.DisplayName</MudText>
+                            @if (!string.IsNullOrEmpty(s.FirstName) || !string.IsNullOrEmpty(s.LastName))
+                            {
+                                <MudText Typo="Typo.caption" Color="Color.Secondary">
+                                    (@(string.Join(" ", new[] { s.FirstName, s.LastName }.Where(x => !string.IsNullOrEmpty(x)))))
+                                </MudText>
+                            }
+                        </MudStack>
+                    </MudListItem>
+                }
+            </MudList>
+        }
+        else if (!string.IsNullOrWhiteSpace(_linkSearch))
+        {
+            <MudText Typo="Typo.caption" Color="Color.Secondary">No matching verified players found.</MudText>
+        }
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@(() => _showLinkDialog = false)">Cancel</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Info"
+                   Disabled="@(_selectedLinkPlayer == null)"
+                   OnClick="ConfirmLink">Link</MudButton>
+    </DialogActions>
+</MudDialog>
+
+<MudDialog @bind-Visible="_showInviteDialog">
+    <TitleContent>Invite "@_invitingPlayer?.DisplayName" to join</TitleContent>
+    <DialogContent>
+        <MudText Typo="Typo.body2" Class="mb-3">
+            Send an invite link. When they register, their new account will be linked to this player
+            and any existing match history will be transferred.
+        </MudText>
+
+        @if (!string.IsNullOrEmpty(_inviteLink))
+        {
+            <MudTextField Value="@_inviteLink" Label="Invite link" Variant="Variant.Outlined"
+                          ReadOnly="true" Class="mb-3" />
+
+            <MudStack Row="true" Spacing="2" Class="mb-4">
+                <MudButton Variant="Variant.Outlined" Color="Color.Primary"
+                           StartIcon="@Icons.Material.Filled.ContentCopy"
+                           OnClick="CopyInviteLink">Copy link</MudButton>
+            </MudStack>
+
+            <MudDivider Class="mb-3" />
+
+            <MudText Typo="Typo.subtitle2" Class="mb-2">Or email the link</MudText>
+            <MudTextField @bind-Value="_inviteEmail" Label="Recipient email" Variant="Variant.Outlined"
+                          InputType="InputType.Email" Immediate="true" Class="mb-2" />
+        }
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@(() => _showInviteDialog = false)">Close</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                   StartIcon="@Icons.Material.Filled.Email"
+                   Disabled="@(_sendingInvite || string.IsNullOrWhiteSpace(_inviteEmail))"
+                   OnClick="SendInviteEmail">
+            @(_sendingInvite ? "Sending…" : "Send email")
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    private bool _loading = true;
+    private List<MyPlayerRowDto> _players = [];
+    private string _searchText = "";
+
+    private bool _showPlayerDialog;
+    private int? _editingPlayerId;
+    private LightPlayerForm _form = new();
+    private bool _firstNamePreFilled;
+    private bool _lastNamePreFilled;
+    private List<SimilarPlayerDto> _suggestions = [];
+    private CancellationTokenSource? _debounce;
+
+    private bool _showLinkDialog;
+    private MyPlayerRowDto? _linkingPlayer;
+    private string _linkSearch = "";
+    private List<SimilarPlayerDto> _linkSuggestions = [];
+    private SimilarPlayerDto? _selectedLinkPlayer;
+    private CancellationTokenSource? _linkDebounce;
+
+    private bool _showInviteDialog;
+    private MyPlayerRowDto? _invitingPlayer;
+    private string _inviteLink = "";
+    private Guid _inviteToken;
+    private string _inviteEmail = "";
+    private bool _sendingInvite;
+
+    private sealed class LightPlayerForm
+    {
+        public string DisplayName { get; set; } = "";
+        public string? FirstName { get; set; }
+        public string? LastName { get; set; }
+        public string? Email { get; set; }
+        public string? MobileNumber { get; set; }
+        public PlayerSex? CompetitionCategory { get; set; }
+    }
+
+    private bool FilterPlayers(MyPlayerRowDto row) =>
+        string.IsNullOrWhiteSpace(_searchText) ||
+        row.DisplayName.Contains(_searchText, StringComparison.OrdinalIgnoreCase) ||
+        (row.FirstName ?? "").Contains(_searchText, StringComparison.OrdinalIgnoreCase) ||
+        (row.LastName ?? "").Contains(_searchText, StringComparison.OrdinalIgnoreCase);
+
+    protected override async Task OnInitializedAsync() => await LoadPlayers();
+
+    private async Task LoadPlayers()
+    {
+        _loading = true;
+        _players = await PlayerService.GetMyPlayersAsync();
+        _loading = false;
+    }
+
+    private void OpenCreateDialog()
+    {
+        _editingPlayerId = null;
+        _form = new LightPlayerForm();
+        _firstNamePreFilled = false;
+        _lastNamePreFilled = false;
+        _suggestions = [];
+        _showPlayerDialog = true;
+    }
+
+    private void OpenEditDialog(MyPlayerRowDto player)
+    {
+        _editingPlayerId = player.PlayerId;
+        _form = new LightPlayerForm
+        {
+            DisplayName = player.DisplayName,
+            FirstName = player.FirstName,
+            LastName = player.LastName,
+            Email = player.Email,
+            MobileNumber = player.MobileNumber,
+            CompetitionCategory = player.Sex
+        };
+        _firstNamePreFilled = !string.IsNullOrEmpty(player.FirstName);
+        _lastNamePreFilled = !string.IsNullOrEmpty(player.LastName);
+        _suggestions = [];
+        _showPlayerDialog = true;
+    }
+
+    private async Task OnDisplayNameChanged(string value)
+    {
+        _form.DisplayName = value;
+        AutoFillNames(value);
+
+        _debounce?.Cancel();
+        _debounce = new CancellationTokenSource();
+        try
+        {
+            await Task.Delay(300, _debounce.Token);
+            _suggestions = string.IsNullOrWhiteSpace(value)
+                ? []
+                : await PlayerService.SearchSimilarVerifiedPlayersAsync(value, 5);
+            StateHasChanged();
+        }
+        catch (TaskCanceledException) { }
+    }
+
+    private void AutoFillNames(string displayName)
+    {
+        if (string.IsNullOrWhiteSpace(displayName)) return;
+
+        var words = displayName.Trim().Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (words.Length >= 1 && !_firstNamePreFilled)
+            _form.FirstName = words[0];
+        if (words.Length >= 2 && !_lastNamePreFilled)
+            _form.LastName = string.Join(" ", words.Skip(1));
+    }
+
+    private async Task SaveLightPlayer()
+    {
+        if (string.IsNullOrWhiteSpace(_form.DisplayName)) return;
+
+        try
+        {
+            if (_editingPlayerId.HasValue)
+            {
+                await PlayerService.UpdateMyLightPlayerAsync(_editingPlayerId.Value,
+                    new UpdateMyLightPlayerRequest(
+                        _form.DisplayName.Trim(), _form.FirstName, _form.LastName,
+                        _form.Email, _form.MobileNumber, _form.CompetitionCategory));
+                Snackbar.Add("Player updated.", Severity.Success);
+            }
+            else
+            {
+                await PlayerService.CreateMyLightPlayerAsync(
+                    new CreateMyLightPlayerRequest(
+                        _form.DisplayName.Trim(), _form.FirstName, _form.LastName,
+                        _form.Email, _form.MobileNumber, _form.CompetitionCategory));
+                Snackbar.Add("Player added.", Severity.Success);
+            }
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+            return;
+        }
+
+        _showPlayerDialog = false;
+        await LoadPlayers();
+    }
+
+    private async Task DeleteLightPlayer(MyPlayerRowDto player)
+    {
+        var confirmed = await DialogService.ShowMessageBoxAsync(
+            "Delete Player?",
+            $"Are you sure you want to delete \"{player.DisplayName}\"? This cannot be undone.",
+            yesText: "Delete", cancelText: "Cancel");
+
+        if (confirmed != true) return;
+
+        try
+        {
+            await PlayerService.DeleteMyLightPlayerAsync(player.PlayerId);
+            Snackbar.Add("Player deleted.", Severity.Warning);
+            await LoadPlayers();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Warning);
+        }
+    }
+
+    private async Task OpenLinkDialog(MyPlayerRowDto player)
+    {
+        _linkingPlayer = player;
+        _linkSearch = player.DisplayName;
+        _selectedLinkPlayer = null;
+        _showLinkDialog = true;
+        _linkSuggestions = await PlayerService.SearchSimilarVerifiedPlayersAsync(player.DisplayName, 10);
+        StateHasChanged();
+    }
+
+    private async Task OnLinkSearchChanged(string value)
+    {
+        _linkSearch = value;
+        _selectedLinkPlayer = null;
+
+        _linkDebounce?.Cancel();
+        _linkDebounce = new CancellationTokenSource();
+        try
+        {
+            await Task.Delay(300, _linkDebounce.Token);
+            _linkSuggestions = string.IsNullOrWhiteSpace(value)
+                ? []
+                : await PlayerService.SearchSimilarVerifiedPlayersAsync(value, 10);
+            StateHasChanged();
+        }
+        catch (TaskCanceledException) { }
+    }
+
+    private async Task ConfirmLink()
+    {
+        if (_linkingPlayer == null || _selectedLinkPlayer == null) return;
+
+        var confirmed = await DialogService.ShowMessageBoxAsync(
+            "Link Player?",
+            $"Match history for \"{_linkingPlayer.DisplayName}\" will be transferred to \"{_selectedLinkPlayer.DisplayName}\" (verified).",
+            yesText: "Link", cancelText: "Cancel");
+
+        if (confirmed != true) return;
+
+        try
+        {
+            await PlayerService.LinkLightToVerifiedAsync(_linkingPlayer.PlayerId, _selectedLinkPlayer.PlayerId);
+            Snackbar.Add($"Linked to \"{_selectedLinkPlayer.DisplayName}\". Match history transferred.", Severity.Success);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+            return;
+        }
+
+        _showLinkDialog = false;
+        await LoadPlayers();
+    }
+
+    private async Task LinkToVerified(SimilarPlayerDto verified)
+    {
+        if (_editingPlayerId == null) return;
+
+        var confirmed = await DialogService.ShowMessageBoxAsync(
+            "Link Player?",
+            $"Match history will be transferred to \"{verified.DisplayName}\" (verified).",
+            yesText: "Link", cancelText: "Cancel");
+
+        if (confirmed != true) return;
+
+        try
+        {
+            await PlayerService.LinkLightToVerifiedAsync(_editingPlayerId.Value, verified.PlayerId);
+            Snackbar.Add($"Linked to \"{verified.DisplayName}\". Match history transferred.", Severity.Success);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+            return;
+        }
+
+        _showPlayerDialog = false;
+        await LoadPlayers();
+    }
+
+    private async Task OpenInviteDialog(MyPlayerRowDto player)
+    {
+        _invitingPlayer = player;
+        _inviteEmail = player.Email ?? "";
+        _sendingInvite = false;
+
+        try
+        {
+            var dto = await InvitationService.CreateOrReuseLightPlayerInvitationAsync(player.PlayerId);
+            _inviteToken = dto.Token;
+            _inviteLink = dto.InviteUrl;
+            _showInviteDialog = true;
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+    }
+
+    private async Task CopyInviteLink()
+    {
+        if (string.IsNullOrEmpty(_inviteLink)) return;
+        try
+        {
+            await JS.InvokeVoidAsync("navigator.clipboard.writeText", _inviteLink);
+            Snackbar.Add("Invite link copied to clipboard.", Severity.Success);
+        }
+        catch
+        {
+            Snackbar.Add("Couldn't copy automatically — please copy the link manually.", Severity.Warning);
+        }
+    }
+
+    private async Task SendInviteEmail()
+    {
+        if (_invitingPlayer is null || string.IsNullOrWhiteSpace(_inviteEmail)) return;
+
+        _sendingInvite = true;
+        try
+        {
+            await InvitationService.SendInvitationEmailAsync(_inviteToken, _inviteEmail.Trim());
+            Snackbar.Add($"Invite sent to {_inviteEmail.Trim()}.", Severity.Success);
+            _showInviteDialog = false;
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Failed to send email: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _sendingInvite = false;
+        }
+    }
+}

--- a/DropShot.UI/Services/IInvitationService.cs
+++ b/DropShot.UI/Services/IInvitationService.cs
@@ -1,11 +1,20 @@
+using DropShot.Shared.Dtos;
+
 namespace DropShot.UI.Services;
 
 /// <summary>
-/// Invitation domain abstraction. Marker interface at phase 3 — populated in
-/// phases 4–5 alongside Invite, MobileAuth, and VerifyResult. Required
-/// endpoints (<c>POST /api/players/{id}/link-request</c>, the
-/// <c>/api/invitations</c> family) land per the API gap log.
+/// Invitation domain abstraction. Phase 5 light-player surface; Invite +
+/// MobileAuth + VerifyResult flows extend this in later phases.
 /// </summary>
 public interface IInvitationService
 {
+    /// <summary>
+    /// Reuse the most recent unaccepted invitation for the given light player
+    /// (created by the current user) or create a new one. Returns the token
+    /// and a fully-qualified invite URL the host can render in a copy field.
+    /// </summary>
+    Task<LightPlayerInvitationDto> CreateOrReuseLightPlayerInvitationAsync(int lightPlayerId, CancellationToken ct = default);
+
+    /// <summary>Send the invitation email server-side using the invitation token.</summary>
+    Task SendInvitationEmailAsync(Guid token, string email, CancellationToken ct = default);
 }

--- a/DropShot.UI/Services/IPlayerService.cs
+++ b/DropShot.UI/Services/IPlayerService.cs
@@ -49,4 +49,30 @@ public interface IPlayerService
 
     /// <summary>Add an existing (non-light) player to the club's roster.</summary>
     Task LinkExistingPlayerToClubAsync(int clubId, int playerId, CancellationToken ct = default);
+
+    // ── My Players (phase 5 — user-owned light players + bookmarked verified) ──
+
+    /// <summary>Light players the current user created plus verified players they've bookmarked.</summary>
+    Task<List<MyPlayerRowDto>> GetMyPlayersAsync(CancellationToken ct = default);
+
+    Task<PlayerDto> CreateMyLightPlayerAsync(CreateMyLightPlayerRequest request, CancellationToken ct = default);
+
+    /// <summary>Update a light player owned by the current user. Throws if not owned.</summary>
+    Task<PlayerDto> UpdateMyLightPlayerAsync(int playerId, UpdateMyLightPlayerRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Delete a light player owned by the current user. Throws if the player has
+    /// match history (callers should use <c>LinkLightToVerifiedAsync</c> first).
+    /// </summary>
+    Task DeleteMyLightPlayerAsync(int playerId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Migrate match history from a user-owned light player to a verified player,
+    /// delete the light record, and bookmark the verified player. The whole
+    /// operation runs server-side so MAUI gets the same atomic semantics.
+    /// </summary>
+    Task LinkLightToVerifiedAsync(int lightPlayerId, int verifiedPlayerId, CancellationToken ct = default);
+
+    /// <summary>Fuzzy-rank verified players by display-name similarity, capped to <paramref name="max"/>.</summary>
+    Task<List<SimilarPlayerDto>> SearchSimilarVerifiedPlayersAsync(string term, int max, CancellationToken ct = default);
 }

--- a/DropShot/Controllers/InvitationsController.cs
+++ b/DropShot/Controllers/InvitationsController.cs
@@ -1,0 +1,47 @@
+using DropShot.Shared.Dtos;
+using DropShot.UI.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DropShot.Controllers;
+
+/// <summary>
+/// Light-player invitation endpoints. Backs the My Players invite flow
+/// (phase 5). The Invite + MobileAuth + VerifyResult acceptance flows extend
+/// this in later phases.
+/// </summary>
+[ApiController]
+[Route("api/invitations")]
+[Authorize(AuthenticationSchemes = "Bearer")]
+public class InvitationsController(IInvitationService invitations) : ControllerBase
+{
+    [HttpPost("light-player/{lightPlayerId:int}")]
+    public async Task<ActionResult<LightPlayerInvitationDto>> CreateOrReuse(
+        int lightPlayerId, CancellationToken ct)
+    {
+        try
+        {
+            return await invitations.CreateOrReuseLightPlayerInvitationAsync(lightPlayerId, ct);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Forbid();
+        }
+    }
+
+    [HttpPost("{token:guid}/send-email")]
+    public async Task<IActionResult> SendEmail(
+        Guid token, [FromBody] SendInvitationEmailRequest req, CancellationToken ct)
+    {
+        try
+        {
+            await invitations.SendInvitationEmailAsync(token, req.Email, ct);
+            return NoContent();
+        }
+        catch (KeyNotFoundException) { return NotFound(); }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { message = ex.Message });
+        }
+    }
+}

--- a/DropShot/Controllers/PlayersController.cs
+++ b/DropShot/Controllers/PlayersController.cs
@@ -123,6 +123,74 @@ public class PlayersController(
         return NoContent();
     }
 
+    /// <summary>The current user's "my players" — light players they own + bookmarked verified players.</summary>
+    [HttpGet("mine")]
+    public async Task<ActionResult<List<MyPlayerRowDto>>> GetMine(CancellationToken ct)
+    {
+        return await playerService.GetMyPlayersAsync(ct);
+    }
+
+    [HttpPost("mine")]
+    public async Task<ActionResult<PlayerDto>> CreateMine(
+        [FromBody] CreateMyLightPlayerRequest req, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(req.DisplayName))
+            return BadRequest(new { message = "DisplayName is required." });
+        try
+        {
+            var dto = await playerService.CreateMyLightPlayerAsync(req, ct);
+            return CreatedAtAction(nameof(Get), new { id = dto.PlayerId }, dto);
+        }
+        catch (InvalidOperationException) { return Forbid(); }
+    }
+
+    [HttpPut("mine/{id:int}")]
+    public async Task<ActionResult<PlayerDto>> UpdateMine(
+        int id, [FromBody] UpdateMyLightPlayerRequest req, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(req.DisplayName))
+            return BadRequest(new { message = "DisplayName is required." });
+        try
+        {
+            return await playerService.UpdateMyLightPlayerAsync(id, req, ct);
+        }
+        catch (KeyNotFoundException) { return NotFound(); }
+        catch (InvalidOperationException) { return Forbid(); }
+    }
+
+    [HttpDelete("mine/{id:int}")]
+    public async Task<IActionResult> DeleteMine(int id, CancellationToken ct)
+    {
+        try
+        {
+            await playerService.DeleteMyLightPlayerAsync(id, ct);
+            return NoContent();
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Conflict(new { message = ex.Message });
+        }
+    }
+
+    [HttpPost("mine/{lightId:int}/link-to/{verifiedId:int}")]
+    public async Task<IActionResult> LinkLightToVerified(int lightId, int verifiedId, CancellationToken ct)
+    {
+        try
+        {
+            await playerService.LinkLightToVerifiedAsync(lightId, verifiedId, ct);
+            return NoContent();
+        }
+        catch (KeyNotFoundException) { return NotFound(); }
+        catch (InvalidOperationException) { return Forbid(); }
+    }
+
+    [HttpGet("search-similar")]
+    public async Task<ActionResult<List<SimilarPlayerDto>>> SearchSimilar(
+        [FromQuery] string term, [FromQuery] int max = 5, CancellationToken ct = default)
+    {
+        return await playerService.SearchSimilarVerifiedPlayersAsync(term, max, ct);
+    }
+
     private static PlayerDto ToDto(Player p) => new(
         p.PlayerId, p.DisplayName, p.FirstName, p.LastName, p.Email,
         p.DateOfBirth, (DropShot.Shared.PlayerSex?)p.Sex,

--- a/DropShot/Services/WebInvitationService.cs
+++ b/DropShot/Services/WebInvitationService.cs
@@ -1,11 +1,95 @@
+using DropShot.Data;
+using DropShot.Models;
+using DropShot.Shared.Dtos;
 using DropShot.UI.Services;
+using DropShot.UI.Services.Auth;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 
 namespace DropShot.Services;
 
 /// <summary>
-/// Phase 3 placeholder. Populated in phases 4–5 alongside Invite, MobileAuth,
-/// VerifyResult, and the <c>/api/invitations</c> endpoint family.
+/// Web implementation of <see cref="IInvitationService"/>. Builds the
+/// fully-qualified invite URL from <c>App:BaseUrl</c> so MAUI receives a URL
+/// pointing to the production web host (not the MAUI app's null base).
 /// </summary>
-public sealed class WebInvitationService : IInvitationService
+public sealed class WebInvitationService(
+    IDbContextFactory<MyDbContext> dbFactory,
+    ICurrentUser currentUser,
+    EmailService emailService,
+    EmailTemplateService emailTemplates,
+    IConfiguration config) : IInvitationService
 {
+    public async Task<LightPlayerInvitationDto> CreateOrReuseLightPlayerInvitationAsync(
+        int lightPlayerId, CancellationToken ct = default)
+    {
+        var userId = currentUser.UserId
+            ?? throw new InvalidOperationException("Not authenticated.");
+
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+
+        var existing = await db.PlayerInvitations
+            .Where(i => i.LightPlayerId == lightPlayerId
+                && i.CreatedByUserId == userId
+                && i.AcceptedAt == null)
+            .OrderByDescending(i => i.CreatedAt)
+            .FirstOrDefaultAsync(ct);
+
+        Guid token;
+        if (existing is not null)
+        {
+            token = existing.Token;
+        }
+        else
+        {
+            var owns = await db.Players.AnyAsync(p =>
+                p.PlayerId == lightPlayerId && p.IsLight && p.CreatedByUserId == userId, ct);
+            if (!owns)
+                throw new InvalidOperationException("Only your own light players can be invited.");
+
+            var invite = new PlayerInvitation
+            {
+                Token = Guid.NewGuid(),
+                LightPlayerId = lightPlayerId,
+                CreatedByUserId = userId,
+                CreatedAt = DateTime.UtcNow
+            };
+            db.PlayerInvitations.Add(invite);
+            await db.SaveChangesAsync(ct);
+            token = invite.Token;
+        }
+
+        var baseUrl = config["App:BaseUrl"]?.TrimEnd('/') ?? "";
+        var url = $"{baseUrl}/invite/{token}";
+        return new LightPlayerInvitationDto(token, url);
+    }
+
+    public async Task SendInvitationEmailAsync(Guid token, string email, CancellationToken ct = default)
+    {
+        var userId = currentUser.UserId
+            ?? throw new InvalidOperationException("Not authenticated.");
+
+        if (!new System.ComponentModel.DataAnnotations.EmailAddressAttribute().IsValid(email))
+            throw new InvalidOperationException("Invalid email address.");
+
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var invite = await db.PlayerInvitations
+            .Include(i => i.LightPlayer)
+            .FirstOrDefaultAsync(i => i.Token == token, ct)
+            ?? throw new KeyNotFoundException("Invitation not found.");
+
+        if (invite.CreatedByUserId != userId)
+            throw new InvalidOperationException("You can only send your own invitations.");
+
+        invite.SentToEmail = email.Trim();
+        await db.SaveChangesAsync(ct);
+
+        var baseUrl = config["App:BaseUrl"]?.TrimEnd('/') ?? "";
+        var inviteLink = $"{baseUrl}/invite/{token}";
+        var displayName = invite.LightPlayer?.DisplayName ?? "this player";
+        var subject = $"You've been invited to join DropShot as \"{displayName}\"";
+        var html = emailTemplates.PlayerInvitationEmail(displayName, inviteLink);
+
+        await emailService.SendEmailAsync(email.Trim(), subject, html, isHtml: true);
+    }
 }

--- a/DropShot/Services/WebPlayerService.cs
+++ b/DropShot/Services/WebPlayerService.cs
@@ -264,6 +264,182 @@ public sealed class WebPlayerService(
         await db.SaveChangesAsync(ct);
     }
 
+    // ── My Players (phase 5) ────────────────────────────────────────────
+
+    public async Task<List<MyPlayerRowDto>> GetMyPlayersAsync(CancellationToken ct = default)
+    {
+        var userId = currentUser.UserId;
+        if (string.IsNullOrEmpty(userId)) return [];
+
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+
+        var lightPlayers = await db.Players
+            .Where(p => p.IsLight && p.CreatedByUserId == userId)
+            .OrderBy(p => p.DisplayName)
+            .ToListAsync(ct);
+
+        var bookmarkedIds = await db.UserPlayers
+            .Where(up => up.UserId == userId)
+            .Select(up => up.PlayerId)
+            .ToListAsync(ct);
+
+        var bookmarkedPlayers = bookmarkedIds.Count > 0
+            ? await db.Players
+                .Include(p => p.User)
+                .Where(p => bookmarkedIds.Contains(p.PlayerId) && p.UserId != userId)
+                .OrderBy(p => p.DisplayName)
+                .ToListAsync(ct)
+            : new List<Player>();
+
+        var allIds = lightPlayers.Select(p => p.PlayerId)
+            .Concat(bookmarkedPlayers.Select(p => p.PlayerId))
+            .ToList();
+
+        var withMatchHistoryIds = await db.SavedMatch
+            .Where(m => allIds.Contains(m.Player1Id ?? 0) || allIds.Contains(m.Player2Id ?? 0)
+                || allIds.Contains(m.Player3Id ?? 0) || allIds.Contains(m.Player4Id ?? 0))
+            .SelectMany(m => new[] { m.Player1Id, m.Player2Id, m.Player3Id, m.Player4Id })
+            .Where(id => id.HasValue && allIds.Contains(id.Value))
+            .Select(id => id!.Value)
+            .Distinct()
+            .ToListAsync(ct);
+        var hasHistory = withMatchHistoryIds.ToHashSet();
+
+        return lightPlayers.Select(p => new MyPlayerRowDto(
+                p.PlayerId, p.DisplayName, p.FirstName, p.LastName, true,
+                p.Email, p.MobileNumber, (DropShot.Shared.PlayerSex?)p.Sex,
+                p.ProfileImagePath, hasHistory.Contains(p.PlayerId)))
+            .Concat(bookmarkedPlayers.Select(p => new MyPlayerRowDto(
+                p.PlayerId, p.DisplayName, p.FirstName, p.LastName, false,
+                p.Email, p.MobileNumber, (DropShot.Shared.PlayerSex?)p.Sex,
+                p.User?.ProfileImagePath ?? p.ProfileImagePath, hasHistory.Contains(p.PlayerId))))
+            .OrderBy(p => p.DisplayName)
+            .ToList();
+    }
+
+    public async Task<PlayerDto> CreateMyLightPlayerAsync(CreateMyLightPlayerRequest request, CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(currentUser.UserId))
+            throw new InvalidOperationException("Not authenticated.");
+
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var player = new Player
+        {
+            DisplayName = request.DisplayName.Trim(),
+            FirstName = NullIfEmpty(request.FirstName),
+            LastName = NullIfEmpty(request.LastName),
+            Email = NullIfEmpty(request.Email),
+            MobileNumber = NullIfEmpty(request.MobileNumber),
+            Sex = (DropShot.Models.PlayerSex?)request.Sex,
+            IsLight = true,
+            CreatedByUserId = currentUser.UserId
+        };
+        db.Players.Add(player);
+        await db.SaveChangesAsync(ct);
+        return ToDto(player);
+    }
+
+    public async Task<PlayerDto> UpdateMyLightPlayerAsync(int playerId, UpdateMyLightPlayerRequest request, CancellationToken ct = default)
+    {
+        var userId = currentUser.UserId;
+        if (string.IsNullOrEmpty(userId))
+            throw new InvalidOperationException("Not authenticated.");
+
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var p = await db.Players.FindAsync([playerId], ct)
+            ?? throw new KeyNotFoundException($"Player {playerId} not found.");
+        if (!p.IsLight || p.CreatedByUserId != userId)
+            throw new InvalidOperationException("Only your own light players can be edited.");
+
+        p.DisplayName = request.DisplayName.Trim();
+        p.FirstName = NullIfEmpty(request.FirstName);
+        p.LastName = NullIfEmpty(request.LastName);
+        p.Email = NullIfEmpty(request.Email);
+        p.MobileNumber = NullIfEmpty(request.MobileNumber);
+        p.Sex = (DropShot.Models.PlayerSex?)request.Sex;
+        await db.SaveChangesAsync(ct);
+        return ToDto(p);
+    }
+
+    public async Task DeleteMyLightPlayerAsync(int playerId, CancellationToken ct = default)
+    {
+        var userId = currentUser.UserId;
+        if (string.IsNullOrEmpty(userId)) return;
+
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var p = await db.Players.FindAsync([playerId], ct);
+        if (p is null || !p.IsLight || p.CreatedByUserId != userId) return;
+
+        var hasMatches = await db.SavedMatch.AnyAsync(m =>
+            m.Player1Id == playerId || m.Player2Id == playerId
+            || m.Player3Id == playerId || m.Player4Id == playerId, ct);
+        if (hasMatches)
+            throw new InvalidOperationException(
+                "This player has match history. Use 'Link' to transfer their records to a verified player first.");
+
+        db.Players.Remove(p);
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task LinkLightToVerifiedAsync(int lightPlayerId, int verifiedPlayerId, CancellationToken ct = default)
+    {
+        var userId = currentUser.UserId;
+        if (string.IsNullOrEmpty(userId))
+            throw new InvalidOperationException("Not authenticated.");
+
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var lightPlayer = await db.Players.FindAsync([lightPlayerId], ct)
+            ?? throw new KeyNotFoundException($"Player {lightPlayerId} not found.");
+        if (!lightPlayer.IsLight || lightPlayer.CreatedByUserId != userId)
+            throw new InvalidOperationException("Only your own light players can be linked.");
+
+        var verifiedExists = await db.Players.AnyAsync(p => p.PlayerId == verifiedPlayerId && !p.IsLight, ct);
+        if (!verifiedExists)
+            throw new KeyNotFoundException($"Verified player {verifiedPlayerId} not found.");
+
+        var affected = await db.SavedMatch
+            .Where(m => m.Player1Id == lightPlayerId || m.Player2Id == lightPlayerId
+                || m.Player3Id == lightPlayerId || m.Player4Id == lightPlayerId
+                || m.WinnerPlayerId == lightPlayerId)
+            .ToListAsync(ct);
+        foreach (var m in affected)
+        {
+            if (m.Player1Id == lightPlayerId) m.Player1Id = verifiedPlayerId;
+            if (m.Player2Id == lightPlayerId) m.Player2Id = verifiedPlayerId;
+            if (m.Player3Id == lightPlayerId) m.Player3Id = verifiedPlayerId;
+            if (m.Player4Id == lightPlayerId) m.Player4Id = verifiedPlayerId;
+            if (m.WinnerPlayerId == lightPlayerId) m.WinnerPlayerId = verifiedPlayerId;
+        }
+
+        db.Players.Remove(lightPlayer);
+
+        var alreadyBookmarked = await db.UserPlayers
+            .AnyAsync(up => up.UserId == userId && up.PlayerId == verifiedPlayerId, ct);
+        if (!alreadyBookmarked)
+            db.UserPlayers.Add(new UserPlayer { UserId = userId, PlayerId = verifiedPlayerId });
+
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task<List<SimilarPlayerDto>> SearchSimilarVerifiedPlayersAsync(string term, int max, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(term)) return [];
+        var safeMax = Math.Clamp(max, 1, 25);
+
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var matches = await db.Players
+            .Where(p => !p.IsLight
+                && (p.DisplayName.Contains(term)
+                    || (p.FirstName != null && p.FirstName.Contains(term))
+                    || (p.LastName != null && p.LastName.Contains(term))))
+            .OrderBy(p => p.DisplayName)
+            .Take(safeMax)
+            .ToListAsync(ct);
+
+        return matches.Select(p => new SimilarPlayerDto(
+            p.PlayerId, p.DisplayName, p.FirstName, p.LastName)).ToList();
+    }
+
     private static string? NullIfEmpty(string? s) =>
         string.IsNullOrWhiteSpace(s) ? null : s.Trim();
 


### PR DESCRIPTION
## Summary

Phase 5 second PR. Brings per-user "My Players" to MAUI — light-player CRUD + invite flow.

- \`IPlayerService\` gains six my-players methods (Get / Create / Update / Delete / LinkLightToVerified / SearchSimilarVerifiedPlayers).
- \`IInvitationService\` (phase-3 stub) gets fleshed out with \`CreateOrReuseLightPlayerInvitationAsync\` + \`SendInvitationEmailAsync\`.
- New endpoints under \`/api/players/mine\` and \`/api/invitations\`.
- \`MyPlayerRowDto.HasMatchHistory\` is computed server-side so the page hides the delete button on rows that need migrating first.

**Fuzzy search trade-off**: the original page used \`FuzzySearchService\` for similar-player ranking, but it's JS-backed (\`IJSRuntime\`) and won't run in a server controller. The cross-host port falls back to DB LIKE; fuzzy ranking can come back as a later server-side port.

**Invite flow**: server builds the fully-qualified URL from \`App:BaseUrl\` so MAUI receives a URL pointing to production. Email send runs server-side via the existing \`EmailService\` + \`EmailTemplateService\`.

Stacks on \`main\` (last phase-5 PR #478 already merged).

## Test plan

- [x] \`dotnet build DropShot.sln\` — 0 errors, 7 warnings (unchanged).
- [x] \`dotnet test DropShot.Tests\` — 28/28 pass.
- [ ] Web smoke: \`/players/mine\` create / edit / delete / invite-link copy / invite email send.
- [ ] Web smoke: light-player with match history shows the link-icon (warning), not the delete-icon; linking transfers history.
- [ ] MAUI Windows smoke: same flows against the API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)