### PR TITLE
Phase 7: move CreateEventDialog into DropShot.UI (phase 5 deferral)

### DIFF
--- a/DropShot.UI/Components/Shared/CreateEventDialog.razor
+++ b/DropShot.UI/Components/Shared/CreateEventDialog.razor
@@ -1,4 +1,5 @@
-@using DropShot.Models
+@using DropShot.Shared
+@using DropShot.Shared.Dtos
 
 <MudDialog>
     <TitleContent>Create Event</TitleContent>
@@ -128,7 +129,7 @@
 
 @code {
     [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = null!;
-    [Parameter] public List<Club> Clubs { get; set; } = [];
+    [Parameter] public List<ClubDto> Clubs { get; set; } = [];
 
     private MudForm? _form;
     private bool _isValid;

--- a/DropShot/Components/Pages/Competitions.razor
+++ b/DropShot/Components/Pages/Competitions.razor
@@ -743,7 +743,11 @@
     private async Task OpenCreateEventDialogAsync()
     {
         await using var db = DbFactory.CreateDbContext();
-        var clubs = await db.Clubs.OrderBy(c => c.Name).ToListAsync();
+        var clubEntities = await db.Clubs.Include(c => c.Courts).OrderBy(c => c.Name).ToListAsync();
+        var clubs = clubEntities.Select(c => new ClubDto(
+            c.ClubId, c.Name, c.AddressLine1, c.AddressLine2,
+            c.Town, c.Postcode, c.Phone, c.Email, c.Website,
+            c.Courts.Count)).ToList();
 
         var parameters = new DialogParameters<CreateEventDialog> { { x => x.Clubs, clubs } };
         var dialog = await DialogService.ShowAsync<CreateEventDialog>("Create Event", parameters,
@@ -772,8 +776,8 @@
             var comp = new Competition
             {
                 CompetitionName = c.Name,
-                CompetitionFormat = c.Format,
-                EligibleSex = c.EligibleSex,
+                CompetitionFormat = (DropShot.Models.CompetitionFormat)c.Format,
+                EligibleSex = (DropShot.Models.PlayerSex?)c.EligibleSex,
                 MaxAge = c.MaxAge,
                 MinAge = c.MinAge,
                 TeamSize = c.TeamSize,


### PR DESCRIPTION
Closes the \`CreateEventDialog\` deferral noted at the end of phase 5.

- \`Clubs\` parameter switches from \`List<DropShot.Models.Club>\` to \`List<ClubDto>\` (strict superset of the fields the dialog uses).
- \`@using DropShot.Models\` → \`@using DropShot.Shared\` + \`DropShot.Shared.Dtos\`. The dialog's record types now reference \`DropShot.Shared.CompetitionFormat\`/\`PlayerSex\`.
- \`Competitions.razor\` (the only caller) projects loaded clubs to \`ClubDto\` at the call site and adds explicit \`(DropShot.Models.CompetitionFormat)\` / \`(DropShot.Models.PlayerSex?)\` casts when populating the entity, matching the existing duplicate-enum pattern across the codebase.

Phase 7 remaining: Home, Competitions, CompetitionPage, Upgrade, TennisScore + score dialogs + TeamMatchScoring. Each carries deeper refactoring (PayPal split for Upgrade, Landing.razor extraction for Home, RubberResolutionService for the scoring chain) and needs its own dedicated session.

## Test plan
- [x] Build clean, 28/28 tests.
- [ ] Web smoke: \`/competitions\` → "Create Event" button still opens the dialog, creates event + competitions identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)