### PR TITLE
Phase 7: move SubmitScoreDialog with ICompetitionService.SubmitFixtureScoreAsync

### DIFF
--- a/DropShot.Maui/Services/HttpCompetitionService.cs
+++ b/DropShot.Maui/Services/HttpCompetitionService.cs
@@ -40,4 +40,11 @@ public sealed class HttpCompetitionService(HttpClient http) : ICompetitionServic
             $"api/competitions/fixtures/{fixtureId}/approve-result", request, ct);
         resp.EnsureSuccessStatusCode();
     }
+
+    public async Task SubmitFixtureScoreAsync(int fixtureId, SubmitFixtureScoreRequest request, CancellationToken ct = default)
+    {
+        var resp = await http.PostAsJsonAsync(
+            $"api/competitions/fixtures/{fixtureId}/submit-score", request, ct);
+        resp.EnsureSuccessStatusCode();
+    }
 }

--- a/DropShot.Shared/Dtos/CompetitionDtos.cs
+++ b/DropShot.Shared/Dtos/CompetitionDtos.cs
@@ -159,6 +159,23 @@ public record FixtureScoreOverride(
     int AwayGamesTotal);
 
 /// <summary>
+/// Submit a fixture score for the first time. Used by SubmitScoreDialog.
+/// The dialog validates set scores client-side; the request carries the
+/// already-validated, summarised result. <c>WinnerPlayerId</c> may be null
+/// in fixed-set mode when the match was tied. <c>AdminOverride</c> bypasses
+/// "RequireVerification" — admin submissions go straight to Completed and
+/// preserve any prior result for audit.
+/// </summary>
+public record SubmitFixtureScoreRequest(
+    string ResultSummary,
+    int? WinnerPlayerId,
+    int HomeSetsWon,
+    int AwaySetsWon,
+    int HomeGamesTotal,
+    int AwayGamesTotal,
+    bool AdminOverride);
+
+/// <summary>
 /// Response body returned with HTTP 409 when an admin action would violate a
 /// competition's eligibility rules (sex / age / allow-list / mixed-doubles
 /// pairing / MTT composition). The admin UI shows these as a confirmation

--- a/DropShot.UI/Components/Shared/SubmitScoreDialog.razor
+++ b/DropShot.UI/Components/Shared/SubmitScoreDialog.razor
@@ -1,11 +1,4 @@
-@using DropShot.Data
-@using DropShot.Models
-@using DropShot.Services
-@using Microsoft.EntityFrameworkCore
-
-@inject IDbContextFactory<MyDbContext> DbFactory
-@inject ResultVerificationService ResultVerificationService
-@inject BackgroundTaskQueue BackgroundTasks
+@inject ICompetitionService CompetitionService
 @inject ISnackbar Snackbar
 
 <MudDialog>
@@ -17,13 +10,13 @@
             <MudText Typo="Typo.body1">
                 <strong>@_side1</strong> vs <strong>@_side2</strong>
             </MudText>
-            @if (!string.IsNullOrEmpty(Fixture.Competition?.CompetitionName))
+            @if (!string.IsNullOrEmpty(CompetitionName))
             {
                 <MudText Typo="Typo.caption" Color="Color.Secondary">
-                    @Fixture.Competition.CompetitionName@(Fixture.FixtureLabel != null ? $" — {Fixture.FixtureLabel}" : "")
-                    &nbsp;·&nbsp;@(Fixture.Competition?.MatchFormat == MatchFormatType.FixedSets ? $"{_bestOf} sets" : $"Best of {_bestOf}")
-                    &nbsp;·&nbsp;@_gamesPerSet games/set
-                    &nbsp;·&nbsp;@(_setWinMode == SetWinMode.WinBy2 ? "Win by 2" : "First to")
+                    @CompetitionName@(Fixture.FixtureLabel != null ? $" — {Fixture.FixtureLabel}" : "")
+                    &nbsp;·&nbsp;@(MatchFormat == MatchFormatType.FixedSets ? $"{_bestOf} sets" : $"Best of {_bestOf}")
+                    &nbsp;·&nbsp;@GamesPerSet games/set
+                    &nbsp;·&nbsp;@(SetWinMode == SetWinMode.WinBy2 ? "Win by 2" : "First to")
                 </MudText>
             }
 
