### PR TITLE
Phase 5: move ClubAdmin/ClubLinkRequests into DropShot.UI

### DIFF
--- a/DropShot.Maui/Components/Pages/ClubAdmin/ClubLinkRequests.razor
+++ b/DropShot.Maui/Components/Pages/ClubAdmin/ClubLinkRequests.razor
@@ -1,8 +1,5 @@
 @page "/clubadmin/link-requests"
-@rendermode InteractiveServer
 @attribute [Authorize(Roles = "ClubAdmin,Admin,SuperAdmin")]
 @using Microsoft.AspNetCore.Authorization
-
-<MudProviders />
 
 <DropShot.UI.Components.Pages.ClubAdmin.ClubLinkRequests />

--- a/DropShot.Maui/Services/HttpClubService.cs
+++ b/DropShot.Maui/Services/HttpClubService.cs
@@ -72,4 +72,20 @@ public sealed class HttpClubService(HttpClient http) : IClubService
         var resp = await http.DeleteAsync($"api/clubs/{clubId}/link-requests/mine", ct);
         resp.EnsureSuccessStatusCode();
     }
+
+    public async Task<List<ClubLinkRequestDto>> GetPendingLinkRequestsForAdminAsync(CancellationToken ct = default) =>
+        await http.GetFromJsonAsync<List<ClubLinkRequestDto>>(
+            "api/clubadmin/link-requests", ct) ?? [];
+
+    public async Task ApproveLinkRequestAsync(int requestId, CancellationToken ct = default)
+    {
+        var resp = await http.PostAsync($"api/clubadmin/link-requests/{requestId}/approve", null, ct);
+        resp.EnsureSuccessStatusCode();
+    }
+
+    public async Task RejectLinkRequestAsync(int requestId, CancellationToken ct = default)
+    {
+        var resp = await http.PostAsync($"api/clubadmin/link-requests/{requestId}/reject", null, ct);
+        resp.EnsureSuccessStatusCode();
+    }
 }

