### PR TITLE
Phase 5: move Admin/UserManagement into DropShot.UI

### DIFF
--- a/DropShot.Maui/Components/Pages/Admin/UserManagement.razor
+++ b/DropShot.Maui/Components/Pages/Admin/UserManagement.razor
@@ -1,8 +1,5 @@
 @page "/admin/users"
-@rendermode InteractiveServer
 @attribute [Authorize(Roles = "Admin,SuperAdmin")]
 @using Microsoft.AspNetCore.Authorization
-
-<MudProviders />
 
 <DropShot.UI.Components.Pages.Admin.UserManagement />

--- a/DropShot.Maui/MauiProgram.cs
+++ b/DropShot.Maui/MauiProgram.cs
@@ -57,6 +57,7 @@ public static class MauiProgram
         builder.Services.AddScoped<IInvitationService, HttpInvitationService>();
         builder.Services.AddScoped<IMatchService, HttpMatchService>();
         builder.Services.AddScoped<IScoreboardService, HttpScoreboardService>();
+        builder.Services.AddScoped<IUserService, HttpUserService>();
 
         // Required for [Authorize] attributes and <AuthorizeView>
         builder.Services.AddAuthorizationCore();

--- a/DropShot.Maui/Services/HttpUserService.cs
+++ b/DropShot.Maui/Services/HttpUserService.cs
@@ -1,0 +1,58 @@
+using System.Net.Http.Json;
+using DropShot.Shared.Dtos;
+using DropShot.UI.Services;
+
+namespace DropShot.Maui.Services;
+
+/// <summary>
+/// MAUI HTTP implementation of <see cref="IUserService"/>. Talks to the
+/// <c>/api/users</c> endpoint family added in phase 5 alongside the
+/// Admin/UserManagement page move.
+/// </summary>
+public sealed class HttpUserService(HttpClient http) : IUserService
+{
+    public async Task<List<UserManagementRowDto>> GetAllAsync(CancellationToken ct = default) =>
+        await http.GetFromJsonAsync<List<UserManagementRowDto>>("api/users", ct) ?? [];
+
+    public async Task SetRoleAsync(string userId, string role, bool granted, CancellationToken ct = default)
+    {
+        var resp = await http.PutAsJsonAsync(
+            $"api/users/{userId}/role",
+            new SetUserRoleRequest(role, granted), ct);
+        resp.EnsureSuccessStatusCode();
+    }
+
+    public async Task SetPremiumAsync(string userId, bool isSubscribed, CancellationToken ct = default)
+    {
+        var resp = await http.PutAsJsonAsync(
+            $"api/users/{userId}/premium",
+            new SetUserPremiumRequest(isSubscribed), ct);
+        resp.EnsureSuccessStatusCode();
+    }
+
+    public async Task UpdateAsync(string userId, UpdateUserRequest request, CancellationToken ct = default)
+    {
+        var resp = await http.PutAsJsonAsync($"api/users/{userId}", request, ct);
+        resp.EnsureSuccessStatusCode();
+    }
+
+    public async Task DeleteAsync(string userId, CancellationToken ct = default)
+    {
+        var resp = await http.DeleteAsync($"api/users/{userId}", ct);
+        resp.EnsureSuccessStatusCode();
+    }
+
+    public async Task AddClubAdminAsync(string userId, int clubId, CancellationToken ct = default)
+    {
+        var resp = await http.PostAsJsonAsync(
+            $"api/users/{userId}/club-admins",
+            new AddClubAdminRequest(clubId), ct);
+        resp.EnsureSuccessStatusCode();
+    }
+
+    public async Task RemoveClubAdminAsync(string userId, int clubId, CancellationToken ct = default)
+    {
+        var resp = await http.DeleteAsync($"api/users/{userId}/club-admins/{clubId}", ct);
+        resp.EnsureSuccessStatusCode();
+    }
+}

