### PR TITLE
Phase 7: add rubber-scoring service surface (prep for dialog moves)

### DIFF
--- a/DropShot.Maui/Services/HttpCompetitionService.cs
+++ b/DropShot.Maui/Services/HttpCompetitionService.cs
@@ -76,4 +76,16 @@ public sealed class HttpCompetitionService(HttpClient http) : ICompetitionServic
             throw new InvalidOperationException(string.IsNullOrEmpty(body) ? resp.ReasonPhrase ?? "Failed to enter." : body);
         }
     }
+
+    public Task<FixtureRubberContextDto?> GetFixtureRubberContextAsync(int fixtureId, CancellationToken ct = default) =>
+        http.GetFromJsonAsync<FixtureRubberContextDto>(
+            $"api/competitions/fixtures/{fixtureId}/rubber-context", ct);
+
+    public async Task SubmitRubberScoresAsync(
+        int fixtureId, SubmitRubberScoresRequest request, CancellationToken ct = default)
+    {
+        var resp = await http.PostAsJsonAsync(
+            $"api/competitions/fixtures/{fixtureId}/submit-rubber-scores", request, ct);
+        resp.EnsureSuccessStatusCode();
+    }
 }

--- a/DropShot.Shared/Dtos/CompetitionDtos.cs
+++ b/DropShot.Shared/Dtos/CompetitionDtos.cs
@@ -360,3 +360,72 @@ public record SetCompetitionRubberTemplateKeyRequest(string? TemplateKey);
 public record SetTeamCaptainRequest(int CaptainPlayerId);
 
 public record TeamValidationResultDto(bool IsValid, List<string> Errors);
+
+/// <summary>
+/// Bundle returned to the rubber-scoring dialogs (single + bulk). Carries the
+/// fixture's match-config knobs so the dialog can render set inputs and run
+/// per-set validation client-side without a separate competition fetch.
+/// <c>IsAlreadyFinalised</c> tells admin-edit flows whether the fixture is
+/// AwaitingVerification/Completed (in which case re-submitting an admin score
+/// updates aggregates in place rather than regenerating verification tokens).
+/// </summary>
+public record FixtureRubberContextDto(
+    int CompetitionFixtureId,
+    int CompetitionId,
+    string? CompetitionName,
+    string? FixtureLabel,
+    int? HomeTeamId,
+    int? AwayTeamId,
+    string HomeTeamName,
+    string AwayTeamName,
+    MatchFormatType MatchFormat,
+    int BestOf,
+    int NumberOfSets,
+    int GamesPerSet,
+    SetWinMode SetWinMode,
+    bool RequireVerification,
+    bool IsAlreadyFinalised,
+    IReadOnlyList<RubberDialogDto> Rubbers);
+
+public record RubberDialogDto(
+    int RubberId,
+    int Order,
+    string Name,
+    int CourtNumber,
+    int? HomePlayer1Id,
+    string? HomePlayer1Name,
+    int? HomePlayer2Id,
+    string? HomePlayer2Name,
+    int? AwayPlayer1Id,
+    string? AwayPlayer1Name,
+    int? AwayPlayer2Id,
+    string? AwayPlayer2Name,
+    bool IsComplete,
+    int? SavedMatchId,
+    IReadOnlyList<RubberSetScoreDto> ExistingSetScores);
+
+public record RubberSetScoreDto(int Home, int Away);
+
+/// <summary>
+/// Bulk-submit rubber scores for a fixture. The single-rubber dialog sends
+/// one entry; the "enter all scores" dialog sends every rubber. Server runs
+/// the same fixture-finalisation cascade either way: persists the rubber
+/// rows, then if every rubber is complete runs the score / tie-break
+/// resolution + notification or verification email pipeline + bracket
+/// progression. <c>AdminOverride = true</c> bypasses RequireVerification
+/// and updates aggregates in place when the fixture is already finalised
+/// (no verification-token regeneration, no resent emails).
+/// </summary>
+public record SubmitRubberScoresRequest(
+    bool AdminOverride,
+    IReadOnlyList<RubberScoreEntry> Scores);
+
+public record RubberScoreEntry(
+    int RubberId,
+    int HomeSetsWon,
+    int AwaySetsWon,
+    int HomeGamesTotal,
+    int AwayGamesTotal,
+    int? LastSetHomeGames,
+    int? LastSetAwayGames,
+    IReadOnlyList<RubberSetScoreDto> SetScores);

