### PR TITLE
Phase 5: restore Players "Link account" dropdown via /api/users/for-linking

### DIFF
--- a/DropShot.Maui/Services/HttpPlayerService.cs
+++ b/DropShot.Maui/Services/HttpPlayerService.cs
@@ -109,4 +109,15 @@ public sealed class HttpPlayerService(HttpClient http) : IPlayerService
     public async Task<List<SimilarPlayerDto>> SearchSimilarVerifiedPlayersAsync(string term, int max, CancellationToken ct = default) =>
         await http.GetFromJsonAsync<List<SimilarPlayerDto>>(
             $"api/players/search-similar?term={Uri.EscapeDataString(term)}&max={max}", ct) ?? [];
+
+    public async Task<List<ApplicationUserDto>> GetUsersForLinkingAsync(CancellationToken ct = default) =>
+        await http.GetFromJsonAsync<List<ApplicationUserDto>>("api/users/for-linking", ct) ?? [];
+
+    public async Task LinkPlayerAccountAsync(int playerId, string? userId, CancellationToken ct = default)
+    {
+        var resp = await http.PutAsJsonAsync(
+            $"api/players/{playerId}/account",
+            new LinkPlayerAccountRequest(userId), ct);
+        resp.EnsureSuccessStatusCode();
+    }
 }

--- a/DropShot.Shared/Dtos/PlayerDtos.cs
+++ b/DropShot.Shared/Dtos/PlayerDtos.cs
@@ -107,6 +107,17 @@ public record UpdateMyLightPlayerRequest(
     PlayerSex? Sex);
 
 /// <summary>
+/// Minimal projection of an <c>ApplicationUser</c>. Used by the SuperAdmin
+/// Players page's "Link account" dropdown and (later) Admin/UserManagement.
+/// </summary>
+public record ApplicationUserDto(
+    string Id,
+    string? UserName,
+    string? Email);
+
+public record LinkPlayerAccountRequest(string? UserId);
+
+/// <summary>
 /// Suggested "similar" verified player surfaced while typing a display name.
 /// Web ranks via <c>FuzzySearchService</c>; MAUI hits the same endpoint.
 /// </summary>

--- a/DropShot.UI/Components/Pages/Players.razor
+++ b/DropShot.UI/Components/Pages/Players.razor
@@ -1,10 +1,9 @@
 @inject IPlayerService PlayerService
 @inject ISnackbar Snackbar
 
-@* Account-linking dropdown deferred to phase 5 (needs GET /api/users + admin
-   gating alongside Admin/UserManagement). Routing + auth + MudProviders are
-   supplied by host shims (web: DropShot/Components/Pages/Players.razor;
-   MAUI: DropShot.Maui/Components/Pages/Players.razor). *@
+@* Routing + auth + MudProviders supplied by host shims (web:
+   DropShot/Components/Pages/Players.razor; MAUI:
+   DropShot.Maui/Components/Pages/Players.razor). *@
 
 <MudText Typo="Typo.h4" Class="mb-4">Players</MudText>
 
@@ -65,6 +64,9 @@
         <MudTd DataLabel="Actions">
             <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="Size.Small"
                            OnClick="@(() => StartEdit(context))" />
+            <MudIconButton Icon="@Icons.Material.Filled.Link" Size="Size.Small" Color="Color.Info"
+                           aria-label="Link to account"
+                           OnClick="@(() => StartLink(context))" />
             <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small" Color="Color.Error"
                            OnClick="@(() => DeletePlayer(context))" />
         </MudTd>
@@ -168,6 +170,24 @@
     </DialogActions>
 </MudDialog>
 
+@* ── Link to Account Dialog ────────────────────────────────── *@
+<MudDialog @bind-Visible="_showLinkDialog">
+    <TitleContent>Link "@_linkingPlayer?.DisplayName" to Account</TitleContent>
+    <DialogContent>
+        <MudSelect @bind-Value="_selectedUserId" Label="Select Account" Variant="Variant.Outlined">
+            <MudSelectItem T="string" Value="@null">— Unlink —</MudSelectItem>
+            @foreach (var u in _aspNetUsers)
+            {
+                <MudSelectItem T="string" Value="@u.Id">@u.UserName</MudSelectItem>
+            }
+        </MudSelect>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@(() => _showLinkDialog = false)">Cancel</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Info" OnClick="SaveLink">Save</MudButton>
+    </DialogActions>
+</MudDialog>
+
 @code {
     private bool _loading = true;
     private List<PlayerWithClubsDto> _players = [];
@@ -184,6 +204,11 @@
     private bool _showAddDialog;
     private bool _showEditDialog;
     private int? _editingPlayerId;
+
+    private bool _showLinkDialog;
+    private PlayerWithClubsDto? _linkingPlayer;
+    private string? _selectedUserId;
+    private List<ApplicationUserDto> _aspNetUsers = [];
 
     private PlayerForm _form = new();
 
@@ -273,6 +298,23 @@
     {
         await PlayerService.DeletePlayerAsync(player.PlayerId);
         Snackbar.Add("Player deleted.", Severity.Warning);
+        await LoadPlayers();
+    }
+
+    private async Task StartLink(PlayerWithClubsDto player)
+    {
+        _linkingPlayer = player;
+        _selectedUserId = player.UserId;
+        _aspNetUsers = await PlayerService.GetUsersForLinkingAsync();
+        _showLinkDialog = true;
+    }
+
+    private async Task SaveLink()
+    {
+        if (_linkingPlayer is null) return;
+        await PlayerService.LinkPlayerAccountAsync(_linkingPlayer.PlayerId, _selectedUserId);
+        _showLinkDialog = false;
+        Snackbar.Add("Account link updated.", Severity.Success);
         await LoadPlayers();
     }
 }

