### PR TITLE
Phase 6 prep: lift GameState + SetScore to DropShot.Shared

### DIFF
--- a/DropShot.Shared/GameState.cs
+++ b/DropShot.Shared/GameState.cs
@@ -1,4 +1,4 @@
-namespace DropShot.Models;
+namespace DropShot.Shared;
 
 public record GameState(
     int UserPts,

--- a/DropShot.Shared/SetScore.cs
+++ b/DropShot.Shared/SetScore.cs
@@ -1,4 +1,4 @@
-namespace DropShot.Models;
+namespace DropShot.Shared;
 
 public class SetScore
 {

--- a/DropShot/Components/Pages/Scoreboard.razor
+++ b/DropShot/Components/Pages/Scoreboard.razor
@@ -3,6 +3,7 @@
 @attribute [Authorize(Roles = "Admin,SuperAdmin,ClubAdmin")]
 @using DropShot.Data
 @using DropShot.Models
+@using DropShot.Shared
 @using DropShot.Services
 @using Microsoft.AspNetCore.Authorization
 @using Microsoft.AspNetCore.SignalR.Client

--- a/DropShot/Components/Scoreboards/DefaultScoreboard.razor
+++ b/DropShot/Components/Scoreboards/DefaultScoreboard.razor
@@ -1,4 +1,5 @@
 @using DropShot.Models
+@using DropShot.Shared
 
 <div class="default-scoreboard">
     @if (SelectedCourt != null)

--- a/DropShot/Components/Scoreboards/WimbledonScoreboard.razor
+++ b/DropShot/Components/Scoreboards/WimbledonScoreboard.razor
@@ -1,4 +1,5 @@
 @using DropShot.Models
+@using DropShot.Shared
 @implements IDisposable
 
 <div class="wimbledon-board">

--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -748,9 +748,9 @@
         }
 
         // Broadcast initial state so the scoreboard shows player names and serve indicator immediately.
-        var initialState = new GameState(
+        var initialState = new DropShot.Shared.GameState(
             0, 0, 0, 0, 0, 0, false, 0, _state.IsUserServing,
-            0, 0, new List<SetScore>(), DateTime.Now, false,
+            0, 0, new List<DropShot.Shared.SetScore>(), DateTime.Now, false,
             GetUserDisplayName(), GetOpponentDisplayName()
         );
         if (hubConnection is not null)
@@ -806,7 +806,7 @@
     {
         if (CurrentMatch == null) return;
         var snapshotList = _state.SetScores.Select(s => s.Clone()).ToList();
-        var initialState = new GameState(_state.UserPoints, _state.OppPoints, _state.UserGames, _state.OppGames, _state.UserSets, _state.OppSets, _state.IsTieBreak, _state.DeuceCount, _state.IsUserServing, _state.UserGames, _state.OppGames, snapshotList, DateTime.Now, false, GetUserDisplayName(), GetOpponentDisplayName());
+        var initialState = new DropShot.Shared.GameState(_state.UserPoints, _state.OppPoints, _state.UserGames, _state.OppGames, _state.UserSets, _state.OppSets, _state.IsTieBreak, _state.DeuceCount, _state.IsUserServing, _state.UserGames, _state.OppGames, snapshotList, DateTime.Now, false, GetUserDisplayName(), GetOpponentDisplayName());
         history.Push(initialState);
         CurrentMatch.History = history;
         CurrentMatch.HistoryList = history.ToList();
@@ -980,7 +980,7 @@
             if (savedMatch != null && !string.IsNullOrEmpty(savedMatch.MatchJson))
             {
                 CurrentMatch = JsonConvert.DeserializeObject<Match>(savedMatch.MatchJson) ?? new Match();
-                history = new Stack<GameState>(CurrentMatch.HistoryList.AsEnumerable().Reverse());
+                history = new Stack<DropShot.Shared.GameState>(CurrentMatch.HistoryList.AsEnumerable().Reverse());
                 if (history.Any())
                     ScoreService.RestoreFromGameState(_state, history.Peek());
                 _state.GameScoring = CurrentMatch.GameScoring;
@@ -1188,7 +1188,7 @@
         await SetImmersive(_isImmersive);
     }
 
-    private Stack<GameState> history = new(new[] { new GameState(0, 0, 0, 0, 0, 0, false, 0, false, 0, 0, new List<SetScore>(), DateTime.Now, false, "", "") });
+    private Stack<DropShot.Shared.GameState> history = new(new[] { new DropShot.Shared.GameState(0, 0, 0, 0, 0, 0, false, 0, false, 0, 0, new List<DropShot.Shared.SetScore>(), DateTime.Now, false, "", "") });
 
 
 
@@ -1388,7 +1388,7 @@
     {
         var snapshotList = _state.SetScores.Select(s => s.Clone()).ToList();
 
-        history.Push(new GameState(_state.UserPoints, _state.OppPoints, _state.UserGames, _state.OppGames, _state.UserSets, _state.OppSets, _state.IsTieBreak, _state.DeuceCount, _state.IsUserServing, _state.UserGames, _state.OppGames, snapshotList, DateTime.Now, _state.IsMatchEnded, GetUserDisplayName(), GetOpponentDisplayName()));
+        history.Push(new DropShot.Shared.GameState(_state.UserPoints, _state.OppPoints, _state.UserGames, _state.OppGames, _state.UserSets, _state.OppSets, _state.IsTieBreak, _state.DeuceCount, _state.IsUserServing, _state.UserGames, _state.OppGames, snapshotList, DateTime.Now, _state.IsMatchEnded, GetUserDisplayName(), GetOpponentDisplayName()));
 
         await PersistAndBroadcast();
     }
@@ -1607,13 +1607,13 @@
         return $"{side1} vs {side2}";
     }
 
-    private static Color FixtureStatusColor(FixtureStatus s) => s switch
+    private static Color FixtureStatusColor(DropShot.Models.FixtureStatus s) => s switch
     {
-        FixtureStatus.Scheduled => Color.Default,
-        FixtureStatus.InProgress => Color.Warning,
-        FixtureStatus.Completed => Color.Success,
-        FixtureStatus.Cancelled => Color.Error,
-        FixtureStatus.Walkover => Color.Info,
+        DropShot.Models.FixtureStatus.Scheduled => Color.Default,
+        DropShot.Models.FixtureStatus.InProgress => Color.Warning,
+        DropShot.Models.FixtureStatus.Completed => Color.Success,
+        DropShot.Models.FixtureStatus.Cancelled => Color.Error,
+        DropShot.Models.FixtureStatus.Walkover => Color.Info,
         _ => Color.Default
     };
 

--- a/DropShot/Models/Match.cs
+++ b/DropShot/Models/Match.cs
@@ -1,3 +1,5 @@
+using DropShot.Shared;
+
 namespace DropShot.Models;
 
 public class Match

--- a/DropShot/Models/TennisMatchState.cs
+++ b/DropShot/Models/TennisMatchState.cs
@@ -1,3 +1,5 @@
+using DropShot.Shared;
+
 namespace DropShot.Models;
 
 public enum SetWinMode : byte

--- a/DropShot/Services/TennisScoreService.cs
+++ b/DropShot/Services/TennisScoreService.cs
@@ -104,7 +104,7 @@ public class TennisScoreService
 
     public void EndSet(TennisMatchState s)
     {
-        s.SetScores.Add(new SetScore
+        s.SetScores.Add(new DropShot.Shared.SetScore
         {
             SetNumber = s.SetScores.Count + 1,
             UserGames = s.UserGames,
@@ -165,7 +165,7 @@ public class TennisScoreService
         s.SetScores.Clear();
     }
 
-    public void RestoreFromGameState(TennisMatchState s, GameState gs)
+    public void RestoreFromGameState(TennisMatchState s, DropShot.Shared.GameState gs)
     {
         s.UserPoints = gs.UserPts;
         s.OppPoints = gs.OppPts;


### PR DESCRIPTION
Phase 6 (Scoreboard / TeamMatchScoring) prep PR. Moves the live-scoring state types — \`GameState\` (record) + \`SetScore\` (mutable class with \`Clone\`) — from \`DropShot/Models/\` into \`DropShot.Shared/\`, namespace \`DropShot.Shared\`. This is the precondition for moving \`Scoreboard.razor\` / \`TeamMatchScoring.razor\` / the \`Scoreboards/*\` subcomponents into the RCL — they parameterise on \`GameState\` directly.

Adds \`using DropShot.Shared\` (or fully-qualified \`DropShot.Shared.GameState\`/\`SetScore\` where the shared namespace would otherwise cause ambiguity with duplicate enums in \`DropShot.Models\`) to consumers. Two \`FixtureStatus\` references in TennisScore.razor are fully-qualified to \`DropShot.Models.FixtureStatus\` to keep the existing duplicate-enum pattern.

**Deferred to follow-up PR:**
- Page moves (Scoreboard, TeamMatchScoring, Scoreboards/* subcomponents).
- \`Microsoft.AspNetCore.SignalR.Client\` package on MAUI + \`IScoreboardHubFactory\` plumbing — the package surfaced an Android material-design transitive resource conflict that needs investigation. Deferring lets that be its own focused PR rather than mixing transitive-dep debugging with the entity-type lift here.

## Test plan
- [x] Build clean, 28/28 tests.
- [ ] Web smoke: \`/score\` still loads / SignalR scoreboard updates work / fullscreen toggle works (no behavioural change).
- [ ] Web smoke: \`/match/{id}\` (TennisScore) still scores correctly (no behavioural change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)