--- a/DropShot.UI/Services/ICompetitionService.cs
+++ b/DropShot.UI/Services/ICompetitionService.cs
@@ -80,4 +80,25 @@ public interface ICompetitionService
     /// message when any of them fail.
     /// </summary>
     Task EnterCompetitionAsync(int competitionId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Loads the rubber-scoring context for a team-match fixture: per-rubber
+    /// player names + existing set scores, plus the fixture's match-config
+    /// knobs (BestOf, GamesPerSet, SetWinMode, MatchFormat, RequireVerification).
+    /// Backs RubberScoreDialog and BulkRubberScoreDialog (phase 7).
+    /// </summary>
+    Task<FixtureRubberContextDto?> GetFixtureRubberContextAsync(int fixtureId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Submit one or many rubber scores for a fixture in a single call. The
+    /// single-rubber dialog sends one entry; the "enter all" dialog sends
+    /// every rubber. Server persists each rubber, then if every rubber is
+    /// complete runs the same finalisation cascade as the live-scoring path:
+    /// score / tie-break resolution, notification or verification emails,
+    /// and bracket progression. <c>AdminOverride = true</c> bypasses
+    /// RequireVerification and (for an already-finalised fixture) updates
+    /// aggregates in place without resetting verification tokens or resending
+    /// emails.
+    /// </summary>
+    Task SubmitRubberScoresAsync(int fixtureId, SubmitRubberScoresRequest request, CancellationToken ct = default);
 }

--- a/DropShot/Controllers/CompetitionsController.cs
+++ b/DropShot/Controllers/CompetitionsController.cs
@@ -446,6 +446,74 @@ public class CompetitionsController(
     public async Task<ActionResult<MyCompetitionsViewDto>> GetMyCompetitionsView(CancellationToken ct)
         => await competitionService.GetMyCompetitionsViewAsync(ct);
 
+    /// <summary>
+    /// Loads the rubber-scoring context for a team-match fixture. Backs
+    /// RubberScoreDialog and BulkRubberScoreDialog (phase 7). Caller must be
+    /// able to view the competition.
+    /// </summary>
+    [HttpGet("fixtures/{fixtureId:int}/rubber-context")]
+    public async Task<ActionResult<FixtureRubberContextDto>> GetFixtureRubberContext(
+        int fixtureId, CancellationToken ct)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var fx = await db.CompetitionFixtures
+            .Select(f => new { f.CompetitionFixtureId, f.CompetitionId })
+            .FirstOrDefaultAsync(f => f.CompetitionFixtureId == fixtureId, ct);
+        if (fx is null) return NotFound();
+        if (!await authzService.CanViewCompetitionAsync(User, fx.CompetitionId)) return Forbid();
+
+        var dto = await competitionService.GetFixtureRubberContextAsync(fixtureId, ct);
+        return dto is null ? NotFound() : dto;
+    }
+
+    /// <summary>
+    /// Submit one or many rubber scores for a fixture (single dialog or bulk
+    /// dialog). Backs phase 7 RubberScoreDialog/BulkRubberScoreDialog. Server
+    /// enforces that <c>AdminOverride</c> is honoured only for competition
+    /// admins; non-admin requests must come from a participant of one of the
+    /// fixture's teams.
+    /// </summary>
+    [HttpPost("fixtures/{fixtureId:int}/submit-rubber-scores")]
+    public async Task<IActionResult> SubmitRubberScores(
+        int fixtureId, [FromBody] SubmitRubberScoresRequest req, CancellationToken ct)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var fx = await db.CompetitionFixtures
+            .Include(f => f.Competition)
+            .FirstOrDefaultAsync(f => f.CompetitionFixtureId == fixtureId, ct);
+        if (fx is null) return NotFound();
+
+        var canEdit = await authzService.CanEditCompetitionAsync(User, fx.Competition?.HostClubId, fx.CompetitionId);
+        if (req.AdminOverride && !canEdit) return Forbid();
+
+        if (!canEdit)
+        {
+            // Non-admin: must be on one of the fixture's teams.
+            var userId = userManager.GetUserId(User);
+            if (string.IsNullOrEmpty(userId)) return Forbid();
+            var myPlayerId = await db.Players
+                .Where(p => p.UserId == userId)
+                .Select(p => (int?)p.PlayerId)
+                .FirstOrDefaultAsync(ct);
+            if (myPlayerId is null) return Forbid();
+            var onATeam = await db.CompetitionParticipants
+                .AnyAsync(cp => cp.CompetitionId == fx.CompetitionId
+                    && cp.PlayerId == myPlayerId
+                    && cp.TeamId.HasValue
+                    && (cp.TeamId == fx.HomeTeamId || cp.TeamId == fx.AwayTeamId), ct);
+            if (!onATeam) return Forbid();
+        }
+
+        var safeReq = req with { AdminOverride = canEdit && req.AdminOverride };
+
+        try
+        {
+            await competitionService.SubmitRubberScoresAsync(fixtureId, safeReq, ct);
+            return NoContent();
+        }
+        catch (KeyNotFoundException ex) { return NotFound(new { message = ex.Message }); }
+    }
+
     /// <summary>Awaiting-verification fixtures the caller is allowed to review.</summary>
     [HttpGet("pending-verification")]
     public async Task<ActionResult<List<CompetitionFixtureDto>>> GetPendingVerificationFixtures(CancellationToken ct)

