### PR TITLE
Phase 7: move ClaimCourtDialog with ICourtClaimService

### DIFF
--- a/DropShot.Tests/Helpers/DropShotTestContext.cs
+++ b/DropShot.Tests/Helpers/DropShotTestContext.cs
@@ -104,7 +104,9 @@ public class DropShotTestContext : BunitContext
 
         Services.AddScoped(_ => Substitute.For<JwtTokenService>(config, userManager));
 
-        Services.AddScoped(_ => new CourtClaimService(DbFactory));
+        var courtClaim = new CourtClaimService(DbFactory);
+        Services.AddScoped(_ => courtClaim);
+        Services.AddScoped<ICourtClaimService>(_ => courtClaim);
 
         Services.AddSingleton<QrLoginService>();
         Services.AddSingleton<BackgroundTaskQueue>();

--- a/DropShot.UI/Components/Shared/ClaimCourtDialog.razor
+++ b/DropShot.UI/Components/Shared/ClaimCourtDialog.razor
@@ -1,7 +1,6 @@
-@using DropShot.Services
 @using Microsoft.AspNetCore.SignalR.Client
-@inject NavigationManager Navigation
-@inject CourtClaimService CourtClaim
+@inject ICourtClaimService CourtClaim
+@inject IScoreboardHubFactory HubFactory
 @implements IAsyncDisposable
 
 <MudDialog>
@@ -37,10 +36,7 @@
 
     protected override async Task OnInitializedAsync()
     {
-        _hub = new HubConnectionBuilder()
-            .WithUrl(Navigation.ToAbsoluteUri("/chathub"))
-            .Build();
-
+        _hub = HubFactory.Create();
         _hub.On<int, int, bool>("CourtChallengeResponse", OnResponse);
 
         await _hub.StartAsync();

--- a/DropShot.UI/Services/ICourtClaimService.cs
+++ b/DropShot.UI/Services/ICourtClaimService.cs
@@ -1,0 +1,18 @@
+namespace DropShot.UI.Services;
+
+/// <summary>
+/// Court-claim coordination: figuring out whether a SavedMatch on a court is
+/// still active or abandoned, and acting on the result. Phase 7 surface —
+/// covers what <c>ClaimCourtDialog</c> needs (stale check + force-end) so
+/// the dialog can move into the RCL. The full evaluation surface
+/// (<c>EvaluateAsync</c>, grace tracking) stays web-only for now since its
+/// only caller is <c>TennisScore.razor</c>.
+/// </summary>
+public interface ICourtClaimService
+{
+    /// <summary>True when the SavedMatch hasn't seen activity for the abandon threshold.</summary>
+    Task<bool> IsStaleAsync(int savedMatchId, CancellationToken ct = default);
+
+    /// <summary>Mark the SavedMatch complete and clear the grace window.</summary>
+    Task EndMatchAsync(int savedMatchId, CancellationToken ct = default);
+}

--- a/DropShot/Program.cs
+++ b/DropShot/Program.cs
@@ -116,6 +116,7 @@ builder.Services.AddScoped<UserState>();
 builder.Services.AddScoped<TennisScoreService>();
 builder.Services.AddScoped<ClubAuthorizationService>();
 builder.Services.AddSingleton<CourtClaimService>();
+builder.Services.AddSingleton<ICourtClaimService>(sp => sp.GetRequiredService<CourtClaimService>());
 builder.Services.AddSingleton<SiteSettingsService>();
 builder.Services.AddScoped<JwtTokenService>();
 builder.Services.AddSingleton<EmailService>();

--- a/DropShot/Services/CourtClaimService.cs
+++ b/DropShot/Services/CourtClaimService.cs
@@ -1,5 +1,6 @@
 using DropShot.Data;
 using DropShot.Models;
+using DropShot.UI.Services;
 using Microsoft.EntityFrameworkCore;
 
 namespace DropShot.Services;
@@ -10,7 +11,7 @@ namespace DropShot.Services;
 /// <see cref="AbandonAfter"/> are treated as abandoned and auto-closed
 /// so the next user can claim the court without interaction.
 /// </summary>
-public sealed class CourtClaimService
+public sealed class CourtClaimService : ICourtClaimService
 {
     public static readonly TimeSpan AbandonAfter = TimeSpan.FromMinutes(10);
     public static readonly TimeSpan GraceAfterYes = TimeSpan.FromMinutes(15);


### PR DESCRIPTION
\`ICourtClaimService\` surfaces \`IsStaleAsync\` + \`EndMatchAsync\` — the only methods \`ClaimCourtDialog\` needs. \`CourtClaimService\` implements it directly (signatures match); web DI re-registers the existing singleton under the interface; test context mirrors.

Dialog moves to \`DropShot.UI/Components/Shared/\` and:
- \`@inject CourtClaimService\` → \`@inject ICourtClaimService\`
- inline \`HubConnectionBuilder.WithUrl(NavigationManager.ToAbsoluteUri("/chathub"))\` → \`IScoreboardHubFactory.Create()\` so the JWT-bearer flow that #485 added is picked up when the dialog eventually ships on MAUI.

Consumer (\`TennisScore.razor\`) is still web-only.

## Test plan
- [x] Build clean, 28/28 tests.
- [ ] Web smoke: starting a match on a busy court still triggers the challenge dialog and resolves correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)