### PR TITLE
Phase 7: extend ICourtClaimService with ExtendGraceAsync (prep)

### DIFF
--- a/DropShot.UI/Services/ICourtClaimService.cs
+++ b/DropShot.UI/Services/ICourtClaimService.cs
@@ -13,6 +13,15 @@ public interface ICourtClaimService
     /// <summary>True when the SavedMatch hasn't seen activity for the abandon threshold.</summary>
     Task<bool> IsStaleAsync(int savedMatchId, CancellationToken ct = default);
 
+    /// <summary>
+    /// Extend the grace window after the occupant says "yes, I'm still playing"
+    /// in response to a court-challenge. Pushes <c>ClaimGraceUntilUtc</c>
+    /// forward and refreshes <c>LastActivityAt</c> so the abandon timer
+    /// resets. PR 7b's TennisScore move calls this from the CourtChallenge
+    /// SignalR handler.
+    /// </summary>
+    Task ExtendGraceAsync(int savedMatchId, CancellationToken ct = default);
+
     /// <summary>Mark the SavedMatch complete and clear the grace window.</summary>
     Task EndMatchAsync(int savedMatchId, CancellationToken ct = default);
 }


### PR DESCRIPTION
## Summary

Lifts \`CourtClaimService.ExtendGraceAsync\` onto the host-agnostic \`ICourtClaimService\` interface. The concrete web implementation already exposes the method — this PR just makes it reachable from \`DropShot.UI\` so PR 7b's TennisScore migration can call it from the moved RCL component (the CourtChallenge SignalR handler's "yes, I'm still playing" path).

## Scope clarification — TennisScore.razor migration is multi-PR

Originally scoped this PR to also lift \`Match\` and \`TennisMatchState\` from \`DropShot.Models\` to \`DropShot.Shared\` (so the moved TennisScore page could reach them). Investigation found that adding \`using DropShot.Shared\` to the relevant call sites surfaces a large pre-existing duplicate-enum problem: \`FixtureStatus\`, \`FriendStatus\`, \`MatchFormatType\`, \`StageType\`, \`ParticipantStatus\`, \`PlayerSex\`, \`CompetitionFormat\`, and \`LeagueScoringMode\` are all duplicated between \`DropShot.Models\` and \`DropShot.Shared\`, causing ~30 ambiguous-reference errors in \`CompetitionPage.razor\` / \`TennisScore.razor\` / \`FixtureSimulationService\` alone.

PR 7b will need to deduplicate the enums (likely by deleting the \`DropShot.Models\` copies, since they're functionally identical and \`DropShot.Shared\` is the right home) as part of its work, then do the type lift, then move the TennisScore page (~1,658 lines) with its full service surface (a substantial new \`IMatchScoringService\` covering ~10 EF read/write operations: \`GetMatchSetupContextAsync\`, \`LoadIncompleteMatchAsync\`, \`SaveInitialMatchAsync\`, \`PersistMatchStateAsync\`, \`CompleteFixtureAsync\`, \`CompleteRubberAsync\`, \`DiscardMatchAsync\`, \`SavePlayerSettingsAsync\`, \`AddFriendAsync\`, etc.) plus an HTTP impl for MAUI plus API endpoints. That's a multi-PR effort even after this prep lands.

## Test plan

- [x] \`dotnet build DropShot.sln\` clean (0 errors)
- [x] \`dotnet test DropShot.Tests\` — all 28 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)