### PR TITLE
Phase 7: add casual-match recent-results service surface (prep for Home move)

### DIFF
--- a/DropShot.Maui/Services/HttpMatchService.cs
+++ b/DropShot.Maui/Services/HttpMatchService.cs
@@ -19,4 +19,9 @@ public sealed class HttpMatchService(HttpClient http) : IMatchService
         return await http.GetFromJsonAsync<List<ActiveMatchDto>>(
             $"api/matches/mine{qs}", ct) ?? [];
     }
+
+    public async Task<List<RecentCasualMatchDto>> GetMyRecentCasualMatchesAsync(
+        int limit = 6, CancellationToken ct = default)
+        => await http.GetFromJsonAsync<List<RecentCasualMatchDto>>(
+            $"api/matches/casual/recent?limit={limit}", ct) ?? [];
 }

--- a/DropShot.Shared/Dtos/MatchDtos.cs
+++ b/DropShot.Shared/Dtos/MatchDtos.cs
@@ -14,3 +14,32 @@ public record ActiveMatchDto(
     int? CourtId,
     string? CourtName,
     DateTime CreatedAt);
+
+/// <summary>
+/// One set's game count for a casual match. May represent the only
+/// set when the match was scored in game-only mode (no per-set
+/// breakdown was recorded), in which case <see cref="SetNumber"/> == 1.
+/// </summary>
+public record CasualSetScoreDto(int SetNumber, int Player1Games, int Player2Games);
+
+/// <summary>
+/// Recently completed casual match (a SavedMatch row not linked to a
+/// CompetitionFixture). Backs Home.razor's "My Recent Results" list.
+/// Sets are pre-parsed from MatchJson server-side so the shared RCL
+/// never deserializes the Match graph.
+/// </summary>
+public record RecentCasualMatchDto(
+    int SavedMatchId,
+    string? Player1,
+    string? Player2,
+    string? Player3,
+    string? Player4,
+    int? Player1Id,
+    int? Player2Id,
+    int? Player3Id,
+    int? Player4Id,
+    string? WinnerName,
+    int? WinnerPlayerId,
+    DateTime CreatedAt,
+    DateTime? CompletedAt,
+    IReadOnlyList<CasualSetScoreDto> Sets);

--- a/DropShot.UI/Services/IMatchService.cs
+++ b/DropShot.UI/Services/IMatchService.cs
@@ -14,4 +14,13 @@ public interface IMatchService
     /// token to scope to matches started on their device.
     /// </summary>
     Task<List<ActiveMatchDto>> GetMyActiveMatchesAsync(string? deviceToken, CancellationToken ct = default);
+
+    /// <summary>
+    /// Recently completed casual matches the current user participated in.
+    /// Returns an empty list when no user is signed in or no Player profile
+    /// maps to the current UserId. Excludes SavedMatch rows linked to a
+    /// CompetitionFixture (those render as fixture results, not casual).
+    /// </summary>
+    Task<List<RecentCasualMatchDto>> GetMyRecentCasualMatchesAsync(
+        int limit = 6, CancellationToken ct = default);
 }

--- a/DropShot/Controllers/MatchesController.cs
+++ b/DropShot/Controllers/MatchesController.cs
@@ -26,4 +26,15 @@ public class MatchesController(IMatchService matches) : ControllerBase
     {
         return await matches.GetMyActiveMatchesAsync(deviceToken, ct);
     }
+
+    /// <summary>
+    /// Recently completed casual matches the caller participated in.
+    /// SavedMatch rows already linked to a CompetitionFixture are excluded.
+    /// </summary>
+    [HttpGet("casual/recent")]
+    public async Task<ActionResult<List<RecentCasualMatchDto>>> GetRecentCasual(
+        [FromQuery] int limit = 6, CancellationToken ct = default)
+    {
+        return await matches.GetMyRecentCasualMatchesAsync(limit, ct);
+    }
 }

--- a/DropShot/Services/WebMatchService.cs
+++ b/DropShot/Services/WebMatchService.cs
@@ -1,8 +1,10 @@
 using DropShot.Data;
+using DropShot.Models;
 using DropShot.Shared.Dtos;
 using DropShot.UI.Services;
 using DropShot.UI.Services.Auth;
 using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
 
 namespace DropShot.Services;
 
@@ -50,5 +52,83 @@ public sealed class WebMatchService(
             m.CourtId,
             m.CourtId.HasValue && courtNames.TryGetValue(m.CourtId.Value, out var n) ? n : null,
             m.CreatedAt)).ToList();