--- a/DropShot.Shared/Dtos/UserDtos.cs
+++ b/DropShot.Shared/Dtos/UserDtos.cs
@@ -1,0 +1,25 @@
+namespace DropShot.Shared.Dtos;
+
+/// <summary>
+/// Row in the Admin/UserManagement table. Combines the ApplicationUser fields
+/// the page needs with role flags and the user's club-admin assignments.
+/// </summary>
+public record UserManagementRowDto(
+    string Id,
+    string? UserName,
+    string? Email,
+    string? DisplayName,
+    bool IsSuperAdmin,
+    bool IsAdmin,
+    bool IsSubscribed,
+    IReadOnlyList<ClubAdminAssignmentDto> ClubAssignments);
+
+public record ClubAdminAssignmentDto(int ClubId, string ClubName);
+
+public record UpdateUserRequest(string UserName, string Email);
+
+public record SetUserRoleRequest(string Role, bool Granted);
+
+public record SetUserPremiumRequest(bool IsSubscribed);
+
+public record AddClubAdminRequest(int ClubId);

--- a/DropShot.Tests/Helpers/DropShotTestContext.cs
+++ b/DropShot.Tests/Helpers/DropShotTestContext.cs
@@ -126,6 +126,7 @@ public class DropShotTestContext : BunitContext
         Services.AddScoped<IInvitationService, WebInvitationService>();
         Services.AddScoped<IMatchService, WebMatchService>();
         Services.AddScoped<IScoreboardService, WebScoreboardService>();
+        Services.AddScoped<IUserService, WebUserService>();
 
         // Logging
         Services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));