--- a/DropShot.Shared/Dtos/ClubDtos.cs
+++ b/DropShot.Shared/Dtos/ClubDtos.cs
@@ -49,7 +49,8 @@ public record ClubLinkRequestDto(
     string? UserEmail,
     string Status,
     DateTime RequestedAt,
-    DateTime? ResolvedAt);
+    DateTime? ResolvedAt,
+    string? UserDisplayName = null);
 
 public record ClubDetailDto(
     int ClubId,

--- a/DropShot.UI/Components/Pages/ClubAdmin/ClubLinkRequests.razor
+++ b/DropShot.UI/Components/Pages/ClubAdmin/ClubLinkRequests.razor
@@ -1,0 +1,92 @@
+@inject IClubService ClubService
+@inject ICurrentUser CurrentUser
+@inject ISnackbar Snackbar
+
+@* Routing + auth + MudProviders supplied by host shims. *@
+
+<MudText Typo="Typo.h4" Class="mb-4">Club Link Requests</MudText>
+
+@if (_loading)
+{
+    <MudProgressLinear Indeterminate="true" />
+}
+else if (!CurrentUser.IsAdmin && CurrentUser.AdminClubIds.Count == 0)
+{
+    <MudAlert Severity="Severity.Info">
+        You don't administer any clubs, so there are no link requests to review.
+    </MudAlert>
+}
+else if (_requests.Count == 0)
+{
+    <MudAlert Severity="Severity.Info">No pending link requests.</MudAlert>
+}
+else
+{
+    <MudTable Items="@_requests" Hover="true" Dense="true" Breakpoint="Breakpoint.Sm">
+        <HeaderContent>
+            <MudTh>Club</MudTh>
+            <MudTh>User</MudTh>
+            <MudTh>Email</MudTh>
+            <MudTh>Requested</MudTh>
+            <MudTh Style="width:200px"></MudTh>
+        </HeaderContent>
+        <RowTemplate>
+            <MudTd DataLabel="Club">@context.ClubName</MudTd>
+            <MudTd DataLabel="User">@(string.IsNullOrEmpty(context.UserDisplayName) ? context.UserName : context.UserDisplayName)</MudTd>
+            <MudTd DataLabel="Email">@(context.UserEmail ?? "—")</MudTd>
+            <MudTd DataLabel="Requested">@context.RequestedAt.ToLocalTime().ToString("dd MMM yyyy HH:mm")</MudTd>
+            <MudTd>
+                <MudStack Row="true" Spacing="1">
+                    <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Success"
+                               OnClick="@(() => Approve(context))">Approve</MudButton>
+                    <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Error"
+                               OnClick="@(() => Reject(context))">Reject</MudButton>
+                </MudStack>
+            </MudTd>
+        </RowTemplate>
+    </MudTable>
+}
+
+@code {
+    private bool _loading = true;
+    private List<ClubLinkRequestDto> _requests = [];
+
+    protected override async Task OnInitializedAsync() => await LoadRequests();
+
+    private async Task LoadRequests()
+    {
+        _loading = true;
+        _requests = await ClubService.GetPendingLinkRequestsForAdminAsync();
+        _loading = false;
+    }
+
+    private async Task Approve(ClubLinkRequestDto request)
+    {
+        try
+        {
+            await ClubService.ApproveLinkRequestAsync(request.ClubLinkRequestId);
+            _requests.Remove(request);
+            var who = string.IsNullOrEmpty(request.UserDisplayName) ? request.UserName : request.UserDisplayName;
+            Snackbar.Add($"Approved {who} → {request.ClubName}.", Severity.Success);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+    }
+
+    private async Task Reject(ClubLinkRequestDto request)
+    {
+        try
+        {
+            await ClubService.RejectLinkRequestAsync(request.ClubLinkRequestId);
+            _requests.Remove(request);
+            var who = string.IsNullOrEmpty(request.UserDisplayName) ? request.UserName : request.UserDisplayName;
+            Snackbar.Add($"Rejected {who}.", Severity.Warning);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+    }
+}

--- a/DropShot.UI/Services/IClubService.cs
+++ b/DropShot.UI/Services/IClubService.cs
@@ -26,4 +26,23 @@ public interface IClubService
 
     Task RequestClubLinkAsync(int clubId, CancellationToken ct = default);
     Task CancelMyClubLinkRequestAsync(int clubId, CancellationToken ct = default);
+
+    // ── Club admin moderation (phase 5 — backs ClubAdmin/ClubLinkRequests) ──
+
+    /// <summary>
+    /// Pending link requests across every club the caller administers. Admin
+    /// and SuperAdmin see all pending requests; ClubAdmin sees just their
+    /// admin clubs' requests.
+    /// </summary>
+    Task<List<ClubLinkRequestDto>> GetPendingLinkRequestsForAdminAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Approve a link request: ensures a verified Player record exists for the
+    /// requesting user, links them to the club via ClubPlayer, marks the
+    /// request approved, and notifies the requester by email.
+    /// </summary>
+    Task ApproveLinkRequestAsync(int requestId, CancellationToken ct = default);
+
+    /// <summary>Reject a link request and notify the requester by email.</summary>
+    Task RejectLinkRequestAsync(int requestId, CancellationToken ct = default);
 }

--- a/DropShot/Controllers/ClubAdminController.cs
+++ b/DropShot/Controllers/ClubAdminController.cs
@@ -1,0 +1,54 @@
+using DropShot.Shared.Dtos;
+using DropShot.UI.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DropShot.Controllers;
+
+/// <summary>
+/// Cross-club moderation endpoints for the ClubAdmin/Admin/SuperAdmin roles.
+/// Backs ClubAdmin/ClubLinkRequests (phase 5). All routes require an admin
+/// role; per-request authorisation (does the caller administer the request's
+/// club?) lives in <see cref="IClubService"/>.
+/// </summary>
+[ApiController]
+[Route("api/clubadmin")]
+[Authorize(AuthenticationSchemes = "Bearer", Roles = "ClubAdmin,Admin,SuperAdmin")]
+public class ClubAdminController(IClubService clubs) : ControllerBase
+{
+    [HttpGet("link-requests")]
+    public async Task<ActionResult<List<ClubLinkRequestDto>>> GetPendingLinkRequests(CancellationToken ct)
+    {
+        return await clubs.GetPendingLinkRequestsForAdminAsync(ct);
+    }
+
+    [HttpPost("link-requests/{requestId:int}/approve")]
+    public async Task<IActionResult> Approve(int requestId, CancellationToken ct)
+    {
+        try
+        {
+            await clubs.ApproveLinkRequestAsync(requestId, ct);
+            return NoContent();
+        }
+        catch (KeyNotFoundException) { return NotFound(); }
+        catch (InvalidOperationException ex)
+        {
+            return Conflict(new { message = ex.Message });
+        }
+    }
+
+    [HttpPost("link-requests/{requestId:int}/reject")]
+    public async Task<IActionResult> Reject(int requestId, CancellationToken ct)
+    {
+        try
+        {
+            await clubs.RejectLinkRequestAsync(requestId, ct);
+            return NoContent();
+        }
+        catch (KeyNotFoundException) { return NotFound(); }
+        catch (InvalidOperationException ex)
+        {
+            return Conflict(new { message = ex.Message });
+        }
+    }
+}

--- a/DropShot/Services/WebClubService.cs
+++ b/DropShot/Services/WebClubService.cs
@@ -15,7 +15,8 @@ namespace DropShot.Services;
 /// </summary>
 public sealed class WebClubService(
     IDbContextFactory<MyDbContext> dbFactory,
-    ICurrentUser currentUser) : IClubService
+    ICurrentUser currentUser,
+    AdminEmailService adminEmail) : IClubService
 {
     public async Task<List<ClubDto>> GetClubsAsync(CancellationToken ct = default)
     {
@@ -173,6 +174,109 @@ public sealed class WebClubService(
         if (pending.Count == 0) return;
         db.ClubLinkRequests.RemoveRange(pending);
         await db.SaveChangesAsync(ct);
+    }
+
+    // ── Club admin moderation ───────────────────────────────────────────
+
+    public async Task<List<ClubLinkRequestDto>> GetPendingLinkRequestsForAdminAsync(CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+
+        IQueryable<ClubLinkRequest> q = db.ClubLinkRequests
+            .Include(r => r.Club)
+            .Include(r => r.User)
+            .Where(r => r.Status == ClubLinkRequestStatus.Pending);
+
+        if (!currentUser.IsAdmin)
+        {
+            var adminClubIds = currentUser.AdminClubIds.ToList();
+            if (adminClubIds.Count == 0) return [];
+            q = q.Where(r => adminClubIds.Contains(r.ClubId));
+        }
+
+        var rows = await q.OrderByDescending(r => r.RequestedAt).ToListAsync(ct);
+        return rows.Select(r => new ClubLinkRequestDto(
+            r.ClubLinkRequestId, r.ClubId, r.Club.Name,
+            r.UserId, r.User.UserName ?? "", r.User.Email,
+            r.Status.ToString(), r.RequestedAt, r.ResolvedAt,
+            r.User.DisplayName)).ToList();
+    }
+
+    public async Task ApproveLinkRequestAsync(int requestId, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var fresh = await db.ClubLinkRequests
+            .Include(r => r.Club)
+            .Include(r => r.User)
+            .FirstOrDefaultAsync(r => r.ClubLinkRequestId == requestId, ct)
+            ?? throw new KeyNotFoundException($"Link request {requestId} not found.");
+
+        if (fresh.Status != ClubLinkRequestStatus.Pending)
+            throw new InvalidOperationException("Request already resolved.");
+
+        if (!currentUser.CanEditClub(fresh.ClubId))
+            throw new InvalidOperationException("Not authorised for this club.");
+
+        var player = await db.Players.FirstOrDefaultAsync(p => p.UserId == fresh.UserId && !p.IsLight, ct);
+        if (player is null)
+        {
+            var displayName = fresh.User.DisplayName is { Length: > 0 }
+                ? fresh.User.DisplayName
+                : fresh.User.UserName ?? "Player";
+            player = new Player
+            {
+                DisplayName = displayName,
+                Email = fresh.User.Email,
+                UserId = fresh.UserId,
+                IsLight = false,
+                CreatedAt = DateTime.UtcNow
+            };
+            db.Players.Add(player);
+            await db.SaveChangesAsync(ct);
+        }
+
+        var alreadyLinked = await db.ClubPlayers
+            .AnyAsync(cp => cp.ClubId == fresh.ClubId && cp.PlayerId == player.PlayerId, ct);
+        if (!alreadyLinked)
+        {
+            db.ClubPlayers.Add(new ClubPlayer
+            {
+                ClubId = fresh.ClubId,
+                PlayerId = player.PlayerId,
+                JoinedAt = DateTime.UtcNow,
+                IsActive = true
+            });
+        }
+
+        fresh.Status = ClubLinkRequestStatus.Approved;
+        fresh.ResolvedAt = DateTime.UtcNow;
+        fresh.ResolvedByUserId = currentUser.UserId;
+        await db.SaveChangesAsync(ct);
+
+        await adminEmail.SendClubLinkRequestApprovedAsync(fresh.Club, fresh.User);
+    }
+
+    public async Task RejectLinkRequestAsync(int requestId, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var fresh = await db.ClubLinkRequests
+            .Include(r => r.Club)
+            .Include(r => r.User)
+            .FirstOrDefaultAsync(r => r.ClubLinkRequestId == requestId, ct)
+            ?? throw new KeyNotFoundException($"Link request {requestId} not found.");
+
+        if (fresh.Status != ClubLinkRequestStatus.Pending)
+            throw new InvalidOperationException("Request already resolved.");
+
+        if (!currentUser.CanEditClub(fresh.ClubId))
+            throw new InvalidOperationException("Not authorised for this club.");
+
+        fresh.Status = ClubLinkRequestStatus.Rejected;
+        fresh.ResolvedAt = DateTime.UtcNow;
+        fresh.ResolvedByUserId = currentUser.UserId;
+        await db.SaveChangesAsync(ct);
+
+        await adminEmail.SendClubLinkRequestRejectedAsync(fresh.Club, fresh.User);
     }
 
     private static Club ApplyTo(Club c, SaveClubRequest req)


### PR DESCRIPTION
Phase 5. Brings the cross-club link-request moderation page to MAUI.

\`IClubService\` gains \`GetPendingLinkRequestsForAdminAsync\` (Admin/SuperAdmin see all pending; ClubAdmin sees their admin clubs only), \`ApproveLinkRequestAsync\` (creates verified Player + ClubPlayer + sends approval email), \`RejectLinkRequestAsync\` (status update + rejection email). \`ClubLinkRequestDto\` picks up an optional \`UserDisplayName\` so the page renders the existing DisplayName-fallback-to-UserName chain without a second round trip.

New \`ClubAdminController\` at \`/api/clubadmin/link-requests\` with GET / approve / reject endpoints, all \`[Authorize(Roles=ClubAdmin,Admin,SuperAdmin)]\`. Per-request authorisation enforced server-side via \`ICurrentUser.CanEditClub\`.

## Test plan
- [x] Build clean, 28/28 tests.
- [ ] Web: ClubAdmin sees pending requests for their clubs only; approve sends the approval email + creates Player + ClubPlayer; reject sends rejection email.
- [ ] MAUI: same flow against the API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)