### PR TITLE
Phase 7: add fixture-list service surface for current user (prep for Home move)

### DIFF
--- a/DropShot.Maui/Services/HttpCompetitionService.cs
+++ b/DropShot.Maui/Services/HttpCompetitionService.cs
@@ -55,6 +55,15 @@ public sealed class HttpCompetitionService(HttpClient http) : ICompetitionServic
     public async Task<List<CompetitionFixtureDto>> GetPendingVerificationFixturesAsync(CancellationToken ct = default) =>
         await http.GetFromJsonAsync<List<CompetitionFixtureDto>>("api/competitions/pending-verification", ct) ?? [];
 
+    public async Task<List<CompetitionFixtureDto>> GetMyUpcomingFixturesAsync(CancellationToken ct = default) =>
+        await http.GetFromJsonAsync<List<CompetitionFixtureDto>>(
+            "api/competitions/mine/upcoming-fixtures", ct) ?? [];
+
+    public async Task<List<CompetitionFixtureDto>> GetMyRecentCompletedFixturesAsync(
+        int limit = 6, CancellationToken ct = default) =>
+        await http.GetFromJsonAsync<List<CompetitionFixtureDto>>(
+            $"api/competitions/mine/recent-fixtures?limit={limit}", ct) ?? [];
+
     public async Task ToggleArchiveAsync(int competitionId, CancellationToken ct = default)
     {
         var resp = await http.PostAsync($"api/competitions/{competitionId}/toggle-archive", null, ct);

--- a/DropShot.UI/Services/ICompetitionService.cs
+++ b/DropShot.UI/Services/ICompetitionService.cs
@@ -62,6 +62,23 @@ public interface ICompetitionService
     Task<List<CompetitionFixtureDto>> GetPendingVerificationFixturesAsync(CancellationToken ct = default);
 
     /// <summary>
+    /// Upcoming fixtures (Scheduled or InProgress) the current user is in,
+    /// either as a singles/doubles player or via a team they're a member of.
+    /// Returns an empty list when no user is signed in or the user has no
+    /// Player profile. Each fixture carries its <c>CompetitionName</c>.
+    /// </summary>
+    Task<List<CompetitionFixtureDto>> GetMyUpcomingFixturesAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Most-recently completed fixtures (with a <c>ResultSummary</c>) the
+    /// current user participated in, either directly or via a team. Returns
+    /// an empty list when no user is signed in or the user has no Player
+    /// profile. Each fixture carries its <c>CompetitionName</c>.
+    /// </summary>
+    Task<List<CompetitionFixtureDto>> GetMyRecentCompletedFixturesAsync(
+        int limit = 6, CancellationToken ct = default);
+
+    /// <summary>
     /// Toggle the IsArchived flag on a competition. Caller must be able to
     /// edit the competition; the server performs the final auth check.
     /// </summary>

--- a/DropShot/Controllers/CompetitionsController.cs
+++ b/DropShot/Controllers/CompetitionsController.cs
@@ -543,6 +543,17 @@ public class CompetitionsController(
     public async Task<ActionResult<List<CompetitionFixtureDto>>> GetPendingVerificationFixtures(CancellationToken ct)
         => await competitionService.GetPendingVerificationFixturesAsync(ct);
 
+    /// <summary>Upcoming fixtures the current user is in (player or team).</summary>
+    [HttpGet("mine/upcoming-fixtures")]
+    public async Task<ActionResult<List<CompetitionFixtureDto>>> GetMyUpcomingFixtures(CancellationToken ct)
+        => await competitionService.GetMyUpcomingFixturesAsync(ct);
+
+    /// <summary>Recently completed fixtures the current user participated in.</summary>
+    [HttpGet("mine/recent-fixtures")]
+    public async Task<ActionResult<List<CompetitionFixtureDto>>> GetMyRecentCompletedFixtures(
+        [FromQuery] int limit = 6, CancellationToken ct = default)
+        => await competitionService.GetMyRecentCompletedFixturesAsync(limit, ct);
+
     [HttpPost("{id:int}/toggle-archive")]
     public async Task<IActionResult> ToggleArchive(int id, CancellationToken ct)
     {

--- a/DropShot/Services/WebCompetitionService.cs
+++ b/DropShot/Services/WebCompetitionService.cs
@@ -622,6 +622,93 @@ public sealed class WebCompetitionService(
         return fixtures.Select(f => ToFixtureDto(f) with { CompetitionName = f.Competition?.CompetitionName }).ToList();
     }
 
+    public async Task<List<CompetitionFixtureDto>> GetMyUpcomingFixturesAsync(CancellationToken ct = default)
+    {
+        var (db, pid, myTeamIds) = await ResolveCurrentPlayerAsync(ct);
+        if (db is null || pid is null) return [];
+        await using (db)
+        {
+            var fixtures = await db.CompetitionFixtures
+                .Include(f => f.Competition)
+                .Include(f => f.Stage)
+                .Include(f => f.Player1).Include(f => f.Player2)
+                .Include(f => f.Player3).Include(f => f.Player4)
+                .Include(f => f.HomeTeam).Include(f => f.AwayTeam)
+                .Where(f => (f.Player1Id == pid || f.Player2Id == pid
+                             || f.Player3Id == pid || f.Player4Id == pid
+                             || (f.HomeTeamId.HasValue && myTeamIds.Contains(f.HomeTeamId.Value))
+                             || (f.AwayTeamId.HasValue && myTeamIds.Contains(f.AwayTeamId.Value)))
+                         && (f.Status == DropShot.Models.FixtureStatus.Scheduled
+                             || f.Status == DropShot.Models.FixtureStatus.InProgress))
+                .OrderBy(f => f.ScheduledAt)
+                .ToListAsync(ct);
+
+            return fixtures
+                .Select(f => ToFixtureDto(f) with { CompetitionName = f.Competition?.CompetitionName })
+                .ToList();
+        }
+    }
+
+    public async Task<List<CompetitionFixtureDto>> GetMyRecentCompletedFixturesAsync(
+        int limit = 6, CancellationToken ct = default)
+    {
+        var safeLimit = Math.Clamp(limit, 1, 50);
+        var (db, pid, myTeamIds) = await ResolveCurrentPlayerAsync(ct);
+        if (db is null || pid is null) return [];
+        await using (db)
+        {
+            var fixtures = await db.CompetitionFixtures
+                .Include(f => f.Competition)
+                .Include(f => f.Player1).Include(f => f.Player2)
+                .Include(f => f.Player3).Include(f => f.Player4)
+                .Include(f => f.HomeTeam).Include(f => f.AwayTeam)
+                .Where(f => (f.Player1Id == pid || f.Player2Id == pid
+                             || f.Player3Id == pid || f.Player4Id == pid
+                             || (f.HomeTeamId.HasValue && myTeamIds.Contains(f.HomeTeamId.Value))
+                             || (f.AwayTeamId.HasValue && myTeamIds.Contains(f.AwayTeamId.Value)))
+                         && f.Status == DropShot.Models.FixtureStatus.Completed
+                         && f.ResultSummary != null)
+                .OrderByDescending(f => f.CompletedAt ?? f.ScheduledAt)
+                .Take(safeLimit)
+                .ToListAsync(ct);
+
+            return fixtures
+                .Select(f => ToFixtureDto(f) with { CompetitionName = f.Competition?.CompetitionName })
+                .ToList();
+        }
+    }
+
+    /// <summary>
+    /// Loads the current user's player ID and the teams they're a member of.
+    /// Returns (null, null, []) when there's no signed-in user or no Player
+    /// row maps to the UserId — callers short-circuit to an empty result.
+    /// The DbContext is returned so the caller can keep using it (saves the
+    /// second CreateDbContextAsync round-trip).
+    /// </summary>
+    private async Task<(MyDbContext? Db, int? PlayerId, List<int> MyTeamIds)>
+        ResolveCurrentPlayerAsync(CancellationToken ct)
+    {
+        var userId = currentUser.UserId;
+        if (string.IsNullOrEmpty(userId)) return (null, null, []);
+
+        var db = await dbFactory.CreateDbContextAsync(ct);
+        var pid = await db.Players
+            .Where(p => p.UserId == userId)
+            .Select(p => (int?)p.PlayerId)
+            .FirstOrDefaultAsync(ct);
+        if (pid is null)
+        {
+            await db.DisposeAsync();
+            return (null, null, []);
+        }
+
+        var teamIds = await db.CompetitionParticipants
+            .Where(cp => cp.PlayerId == pid && cp.TeamId != null)
+            .Select(cp => cp.TeamId!.Value)
+            .ToListAsync(ct);
+        return (db, pid, teamIds);
+    }
+
     public async Task ToggleArchiveAsync(int competitionId, CancellationToken ct = default)
     {
         var user = httpContextAccessor.HttpContext?.User ?? new ClaimsPrincipal();


### PR DESCRIPTION
## Summary
- Adds `ICompetitionService.GetMyUpcomingFixturesAsync` and `GetMyRecentCompletedFixturesAsync(limit)` so PR 6b (Home.razor move) has the two read paths it needs for "Your Upcoming Matches" and "My Recent Results".
- Web impl ports both EF queries verbatim from `Home.razor:377-410`, sharing a private `ResolveCurrentPlayerAsync` helper that loads the player ID + team memberships in one DbContext open. Each fixture is enriched with `CompetitionName` via `with` so the UI can group / label without an extra service hop.
- HTTP impl + two new endpoints under `api/competitions/mine/{upcoming,recent}-fixtures`. Bearer-authorized via the controller's class-level attribute.
- No page or component move in this PR — `Home.razor` still renders directly from EF; the new service surface is unconsumed until PR 6b.

## Notes
- Server resolves the player from `ICurrentUser` (matches the convention from PR #494).
- Team-based fixture matching mirrors Home: `f.HomeTeamId/AwayTeamId` ∈ user's `CompetitionParticipants.TeamId` set.
- Limit on the recent endpoint clamped to `[1, 50]` server-side.
- This PR is independent of [#501](https://github.com/kingbeazer/DropShot/pull/501) (PR 5, casual-match service surface). Both branch from `main`; PR 6b will depend on both.

## Test plan
- [x] `dotnet build DropShot.sln` — 0 errors, no new warnings
- [ ] `dotnet run --project DropShot`, sign in as a user with upcoming + completed fixtures, hit `/` — both panels still render identically (regression check; new service surface is unconsumed)
- [ ] `GET /api/competitions/mine/upcoming-fixtures` with a JWT — returns the same fixture set Home shows in "Your Upcoming Matches" for that user
- [ ] `GET /api/competitions/mine/recent-fixtures?limit=6` — returns the same Completed fixtures with `CompletedAt`/`ResultSummary` populated; ordered by completion recency
- [ ] Both endpoints return `[]` for a signed-in user with no `Player` row and for an anonymous caller (401 actually, since Bearer-required — verify with `curl` against a dev token)
- [ ] `dotnet build DropShot.Maui` — passes; no `DropShot.Models` leakage

🤖 Generated with [Claude Code](https://claude.com/claude-code)