--- a/DropShot.UI/Components/Pages/Admin/UserManagement.razor
+++ b/DropShot.UI/Components/Pages/Admin/UserManagement.razor
@@ -1,0 +1,308 @@
+@inject IUserService UserService
+@inject IClubService ClubService
+@inject ICurrentUser CurrentUser
+@inject ISnackbar Snackbar
+@inject IDialogService Dialog
+
+@* Routing + auth + MudProviders supplied by host shims. *@
+
+@if (_error is not null)
+{
+    <MudAlert Severity="Severity.Error" Class="mb-4">@_error</MudAlert>
+}
+
+<MudText Typo="Typo.h4" Class="mb-4">User Management</MudText>
+
+<MudTextField @bind-Value="_searchText" Placeholder="Search users..."
+              Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search"
+              Immediate="true" Class="mb-4" />
+
+<MudTable Items="@_rows" Hover="true" Breakpoint="Breakpoint.Sm" Loading="@_loading" Dense="true"
+          Filter="@(row => FilterUsers(row))">
+    <HeaderContent>
+        <MudTh>Username</MudTh>
+        <MudTh>Email</MudTh>
+        @if (_isSuperAdmin)
+        {
+            <MudTh Style="text-align:center">Super Admin</MudTh>
+            <MudTh Style="text-align:center">Admin</MudTh>
+            <MudTh Style="text-align:center">Premium</MudTh>
+        }
+        <MudTh>Club Admin Assignments</MudTh>
+        <MudTh></MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd DataLabel="Username">@context.UserName</MudTd>
+        <MudTd DataLabel="Email">@context.Email</MudTd>
+
+        @if (_isSuperAdmin)
+        {
+            <MudTd DataLabel="Super Admin" Style="text-align:center">
+                <MudSwitch T="bool"
+                           Value="@context.IsSuperAdmin"
+                           ValueChanged="@(v => ToggleSuperAdmin(context, v))"
+                           Disabled="@(context.Id == CurrentUser.UserId)"
+                           Color="Color.Error" />
+            </MudTd>
+            <MudTd DataLabel="Admin" Style="text-align:center">
+                <MudSwitch T="bool"
+                           Value="@context.IsAdmin"
+                           ValueChanged="@(v => ToggleAdmin(context, v))"
+                           Disabled="@(context.IsSuperAdmin)"
+                           Color="Color.Primary" />
+            </MudTd>
+            <MudTd DataLabel="Premium" Style="text-align:center">
+                <MudSwitch T="bool"
+                           Value="@context.IsSubscribed"
+                           ValueChanged="@(v => TogglePremium(context, v))"
+                           Color="Color.Warning" />
+            </MudTd>
+        }
+
+        <MudTd DataLabel="Club Admin">
+            <MudStack Row="true" Wrap="Wrap.Wrap" AlignItems="AlignItems.Center" Spacing="1">
+                @foreach (var ca in context.ClubAssignments)
+                {
+                    <MudChip T="string" Size="Size.Small" Color="Color.Info"
+                             OnClose="@(() => RemoveClubAdmin(context, ca.ClubId))"
+                             CloseIcon="@Icons.Material.Filled.Close">
+                        @ca.ClubName
+                    </MudChip>
+                }
+                <MudIconButton Icon="@Icons.Material.Filled.AddCircleOutline"
+                               Size="Size.Small" Color="Color.Success"
+                               aria-label="Add club admin assignment"
+                               OnClick="@(() => OpenAddClubDialog(context))" />
+            </MudStack>
+        </MudTd>
+
+        <MudTd>
+            @if (_isSuperAdmin || (!context.IsAdmin && !context.IsSuperAdmin))
+            {
+                <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="Size.Small"
+                               Disabled="@(context.Id == CurrentUser.UserId && context.IsSuperAdmin)"
+                               OnClick="@(() => OpenEditDialog(context))" />
+                <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small"
+                               Color="Color.Error"
+                               Disabled="@(context.Id == CurrentUser.UserId)"
+                               OnClick="@(() => DeleteUserAsync(context))" />
+            }
+        </MudTd>
+    </RowTemplate>
+    <NoRecordsContent>
+        <MudText>No users found.</MudText>
+    </NoRecordsContent>
+</MudTable>
+
+<MudDialog @bind-Visible="_showAddClubDialog">
+    <TitleContent>Assign Club Admin – @(_targetRow?.UserName)</TitleContent>
+    <DialogContent>
+        <MudSelect @bind-Value="_selectedClubId" Label="Select Club" Variant="Variant.Outlined">
+            @foreach (var club in AvailableClubs)
+            {
+                <MudSelectItem T="int?" Value="@((int?)club.ClubId)">@club.Name</MudSelectItem>
+            }
+        </MudSelect>
+        @if (!AvailableClubs.Any())
+        {
+            <MudText Typo="Typo.caption" Class="mt-2" Style="color:grey">
+                This user is already an admin of all clubs.
+            </MudText>
+        }
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@(() => _showAddClubDialog = false)">Cancel</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                   Disabled="@(_selectedClubId == null)"
+                   OnClick="SaveClubAdmin">Add</MudButton>
+    </DialogActions>
+</MudDialog>
+
+<MudDialog @bind-Visible="_showEditDialog">
+    <TitleContent>Edit User – @(_editRow?.UserName)</TitleContent>
+    <DialogContent>
+        <MudGrid Spacing="2">
+            <MudItem xs="12">
+                <MudTextField @bind-Value="_editUsername" Label="Username" Variant="Variant.Outlined" Required="true" />
+            </MudItem>
+            <MudItem xs="12">
+                <MudTextField @bind-Value="_editEmail" Label="Email" Variant="Variant.Outlined"
+                              InputType="InputType.Email" Required="true" />
+            </MudItem>
+        </MudGrid>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@(() => _showEditDialog = false)">Cancel</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="SaveEditAsync">Save</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    private bool _loading = true;
+    private string? _error;
+    private List<UserManagementRowDto> _rows = [];
+    private string _searchText = "";
+    private List<ClubDto> _allClubs = [];
+    private bool _isSuperAdmin;
+
+    private bool FilterUsers(UserManagementRowDto row) =>
+        string.IsNullOrWhiteSpace(_searchText) ||
+        (row.UserName ?? "").Contains(_searchText, StringComparison.OrdinalIgnoreCase) ||
+        (row.Email ?? "").Contains(_searchText, StringComparison.OrdinalIgnoreCase);
+
+    private bool _showAddClubDialog;
+    private UserManagementRowDto? _targetRow;
+    private int? _selectedClubId;
+
+    private bool _showEditDialog;
+    private UserManagementRowDto? _editRow;
+    private string _editUsername = "";
+    private string _editEmail = "";
+
+    private IEnumerable<ClubDto> AvailableClubs =>
+        _targetRow is null
+            ? []
+            : _allClubs.Where(c => _targetRow.ClubAssignments.All(a => a.ClubId != c.ClubId));
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            _isSuperAdmin = CurrentUser.HasRole("SuperAdmin");
+            await LoadAsync();
+        }
+        catch (Exception ex)
+        {
+            _error = $"Failed to load user management: {ex.Message}";
+            _loading = false;
+        }
+    }
+
+    private async Task LoadAsync()
+    {
+        _loading = true;
+        _error = null;
+        try
+        {
+            _allClubs = await ClubService.GetClubsAsync();
+            _rows = await UserService.GetAllAsync();
+            _loading = false;
+        }
+        catch (Exception ex)
+        {
+            _error = $"Failed to load users: {ex.Message}";
+            _loading = false;
+        }
+    }
+
+    private async Task ToggleSuperAdmin(UserManagementRowDto row, bool make)
+    {
+        try
+        {
+            await UserService.SetRoleAsync(row.Id, "SuperAdmin", make);
+            await LoadAsync();
+            Snackbar.Add(
+                $"{row.UserName} {(make ? "granted" : "removed from")} Super Admin role.",
+                make ? Severity.Success : Severity.Warning);
+        }
+        catch (Exception ex) { Snackbar.Add(ex.Message, Severity.Error); }
+    }
+
+    private async Task ToggleAdmin(UserManagementRowDto row, bool make)
+    {
+        try
+        {
+            await UserService.SetRoleAsync(row.Id, "Admin", make);
+            await LoadAsync();
+            Snackbar.Add(
+                $"{row.UserName} {(make ? "granted" : "removed from")} Admin role.",
+                make ? Severity.Success : Severity.Warning);
+        }
+        catch (Exception ex) { Snackbar.Add(ex.Message, Severity.Error); }
+    }
+
+    private async Task TogglePremium(UserManagementRowDto row, bool make)
+    {
+        try
+        {
+            await UserService.SetPremiumAsync(row.Id, make);
+            await LoadAsync();
+            Snackbar.Add(
+                $"{row.UserName} premium {(make ? "enabled" : "disabled")}.",
+                make ? Severity.Success : Severity.Warning);
+        }
+        catch (Exception ex) { Snackbar.Add(ex.Message, Severity.Error); }
+    }
+
+    private void OpenAddClubDialog(UserManagementRowDto row)
+    {
+        _targetRow = row;
+        _selectedClubId = null;
+        _showAddClubDialog = true;
+    }
+
+    private async Task SaveClubAdmin()
+    {
+        if (_targetRow is null || _selectedClubId is null) return;
+        try
+        {
+            await UserService.AddClubAdminAsync(_targetRow.Id, _selectedClubId.Value);
+            var clubName = _allClubs.First(c => c.ClubId == _selectedClubId.Value).Name;
+            Snackbar.Add($"{_targetRow.UserName} is now a Club Admin for {clubName}.", Severity.Success);
+            _showAddClubDialog = false;
+            await LoadAsync();
+        }
+        catch (Exception ex) { Snackbar.Add(ex.Message, Severity.Error); }
+    }
+
+    private void OpenEditDialog(UserManagementRowDto row)
+    {
+        _editRow = row;
+        _editUsername = row.UserName ?? "";
+        _editEmail = row.Email ?? "";
+        _showEditDialog = true;
+    }
+
+    private async Task SaveEditAsync()
+    {
+        if (_editRow is null) return;
+        try
+        {
+            await UserService.UpdateAsync(_editRow.Id, new UpdateUserRequest(_editUsername, _editEmail));
+            Snackbar.Add("User updated successfully.", Severity.Success);
+            _showEditDialog = false;
+            await LoadAsync();
+        }
+        catch (Exception ex) { Snackbar.Add(ex.Message, Severity.Error); }
+    }
+
+    private async Task DeleteUserAsync(UserManagementRowDto row)
+    {
+        var confirmed = await Dialog.ShowMessageBoxAsync(
+            "Delete User",
+            $"Are you sure you want to delete '{row.UserName}'? This cannot be undone.",
+            yesText: "Delete", cancelText: "Cancel");
+
+        if (confirmed != true) return;
+
+        try
+        {
+            await UserService.DeleteAsync(row.Id);
+            _rows.Remove(row);
+            Snackbar.Add($"User '{row.UserName}' deleted.", Severity.Warning);
+        }
+        catch (Exception ex) { Snackbar.Add(ex.Message, Severity.Error); }
+    }
+
+    private async Task RemoveClubAdmin(UserManagementRowDto row, int clubId)
+    {
+        try
+        {
+            await UserService.RemoveClubAdminAsync(row.Id, clubId);
+            var clubName = _allClubs.FirstOrDefault(c => c.ClubId == clubId)?.Name ?? clubId.ToString();
+            Snackbar.Add($"Removed {row.UserName} as Club Admin for {clubName}.", Severity.Warning);
+            await LoadAsync();
+        }
+        catch (Exception ex) { Snackbar.Add(ex.Message, Severity.Error); }
+    }
+}