--- a/DropShot/Services/WebCompetitionService.cs
+++ b/DropShot/Services/WebCompetitionService.cs
@@ -330,6 +330,205 @@ public sealed class WebCompetitionService(
         }
     }
 
+    public async Task<FixtureRubberContextDto?> GetFixtureRubberContextAsync(int fixtureId, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var fx = await db.CompetitionFixtures
+            .AsSplitQuery()
+            .AsNoTracking()
+            .Include(f => f.Competition)
+            .Include(f => f.HomeTeam)
+            .Include(f => f.AwayTeam)
+            .Include(f => f.Rubbers).ThenInclude(r => r.HomePlayer1)
+            .Include(f => f.Rubbers).ThenInclude(r => r.HomePlayer2)
+            .Include(f => f.Rubbers).ThenInclude(r => r.AwayPlayer1)
+            .Include(f => f.Rubbers).ThenInclude(r => r.AwayPlayer2)
+            .FirstOrDefaultAsync(f => f.CompetitionFixtureId == fixtureId, ct);
+        if (fx is null) return null;
+
+        var comp = fx.Competition;
+        var rubbers = fx.Rubbers
+            .OrderBy(r => r.Order)
+            .Select(r => new RubberDialogDto(
+                r.RubberId, r.Order, r.Name, r.CourtNumber,
+                r.HomePlayer1Id, r.HomePlayer1?.DisplayName,
+                r.HomePlayer2Id, r.HomePlayer2?.DisplayName,
+                r.AwayPlayer1Id, r.AwayPlayer1?.DisplayName,
+                r.AwayPlayer2Id, r.AwayPlayer2?.DisplayName,
+                r.IsComplete, r.SavedMatchId,
+                r.SetScores.Select(s => new RubberSetScoreDto(s.Home, s.Away)).ToList()))
+            .ToList();
+
+        return new FixtureRubberContextDto(
+            fx.CompetitionFixtureId,
+            fx.CompetitionId,
+            comp?.CompetitionName,
+            fx.FixtureLabel,
+            fx.HomeTeamId,
+            fx.AwayTeamId,
+            fx.HomeTeam?.Name ?? "Home",
+            fx.AwayTeam?.Name ?? "Away",
+            (DropShot.Shared.MatchFormatType)(comp?.MatchFormat ?? DropShot.Models.MatchFormatType.BestOf),
+            comp?.BestOf ?? 3,
+            comp?.NumberOfSets ?? 3,
+            comp?.GamesPerSet ?? 6,
+            (DropShot.Shared.SetWinMode)(comp?.SetWinMode ?? DropShot.Models.SetWinMode.WinBy2),
+            comp?.RequireVerification ?? false,
+            fx.Status == DropShot.Models.FixtureStatus.AwaitingVerification
+                || fx.Status == DropShot.Models.FixtureStatus.Completed,
+            rubbers);
+    }
+
+    public async Task SubmitRubberScoresAsync(
+        int fixtureId, SubmitRubberScoresRequest request, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+
+        var rubIds = request.Scores.Select(s => s.RubberId).ToList();
+        var dbRubbers = await db.Rubbers
+            .Include(r => r.Fixture)
+            .Where(r => r.CompetitionFixtureId == fixtureId && rubIds.Contains(r.RubberId))
+            .ToListAsync(ct);
+
+        if (dbRubbers.Count != request.Scores.Count)
+            throw new KeyNotFoundException("One or more rubbers were not found on this fixture.");
+
+        foreach (var entry in request.Scores)
+        {
+            var rub = dbRubbers.First(x => x.RubberId == entry.RubberId);
+            rub.IsComplete = true;
+            rub.HomeSetsWon = entry.HomeSetsWon;
+            rub.AwaySetsWon = entry.AwaySetsWon;
+            rub.HomeGamesTotal = entry.HomeGamesTotal;
+            rub.AwayGamesTotal = entry.AwayGamesTotal;
+            rub.HomeGames = entry.LastSetHomeGames;
+            rub.AwayGames = entry.LastSetAwayGames;
+            rub.WinnerTeamId = entry.HomeSetsWon > entry.AwaySetsWon ? rub.Fixture.HomeTeamId
+                             : entry.AwaySetsWon > entry.HomeSetsWon ? rub.Fixture.AwayTeamId
+                             : (int?)null;
+            rub.SavedMatchId = null;
+            rub.SetScoresJson = System.Text.Json.JsonSerializer.Serialize(
+                entry.SetScores.Select(s => new[] { s.Home, s.Away }).ToList());
+        }
+
+        await db.SaveChangesAsync(ct);
+
+        // Finalisation cascade — same flow used by RubberScoreDialog.SubmitAsync
+        // and BulkRubberScoreDialog.SubmitAsync before the move into this service.
+        var allRubbers = await db.Rubbers
+            .Include(r => r.HomePlayer1).Include(r => r.HomePlayer2)
+            .Include(r => r.AwayPlayer1).Include(r => r.AwayPlayer2)
+            .Where(r => r.CompetitionFixtureId == fixtureId)
+            .ToListAsync(ct);
+
+        var fx = await db.CompetitionFixtures
+            .Include(f => f.Competition)
+            .Include(f => f.HomeTeam).ThenInclude(t => t!.Division)
+            .Include(f => f.AwayTeam).ThenInclude(t => t!.Division)
+            .FirstOrDefaultAsync(f => f.CompetitionFixtureId == fixtureId, ct);
+        if (fx is null) return;
+
+        if (fx.HomeTeamId.HasValue && fx.AwayTeamId.HasValue
+            && RubberResolutionService.AllComplete(allRubbers))
+        {
+            var (homeScore, awayScore) = RubberResolutionService.ComputeScore(
+                allRubbers, fx.HomeTeamId.Value, fx.AwayTeamId.Value);
+
+            bool alreadyFinalised = fx.Status == DropShot.Models.FixtureStatus.AwaitingVerification
+                || fx.Status == DropShot.Models.FixtureStatus.Completed;
+
+            fx.ResultSummary = $"{homeScore}-{awayScore}";
+            int? winner = homeScore > awayScore ? fx.HomeTeamId
+                        : awayScore > homeScore ? fx.AwayTeamId
+                        : null;
+
+            if (!winner.HasValue && homeScore == awayScore)
+            {
+                var mode = fx.Competition?.RubberTieBreak ?? DropShot.Shared.RubberTieBreakMode.AdminDecides;
+                winner = await RubberResolutionService.ResolveTieBreakAsync(db, fx, allRubbers, mode);
+            }
+            fx.WinnerTeamId = winner;
+
+            if (request.AdminOverride && alreadyFinalised)
+            {
+                // Admin correcting an already-finalised fixture — update aggregates
+                // in place. Don't regenerate the verification token (the outstanding
+                // admin link must keep working) and don't resend emails.
+                await db.SaveChangesAsync(ct);
+                return;
+            }
+
+            fx.CompletedAt = DateTime.UtcNow;
+            bool requireVerification = !request.AdminOverride
+                && (fx.Competition?.RequireVerification ?? false);
+
+            if (requireVerification)
+            {
+                fx.Status = DropShot.Models.FixtureStatus.AwaitingVerification;
+                fx.VerificationToken = Guid.NewGuid();
+                await db.SaveChangesAsync(ct);
+
+                var compId = fx.CompetitionId;
+                var savedFixtureId = fx.CompetitionFixtureId;
+                backgroundTasks.Run("team-match-verification-emails", async sp =>
+                {
+                    var svc = sp.GetRequiredService<ResultVerificationService>();
+                    var dbf = sp.GetRequiredService<IDbContextFactory<MyDbContext>>();
+                    await using var bgDb = dbf.CreateDbContext();
+                    var fxBg = await bgDb.CompetitionFixtures
+                        .Include(f => f.Competition)
+                        .Include(f => f.HomeTeam).Include(f => f.AwayTeam)
+                        .FirstOrDefaultAsync(f => f.CompetitionFixtureId == savedFixtureId);
+                    if (fxBg is null) return;
+                    var rubsBg = await bgDb.Rubbers
+                        .Include(r => r.HomePlayer1).Include(r => r.HomePlayer2)
+                        .Include(r => r.AwayPlayer1).Include(r => r.AwayPlayer2)
+                        .Where(r => r.CompetitionFixtureId == savedFixtureId)
+                        .ToListAsync();
+                    var adminEmails = await svc.GetAdminEmailsForCompetitionAsync(compId, bgDb);
+                    await svc.SendAdminVerificationEmailsForTeamMatchAsync(fxBg, rubsBg, adminEmails);
+                });
+            }
+            else
+            {
+                fx.Status = DropShot.Models.FixtureStatus.Completed;
+                await db.SaveChangesAsync(ct);
+
+                var savedFixtureId = fx.CompetitionFixtureId;
+                backgroundTasks.Run("team-match-result-notification", async sp =>
+                {
+                    var svc = sp.GetRequiredService<ResultVerificationService>();
+                    var dbf = sp.GetRequiredService<IDbContextFactory<MyDbContext>>();
+                    await using var bgDb = dbf.CreateDbContext();
+                    var fxBg = await bgDb.CompetitionFixtures
+                        .Include(f => f.Competition)
+                        .Include(f => f.HomeTeam).Include(f => f.AwayTeam)
+                        .FirstOrDefaultAsync(f => f.CompetitionFixtureId == savedFixtureId);
+                    if (fxBg is null) return;
+                    var rubsBg = await bgDb.Rubbers
+                        .Include(r => r.HomePlayer1).Include(r => r.HomePlayer2)
+                        .Include(r => r.AwayPlayer1).Include(r => r.AwayPlayer2)
+                        .Where(r => r.CompetitionFixtureId == savedFixtureId)
+                        .ToListAsync();
+                    await svc.SendResultNotificationForTeamMatchAsync(fxBg, rubsBg);
+                });
+
+                await CompetitionProgressionService.TryAdvanceAsync(db, fx.CompetitionId, fx.CompetitionFixtureId);
+            }
+        }
+        else
+        {
+            // Rubbers are in progress but not all done yet — flip Scheduled →
+            // InProgress now that the first score has been recorded. EnsureRubbersAsync
+            // deliberately leaves Scheduled until an actual score lands.
+            if (fx.Status == DropShot.Models.FixtureStatus.Scheduled)
+            {
+                fx.Status = DropShot.Models.FixtureStatus.InProgress;
+                await db.SaveChangesAsync(ct);
+            }
+        }
+    }
+
     private static CompetitionDto ToDto(Competition c) => new(
         c.CompetitionID, c.CompetitionName,
         (DropShot.Shared.CompetitionFormat)c.CompetitionFormat,


### PR DESCRIPTION
## Summary

Prep PR for moving `RubberScoreDialog` and `BulkRubberScoreDialog` into `DropShot.UI`. Adds the service surface they will both consume; **no dialog or page moves in this PR**.

- `ICompetitionService.GetFixtureRubberContextAsync(fixtureId)` — returns home/away team names, the fixture's match-config knobs (BestOf, GamesPerSet, SetWinMode, MatchFormat, RequireVerification), and the per-rubber payload the dialogs render. Single round-trip on dialog open.
- `ICompetitionService.SubmitRubberScoresAsync(fixtureId, request)` — single server method handles both single-rubber and bulk submissions. Persists the rubber rows, then runs the same fixture-finalisation cascade the dialog code does today: score / tie-break resolution, verification or notification emails (queued via `BackgroundTaskQueue`), and bracket progression via `CompetitionProgressionService.TryAdvanceAsync`.
- `AdminOverride` on an already-finalised fixture updates aggregates in place without regenerating verification tokens or resending emails (preserves outstanding admin verify links — same behaviour as the inline code).
- Endpoints: `GET api/competitions/fixtures/{id}/rubber-context`, `POST api/competitions/fixtures/{id}/submit-rubber-scores`. Auth: view-competition for the GET; for the POST, admins can submit with `AdminOverride`, non-admins must be on one of the fixture's teams.

## Test plan

- [ ] `dotnet build DropShot/DropShot.csproj` clean
- [ ] `dotnet build DropShot.Maui` (Windows TF) clean
- [ ] No behavioural change yet — dialogs still call EF directly until PRs 2/3

🤖 Generated with [Claude Code](https://claude.com/claude-code)