+    }
+
+    public async Task<List<RecentCasualMatchDto>> GetMyRecentCasualMatchesAsync(
+        int limit = 6, CancellationToken ct = default)
+    {
+        var userId = currentUser.UserId;
+        if (string.IsNullOrEmpty(userId)) return [];
+
+        var safeLimit = Math.Clamp(limit, 1, 50);
+
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+
+        var pid = await db.Players
+            .Where(p => p.UserId == userId)
+            .Select(p => (int?)p.PlayerId)
+            .FirstOrDefaultAsync(ct);
+        if (pid is null) return [];
+
+        // SavedMatch rows linked to a fixture render as fixture results, not casual.
+        var linkedSavedMatchIds = db.CompetitionFixtures
+            .Where(f => f.SavedMatchId != null)
+            .Select(f => f.SavedMatchId!.Value);
+
+        var rows = await db.SavedMatch
+            .Where(m => m.Complete
+                     && (m.Player1Id == pid || m.Player2Id == pid
+                         || m.Player3Id == pid || m.Player4Id == pid)
+                     && !linkedSavedMatchIds.Contains(m.SavedMatchId))
+            .OrderByDescending(m => m.CompletedAt ?? m.CreatedAt)
+            .Take(safeLimit)
+            .ToListAsync(ct);
+
+        return rows.Select(m => new RecentCasualMatchDto(
+            m.SavedMatchId,
+            m.Player1, m.Player2, m.Player3, m.Player4,
+            m.Player1Id, m.Player2Id, m.Player3Id, m.Player4Id,
+            m.WinnerName, m.WinnerPlayerId,
+            m.CreatedAt, m.CompletedAt,
+            ParseSets(m.MatchJson))).ToList();
+    }
+
+    /// <summary>
+    /// Mirrors <c>ResultCard.razor</c>'s ParseCasualSets: pulls the latest
+    /// GameState snapshot from MatchJson and emits per-set game counts. Falls
+    /// back to a single (UserG, OppG) pseudo-set for game-only scored matches
+    /// that never recorded a per-set breakdown. PR 6 will move ResultCard into
+    /// DropShot.UI and consume this DTO directly, retiring the original parser.
+    /// </summary>
+    private static IReadOnlyList<CasualSetScoreDto> ParseSets(string? matchJson)
+    {
+        if (string.IsNullOrWhiteSpace(matchJson)) return Array.Empty<CasualSetScoreDto>();
+        try
+        {
+            var match = JsonConvert.DeserializeObject<Match>(matchJson);
+            // HistoryList is serialized from a Stack, so index 0 is the most
+            // recent state. Fall back to History (the actual Stack) for older
+            // records that don't have HistoryList populated.
+            var latest = match?.HistoryList?.FirstOrDefault()
+                ?? match?.History?.FirstOrDefault();
+            if (latest is null) return Array.Empty<CasualSetScoreDto>();
+
+            if (latest.SetScores is { Count: > 0 } setScores)
+            {
+                return setScores
+                    .OrderBy(s => s.SetNumber)
+                    .Select(s => new CasualSetScoreDto(s.SetNumber, s.UserGames, s.OpponentGames))
+                    .ToList();
+            }
+
+            if (latest.UserG > 0 || latest.OppG > 0)
+                return new[] { new CasualSetScoreDto(1, latest.UserG, latest.OppG) };
+
+            return Array.Empty<CasualSetScoreDto>();
+        }
+        catch
+        {
+            return Array.Empty<CasualSetScoreDto>();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Extends `IMatchService` with `GetMyRecentCasualMatchesAsync` so PR 6 (Home.razor move) has a DTO-typed read path for the "My Recent Results" mixed list.
- Adds `RecentCasualMatchDto` + `CasualSetScoreDto` to `DropShot.Shared`, with sets pre-parsed server-side so MAUI never sees the `Match`/`HistoryList` graph (those types live server-only in `DropShot.Models`).
- Adds `GET /api/matches/casual/recent?limit=N` to `MatchesController` (Bearer-authorized via the class-level attribute).
- No page or component move in this PR — `Home.razor` still renders directly from EF; the new service surface is unconsumed until PR 6.

## Notes
- Server resolves the player from `ICurrentUser`; no `playerId` parameter (matches the convention from PR #494).
- The `not-linked-to-fixture` exclusion lives in the service — same business rule the existing Home query enforces inline.
- `MatchJson` parser is duplicated (rather than extracted from `ResultCard.razor`) to keep the PR additive; PR 6 retires the original when `ResultCard` moves into `DropShot.UI`.
- Limit is clamped to `[1, 50]` server-side.

## Test plan
- [x] `dotnet build DropShot.sln` — 0 errors, no new warnings
- [ ] `dotnet run --project DropShot`, sign in as a user with completed casual matches, hit `/` — "My Recent Results" still renders identically (regression check; new service surface is unconsumed)
- [ ] `GET /api/matches/casual/recent?limit=6` with a JWT — same `SavedMatchId` set the existing Home query returns; sets populated where `MatchJson` has set breakdowns
- [ ] Spot-check a `MatchJson` row with no `SetScores` populated — endpoint emits a single `SetNumber=1` entry from `UserG`/`OppG` (game-only fallback)
- [ ] `dotnet build DropShot.Maui` — passes; no `DropShot.Models` / `SavedMatch` leakage in the MAUI HTTP path

🤖 Generated with [Claude Code](https://claude.com/claude-code)