--- a/DropShot.UI/Services/IPlayerService.cs
+++ b/DropShot.UI/Services/IPlayerService.cs
@@ -75,4 +75,12 @@ public interface IPlayerService
 
     /// <summary>Fuzzy-rank verified players by display-name similarity, capped to <paramref name="max"/>.</summary>
     Task<List<SimilarPlayerDto>> SearchSimilarVerifiedPlayersAsync(string term, int max, CancellationToken ct = default);
+
+    // ── SuperAdmin account linking (phase 5 — backs Players "Link account") ────
+
+    /// <summary>List ASP.NET Identity users for the SuperAdmin Players "Link account" dropdown.</summary>
+    Task<List<ApplicationUserDto>> GetUsersForLinkingAsync(CancellationToken ct = default);
+
+    /// <summary>Set or clear <c>Player.UserId</c>. Pass <c>null</c> to unlink.</summary>
+    Task LinkPlayerAccountAsync(int playerId, string? userId, CancellationToken ct = default);
 }

--- a/DropShot/Controllers/PlayersController.cs
+++ b/DropShot/Controllers/PlayersController.cs
@@ -191,6 +191,23 @@ public class PlayersController(
         return await playerService.SearchSimilarVerifiedPlayersAsync(term, max, ct);
     }
 
+    /// <summary>
+    /// Set or clear <c>Player.UserId</c>. SuperAdmin only — exposed only for
+    /// the SuperAdmin Players page's "Link account" affordance.
+    /// </summary>
+    [HttpPut("{id:int}/account")]
+    [Authorize(Roles = "SuperAdmin")]
+    public async Task<IActionResult> LinkAccount(
+        int id, [FromBody] LinkPlayerAccountRequest req, CancellationToken ct)
+    {
+        try
+        {
+            await playerService.LinkPlayerAccountAsync(id, req.UserId, ct);
+            return NoContent();
+        }
+        catch (KeyNotFoundException) { return NotFound(); }
+    }
+
     private static PlayerDto ToDto(Player p) => new(
         p.PlayerId, p.DisplayName, p.FirstName, p.LastName, p.Email,
         p.DateOfBirth, (DropShot.Shared.PlayerSex?)p.Sex,

--- a/DropShot/Controllers/UsersController.cs
+++ b/DropShot/Controllers/UsersController.cs
@@ -1,5 +1,6 @@
 using DropShot.Data;
 using DropShot.Shared.Dtos;
+using DropShot.UI.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
@@ -9,8 +10,22 @@ namespace DropShot.Controllers;
 [ApiController]
 [Route("api/[controller]")]
 [Authorize(AuthenticationSchemes = "Bearer")]
-public class UsersController(UserManager<ApplicationUser> userManager) : ControllerBase
+public class UsersController(
+    UserManager<ApplicationUser> userManager,
+    IPlayerService playerService) : ControllerBase
 {
+    /// <summary>
+    /// Minimal user list for the SuperAdmin Players "Link account" dropdown.
+    /// SuperAdmin only — exposing the full user roster anywhere broader needs
+    /// a separate decision (and likely the full Admin/UserManagement migration).
+    /// </summary>
+    [HttpGet("for-linking")]
+    [Authorize(Roles = "SuperAdmin")]
+    public async Task<ActionResult<List<ApplicationUserDto>>> GetForLinking(CancellationToken ct)
+    {
+        return await playerService.GetUsersForLinkingAsync(ct);
+    }
+
     /// <summary>
     /// Toggles a user's premium (subscribed) status. Super-admin only — mirrors
     /// the SuperAdmin-only role switches in User Management.

--- a/DropShot/Services/WebPlayerService.cs
+++ b/DropShot/Services/WebPlayerService.cs
@@ -440,6 +440,22 @@ public sealed class WebPlayerService(
             p.PlayerId, p.DisplayName, p.FirstName, p.LastName)).ToList();
     }
 
+    public async Task<List<ApplicationUserDto>> GetUsersForLinkingAsync(CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var users = await db.Users.OrderBy(u => u.UserName).ToListAsync(ct);
+        return users.Select(u => new ApplicationUserDto(u.Id, u.UserName, u.Email)).ToList();
+    }
+
+    public async Task LinkPlayerAccountAsync(int playerId, string? userId, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var p = await db.Players.FindAsync([playerId], ct)
+            ?? throw new KeyNotFoundException($"Player {playerId} not found.");
+        p.UserId = string.IsNullOrEmpty(userId) ? null : userId;
+        await db.SaveChangesAsync(ct);
+    }
+
     private static string? NullIfEmpty(string? s) =>
         string.IsNullOrWhiteSpace(s) ? null : s.Trim();
 


### PR DESCRIPTION
Closes the SuperAdmin "Link account" deferral from #473 (B.1 Players).

- \`IPlayerService.GetUsersForLinkingAsync\` returns minimal \`ApplicationUserDto\`.
- \`IPlayerService.LinkPlayerAccountAsync(playerId, userId?)\` sets or clears \`Player.UserId\`.
- New endpoints: \`GET /api/users/for-linking\` and \`PUT /api/players/{id}/account\`, both \`[Authorize(Roles=SuperAdmin)]\`.
- Link dialog returns to the moved Players page; SuperAdmin-only on both hosts.

Full \`Admin/UserManagement\` migration (role toggles, club-admin assignments, premium toggle, CRUD) is a separate later PR.

## Test plan
- [x] Build clean, 28/28 tests.
- [ ] Web smoke: SuperAdmin loads \`/players\`, opens link dialog, picks an account → reload shows linked chip.
- [ ] MAUI smoke: same flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)