### PR TITLE
Phase 7: move ReviewResultDialog with ICompetitionService.ApproveFixtureResultAsync

### DIFF
--- a/DropShot.Maui/Services/HttpCompetitionService.cs
+++ b/DropShot.Maui/Services/HttpCompetitionService.cs
@@ -33,4 +33,11 @@ public sealed class HttpCompetitionService(HttpClient http) : ICompetitionServic
             new UpdateParticipantStatusRequest(status), ct);
         resp.EnsureSuccessStatusCode();
     }
+
+    public async Task ApproveFixtureResultAsync(int fixtureId, ApproveFixtureResultRequest request, CancellationToken ct = default)
+    {
+        var resp = await http.PostAsJsonAsync(
+            $"api/competitions/fixtures/{fixtureId}/approve-result", request, ct);
+        resp.EnsureSuccessStatusCode();
+    }
 }

--- a/DropShot.Shared/Dtos/CompetitionDtos.cs
+++ b/DropShot.Shared/Dtos/CompetitionDtos.cs
@@ -142,6 +142,23 @@ public record AddStageRequest(StageType StageType, string? Name = null, int? Sta
 public record AddParticipantRequest(int PlayerId, bool Force = false);
 
 /// <summary>
+/// Approve an awaiting-verification fixture result, optionally overriding the
+/// score. When <c>OverrideScores</c> is non-null, the original ResultSummary
+/// + WinnerPlayerId are preserved on the fixture for audit and the new score
+/// becomes authoritative.
+/// </summary>
+public record ApproveFixtureResultRequest(
+    FixtureScoreOverride? OverrideScores = null);
+
+public record FixtureScoreOverride(
+    string ResultSummary,
+    int WinnerPlayerId,
+    int HomeSetsWon,
+    int AwaySetsWon,
+    int HomeGamesTotal,
+    int AwayGamesTotal);
+
+/// <summary>
 /// Response body returned with HTTP 409 when an admin action would violate a
 /// competition's eligibility rules (sex / age / allow-list / mixed-doubles
 /// pairing / MTT composition). The admin UI shows these as a confirmation

--- a/DropShot.UI/Components/Shared/ReviewResultDialog.razor
+++ b/DropShot.UI/Components/Shared/ReviewResultDialog.razor
@@ -1,9 +1,4 @@
-@using DropShot.Data
-@using DropShot.Models
-@using DropShot.Services
-@using Microsoft.EntityFrameworkCore
-
-@inject IDbContextFactory<MyDbContext> DbFactory
+@inject ICompetitionService CompetitionService
 
 <MudDialog>
     <TitleContent>
@@ -13,7 +8,7 @@
         <MudStack Spacing="3">
             @* Competition & fixture info *@
             <MudText Typo="Typo.subtitle2" Color="Color.Primary">
-                @(Fixture.Competition?.CompetitionName ?? "Competition")
+                @(string.IsNullOrEmpty(CompetitionName) ? "Competition" : CompetitionName)
             </MudText>
             @if (!string.IsNullOrEmpty(Fixture.FixtureLabel))
             {
@@ -114,7 +109,14 @@
 
     [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = default!;
 
-    [Parameter] public CompetitionFixture Fixture { get; set; } = default!;
+    [Parameter, EditorRequired] public CompetitionFixtureDto Fixture { get; set; } = default!;
+    [Parameter] public string? CompetitionName { get; set; }
+
+    /// <summary>
+    /// Number of set fields to render. Caller computes from the competition's
+    /// MatchFormat / BestOf / NumberOfSets — defaults to 3 if not provided.
+    /// </summary>
+    [Parameter] public int MaxSets { get; set; } = 3;
 
     private int _bestOf = 3;
     private int?[] _score1 = new int?[3];
@@ -128,21 +130,17 @@
 
     protected override void OnParametersSet()
     {
-        var comp = Fixture.Competition;
-        _bestOf = comp?.MatchFormat == MatchFormatType.FixedSets
-            ? Math.Max(1, comp.NumberOfSets)
-            : Math.Max(1, comp?.BestOf ?? 3);
+        _bestOf = Math.Max(1, MaxSets);
         _score1 = new int?[_bestOf];
         _score2 = new int?[_bestOf];
 
-        var s1Parts = new[] { Fixture.Player1?.DisplayName, Fixture.Player3?.DisplayName }
-            .Where(n => n != null).ToList();
-        var s2Parts = new[] { Fixture.Player2?.DisplayName, Fixture.Player4?.DisplayName }
-            .Where(n => n != null).ToList();
+        var s1Parts = new[] { Fixture.Player1Name, Fixture.Player3Name }
+            .Where(n => !string.IsNullOrEmpty(n)).ToList();
+        var s2Parts = new[] { Fixture.Player2Name, Fixture.Player4Name }
+            .Where(n => !string.IsNullOrEmpty(n)).ToList();
         _side1 = s1Parts.Any() ? string.Join(" & ", s1Parts) : "Player 1";
         _side2 = s2Parts.Any() ? string.Join(" & ", s2Parts) : "Player 2";
 
-        // Pre-fill edit fields from submitted result
         _winnerPlayerId = Fixture.WinnerPlayerId;
         ParseResultSummary(Fixture.ResultSummary);
     }
@@ -150,12 +148,10 @@
     private void ParseResultSummary(string? summary)
     {
         if (string.IsNullOrEmpty(summary)) return;
-        // Handle both comma-separated and space-separated formats
         var sets = summary.Replace(",", " ").Split(' ', StringSplitOptions.RemoveEmptyEntries);
         for (int i = 0; i < Math.Min(sets.Length, _bestOf); i++)
         {
-            // Handle both regular dash and en-dash
-            var parts = sets[i].Replace("\u2013", "-").Split('-', StringSplitOptions.TrimEntries);
+            var parts = sets[i].Replace("–", "-").Split('-', StringSplitOptions.TrimEntries);
             if (parts.Length == 2 && int.TryParse(parts[0], out var s1) && int.TryParse(parts[1], out var s2))
             {
                 _score1[i] = s1;
@@ -175,14 +171,13 @@
     {
         _error = null;
 
+        FixtureScoreOverride? overrideScores = null;
         if (_editing)
         {
-            var enteredSets = Enumerable.Range(0, _bestOf)
-                .Where(i => _score1[i].HasValue || _score2[i].HasValue)
-                .Select(i => $"{_score1[i] ?? 0}\u2013{_score2[i] ?? 0}")
-                .ToList();
+            var enteredCount = Enumerable.Range(0, _bestOf)
+                .Count(i => _score1[i].HasValue || _score2[i].HasValue);
 
-            if (!enteredSets.Any())
+            if (enteredCount == 0)
             {
                 _error = "Please enter at least one set score.";
                 return;
@@ -193,52 +188,32 @@
                 _error = "Please select a winner.";
                 return;
             }
+
+            var newSummary = string.Join(" ", Enumerable.Range(0, _bestOf)
+                .Where(i => _score1[i].HasValue || _score2[i].HasValue)
+                .Select(i => $"{_score1[i] ?? 0}–{_score2[i] ?? 0}"));
+
+            int homeSets = 0, awaySets = 0, homeGames = 0, awayGames = 0;
+            for (int i = 0; i < _bestOf; i++)
+            {
+                int s1 = _score1[i] ?? 0;
+                int s2 = _score2[i] ?? 0;
+                homeGames += s1;
+                awayGames += s2;
+                if (s1 > s2) homeSets++;
+                else if (s2 > s1) awaySets++;
+            }
+
+            overrideScores = new FixtureScoreOverride(
+                newSummary, _winnerPlayerId.Value, homeSets, awaySets, homeGames, awayGames);
         }
 
         _saving = true;
         try
         {
-            await using var db = DbFactory.CreateDbContext();
-            var fx = await db.CompetitionFixtures
-                .Include(f => f.Competition)
-                .FirstOrDefaultAsync(f => f.CompetitionFixtureId == Fixture.CompetitionFixtureId);
-            if (fx == null) { _error = "Fixture not found."; return; }
-
-            if (_editing)
-            {
-                var newSummary = string.Join(" ", Enumerable.Range(0, _bestOf)
-                    .Where(i => _score1[i].HasValue || _score2[i].HasValue)
-                    .Select(i => $"{_score1[i] ?? 0}\u2013{_score2[i] ?? 0}"));
-
-                // Store original before overwriting
-                fx.OriginalResultSummary = fx.ResultSummary;
-                fx.OriginalWinnerPlayerId = fx.WinnerPlayerId;
-                fx.ResultModifiedByAdmin = true;
-                fx.ResultSummary = newSummary;
-                fx.WinnerPlayerId = _winnerPlayerId;
-
-                int homeSets = 0, awaySets = 0, homeGames = 0, awayGames = 0;
-                for (int i = 0; i < _bestOf; i++)
-                {
-                    int s1 = _score1[i] ?? 0;
-                    int s2 = _score2[i] ?? 0;
-                    homeGames += s1;
-                    awayGames += s2;
-                    if (s1 > s2) homeSets++;
-                    else if (s2 > s1) awaySets++;
-                }
-                fx.HomeSetsWon = homeSets;
-                fx.AwaySetsWon = awaySets;
-                fx.HomeGamesTotal = homeGames;
-                fx.AwayGamesTotal = awayGames;
-            }
-
-            fx.Status = FixtureStatus.Completed;
-            fx.CompletedAt = DateTime.UtcNow;
-            fx.VerificationToken = null;
-
-            await db.SaveChangesAsync();
-            await CompetitionProgressionService.TryAdvanceAsync(db, fx.CompetitionId, fx.CompetitionFixtureId);
+            await CompetitionService.ApproveFixtureResultAsync(
+                Fixture.CompetitionFixtureId,
+                new ApproveFixtureResultRequest(overrideScores));
         }
         catch (Exception)
         {

--- a/DropShot.UI/Services/ICompetitionService.cs
+++ b/DropShot.UI/Services/ICompetitionService.cs
@@ -26,4 +26,12 @@ public interface ICompetitionService
     /// Registered → FullPlayer or Substitute).
     /// </summary>
     Task ConfirmParticipationAsync(int competitionId, ParticipantStatus status, CancellationToken ct = default);
+
+    /// <summary>
+    /// Approve a fixture's awaiting-verification result. Without
+    /// <c>OverrideScores</c> the existing submission is accepted as-is; with
+    /// it, the original result is preserved for audit and the new score
+    /// becomes authoritative. Marks Completed + runs CompetitionProgressionService.
+    /// </summary>
+    Task ApproveFixtureResultAsync(int fixtureId, ApproveFixtureResultRequest request, CancellationToken ct = default);
 }

--- a/DropShot/Components/Pages/Competitions.razor
+++ b/DropShot/Components/Pages/Competitions.razor
@@ -726,10 +726,22 @@
             .Include(f => f.Competition)
             .Include(f => f.Player1).Include(f => f.Player2)
             .Include(f => f.Player3).Include(f => f.Player4)
+            .Include(f => f.HomeTeam)
+            .Include(f => f.AwayTeam)
             .FirstOrDefaultAsync(f => f.CompetitionFixtureId == fixture.CompetitionFixtureId);
         if (loaded == null) return;
 
-        var parameters = new DialogParameters<ReviewResultDialog> { { x => x.Fixture, loaded } };
+        var dto = ToFixtureDto(loaded);
+        var maxSets = loaded.Competition?.MatchFormat == MatchFormatType.FixedSets
+            ? Math.Max(1, loaded.Competition.NumberOfSets)
+            : Math.Max(1, loaded.Competition?.BestOf ?? 3);
+
+        var parameters = new DialogParameters<ReviewResultDialog>
+        {
+            { x => x.Fixture, dto },
+            { x => x.CompetitionName, loaded.Competition?.CompetitionName },
+            { x => x.MaxSets, maxSets }
+        };
         var dialog = await DialogService.ShowAsync<ReviewResultDialog>("Review Result", parameters,
             new DialogOptions { MaxWidth = MaxWidth.Small, FullWidth = true });
         var result = await dialog.Result;
@@ -739,6 +751,22 @@
             Snackbar.Add("Result verified.", Severity.Success);
         }
     }
+
+    private static DropShot.Shared.Dtos.CompetitionFixtureDto ToFixtureDto(CompetitionFixture f) =>
+        new(
+            f.CompetitionFixtureId, f.CompetitionId,
+            f.CompetitionStageId, f.Stage?.Name,
+            f.CourtId, f.Court?.Name,
+            f.ScheduledAt, (DropShot.Shared.FixtureStatus)f.Status,
+            f.FixtureLabel, f.RoundNumber,
+            f.Player1Id, f.Player1?.DisplayName,
+            f.Player2Id, f.Player2?.DisplayName,
+            f.Player3Id, f.Player3?.DisplayName,
+            f.Player4Id, f.Player4?.DisplayName,
+            f.ResultSummary, f.WinnerPlayerId,
+            f.HomeTeamId, f.HomeTeam?.Name,
+            f.AwayTeamId, f.AwayTeam?.Name,
+            f.WinnerTeamId, f.CourtPairId, f.CourtPair?.Name);
 
     private async Task OpenCreateEventDialogAsync()
     {

--- a/DropShot/Components/Pages/Home.razor
+++ b/DropShot/Components/Pages/Home.razor
@@ -612,10 +612,22 @@
             .Include(f => f.Competition)
             .Include(f => f.Player1).Include(f => f.Player2)
             .Include(f => f.Player3).Include(f => f.Player4)
+            .Include(f => f.HomeTeam)
+            .Include(f => f.AwayTeam)
             .FirstOrDefaultAsync(f => f.CompetitionFixtureId == fixture.CompetitionFixtureId);
         if (loaded == null) return;
 
-        var parameters = new DialogParameters<ReviewResultDialog> { { x => x.Fixture, loaded } };
+        var dto = ToFixtureDto(loaded);
+        var maxSets = loaded.Competition?.MatchFormat == MatchFormatType.FixedSets
+            ? Math.Max(1, loaded.Competition.NumberOfSets)
+            : Math.Max(1, loaded.Competition?.BestOf ?? 3);
+
+        var parameters = new DialogParameters<ReviewResultDialog>
+        {
+            { x => x.Fixture, dto },
+            { x => x.CompetitionName, loaded.Competition?.CompetitionName },
+            { x => x.MaxSets, maxSets }
+        };
         var dialog = await DialogService.ShowAsync<ReviewResultDialog>("Review Result", parameters,
             new DialogOptions { MaxWidth = MaxWidth.Small, FullWidth = true });
         var result = await dialog.Result;
@@ -625,4 +637,20 @@
             Snackbar.Add("Result verified.", Severity.Success);
         }
     }
+
+    private static DropShot.Shared.Dtos.CompetitionFixtureDto ToFixtureDto(CompetitionFixture f) =>
+        new(
+            f.CompetitionFixtureId, f.CompetitionId,
+            f.CompetitionStageId, f.Stage?.Name,
+            f.CourtId, f.Court?.Name,
+            f.ScheduledAt, (DropShot.Shared.FixtureStatus)f.Status,
+            f.FixtureLabel, f.RoundNumber,
+            f.Player1Id, f.Player1?.DisplayName,
+            f.Player2Id, f.Player2?.DisplayName,
+            f.Player3Id, f.Player3?.DisplayName,
+            f.Player4Id, f.Player4?.DisplayName,
+            f.ResultSummary, f.WinnerPlayerId,
+            f.HomeTeamId, f.HomeTeam?.Name,
+            f.AwayTeamId, f.AwayTeam?.Name,
+            f.WinnerTeamId, f.CourtPairId, f.CourtPair?.Name);
 }

--- a/DropShot/Controllers/CompetitionsController.cs
+++ b/DropShot/Controllers/CompetitionsController.cs
@@ -371,6 +371,30 @@ public class CompetitionsController(
         catch (InvalidOperationException ex) { return BadRequest(new { message = ex.Message }); }
     }
 
+    /// <summary>
+    /// Approve an awaiting-verification fixture result (optionally overriding
+    /// the score). Backs ReviewResultDialog (phase 7).
+    /// </summary>
+    [HttpPost("fixtures/{fixtureId:int}/approve-result")]
+    public async Task<IActionResult> ApproveFixtureResult(
+        int fixtureId, [FromBody] ApproveFixtureResultRequest req, CancellationToken ct)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var fx = await db.CompetitionFixtures
+            .Include(f => f.Competition)
+            .FirstOrDefaultAsync(f => f.CompetitionFixtureId == fixtureId, ct);
+        if (fx is null) return NotFound();
+        if (!await authzService.CanEditCompetitionAsync(User, fx.Competition?.HostClubId, fx.CompetitionId))
+            return Forbid();
+
+        try
+        {
+            await competitionService.ApproveFixtureResultAsync(fixtureId, req, ct);
+            return NoContent();
+        }
+        catch (KeyNotFoundException) { return NotFound(); }
+    }
+
     [HttpDelete("{id:int}/participants/{playerId:int}")]
     public async Task<IActionResult> RemoveParticipant(int id, int playerId)
     {

--- a/DropShot/Services/WebCompetitionService.cs
+++ b/DropShot/Services/WebCompetitionService.cs
@@ -211,6 +211,36 @@ public sealed class WebCompetitionService(
         await db.SaveChangesAsync(ct);
     }
 
+    public async Task ApproveFixtureResultAsync(
+        int fixtureId, ApproveFixtureResultRequest request, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var fx = await db.CompetitionFixtures
+            .Include(f => f.Competition)
+            .FirstOrDefaultAsync(f => f.CompetitionFixtureId == fixtureId, ct)
+            ?? throw new KeyNotFoundException($"Fixture {fixtureId} not found.");
+
+        if (request.OverrideScores is { } o)
+        {
+            fx.OriginalResultSummary = fx.ResultSummary;
+            fx.OriginalWinnerPlayerId = fx.WinnerPlayerId;
+            fx.ResultModifiedByAdmin = true;
+            fx.ResultSummary = o.ResultSummary;
+            fx.WinnerPlayerId = o.WinnerPlayerId;
+            fx.HomeSetsWon = o.HomeSetsWon;
+            fx.AwaySetsWon = o.AwaySetsWon;
+            fx.HomeGamesTotal = o.HomeGamesTotal;
+            fx.AwayGamesTotal = o.AwayGamesTotal;
+        }
+
+        fx.Status = DropShot.Models.FixtureStatus.Completed;
+        fx.CompletedAt = DateTime.UtcNow;
+        fx.VerificationToken = null;
+
+        await db.SaveChangesAsync(ct);
+        await CompetitionProgressionService.TryAdvanceAsync(db, fx.CompetitionId, fx.CompetitionFixtureId);
+    }
+
     private static CompetitionDto ToDto(Competition c) => new(
         c.CompetitionID, c.CompetitionName,
         (DropShot.Shared.CompetitionFormat)c.CompetitionFormat,


### PR DESCRIPTION
\`ICompetitionService.ApproveFixtureResultAsync(fixtureId, request)\` covers the awaiting-verification approval flow. \`ApproveFixtureResultRequest.OverrideScores\` (optional) lets the caller supply a corrected score; without it the existing submission is accepted as-is. Both branches mark the fixture Completed + run \`CompetitionProgressionService.TryAdvanceAsync\`. New endpoint \`POST /api/competitions/fixtures/{fixtureId}/approve-result\` is gated by \`ClubAuthorizationService.CanEditCompetitionAsync\`.

Dialog moves to \`DropShot.UI/Components/Shared/ReviewResultDialog.razor\` and switches:
- \`@inject IDbContextFactory\` → \`@inject ICompetitionService\`
- \`Fixture\`: \`CompetitionFixture\` entity → \`CompetitionFixtureDto\`
- New \`CompetitionName\` + \`MaxSets\` parameters (caller computes from competition's \`MatchFormat\` / \`BestOf\` / \`NumberOfSets\` — none of which are on the fixture DTO).

Web-only callers (\`Home.razor\` + \`Competitions.razor\`) project entities to DTO at the call site via a small \`ToFixtureDto\` helper.

## Test plan
- [x] Build clean, 28/28 tests.
- [ ] Web: pending-review approval still works on Home + Competitions, both with and without "Modify score".

🤖 Generated with [Claude Code](https://claude.com/claude-code)