### PR TITLE
Phase 6: add Microsoft.AspNetCore.SignalR.Client + IScoreboardHubFactory

### DIFF
--- a/DropShot.Maui/DropShot.Maui.csproj
+++ b/DropShot.Maui/DropShot.Maui.csproj
@@ -69,6 +69,7 @@
         <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.8" />
         <PackageReference Include="MudBlazor" Version="9.2.0" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.4.0" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/DropShot.Maui/MauiProgram.cs
+++ b/DropShot.Maui/MauiProgram.cs
@@ -58,6 +58,7 @@ public static class MauiProgram
         builder.Services.AddScoped<IMatchService, HttpMatchService>();
         builder.Services.AddScoped<IScoreboardService, HttpScoreboardService>();
         builder.Services.AddScoped<IUserService, HttpUserService>();
+        builder.Services.AddScoped<IScoreboardHubFactory, HttpScoreboardHubFactory>();
 
         // Required for [Authorize] attributes and <AuthorizeView>
         builder.Services.AddAuthorizationCore();

--- a/DropShot.Maui/Services/HttpScoreboardHubFactory.cs
+++ b/DropShot.Maui/Services/HttpScoreboardHubFactory.cs
@@ -1,0 +1,31 @@
+using DropShot.UI.Services;
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.Configuration;
+
+namespace DropShot.Maui.Services;
+
+/// <summary>
+/// MAUI implementation of <see cref="IScoreboardHubFactory"/>. Builds the
+/// connection against an absolute URL (<c>App:BaseUrl</c> + <c>/chathub</c>)
+/// and attaches the JWT bearer token via <c>AccessTokenProvider</c> so the
+/// hub authentication picks up the signed-in MAUI user.
+/// </summary>
+public sealed class HttpScoreboardHubFactory(
+    IConfiguration config,
+    AuthService auth) : IScoreboardHubFactory
+{
+    public HubConnection Create()
+    {
+        var baseUrl = config["App:BaseUrl"]?.TrimEnd('/') ?? "";
+        var hubUrl = $"{baseUrl}/chathub";
+
+        return new HubConnectionBuilder()
+            .WithUrl(hubUrl, options =>
+            {
+                options.AccessTokenProvider = () =>
+                    Task.FromResult<string?>(auth.Session?.AccessToken);
+            })
+            .WithAutomaticReconnect()
+            .Build();
+    }
+}

--- a/DropShot.UI/DropShot.UI.csproj
+++ b/DropShot.UI/DropShot.UI.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="9.0.1" />
     <PackageReference Include="MudBlazor" Version="9.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DropShot.UI/Services/IScoreboardHubFactory.cs
+++ b/DropShot.UI/Services/IScoreboardHubFactory.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.SignalR.Client;
+
+namespace DropShot.UI.Services;
+
+/// <summary>
+/// Builds the SignalR <see cref="HubConnection"/> for the scoreboard hub.
+/// Web hosts hand the connection a relative URL via NavigationManager; MAUI
+/// uses an absolute URL (App:BaseUrl) and attaches the JWT bearer token via
+/// AccessTokenProvider so the hub auth pipeline picks up the active session.
+/// </summary>
+public interface IScoreboardHubFactory
+{
+    HubConnection Create();
+}

--- a/DropShot/Program.cs
+++ b/DropShot/Program.cs
@@ -132,6 +132,7 @@ builder.Services.AddScoped<IInvitationService, WebInvitationService>();
 builder.Services.AddScoped<IMatchService, WebMatchService>();
 builder.Services.AddScoped<IScoreboardService, WebScoreboardService>();
 builder.Services.AddScoped<IUserService, WebUserService>();
+builder.Services.AddScoped<IScoreboardHubFactory, WebScoreboardHubFactory>();
 builder.Services.AddSingleton<BackgroundTaskQueue>();
 builder.Services.AddScoped<ResultVerificationService>();
 builder.Services.AddScoped<AdminEmailService>();

--- a/DropShot/Services/WebScoreboardHubFactory.cs
+++ b/DropShot/Services/WebScoreboardHubFactory.cs
@@ -1,0 +1,19 @@
+using DropShot.UI.Services;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.SignalR.Client;
+
+namespace DropShot.Services;
+
+/// <summary>
+/// Web implementation of <see cref="IScoreboardHubFactory"/>. Builds the
+/// connection against the in-process <c>/chathub</c> route resolved through
+/// <see cref="NavigationManager"/>; cookie auth flows automatically.
+/// </summary>
+public sealed class WebScoreboardHubFactory(NavigationManager nav) : IScoreboardHubFactory
+{
+    public HubConnection Create() =>
+        new HubConnectionBuilder()
+            .WithUrl(nav.ToAbsoluteUri("/chathub"))
+            .WithAutomaticReconnect()
+            .Build();
+}


### PR DESCRIPTION
Phase 6 plumbing PR. Adds the SignalR client to MAUI + DropShot.UI at \`9.0.0\` (\`9.0.1\` surfaced an Android Material Design 3 transitive resource conflict in \`Xamarin.Google.Android.Material 1.10\`, \`9.0.0\` sidesteps it cleanly).

\`IScoreboardHubFactory\` abstracts hub connection setup so the moved Scoreboard page can build a \`HubConnection\` without host coupling:

- \`WebScoreboardHubFactory\` — \`NavigationManager.ToAbsoluteUri(\"/chathub\")\`, cookie auth.
- \`HttpScoreboardHubFactory\` — \`App:BaseUrl + \"/chathub\"\` with \`AccessTokenProvider\` returning \`AuthService.Session?.AccessToken\` so the hub auth pipeline picks up the JWT on MAUI.

Both factories use \`WithAutomaticReconnect\` to match the existing \`Reconnected\` handler in \`Scoreboard.razor\`.

The actual page moves (\`Scoreboard\`, \`TeamMatchScoring\`, \`Scoreboards/*\` subcomponents) remain for follow-up PRs — this is just the plumbing they'll consume.

## Test plan
- [x] Build clean across all six projects, 28/28 tests.
- [ ] Web smoke: \`/score\` still renders + receives live SignalR updates (no behavioural change since the page hasn't moved yet).
- [ ] Web smoke: \`/match/{id}\` (TennisScore.razor) still scores + broadcasts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)