### PR TITLE
Phase 7: move TeamMatchScoring into DropShot.UI

### DIFF
--- a/DropShot.Maui/Components/Pages/TeamMatchScoring.razor
+++ b/DropShot.Maui/Components/Pages/TeamMatchScoring.razor
@@ -1,7 +1,6 @@
 @page "/team-match/{FixtureId:int}"
-@rendermode InteractiveServer
-
-<MudProviders />
+@attribute [Authorize]
+@using Microsoft.AspNetCore.Authorization
 
 <DropShot.UI.Components.Pages.TeamMatchScoring FixtureId="@FixtureId" />
 

--- a/DropShot.Maui/Services/HttpCompetitionService.cs
+++ b/DropShot.Maui/Services/HttpCompetitionService.cs
@@ -88,4 +88,16 @@ public sealed class HttpCompetitionService(HttpClient http) : ICompetitionServic
             $"api/competitions/fixtures/{fixtureId}/submit-rubber-scores", request, ct);
         resp.EnsureSuccessStatusCode();
     }
+
+    public async Task EnsureFixtureRubbersAsync(int fixtureId, CancellationToken ct = default)
+    {
+        var resp = await http.PostAsync(
+            $"api/competitions/fixtures/{fixtureId}/ensure-rubbers", null, ct);
+        if (!resp.IsSuccessStatusCode)
+        {
+            var body = await resp.Content.ReadAsStringAsync(ct);
+            throw new InvalidOperationException(
+                string.IsNullOrEmpty(body) ? resp.ReasonPhrase ?? "Failed to ensure rubbers." : body);
+        }
+    }
 }

--- a/DropShot.Shared/Dtos/CompetitionDtos.cs
+++ b/DropShot.Shared/Dtos/CompetitionDtos.cs
@@ -362,12 +362,15 @@ public record SetTeamCaptainRequest(int CaptainPlayerId);
 public record TeamValidationResultDto(bool IsValid, List<string> Errors);
 
 /// <summary>
-/// Bundle returned to the rubber-scoring dialogs (single + bulk). Carries the
-/// fixture's match-config knobs so the dialog can render set inputs and run
-/// per-set validation client-side without a separate competition fetch.
-/// <c>IsAlreadyFinalised</c> tells admin-edit flows whether the fixture is
-/// AwaitingVerification/Completed (in which case re-submitting an admin score
-/// updates aggregates in place rather than regenerating verification tokens).
+/// Bundle returned to the rubber-scoring dialogs (single + bulk) and the
+/// TeamMatchScoring page. Carries the fixture's match-config knobs so the
+/// dialog can render set inputs and run per-set validation client-side
+/// without a separate competition fetch. <c>IsAlreadyFinalised</c> tells
+/// admin-edit flows whether the fixture is AwaitingVerification/Completed
+/// (in which case re-submitting an admin score updates aggregates in place
+/// rather than regenerating verification tokens). <c>LeagueScoring</c> and
+/// <c>HostClubId</c> support the TeamMatchScoring page's running-score chip
+/// and admin-authorisation gate.
 /// </summary>
 public record FixtureRubberContextDto(
     int CompetitionFixtureId,
@@ -385,7 +388,9 @@ public record FixtureRubberContextDto(
     SetWinMode SetWinMode,
     bool RequireVerification,
     bool IsAlreadyFinalised,
-    IReadOnlyList<RubberDialogDto> Rubbers);
+    IReadOnlyList<RubberDialogDto> Rubbers,
+    LeagueScoringMode LeagueScoring = LeagueScoringMode.WinPoints,
+    int? HostClubId = null);
 
 public record RubberDialogDto(
     int RubberId,
@@ -402,7 +407,14 @@ public record RubberDialogDto(
     string? AwayPlayer2Name,
     bool IsComplete,
     int? SavedMatchId,
-    IReadOnlyList<RubberSetScoreDto> ExistingSetScores);
+    IReadOnlyList<RubberSetScoreDto> ExistingSetScores,
+    int? WinnerTeamId = null,
+    int? HomeGames = null,
+    int? AwayGames = null,
+    int? HomeSetsWon = null,
+    int? AwaySetsWon = null,
+    int? HomeGamesTotal = null,
+    int? AwayGamesTotal = null);
 
 public record RubberSetScoreDto(int Home, int Away);
 