--- a/DropShot.UI/Services/IUserService.cs
+++ b/DropShot.UI/Services/IUserService.cs
@@ -1,0 +1,19 @@
+using DropShot.Shared.Dtos;
+
+namespace DropShot.UI.Services;
+
+/// <summary>
+/// User-management domain abstraction. Backs Admin/UserManagement (phase 5).
+/// All operations are gated for Admin / SuperAdmin server-side; the role
+/// toggles + premium toggle are SuperAdmin-only at the controller level.
+/// </summary>
+public interface IUserService
+{
+    Task<List<UserManagementRowDto>> GetAllAsync(CancellationToken ct = default);
+    Task SetRoleAsync(string userId, string role, bool granted, CancellationToken ct = default);
+    Task SetPremiumAsync(string userId, bool isSubscribed, CancellationToken ct = default);
+    Task UpdateAsync(string userId, UpdateUserRequest request, CancellationToken ct = default);
+    Task DeleteAsync(string userId, CancellationToken ct = default);
+    Task AddClubAdminAsync(string userId, int clubId, CancellationToken ct = default);
+    Task RemoveClubAdminAsync(string userId, int clubId, CancellationToken ct = default);
+}

--- a/DropShot/Controllers/UsersController.cs
+++ b/DropShot/Controllers/UsersController.cs
@@ -12,12 +12,12 @@ namespace DropShot.Controllers;
 [Authorize(AuthenticationSchemes = "Bearer")]
 public class UsersController(
     UserManager<ApplicationUser> userManager,
-    IPlayerService playerService) : ControllerBase
+    IPlayerService playerService,
+    IUserService userService) : ControllerBase
 {
     /// <summary>
     /// Minimal user list for the SuperAdmin Players "Link account" dropdown.
-    /// SuperAdmin only — exposing the full user roster anywhere broader needs
-    /// a separate decision (and likely the full Admin/UserManagement migration).
+    /// SuperAdmin only.
     /// </summary>
     [HttpGet("for-linking")]
     [Authorize(Roles = "SuperAdmin")]
@@ -27,9 +27,83 @@ public class UsersController(
     }
 
     /// <summary>
-    /// Toggles a user's premium (subscribed) status. Super-admin only — mirrors
-    /// the SuperAdmin-only role switches in User Management.
+    /// Full user roster with role flags and club-admin assignments. Backs
+    /// Admin/UserManagement (phase 5).
     /// </summary>
+    [HttpGet]
+    [Authorize(Roles = "Admin,SuperAdmin")]
+    public async Task<ActionResult<List<UserManagementRowDto>>> GetAll(CancellationToken ct)
+    {
+        return await userService.GetAllAsync(ct);
+    }
+
+    /// <summary>Toggle a role on a user. SuperAdmin only.</summary>
+    [HttpPut("{id}/role")]
+    [Authorize(Roles = "SuperAdmin")]
+    public async Task<IActionResult> SetRole(string id, [FromBody] SetUserRoleRequest req, CancellationToken ct)
+    {
+        try { await userService.SetRoleAsync(id, req.Role, req.Granted, ct); return NoContent(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+        catch (InvalidOperationException ex) { return BadRequest(new { message = ex.Message }); }
+    }
+
+    /// <summary>Toggle premium subscription. SuperAdmin only.</summary>
+    [HttpPut("{id}/premium")]
+    [Authorize(Roles = "SuperAdmin")]
+    public async Task<IActionResult> SetPremium(string id, [FromBody] SetUserPremiumRequest req, CancellationToken ct)
+    {
+        try { await userService.SetPremiumAsync(id, req.IsSubscribed, ct); return NoContent(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+        catch (InvalidOperationException ex) { return BadRequest(new { message = ex.Message }); }
+    }
+
+    /// <summary>
+    /// Edit username + email. Admin/SuperAdmin can edit anyone, but only a
+    /// SuperAdmin can edit another Admin or SuperAdmin.
+    /// </summary>
+    [HttpPut("{id}")]
+    [Authorize(Roles = "Admin,SuperAdmin")]
+    public async Task<IActionResult> Update(string id, [FromBody] UpdateUserRequest req, CancellationToken ct)
+    {
+        if (!await CanModifyAsync(id)) return Forbid();
+        try { await userService.UpdateAsync(id, req, ct); return NoContent(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+        catch (InvalidOperationException ex) { return BadRequest(new { message = ex.Message }); }
+    }
+
+    /// <summary>
+    /// Delete a user. Same admin-tier rule as Update; in addition the caller
+    /// can never delete themselves.
+    /// </summary>
+    [HttpDelete("{id}")]
+    [Authorize(Roles = "Admin,SuperAdmin")]
+    public async Task<IActionResult> Delete(string id, CancellationToken ct)
+    {
+        var currentUserId = userManager.GetUserId(User);
+        if (currentUserId == id) return BadRequest(new { message = "You cannot delete yourself." });
+        if (!await CanModifyAsync(id)) return Forbid();
+        try { await userService.DeleteAsync(id, ct); return NoContent(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+        catch (InvalidOperationException ex) { return BadRequest(new { message = ex.Message }); }
+    }
+
+    [HttpPost("{id}/club-admins")]
+    [Authorize(Roles = "Admin,SuperAdmin")]
+    public async Task<IActionResult> AddClubAdmin(string id, [FromBody] AddClubAdminRequest req, CancellationToken ct)
+    {
+        try { await userService.AddClubAdminAsync(id, req.ClubId, ct); return NoContent(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+    }
+
+    [HttpDelete("{id}/club-admins/{clubId:int}")]
+    [Authorize(Roles = "Admin,SuperAdmin")]
+    public async Task<IActionResult> RemoveClubAdmin(string id, int clubId, CancellationToken ct)
+    {
+        try { await userService.RemoveClubAdminAsync(id, clubId, ct); return NoContent(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+    }
+
+    /// <summary>Existing premium-toggle convenience endpoint — kept for backwards compat.</summary>
     [HttpPost("{id}/upgrade-premium")]
     [Authorize(Roles = "SuperAdmin")]
     public async Task<IActionResult> UpgradePremium(string id, [FromBody] UpgradePremiumRequest req)
@@ -43,5 +117,23 @@ public class UsersController(
             return BadRequest(new { errors = result.Errors.Select(e => e.Description) });
 
         return NoContent();
+    }
+
+    /// <summary>
+    /// Admin and SuperAdmin can edit/delete; only SuperAdmin can edit/delete
+    /// another Admin or SuperAdmin. Returns false if the target is admin-tier
+    /// and the caller is not SuperAdmin.
+    /// </summary>
+    private async Task<bool> CanModifyAsync(string targetUserId)
+    {
+        var caller = await userManager.GetUserAsync(User);
+        var isCallerSuperAdmin = caller is not null && await userManager.IsInRoleAsync(caller, "SuperAdmin");
+        if (isCallerSuperAdmin) return true;
+
+        var target = await userManager.FindByIdAsync(targetUserId);
+        if (target is null) return true; // 404 will be returned by the action.
+        var targetIsAdmin = await userManager.IsInRoleAsync(target, "Admin")
+            || await userManager.IsInRoleAsync(target, "SuperAdmin");
+        return !targetIsAdmin;
     }
 }

--- a/DropShot/Program.cs
+++ b/DropShot/Program.cs
@@ -131,6 +131,7 @@ builder.Services.AddScoped<ISiteSettingsService, WebSiteSettingsService>();
 builder.Services.AddScoped<IInvitationService, WebInvitationService>();
 builder.Services.AddScoped<IMatchService, WebMatchService>();
 builder.Services.AddScoped<IScoreboardService, WebScoreboardService>();
+builder.Services.AddScoped<IUserService, WebUserService>();
 builder.Services.AddSingleton<BackgroundTaskQueue>();
 builder.Services.AddScoped<ResultVerificationService>();
 builder.Services.AddScoped<AdminEmailService>();

--- a/DropShot/Services/WebUserService.cs
+++ b/DropShot/Services/WebUserService.cs
@@ -1,0 +1,151 @@
+using DropShot.Data;
+using DropShot.Models;
+using DropShot.Shared.Dtos;
+using DropShot.UI.Services;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+
+namespace DropShot.Services;
+
+/// <summary>
+/// Web implementation of <see cref="IUserService"/>. Wraps
+/// <c>UserManager&lt;ApplicationUser&gt;</c> and the <c>ClubAdministrators</c>
+/// table behind a shared interface so MAUI's Admin/UserManagement can talk to
+/// the same surface via API. Role-toggle / premium-toggle authorisation is
+/// enforced at the controller (SuperAdmin only); CRUD ops require Admin or
+/// SuperAdmin and additionally protect against deleting Admins/SuperAdmins
+/// without SuperAdmin rights — that check lives in the controller too.
+/// </summary>
+public sealed class WebUserService(
+    UserManager<ApplicationUser> userManager,
+    IDbContextFactory<MyDbContext> dbFactory) : IUserService
+{
+    public async Task<List<UserManagementRowDto>> GetAllAsync(CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+
+        var allAssignments = await db.ClubAdministrators
+            .Include(ca => ca.Club)
+            .ToListAsync(ct);
+        var assignmentsByUser = allAssignments
+            .GroupBy(ca => ca.UserId)
+            .ToDictionary(g => g.Key, g => g
+                .Select(ca => new ClubAdminAssignmentDto(ca.ClubId, ca.Club.Name))
+                .ToList());
+
+        var users = await userManager.Users.OrderBy(u => u.UserName).ToListAsync(ct);
+
+        var rows = new List<UserManagementRowDto>(users.Count);
+        foreach (var user in users)
+        {
+            var isSuperAdmin = await userManager.IsInRoleAsync(user, "SuperAdmin");
+            var isAdmin = await userManager.IsInRoleAsync(user, "Admin");
+            assignmentsByUser.TryGetValue(user.Id, out var clubs);
+            rows.Add(new UserManagementRowDto(
+                user.Id, user.UserName, user.Email, user.DisplayName,
+                isSuperAdmin, isAdmin, user.IsSubscribed,
+                clubs ?? new List<ClubAdminAssignmentDto>()));
+        }
+        return rows;
+    }
+
+    public async Task SetRoleAsync(string userId, string role, bool granted, CancellationToken ct = default)
+    {
+        var user = await userManager.FindByIdAsync(userId)
+            ?? throw new KeyNotFoundException($"User {userId} not found.");
+
+        IdentityResult result = granted
+            ? await userManager.AddToRoleAsync(user, role)
+            : await userManager.RemoveFromRoleAsync(user, role);
+        if (!result.Succeeded)
+            throw new InvalidOperationException(string.Join(" ", result.Errors.Select(e => e.Description)));
+    }
+
+    public async Task SetPremiumAsync(string userId, bool isSubscribed, CancellationToken ct = default)
+    {
+        var user = await userManager.FindByIdAsync(userId)
+            ?? throw new KeyNotFoundException($"User {userId} not found.");
+        user.IsSubscribed = isSubscribed;
+        var result = await userManager.UpdateAsync(user);
+        if (!result.Succeeded)
+            throw new InvalidOperationException(string.Join(" ", result.Errors.Select(e => e.Description)));
+    }
+
+    public async Task UpdateAsync(string userId, UpdateUserRequest request, CancellationToken ct = default)
+    {
+        var user = await userManager.FindByIdAsync(userId)
+            ?? throw new KeyNotFoundException($"User {userId} not found.");
+
+        var errors = new List<string>();
+        if (user.UserName != request.UserName)
+        {
+            var r = await userManager.SetUserNameAsync(user, request.UserName);
+            if (!r.Succeeded) errors.AddRange(r.Errors.Select(e => e.Description));
+        }
+        if (user.Email != request.Email)
+        {
+            var r = await userManager.SetEmailAsync(user, request.Email);
+            if (!r.Succeeded) errors.AddRange(r.Errors.Select(e => e.Description));
+        }
+        if (errors.Count > 0)
+            throw new InvalidOperationException(string.Join(" ", errors));
+    }
+
+    public async Task DeleteAsync(string userId, CancellationToken ct = default)
+    {
+        var user = await userManager.FindByIdAsync(userId)
+            ?? throw new KeyNotFoundException($"User {userId} not found.");
+
+        await using (var db = await dbFactory.CreateDbContextAsync(ct))
+        {
+            var player = await db.Players.FirstOrDefaultAsync(p => p.UserId == user.Id, ct);
+            if (player is not null)
+            {
+                player.UserId = null;
+                await db.SaveChangesAsync(ct);
+            }
+        }
+
+        var result = await userManager.DeleteAsync(user);
+        if (!result.Succeeded)
+            throw new InvalidOperationException(string.Join(" ", result.Errors.Select(e => e.Description)));
+    }
+
+    public async Task AddClubAdminAsync(string userId, int clubId, CancellationToken ct = default)
+    {
+        var user = await userManager.FindByIdAsync(userId)
+            ?? throw new KeyNotFoundException($"User {userId} not found.");
+
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var exists = await db.ClubAdministrators
+            .AnyAsync(ca => ca.UserId == userId && ca.ClubId == clubId, ct);
+        if (exists) return;
+
+        db.ClubAdministrators.Add(new ClubAdministrator
+        {
+            UserId = userId,
+            ClubId = clubId,
+            AssignedAt = DateTime.UtcNow
+        });
+        await db.SaveChangesAsync(ct);
+
+        if (!await userManager.IsInRoleAsync(user, "ClubAdmin"))
+            await userManager.AddToRoleAsync(user, "ClubAdmin");
+    }
+
+    public async Task RemoveClubAdminAsync(string userId, int clubId, CancellationToken ct = default)
+    {
+        var user = await userManager.FindByIdAsync(userId)
+            ?? throw new KeyNotFoundException($"User {userId} not found.");
+
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var record = await db.ClubAdministrators.FindAsync([userId, clubId], ct);
+        if (record is null) return;
+        db.ClubAdministrators.Remove(record);
+        await db.SaveChangesAsync(ct);
+
+        var remaining = await db.ClubAdministrators.AnyAsync(ca => ca.UserId == userId, ct);
+        if (!remaining)
+            await userManager.RemoveFromRoleAsync(user, "ClubAdmin");
+    }
+}


### PR DESCRIPTION
Phase 5. Brings the SuperAdmin user roster + role/premium toggles + club-admin assignments to MAUI.

New \`IUserService\` wraps \`UserManager<ApplicationUser>\` + \`ClubAdministrators\` behind a host-agnostic interface (Get / SetRole / SetPremium / Update / Delete / AddClubAdmin / RemoveClubAdmin).

Seven new endpoints under \`/api/users\`. Role / premium toggles are SuperAdmin-only; CRUD ops are Admin/SuperAdmin with an "admin-tier guard" — an Admin cannot edit/delete another Admin or SuperAdmin. Self-delete is always rejected. The existing \`/api/users/{id}/upgrade-premium\` endpoint is kept for backwards compat.

## Test plan
- [x] Build clean, 28/28 tests.
- [ ] Web SuperAdmin: toggle Super Admin / Admin / Premium switches → refreshed; chip add/remove club admin; edit username/email; delete a regular user.
- [ ] Web Admin (non-SuperAdmin): cannot edit/delete other Admins or SuperAdmins (Forbid).
- [ ] MAUI smoke: same flows against the API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)