@@ -98,14 +91,23 @@
 @code {
     [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = default!;
 
-    [Parameter] public CompetitionFixture Fixture { get; set; } = default!;
+    [Parameter, EditorRequired] public CompetitionFixtureDto Fixture { get; set; } = default!;
     [Parameter] public bool AdminOverride { get; set; }
+    [Parameter] public string? CompetitionName { get; set; }
+
+    /// <summary>
+    /// Number of set fields to render. Caller computes from the competition's
+    /// MatchFormat / BestOf / NumberOfSets — defaults to 3 if not provided.
+    /// </summary>
+    [Parameter] public int MaxSets { get; set; } = 3;
+
+    [Parameter] public int GamesPerSet { get; set; } = 6;
+    [Parameter] public SetWinMode SetWinMode { get; set; } = SetWinMode.WinBy2;
+    [Parameter] public MatchFormatType MatchFormat { get; set; } = MatchFormatType.BestOf;
 
     private static readonly Dictionary<string, object> _numericAttrs = new() { { "pattern", "[0-9]*" } };
 
     private int _bestOf = 3;
-    private int _gamesPerSet = 6;
-    private SetWinMode _setWinMode = SetWinMode.WinBy2;
     private int?[] _score1 = new int?[3];
     private int?[] _score2 = new int?[3];
     private MudTextField<int?>[] _f1 = new MudTextField<int?>[3];
@@ -134,17 +136,12 @@
 
     protected override void OnParametersSet()
     {
-        var comp = Fixture.Competition;
-        int newBestOf = comp?.MatchFormat == MatchFormatType.FixedSets
-            ? Math.Max(1, comp.NumberOfSets)
-            : Math.Max(1, comp?.BestOf ?? 3);
-        _gamesPerSet = comp?.GamesPerSet ?? 6;
-        _setWinMode = comp?.SetWinMode ?? SetWinMode.WinBy2;
+        int newBestOf = Math.Max(1, MaxSets);
 
-        var s1Parts = new[] { Fixture.Player1?.DisplayName, Fixture.Player3?.DisplayName }
-            .Where(n => n != null).ToList();
-        var s2Parts = new[] { Fixture.Player2?.DisplayName, Fixture.Player4?.DisplayName }
-            .Where(n => n != null).ToList();
+        var s1Parts = new[] { Fixture.Player1Name, Fixture.Player3Name }
+            .Where(n => !string.IsNullOrEmpty(n)).ToList();
+        var s2Parts = new[] { Fixture.Player2Name, Fixture.Player4Name }
+            .Where(n => !string.IsNullOrEmpty(n)).ToList();
 
         _side1 = s1Parts.Any() ? string.Join(" & ", s1Parts) : "Player 1";
         _side2 = s2Parts.Any() ? string.Join(" & ", s2Parts) : "Player 2";
@@ -181,21 +178,19 @@
         // Auto-fill the winning score for the other side
         if (v.HasValue && v.Value >= 0 && !otherScores[idx].HasValue)
         {
-            if (_setWinMode == SetWinMode.FirstTo)
+            if (SetWinMode == SetWinMode.FirstTo)
             {
-                // FirstTo: winner always reaches exactly GamesPerSet
-                if (v.Value < _gamesPerSet)
-                    otherScores[idx] = _gamesPerSet;
+                if (v.Value < GamesPerSet)
+                    otherScores[idx] = GamesPerSet;
             }
             else
             {
-                // WinBy2: determine the minimum winning score
-                if (v.Value < _gamesPerSet - 1)
-                    otherScores[idx] = _gamesPerSet;                // e.g. 4 → 6
-                else if (v.Value == _gamesPerSet - 1)
-                    otherScores[idx] = _gamesPerSet + 1;            // e.g. 5 → 7 (win by 2)
-                else if (v.Value >= _gamesPerSet)
-                    otherScores[idx] = v.Value + 1;                 // e.g. 6 → 7 (tie-break)
+                if (v.Value < GamesPerSet - 1)
+                    otherScores[idx] = GamesPerSet;
+                else if (v.Value == GamesPerSet - 1)
+                    otherScores[idx] = GamesPerSet + 1;
+                else if (v.Value >= GamesPerSet)
+                    otherScores[idx] = v.Value + 1;
             }
         }
 
@@ -259,41 +254,41 @@
                 int winner = Math.Max(s1, s2);
                 int loser = Math.Min(s1, s2);
 
-                if (_setWinMode == SetWinMode.FirstTo)
+                if (SetWinMode == SetWinMode.FirstTo)
                 {
-                    if (winner != _gamesPerSet)
+                    if (winner != GamesPerSet)
                     {
-                        _error = $"Set {i + 1}: winner must reach exactly {_gamesPerSet} games (First to mode).";
+                        _error = $"Set {i + 1}: winner must reach exactly {GamesPerSet} games (First to mode).";
                         return;
                     }
-                    if (loser >= _gamesPerSet)
+                    if (loser >= GamesPerSet)
                     {
-                        _error = $"Set {i + 1}: loser cannot have {loser} games when target is {_gamesPerSet}.";
+                        _error = $"Set {i + 1}: loser cannot have {loser} games when target is {GamesPerSet}.";
                         return;
                     }
                 }
                 else
                 {
-                    if (winner < _gamesPerSet)
+                    if (winner < GamesPerSet)
                     {
-                        _error = $"Set {i + 1}: winner must have at least {_gamesPerSet} games.";
+                        _error = $"Set {i + 1}: winner must have at least {GamesPerSet} games.";
                         return;
                     }
-                    if (winner == _gamesPerSet && loser > _gamesPerSet - 2)
+                    if (winner == GamesPerSet && loser > GamesPerSet - 2)
                     {
-                        _error = $"Set {i + 1}: at {_gamesPerSet} games, opponent can have at most {_gamesPerSet - 2} (Win by 2 mode). Use {_gamesPerSet + 1}-{_gamesPerSet} for a tie-break.";
+                        _error = $"Set {i + 1}: at {GamesPerSet} games, opponent can have at most {GamesPerSet - 2} (Win by 2 mode). Use {GamesPerSet + 1}-{GamesPerSet} for a tie-break.";
                         return;
                     }
-                    if (winner > _gamesPerSet && Math.Abs(s1 - s2) != 1 && Math.Abs(s1 - s2) != 2)
+                    if (winner > GamesPerSet && Math.Abs(s1 - s2) != 1 && Math.Abs(s1 - s2) != 2)
                     {
-                        _error = $"Set {i + 1}: above {_gamesPerSet}-all, the margin must be 1 (tie-break) or 2 (extended).";
+                        _error = $"Set {i + 1}: above {GamesPerSet}-all, the margin must be 1 (tie-break) or 2 (extended).";
                         return;
                     }
                 }
             }
         }
 
-        bool isFixedSets = Fixture.Competition?.MatchFormat == MatchFormatType.FixedSets;
+        bool isFixedSets = MatchFormat == MatchFormatType.FixedSets;
         int side1Sets = 0, side2Sets = 0;
         for (int i = 0; i < _bestOf; i++)
         {
@@ -320,84 +315,15 @@
         try
         {
             var resultSummary = string.Join(" ", enteredSets);
+            int homeGames = Enumerable.Range(0, _bestOf).Sum(i => _score1[i] ?? 0);
+            int awayGames = Enumerable.Range(0, _bestOf).Sum(i => _score2[i] ?? 0);
 
-            await using var db = DbFactory.CreateDbContext();
-            var fx = await db.CompetitionFixtures.FindAsync(Fixture.CompetitionFixtureId);
-            if (fx != null)
-            {
-                // If admin is overriding an existing result, preserve the original for audit
-                if (AdminOverride && fx.ResultSummary != null)
-                {
-                    fx.OriginalResultSummary = fx.ResultSummary;
-                    fx.OriginalWinnerPlayerId = fx.WinnerPlayerId;
-                    fx.ResultModifiedByAdmin = true;
-                }
-
-                fx.ResultSummary  = resultSummary;
-                fx.WinnerPlayerId = _winnerPlayerId;
-                fx.HomeSetsWon    = side1Sets;
-                fx.AwaySetsWon    = side2Sets;
-                fx.HomeGamesTotal = Enumerable.Range(0, _bestOf).Sum(i => _score1[i] ?? 0);
-                fx.AwayGamesTotal = Enumerable.Range(0, _bestOf).Sum(i => _score2[i] ?? 0);
-
-                bool requireVerification = !AdminOverride && (Fixture.Competition?.RequireVerification ?? false);
-                if (requireVerification)
-                {
-                    fx.Status            = FixtureStatus.AwaitingVerification;
-                    fx.VerificationToken = Guid.NewGuid();
-                }
-                else
-                {
-                    fx.Status            = FixtureStatus.Completed;
-                    fx.VerificationToken = null;
-                }
-                fx.CompletedAt = DateTime.UtcNow;
-
-                await db.SaveChangesAsync();
-
-                fx.Competition  = Fixture.Competition!;
-                fx.Player1      = Fixture.Player1;
-                fx.Player2      = Fixture.Player2;
-                fx.Player3      = Fixture.Player3;
-                fx.Player4      = Fixture.Player4;
-                fx.FixtureLabel = Fixture.FixtureLabel;
-
-                // Fire notification + verification emails in the background so the
-                // dialog closes immediately — SMTP latency was blocking the UI.
-                // Bracket progression (in the non-verification path) stays awaited
-                // because the caller's view depends on the advanced state.
-                var competitionId = Fixture.CompetitionId;
-                var fixtureId = Fixture.CompetitionFixtureId;
-                if (requireVerification)
-                {
-                    BackgroundTasks.Run("fixture-verification-emails", async sp =>
-                    {
-                        var svc = sp.GetRequiredService<ResultVerificationService>();
-                        var dbf = sp.GetRequiredService<IDbContextFactory<MyDbContext>>();
-                        await using var bgDb = dbf.CreateDbContext();
-                        var adminEmails = await svc.GetAdminEmailsForCompetitionAsync(competitionId, bgDb);
-                        await Task.WhenAll(
-                            svc.SendResultNotificationAsync(fx),
-                            svc.SendAdminVerificationEmailsAsync(fx, adminEmails));
-                    });
-                }
-                else
-                {
-                    BackgroundTasks.Run("fixture-result-notification", async sp =>
-                    {
-                        var svc = sp.GetRequiredService<ResultVerificationService>();
-                        await svc.SendResultNotificationAsync(fx);
-                    });
-                    try
-                    {
-                        await CompetitionProgressionService.TryAdvanceAsync(db, Fixture.CompetitionId, Fixture.CompetitionFixtureId);
-                    }
-                    catch (Exception)
-                    {
-                        Snackbar.Add("Score saved, but bracket progression failed. An admin may need to follow up.", Severity.Warning);
-                    }
-                }
-            }
+            await CompetitionService.SubmitFixtureScoreAsync(
+                Fixture.CompetitionFixtureId,
+                new SubmitFixtureScoreRequest(
+                    resultSummary, _winnerPlayerId,
+                    side1Sets, side2Sets, homeGames, awayGames,
+                    AdminOverride));
 
             MudDialog.Close(DialogResult.Ok(true));
         }

--- a/DropShot.UI/Services/ICompetitionService.cs
+++ b/DropShot.UI/Services/ICompetitionService.cs
@@ -34,4 +34,14 @@ public interface ICompetitionService
     /// becomes authoritative. Marks Completed + runs CompetitionProgressionService.
     /// </summary>
     Task ApproveFixtureResultAsync(int fixtureId, ApproveFixtureResultRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Submit a fixture score for the first time (or override an existing one
+    /// when the caller is an admin). Server enforces RequireVerification
+    /// (sets Status = AwaitingVerification + a VerificationToken when needed)
+    /// and runs CompetitionProgressionService.TryAdvanceAsync when the
+    /// result is final. Notification / verification emails fire in the
+    /// background so the caller returns immediately.
+    /// </summary>
+    Task SubmitFixtureScoreAsync(int fixtureId, SubmitFixtureScoreRequest request, CancellationToken ct = default);
 }

--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -3656,11 +3656,7 @@ else
 
         // This page is only reachable by admins / competition admins, so anyone
         // who can edit the competition gets the score-validation bypass too.
-        var parameters = new DialogParameters<SubmitScoreDialog>
-        {
-            { x => x.Fixture, loaded },
-            { x => x.AdminOverride, _canEdit }
-        };
+        var parameters = BuildSubmitScoreParameters(loaded, adminOverride: _canEdit);
         var dialog = await DialogService.ShowAsync<SubmitScoreDialog>("Submit Score", parameters);
         var result = await dialog.Result;
         if (result is not null && !result.Canceled)
@@ -3672,16 +3668,47 @@ else
         var loaded = await LoadFixtureForDialogAsync(fixture.CompetitionFixtureId);
         if (loaded == null) return;
 
-        var parameters = new DialogParameters<SubmitScoreDialog>
-        {
-            { x => x.Fixture, loaded },
-            { x => x.AdminOverride, true }
-        };
+        var parameters = BuildSubmitScoreParameters(loaded, adminOverride: true);
         var dialog = await DialogService.ShowAsync<SubmitScoreDialog>("Override Result", parameters);
         var result = await dialog.Result;
         if (result is not null && !result.Canceled)
             await OnParametersSetAsync();
     }
+
+    private static DialogParameters<SubmitScoreDialog> BuildSubmitScoreParameters(CompetitionFixture loaded, bool adminOverride)
+    {
+        var dto = ToFixtureDto(loaded);
+        var comp = loaded.Competition;
+        var maxSets = comp?.MatchFormat == MatchFormatType.FixedSets
+            ? Math.Max(1, comp.NumberOfSets)
+            : Math.Max(1, comp?.BestOf ?? 3);
+        return new DialogParameters<SubmitScoreDialog>
+        {
+            { x => x.Fixture, dto },
+            { x => x.AdminOverride, adminOverride },
+            { x => x.CompetitionName, comp?.CompetitionName },
+            { x => x.MaxSets, maxSets },
+            { x => x.GamesPerSet, comp?.GamesPerSet ?? 6 },
+            { x => x.SetWinMode, (DropShot.Shared.SetWinMode)(comp?.SetWinMode ?? SetWinMode.WinBy2) },
+            { x => x.MatchFormat, (DropShot.Shared.MatchFormatType)(comp?.MatchFormat ?? MatchFormatType.BestOf) }
+        };
+    }
+
+    private static DropShot.Shared.Dtos.CompetitionFixtureDto ToFixtureDto(CompetitionFixture f) =>
+        new(
+            f.CompetitionFixtureId, f.CompetitionId,
+            f.CompetitionStageId, f.Stage?.Name,
+            f.CourtId, f.Court?.Name,
+            f.ScheduledAt, (DropShot.Shared.FixtureStatus)f.Status,
+            f.FixtureLabel, f.RoundNumber,
+            f.Player1Id, f.Player1?.DisplayName,
+            f.Player2Id, f.Player2?.DisplayName,
+            f.Player3Id, f.Player3?.DisplayName,
+            f.Player4Id, f.Player4?.DisplayName,
+            f.ResultSummary, f.WinnerPlayerId,
+            f.HomeTeamId, f.HomeTeam?.Name,
+            f.AwayTeamId, f.AwayTeam?.Name,
+            f.WinnerTeamId, f.CourtPairId, f.CourtPair?.Name);
 
     private void ShowQrCode(CompetitionFixture fixture)
     {

--- a/DropShot/Components/Pages/Home.razor
+++ b/DropShot/Components/Pages/Home.razor
@@ -444,10 +444,21 @@
         var isAdmin = await AuthzService.CanEditCompetitionAsync(
             authState.User, fixture.Competition?.HostClubId, fixture.CompetitionId);
 
+        var dto = ToFixtureDto(fixture);
+        var comp = fixture.Competition;
+        var maxSets = comp?.MatchFormat == MatchFormatType.FixedSets
+            ? Math.Max(1, comp.NumberOfSets)
+            : Math.Max(1, comp?.BestOf ?? 3);
+
         var parameters = new DialogParameters<SubmitScoreDialog>
         {
-            { x => x.Fixture, fixture },
-            { x => x.AdminOverride, isAdmin }
+            { x => x.Fixture, dto },
+            { x => x.AdminOverride, isAdmin },
+            { x => x.CompetitionName, comp?.CompetitionName },
+            { x => x.MaxSets, maxSets },
+            { x => x.GamesPerSet, comp?.GamesPerSet ?? 6 },
+            { x => x.SetWinMode, (DropShot.Shared.SetWinMode)(comp?.SetWinMode ?? SetWinMode.WinBy2) },
+            { x => x.MatchFormat, (DropShot.Shared.MatchFormatType)(comp?.MatchFormat ?? MatchFormatType.BestOf) }
         };
         var dialog = await DialogService.ShowAsync<SubmitScoreDialog>("Submit Score", parameters);
         var result = await dialog.Result;

--- a/DropShot/Controllers/CompetitionsController.cs
+++ b/DropShot/Controllers/CompetitionsController.cs
@@ -395,6 +395,50 @@ public class CompetitionsController(
         catch (KeyNotFoundException) { return NotFound(); }
     }
 
+    /// <summary>
+    /// Submit a fixture score (or admin-override an existing one). Backs
+    /// SubmitScoreDialog (phase 7). Server enforces that only competition
+    /// admins can submit with <c>AdminOverride = true</c>; non-admin requests
+    /// silently coerce <c>AdminOverride</c> back to false.
+    /// </summary>
+    [HttpPost("fixtures/{fixtureId:int}/submit-score")]
+    public async Task<IActionResult> SubmitFixtureScore(
+        int fixtureId, [FromBody] SubmitFixtureScoreRequest req, CancellationToken ct)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var fx = await db.CompetitionFixtures
+            .Include(f => f.Competition)
+            .FirstOrDefaultAsync(f => f.CompetitionFixtureId == fixtureId, ct);
+        if (fx is null) return NotFound();
+
+        var canEdit = await authzService.CanEditCompetitionAsync(User, fx.Competition?.HostClubId, fx.CompetitionId);
+        if (req.AdminOverride && !canEdit) return Forbid();
+
+        // Non-admin: must be a participant in this fixture.
+        if (!canEdit)
+        {
+            var userId = userManager.GetUserId(User);
+            if (string.IsNullOrEmpty(userId)) return Forbid();
+            var myPlayerId = await db.Players
+                .Where(p => p.UserId == userId)
+                .Select(p => (int?)p.PlayerId)
+                .FirstOrDefaultAsync(ct);
+            if (myPlayerId is null) return Forbid();
+            var isParticipant = fx.Player1Id == myPlayerId || fx.Player2Id == myPlayerId
+                || fx.Player3Id == myPlayerId || fx.Player4Id == myPlayerId;
+            if (!isParticipant) return Forbid();
+        }
+
+        var safeReq = req with { AdminOverride = canEdit && req.AdminOverride };
+
+        try
+        {
+            await competitionService.SubmitFixtureScoreAsync(fixtureId, safeReq, ct);
+            return NoContent();
+        }
+        catch (KeyNotFoundException) { return NotFound(); }
+    }
+
     [HttpDelete("{id:int}/participants/{playerId:int}")]
     public async Task<IActionResult> RemoveParticipant(int id, int playerId)
     {

--- a/DropShot/Services/WebCompetitionService.cs
+++ b/DropShot/Services/WebCompetitionService.cs
@@ -19,7 +19,8 @@ public sealed class WebCompetitionService(
     IDbContextFactory<MyDbContext> dbFactory,
     ClubAuthorizationService authzService,
     IHttpContextAccessor httpContextAccessor,
-    ICurrentUser currentUser) : ICompetitionService
+    ICurrentUser currentUser,
+    BackgroundTaskQueue backgroundTasks) : ICompetitionService
 {
     public async Task<List<CompetitionDto>> GetCompetitionsAsync(bool includeArchived = false, CancellationToken ct = default)
     {
@@ -239,6 +240,94 @@ public sealed class WebCompetitionService(
 
         await db.SaveChangesAsync(ct);
         await CompetitionProgressionService.TryAdvanceAsync(db, fx.CompetitionId, fx.CompetitionFixtureId);
+    }
+
+    public async Task SubmitFixtureScoreAsync(
+        int fixtureId, SubmitFixtureScoreRequest request, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var fx = await db.CompetitionFixtures
+            .Include(f => f.Competition)
+            .Include(f => f.Player1)
+            .Include(f => f.Player2)
+            .Include(f => f.Player3)
+            .Include(f => f.Player4)
+            .FirstOrDefaultAsync(f => f.CompetitionFixtureId == fixtureId, ct)
+            ?? throw new KeyNotFoundException($"Fixture {fixtureId} not found.");
+
+        if (request.AdminOverride && fx.ResultSummary != null)
+        {
+            fx.OriginalResultSummary = fx.ResultSummary;
+            fx.OriginalWinnerPlayerId = fx.WinnerPlayerId;
+            fx.ResultModifiedByAdmin = true;
+        }
+
+        fx.ResultSummary = request.ResultSummary;
+        fx.WinnerPlayerId = request.WinnerPlayerId;
+        fx.HomeSetsWon = request.HomeSetsWon;
+        fx.AwaySetsWon = request.AwaySetsWon;
+        fx.HomeGamesTotal = request.HomeGamesTotal;
+        fx.AwayGamesTotal = request.AwayGamesTotal;
+
+        bool requireVerification = !request.AdminOverride && (fx.Competition?.RequireVerification ?? false);
+        if (requireVerification)
+        {
+            fx.Status = DropShot.Models.FixtureStatus.AwaitingVerification;
+            fx.VerificationToken = Guid.NewGuid();
+        }
+        else
+        {
+            fx.Status = DropShot.Models.FixtureStatus.Completed;
+            fx.VerificationToken = null;
+        }
+        fx.CompletedAt = DateTime.UtcNow;
+
+        await db.SaveChangesAsync(ct);
+
+        var competitionId = fx.CompetitionId;
+        var savedFixtureId = fx.CompetitionFixtureId;
+
+        if (requireVerification)
+        {
+            backgroundTasks.Run("fixture-verification-emails", async sp =>
+            {
+                var svc = sp.GetRequiredService<ResultVerificationService>();
+                var dbf = sp.GetRequiredService<IDbContextFactory<MyDbContext>>();
+                await using var bgDb = dbf.CreateDbContext();
+                var fxBg = await bgDb.CompetitionFixtures
+                    .Include(f => f.Competition)
+                    .Include(f => f.Player1)
+                    .Include(f => f.Player2)
+                    .Include(f => f.Player3)
+                    .Include(f => f.Player4)
+                    .FirstOrDefaultAsync(f => f.CompetitionFixtureId == savedFixtureId);
+                if (fxBg is null) return;
+                var adminEmails = await svc.GetAdminEmailsForCompetitionAsync(competitionId, bgDb);
+                await Task.WhenAll(
+                    svc.SendResultNotificationAsync(fxBg),
+                    svc.SendAdminVerificationEmailsAsync(fxBg, adminEmails));
+            });
+        }
+        else
+        {
+            backgroundTasks.Run("fixture-result-notification", async sp =>
+            {
+                var svc = sp.GetRequiredService<ResultVerificationService>();
+                var dbf = sp.GetRequiredService<IDbContextFactory<MyDbContext>>();
+                await using var bgDb = dbf.CreateDbContext();
+                var fxBg = await bgDb.CompetitionFixtures
+                    .Include(f => f.Competition)
+                    .Include(f => f.Player1)
+                    .Include(f => f.Player2)
+                    .Include(f => f.Player3)
+                    .Include(f => f.Player4)
+                    .FirstOrDefaultAsync(f => f.CompetitionFixtureId == savedFixtureId);
+                if (fxBg is null) return;
+                await svc.SendResultNotificationAsync(fxBg);
+            });
+
+            await CompetitionProgressionService.TryAdvanceAsync(db, competitionId, savedFixtureId);
+        }
     }
 
     private static CompetitionDto ToDto(Competition c) => new(


### PR DESCRIPTION
## Summary
- Move `SubmitScoreDialog.razor` into `DropShot.UI/Components/Shared/` so it can render from both Blazor Server and MAUI Blazor Hybrid hosts.
- The dialog now takes a `CompetitionFixtureDto` plus the match-rule parameters it needs (`MaxSets` / `GamesPerSet` / `SetWinMode` / `MatchFormat`) instead of an EF `CompetitionFixture` entity. Score submission goes through the new `ICompetitionService.SubmitFixtureScoreAsync` abstraction.
- New `POST /api/competitions/fixtures/{fixtureId}/submit-score` endpoint backs the MAUI host. The server enforces that `AdminOverride` is honoured only for users with `CanEditCompetition`, and that non-admin submitters must be a participant in the fixture.
- `WebCompetitionService.SubmitFixtureScoreAsync` ports the existing logic (admin-override audit fields, `RequireVerification` → `AwaitingVerification` + token, background notification + verification emails, awaited `CompetitionProgressionService.TryAdvanceAsync` on the non-verification path).
- `Home.razor` and `CompetitionPage.razor` callers now build the DTO + parameters at the call site (using each page's existing `ToFixtureDto` helper pattern).

## Test plan
- [x] `dotnet build DropShot.sln` clean (web + MAUI Windows/Android/iOS/Mac).
- [x] `dotnet test DropShot.Tests` — 28/28 passing.
- [ ] Web smoke: submit a score from `/` and from a competition page; admin override path; verification path.
- [ ] MAUI Windows: submit a score as a participant; verify the same dialog UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)