--- a/DropShot.Shared/Helpers/TeamLeagueScoreCalculator.cs
+++ b/DropShot.Shared/Helpers/TeamLeagueScoreCalculator.cs
@@ -33,4 +33,33 @@ public static class TeamLeagueScoreCalculator
             _ => (homeRubbers, awayRubbers, "rubbers"),
         };
     }
+
+    /// <summary>
+    /// Overload for the rubber-dialog DTO surface used by TeamMatchScoring.
+    /// </summary>
+    public static (int homeFor, int awayFor, string unitLabel) Compute(
+        IEnumerable<RubberDialogDto> rubbers, int homeTeamId, int awayTeamId, LeagueScoringMode mode)
+    {
+        int homeRubbers = 0, awayRubbers = 0;
+        int homeSets = 0, awaySets = 0;
+        int homeGames = 0, awayGames = 0;
+        foreach (var r in rubbers.Where(r => r.IsComplete))
+        {
+            if (r.WinnerTeamId == homeTeamId) homeRubbers++;
+            else if (r.WinnerTeamId == awayTeamId) awayRubbers++;
+            homeSets += r.HomeSetsWon ?? 0;
+            awaySets += r.AwaySetsWon ?? 0;
+            homeGames += r.HomeGamesTotal ?? 0;
+            awayGames += r.AwayGamesTotal ?? 0;
+        }
+        return mode switch
+        {
+            LeagueScoringMode.SetsWon => (homeSets, awaySets, "sets"),
+            LeagueScoringMode.GamesWon => (homeGames, awayGames, "games"),
+            _ => (homeRubbers, awayRubbers, "rubbers"),
+        };
+    }
+
+    public static bool AllComplete(IEnumerable<RubberDialogDto> rubbers)
+        => rubbers.All(r => r.IsComplete);
 }

--- a/DropShot.UI/Components/Pages/TeamMatchScoring.razor
+++ b/DropShot.UI/Components/Pages/TeamMatchScoring.razor
@@ -1,0 +1,297 @@
+@using DropShot.Shared.Helpers
+
+@inject ICompetitionService CompetitionService
+@inject ICurrentUser CurrentUser
+@inject NavigationManager Navigation
+@inject IDialogService DialogService
+
+@* Routing + auth + MudProviders supplied by host shims. *@
+
+@if (_loading)
+{
+    <MudProgressLinear Indeterminate="true" Color="Color.Primary" />
+}
+else if (_resolutionError != null)
+{
+    <MudContainer MaxWidth="MaxWidth.Medium" Class="py-4">
+        <MudAlert Severity="Severity.Error" Class="mb-3">
+            <MudText Typo="Typo.body1" Class="mb-2">@_resolutionError</MudText>
+            @if (_isCompetitionAdmin)
+            {
+                <MudText Typo="Typo.body2">
+                    Fix the team roster in the competition setup, then reload this page.
+                    The rubber template requires specific role tags on each team member
+                    (for example MA / MB for a men's doubles). Roles are assigned in the
+                    <strong>Teams</strong> section of the setup page.
+                </MudText>
+            }
+            else
+            {
+                <MudText Typo="Typo.body2">
+                    Ask a competition admin to assign the missing role on the team roster.
+                </MudText>
+            }
+        </MudAlert>
+        <MudStack Row="true" Spacing="2">
+            @if (_isCompetitionAdmin && _context is not null)
+            {
+                <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                           StartIcon="@Icons.Material.Filled.ManageAccounts"
+                           Href="@($"/competition/{_context.CompetitionId}#section-teams")">
+                    Fix team roster
+                </MudButton>
+            }
+            @if (_context is not null)
+            {
+                <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.ArrowBack"
+                           Href="@($"/competitions/{_context.CompetitionId}/view")">
+                    Back to Competition
+                </MudButton>
+            }
+        </MudStack>
+    </MudContainer>
+}
+else if (_context is null)
+{
+    <MudAlert Severity="Severity.Error">Fixture not found.</MudAlert>
+}
+else
+{
+    <MudContainer MaxWidth="MaxWidth.Large" Class="py-4">
+        <MudPaper Class="pa-4 mb-4" Elevation="2">
+            <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
+                <MudStack Spacing="0">
+                    <MudText Typo="Typo.h5">@_context.CompetitionName</MudText>
+                    <MudText Typo="Typo.subtitle1" Color="Color.Tertiary">
+                        @_context.HomeTeamName vs @_context.AwayTeamName
+                        @if (!string.IsNullOrEmpty(_context.FixtureLabel))
+                        {
+                            <span> — @_context.FixtureLabel</span>
+                        }
+                    </MudText>
+                </MudStack>
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                    <MudChip T="string" Size="Size.Large" Color="@(_allComplete ? Color.Success : Color.Primary)">
+                        @_homeScore — @_awayScore @_scoreUnit
+                    </MudChip>
+                    @if (!_allComplete && _context.Rubbers.Any(r => !r.IsComplete && !r.SavedMatchId.HasValue))
+                    {
+                        <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Primary"
+                                   StartIcon="@Icons.Material.Filled.PlaylistAddCheck"
+                                   OnClick="OpenBulkRubberDialogAsync">Enter all scores</MudButton>
+                    }
+                </MudStack>
+            </MudStack>
+        </MudPaper>
+
+        @foreach (var group in _context.Rubbers.GroupBy(r => r.CourtNumber).OrderBy(g => g.Key))
+        {
+            <MudText Typo="Typo.h6" Class="mb-2">Court @group.Key</MudText>
+            <MudGrid Spacing="3" Class="mb-4">
+                <MudItem xs="12">
+                    @foreach (var r in group.OrderBy(r => r.Order))
+                    {
+                        @RenderRubber(r)
+                    }
+                </MudItem>
+            </MudGrid>
+        }
+
+        @if (_allComplete)
+        {
+            <MudAlert Severity="Severity.Success" Class="mt-4">
+                Match complete: @_context.HomeTeamName @_homeScore — @_awayScore @_scoreUnit @_context.AwayTeamName
+                @if (_homeScore == _awayScore)
+                {
+                    <span> (Draw)</span>
+                }
+            </MudAlert>
+        }
+
+        <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.ArrowBack"
+                   Href="@($"/competitions/{_context.CompetitionId}/view")">
+            Back to Competition
+        </MudButton>
+    </MudContainer>
+}
+
+@code {
+    [Parameter] public int FixtureId { get; set; }
+    [SupplyParameterFromQuery(Name = "edit")] public int? EditMode { get; set; }
+
+    private FixtureRubberContextDto? _context;
+    private bool _loading = true;
+    private int _homeScore;
+    private int _awayScore;
+    private string _scoreUnit = "rubbers";
+    private bool _allComplete;
+    private string? _resolutionError;
+    private bool _isCompetitionAdmin;
+
+    private bool CanEditCompletedRubber => _isCompetitionAdmin && EditMode == 1;
+
+    protected override async Task OnInitializedAsync() => await LoadAsync();
+
+    private async Task LoadAsync()
+    {
+        _resolutionError = null;
+        try
+        {
+            await CompetitionService.EnsureFixtureRubbersAsync(FixtureId);
+        }
+        catch (InvalidOperationException ex)
+        {
+            _resolutionError = ex.Message;
+        }
+
+        _context = await CompetitionService.GetFixtureRubberContextAsync(FixtureId);
+        if (_context is not null)
+        {
+            _isCompetitionAdmin = CurrentUser.CanEditCompetition(_context.HostClubId);
+            ComputeScores();
+        }
+
+        _loading = false;
+    }
+
+    private void ComputeScores()
+    {
+        if (_context is null) { _allComplete = false; return; }
+
+        if (_context.HomeTeamId.HasValue && _context.AwayTeamId.HasValue)
+        {
+            (_homeScore, _awayScore, _scoreUnit) = TeamLeagueScoreCalculator.Compute(
+                _context.Rubbers, _context.HomeTeamId.Value, _context.AwayTeamId.Value, _context.LeagueScoring);
+        }
+        _allComplete = _context.Rubbers.Count > 0 && TeamLeagueScoreCalculator.AllComplete(_context.Rubbers);
+    }
+
+    private bool CanStart(RubberDialogDto rubber)
+    {
+        if (_context is null) return false;
+        if (rubber.IsComplete || rubber.SavedMatchId.HasValue) return false;
+
+        // Within the same court, rubbers play sequentially by Order.
+        var sameCourt = _context.Rubbers.Where(r => r.CourtNumber == rubber.CourtNumber)
+            .OrderBy(r => r.Order).ToList();
+        var idx = sameCourt.IndexOf(rubber);
+        if (idx == 0) return true;
+        return sameCourt[idx - 1].IsComplete;
+    }
+
+    private void StartRubber(RubberDialogDto rubber)
+    {
+        var returnUrl = $"/team-match/{FixtureId}";
+        Navigation.NavigateTo(
+            $"/tennisscore?RubberId={rubber.RubberId}&ReturnUrl={Uri.EscapeDataString(returnUrl)}&AutoStart=true");
+    }
+
+    private void ResumeRubber(RubberDialogDto rubber)
+    {
+        if (rubber.SavedMatchId.HasValue)
+        {
+            var returnUrl = $"/team-match/{FixtureId}";
+            Navigation.NavigateTo($"/match/{rubber.SavedMatchId}?ReturnUrl={Uri.EscapeDataString(returnUrl)}");
+        }
+    }
+
+    private async Task OpenBulkRubberDialogAsync()
+    {
+        var parameters = new DialogParameters<BulkRubberScoreDialog>
+        {
+            { x => x.FixtureId, FixtureId },
+            { x => x.AdminOverride, _isCompetitionAdmin }
+        };
+        var dlg = await DialogService.ShowAsync<BulkRubberScoreDialog>(
+            "Enter all rubber scores",
+            parameters,
+            new DialogOptions { FullWidth = true, MaxWidth = MaxWidth.Medium, CloseOnEscapeKey = true });
+        var res = await dlg.Result;
+        if (res is not null && !res.Canceled)
+        {
+            await LoadAsync();
+            StateHasChanged();
+        }
+    }
+
+    private async Task EnterRubberScore(RubberDialogDto rubber)
+    {
+        var parameters = new DialogParameters<RubberScoreDialog>
+        {
+            { x => x.FixtureId, FixtureId },
+            { x => x.RubberId, rubber.RubberId },
+            { x => x.AdminOverride, _isCompetitionAdmin }
+        };
+        var dialog = await DialogService.ShowAsync<RubberScoreDialog>("Enter rubber score", parameters);
+        var result = await dialog.Result;
+        if (result != null && !result.Canceled)
+        {
+            await LoadAsync();
+            StateHasChanged();
+        }
+    }
+
+    private RenderFragment RenderRubber(RubberDialogDto rubber) => __builder =>
+    {
+        var homeTeam = _context?.HomeTeamName ?? "Home";
+        var awayTeam = _context?.AwayTeamName ?? "Away";
+        var homePair = $"{rubber.HomePlayer1Name} & {rubber.HomePlayer2Name}";
+        var awayPair = $"{rubber.AwayPlayer1Name} & {rubber.AwayPlayer2Name}";
+        <MudCard Class="mb-2" Outlined="true">
+            <MudCardContent>
+                <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Spacing="3">
+                    <MudStack Spacing="1" Style="flex:1; min-width:0">
+                        <MudText Typo="Typo.subtitle2">@rubber.Name (rubber @rubber.Order)</MudText>
+                        <MudStack Row="true" AlignItems="AlignItems.Baseline" Spacing="2">
+                            <MudText Typo="Typo.body2" Style="font-weight:600; min-width:90px">@homeTeam</MudText>
+                            <MudText Typo="Typo.body2" Style="opacity:0.9">@homePair</MudText>
+                        </MudStack>
+                        <MudStack Row="true" AlignItems="AlignItems.Baseline" Spacing="2">
+                            <MudText Typo="Typo.body2" Style="font-weight:600; min-width:90px">@awayTeam</MudText>
+                            <MudText Typo="Typo.body2" Style="opacity:0.9">@awayPair</MudText>
+                        </MudStack>
+                    </MudStack>
+                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                        @if (rubber.IsComplete)
+                        {
+                            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                                <MudChip T="string" Size="Size.Small" Color="Color.Success">
+                                    @(rubber.HomeSetsWon.HasValue && rubber.AwaySetsWon.HasValue
+                                        ? $"{rubber.HomeSetsWon} — {rubber.AwaySetsWon} sets"
+                                        : $"{rubber.HomeGames} — {rubber.AwayGames}")
+                                </MudChip>
+                                @if (rubber.ExistingSetScores.Count > 0)
+                                {
+                                    <MudText Typo="Typo.caption" Color="Color.Secondary">
+                                        (@string.Join(", ", rubber.ExistingSetScores.Select(s => $"{s.Home}-{s.Away}")))
+                                    </MudText>
+                                }
+                                @if (CanEditCompletedRubber)
+                                {
+                                    <MudIconButton Size="Size.Small" Icon="@Icons.Material.Filled.Edit"
+                                                   OnClick="@(() => EnterRubberScore(rubber))" />
+                                }
+                            </MudStack>
+                        }
+                        else if (rubber.SavedMatchId.HasValue)
+                        {
+                            <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Warning"
+                                       OnClick="@(() => ResumeRubber(rubber))">Resume</MudButton>
+                        }
+                        else if (CanStart(rubber))
+                        {
+                            <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary"
+                                       OnClick="@(() => StartRubber(rubber))">Play</MudButton>
+                            <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Primary"
+                                       OnClick="@(() => EnterRubberScore(rubber))">Enter score</MudButton>
+                        }
+                        else
+                        {
+                            <MudChip T="string" Size="Size.Small" Color="Color.Default">Waiting</MudChip>
+                        }
+                    </MudStack>
+                </MudStack>
+            </MudCardContent>
+        </MudCard>
+    };
+}

--- a/DropShot.UI/Services/ICompetitionService.cs
+++ b/DropShot.UI/Services/ICompetitionService.cs
@@ -83,11 +83,22 @@ public interface ICompetitionService
 
     /// <summary>
     /// Loads the rubber-scoring context for a team-match fixture: per-rubber
-    /// player names + existing set scores, plus the fixture's match-config
-    /// knobs (BestOf, GamesPerSet, SetWinMode, MatchFormat, RequireVerification).
-    /// Backs RubberScoreDialog and BulkRubberScoreDialog (phase 7).
+    /// player names + existing set scores + score aggregates, plus the fixture's
+    /// match-config knobs (BestOf, GamesPerSet, SetWinMode, MatchFormat,
+    /// RequireVerification, LeagueScoring, HostClubId). Backs both rubber
+    /// scoring dialogs and the TeamMatchScoring page.
     /// </summary>
     Task<FixtureRubberContextDto?> GetFixtureRubberContextAsync(int fixtureId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Lazily creates the Rubber rows for a team-match fixture by resolving
+    /// each rubber template's roles against the home and away team rosters.
+    /// Idempotent (returns immediately if rubbers already exist). Throws
+    /// <see cref="InvalidOperationException"/> with a user-facing message when
+    /// role resolution fails (missing or duplicate role assignments) — the
+    /// TeamMatchScoring page surfaces this as a recoverable error.
+    /// </summary>
+    Task EnsureFixtureRubbersAsync(int fixtureId, CancellationToken ct = default);
 
     /// <summary>
     /// Submit one or many rubber scores for a fixture in a single call. The

--- a/DropShot/Controllers/CompetitionsController.cs
+++ b/DropShot/Controllers/CompetitionsController.cs
@@ -467,6 +467,30 @@ public class CompetitionsController(
     }
 
     /// <summary>
+    /// Lazily creates rubber rows for a fixture. Idempotent. Returns 400 with
+    /// a user-facing message if role resolution fails (missing or duplicate
+    /// role tags). Caller must be able to view the competition; fixture must
+    /// have both home and away teams set.
+    /// </summary>
+    [HttpPost("fixtures/{fixtureId:int}/ensure-rubbers")]
+    public async Task<IActionResult> EnsureFixtureRubbers(int fixtureId, CancellationToken ct)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var fx = await db.CompetitionFixtures
+            .Select(f => new { f.CompetitionFixtureId, f.CompetitionId })
+            .FirstOrDefaultAsync(f => f.CompetitionFixtureId == fixtureId, ct);
+        if (fx is null) return NotFound();
+        if (!await authzService.CanViewCompetitionAsync(User, fx.CompetitionId)) return Forbid();
+
+        try
+        {
+            await competitionService.EnsureFixtureRubbersAsync(fixtureId, ct);
+            return NoContent();
+        }
+        catch (InvalidOperationException ex) { return BadRequest(ex.Message); }
+    }
+
+    /// <summary>
     /// Submit one or many rubber scores for a fixture (single dialog or bulk
     /// dialog). Backs phase 7 RubberScoreDialog/BulkRubberScoreDialog. Server
     /// enforces that <c>AdminOverride</c> is honoured only for competition

--- a/DropShot/Services/WebCompetitionService.cs
+++ b/DropShot/Services/WebCompetitionService.cs
@@ -20,7 +20,8 @@ public sealed class WebCompetitionService(
     ClubAuthorizationService authzService,
     IHttpContextAccessor httpContextAccessor,
     ICurrentUser currentUser,
-    BackgroundTaskQueue backgroundTasks) : ICompetitionService
+    BackgroundTaskQueue backgroundTasks,
+    RubberResolutionService rubberResolver) : ICompetitionService
 {
     public async Task<List<CompetitionDto>> GetCompetitionsAsync(bool includeArchived = false, CancellationToken ct = default)
     {
@@ -356,7 +357,9 @@ public sealed class WebCompetitionService(
                 r.AwayPlayer1Id, r.AwayPlayer1?.DisplayName,
                 r.AwayPlayer2Id, r.AwayPlayer2?.DisplayName,
                 r.IsComplete, r.SavedMatchId,
-                r.SetScores.Select(s => new RubberSetScoreDto(s.Home, s.Away)).ToList()))
+                r.SetScores.Select(s => new RubberSetScoreDto(s.Home, s.Away)).ToList(),
+                r.WinnerTeamId, r.HomeGames, r.AwayGames,
+                r.HomeSetsWon, r.AwaySetsWon, r.HomeGamesTotal, r.AwayGamesTotal))
             .ToList();
 
         return new FixtureRubberContextDto(
@@ -376,7 +379,22 @@ public sealed class WebCompetitionService(
             comp?.RequireVerification ?? false,
             fx.Status == DropShot.Models.FixtureStatus.AwaitingVerification
                 || fx.Status == DropShot.Models.FixtureStatus.Completed,
-            rubbers);
+            rubbers,
+            (DropShot.Shared.LeagueScoringMode)(comp?.LeagueScoring ?? DropShot.Models.LeagueScoringMode.WinPoints),
+            comp?.HostClubId);
+    }
+
+    public async Task EnsureFixtureRubbersAsync(int fixtureId, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        try
+        {
+            await rubberResolver.EnsureRubbersAsync(db, fixtureId);
+        }
+        catch (RubberResolutionException ex)
+        {
+            throw new InvalidOperationException(ex.Message);
+        }
     }
 
     public async Task SubmitRubberScoresAsync(


### PR DESCRIPTION
Re-opening as #498 was auto-closed when its stacked base branch was deleted on merge of #497.

## Summary

Final PR in the rubber-scoring slice. `/team-match/{FixtureId}` now renders from DTOs on both web and MAUI.

- New RCL page at `DropShot.UI/Components/Pages/TeamMatchScoring.razor` consumes `ICompetitionService` only — no `IDbContextFactory`, no entity types. Web shim and MAUI shim wrap it.
- New `ICompetitionService.EnsureFixtureRubbersAsync` lazily creates rubber rows by resolving template roles against team rosters (idempotent). On role-mismatch the page shows the existing "fix the roster" recoverable UI.
- `FixtureRubberContextDto` gains `LeagueScoring` + `HostClubId`. `RubberDialogDto` gains the score aggregates. Existing dialog callers unaffected — new fields default to null.
- `TeamLeagueScoreCalculator` gets a `RubberDialogDto` overload + `AllComplete` helper.

The page's "Play" / "Resume" buttons still navigate to `/tennisscore` and `/match/{id}` — those routes are PRs 5–7 of phase 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)