### PR TITLE
Phase 7: deduplicate 9 enums between DropShot.Models and DropShot.Shared

### DIFF
--- a/DropShot.Tests/Pages/HomeTests.cs
+++ b/DropShot.Tests/Pages/HomeTests.cs
@@ -2,6 +2,7 @@ using Bunit;
 using DropShot.Components.Pages;
 using DropShot.Data;
 using DropShot.Models;
+using DropShot.Shared;
 using DropShot.Tests.Helpers;
 using Microsoft.EntityFrameworkCore;
 using Xunit;

--- a/DropShot/Components/Account/Pages/Manage/Index.razor
+++ b/DropShot/Components/Account/Pages/Manage/Index.razor
@@ -4,6 +4,7 @@
 @using Microsoft.AspNetCore.Identity
 @using DropShot.Data
 @using DropShot.Models
+@using DropShot.Shared
 @using Microsoft.EntityFrameworkCore
 
 @inject UserManager<ApplicationUser> UserManager

--- a/DropShot/Components/Account/Pages/Register.razor
+++ b/DropShot/Components/Account/Pages/Register.razor
@@ -8,6 +8,7 @@
 @using Microsoft.AspNetCore.Authentication
 @using DropShot.Data
 @using DropShot.Models
+@using DropShot.Shared
 @using Microsoft.EntityFrameworkCore
 
 @inject UserManager<ApplicationUser> UserManager

--- a/DropShot/Components/Competitions/Setup/DivisionsSection.razor
+++ b/DropShot/Components/Competitions/Setup/DivisionsSection.razor
@@ -1,5 +1,6 @@
 @using DropShot.Components.Pages
 @using DropShot.Models
+@using DropShot.Shared
 
 <MudPaper id="section-divisions" Class="pa-4 mb-4 setup-section" Elevation="0"
          Style="background: rgba(255,255,255,0.08); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border: 1px solid rgba(255,255,255,0.12); border-radius: 12px; color: white;">

--- a/DropShot/Components/Competitions/Setup/FixturesSection.razor
+++ b/DropShot/Components/Competitions/Setup/FixturesSection.razor
@@ -1,4 +1,5 @@
 @using DropShot.Models
+@using DropShot.Shared
 
 <MudPaper id="section-fixtures" Class="pa-4 setup-section" Elevation="0"
      Style="background: rgba(255,255,255,0.08); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border: 1px solid rgba(255,255,255,0.12); border-radius: 12px; color: white;">

--- a/DropShot/Components/Competitions/Setup/StagesSection.razor
+++ b/DropShot/Components/Competitions/Setup/StagesSection.razor
@@ -1,4 +1,5 @@
 @using DropShot.Models
+@using DropShot.Shared
 
 <MudPaper id="section-stages" Class="pa-4 mb-4 setup-section" Elevation="0"
      Style="background: rgba(255,255,255,0.08); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border: 1px solid rgba(255,255,255,0.12); border-radius: 12px; color: white;">

--- a/DropShot/Components/Competitions/Setup/TeamsSection.razor
+++ b/DropShot/Components/Competitions/Setup/TeamsSection.razor
@@ -1,4 +1,5 @@
 @using DropShot.Models
+@using DropShot.Shared
 
 @{
     var isDoubles = Format is CompetitionFormat.Doubles or CompetitionFormat.MixedDoubles;

--- a/DropShot/Components/MatchSetupWizard.razor
+++ b/DropShot/Components/MatchSetupWizard.razor
@@ -1,6 +1,7 @@
 @using System.Security.Claims
 @using DropShot.Data
 @using DropShot.Models
+@using DropShot.Shared
 @using DropShot.Services
 @using Microsoft.EntityFrameworkCore
 

--- a/DropShot/Components/Pages/Clubs.razor
+++ b/DropShot/Components/Pages/Clubs.razor
@@ -5,6 +5,7 @@
 @using Microsoft.EntityFrameworkCore
 @using DropShot.Models
 @using DropShot.Data
+@using DropShot.Shared
 @using DropShot.Shared.Dtos
 @using DropShot.Shared.Extensions
 @inject IDbContextFactory<MyDbContext> DbFactory

--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -7,6 +7,7 @@
 @using DropShot.Data
 @using DropShot.Models
 @using DropShot.Services
+@using DropShot.Shared
 @using DropShot.Shared.Extensions
 @using Microsoft.EntityFrameworkCore
 
@@ -3699,7 +3700,7 @@ else
             f.CompetitionFixtureId, f.CompetitionId,
             f.CompetitionStageId, f.Stage?.Name,
             f.CourtId, f.Court?.Name,
-            f.ScheduledAt, (DropShot.Shared.FixtureStatus)f.Status,
+            f.ScheduledAt, f.Status,
             f.FixtureLabel, f.RoundNumber,
             f.Player1Id, f.Player1?.DisplayName,
             f.Player2Id, f.Player2?.DisplayName,

--- a/DropShot/Components/Pages/Home.razor
+++ b/DropShot/Components/Pages/Home.razor
@@ -2,6 +2,7 @@
 @rendermode InteractiveServer
 @using DropShot.Data
 @using DropShot.Models
+@using DropShot.Shared
 @using Microsoft.AspNetCore.SignalR.Client
 @using Microsoft.EntityFrameworkCore
 @using Newtonsoft.Json
@@ -654,7 +655,7 @@
             f.CompetitionFixtureId, f.CompetitionId,
             f.CompetitionStageId, f.Stage?.Name,
             f.CourtId, f.Court?.Name,
-            f.ScheduledAt, (DropShot.Shared.FixtureStatus)f.Status,
+            f.ScheduledAt, f.Status,
             f.FixtureLabel, f.RoundNumber,
             f.Player1Id, f.Player1?.DisplayName,
             f.Player2Id, f.Player2?.DisplayName,

--- a/DropShot/Components/Pages/VerifyResult.razor
+++ b/DropShot/Components/Pages/VerifyResult.razor
@@ -2,6 +2,7 @@
 @rendermode InteractiveServer
 @using DropShot.Data
 @using DropShot.Models
+@using DropShot.Shared
 @using DropShot.Services
 @using Microsoft.EntityFrameworkCore
 

--- a/DropShot/Components/TennisScore.razor
+++ b/DropShot/Components/TennisScore.razor
@@ -1,5 +1,6 @@
 ﻿    @using System.ComponentModel.DataAnnotations
 @using DropShot.Models;
+@using DropShot.Shared;
 @using DropShot.Data;
 @using Microsoft.AspNetCore.SignalR.Client
 @using Microsoft.EntityFrameworkCore
@@ -1607,13 +1608,13 @@
         return $"{side1} vs {side2}";
     }
 
-    private static Color FixtureStatusColor(DropShot.Models.FixtureStatus s) => s switch
+    private static Color FixtureStatusColor(FixtureStatus s) => s switch
     {
-        DropShot.Models.FixtureStatus.Scheduled => Color.Default,
-        DropShot.Models.FixtureStatus.InProgress => Color.Warning,
-        DropShot.Models.FixtureStatus.Completed => Color.Success,
-        DropShot.Models.FixtureStatus.Cancelled => Color.Error,
-        DropShot.Models.FixtureStatus.Walkover => Color.Info,
+        FixtureStatus.Scheduled => Color.Default,
+        FixtureStatus.InProgress => Color.Warning,
+        FixtureStatus.Completed => Color.Success,
+        FixtureStatus.Cancelled => Color.Error,
+        FixtureStatus.Walkover => Color.Info,
         _ => Color.Default
     };
 

--- a/DropShot/Controllers/CompetitionsController.cs
+++ b/DropShot/Controllers/CompetitionsController.cs
@@ -1,6 +1,7 @@
 using DropShot.Data;
 using DropShot.Models;
 using DropShot.Services;
+using DropShot.Shared;
 using DropShot.Shared.Dtos;
 using DropShot.UI.Services;
 using Microsoft.AspNetCore.Authorization;
@@ -77,21 +78,21 @@ public class CompetitionsController(
 
         return new CompetitionDetailDto(
             c.CompetitionID, c.CompetitionName,
-            (DropShot.Shared.CompetitionFormat)c.CompetitionFormat,
+            c.CompetitionFormat,
             c.MaxParticipants, c.StartDate, c.EndDate, c.MaxAge, c.MinAge,
-            (DropShot.Shared.PlayerSex?)c.EligibleSex,
+            c.EligibleSex,
             c.HostClubId, c.HostClub?.Name, c.RulesSetId, c.Rules?.Name,
             c.EventId, c.Event?.Name,
             c.Stages.Select(s => new CompetitionStageDto(
                 s.CompetitionStageId, s.Name, s.StageOrder,
-                (DropShot.Shared.StageType)s.StageType)).ToList(),
+                s.StageType)).ToList(),
             c.Participants.Select(p => new CompetitionParticipantDto(
                 p.PlayerId, p.Player?.DisplayName ?? "",
-                (DropShot.Shared.ParticipantStatus)p.Status,
+                p.Status,
                 p.RegisteredAt, p.TeamId, p.Team?.Name,
                 p.Player?.MobileNumber,
                 p.Role,
-                (DropShot.Shared.PlayerSex?)p.Player?.Sex,
+                p.Player?.Sex,
                 p.CompetitionDivisionId,
                 p.Division?.Name)).ToList(),
             c.IsArchived,
@@ -227,7 +228,7 @@ public class CompetitionsController(
         if (comp is null) return NotFound();
         if (!await authzService.CanEditCompetitionAsync(User, comp.HostClubId)) return Forbid();
 
-        var modelType = (DropShot.Models.StageType)req.StageType;
+        var modelType = (StageType)req.StageType;
         var nextOrder = await db.CompetitionStages
             .Where(s => s.CompetitionId == id)
             .Select(s => (int?)s.StageOrder).MaxAsync() ?? 0;
@@ -241,7 +242,7 @@ public class CompetitionsController(
         db.CompetitionStages.Add(stage);
         await db.SaveChangesAsync();
         return Ok(new CompetitionStageDto(stage.CompetitionStageId, stage.Name,
-            stage.StageOrder, (DropShot.Shared.StageType)stage.StageType));
+            stage.StageOrder, stage.StageType));
     }
 
     [HttpDelete("{id:int}/stages/{stageId:int}")]
@@ -312,7 +313,7 @@ public class CompetitionsController(
         var cp = new CompetitionParticipant
         {
             CompetitionId = id, PlayerId = req.PlayerId,
-            RegisteredAt = DateTime.UtcNow, Status = DropShot.Models.ParticipantStatus.Registered
+            RegisteredAt = DateTime.UtcNow, Status = ParticipantStatus.Registered
         };
         db.CompetitionParticipants.Add(cp);
         await db.SaveChangesAsync();
@@ -330,7 +331,7 @@ public class CompetitionsController(
 
         var cp = await db.CompetitionParticipants.FindAsync(id, playerId);
         if (cp is null) return NotFound();
-        cp.Status = (DropShot.Models.ParticipantStatus)req.Status;
+        cp.Status = (ParticipantStatus)req.Status;
         await db.SaveChangesAsync();
         return Ok();
     }
@@ -676,7 +677,7 @@ public class CompetitionsController(
 
         var members = await db.CompetitionParticipants
             .Where(cp => cp.CompetitionId == id && cp.TeamId == teamId
-                && cp.Status == DropShot.Models.ParticipantStatus.FullPlayer)
+                && cp.Status == ParticipantStatus.FullPlayer)
             .Include(cp => cp.Player)
             .ToListAsync();
 
@@ -836,7 +837,7 @@ public class CompetitionsController(
 
         var confirmedParticipantIds = await db.CompetitionParticipants
             .Where(cp => cp.CompetitionId == id && playerIds.Contains(cp.PlayerId)
-                && cp.Status == DropShot.Models.ParticipantStatus.FullPlayer)
+                && cp.Status == ParticipantStatus.FullPlayer)
             .Select(cp => cp.PlayerId)
             .ToListAsync();
         var missingParticipant = playerIds.Except(confirmedParticipantIds).ToList();
@@ -854,7 +855,7 @@ public class CompetitionsController(
                 warnings.Add(new EligibilityWarning(v.Code, $"{p.DisplayName}: {v.Message}"));
         }
 
-        if (comp.CompetitionFormat == DropShot.Models.CompetitionFormat.MixedDoubles)
+        if (comp.CompetitionFormat == CompetitionFormat.MixedDoubles)
         {
             AppendMixedDoublesWarnings(warnings, players, req);
         }
@@ -887,10 +888,10 @@ public class CompetitionsController(
         Check(req.Player2Id, req.Player4Id, "Away pair");
     }
 
-    private static string FormatSexPair(DropShot.Models.PlayerSex sex) => sex switch
+    private static string FormatSexPair(PlayerSex sex) => sex switch
     {
-        DropShot.Models.PlayerSex.Male => "two males",
-        DropShot.Models.PlayerSex.Female => "two females",
+        PlayerSex.Male => "two males",
+        PlayerSex.Female => "two females",
         _ => "both the same",
     };
 
@@ -1087,7 +1088,7 @@ public class CompetitionsController(
 
         // Find round-robin stage IDs for this competition
         var rrStageIds = await db.CompetitionStages
-            .Where(s => s.CompetitionId == id && s.StageType == DropShot.Models.StageType.RoundRobin)
+            .Where(s => s.CompetitionId == id && s.StageType == StageType.RoundRobin)
             .Select(s => s.CompetitionStageId)
             .ToListAsync();
 
@@ -1097,7 +1098,7 @@ public class CompetitionsController(
             .Where(f => f.CompetitionId == id
                         && f.CompetitionStageId != null
                         && rrStageIds.Contains(f.CompetitionStageId!.Value)
-                        && f.Status == DropShot.Models.FixtureStatus.Completed
+                        && f.Status == FixtureStatus.Completed
                         && f.WinnerPlayerId != null)
             .Include(f => f.Player1)
             .Include(f => f.Player2)
@@ -1189,13 +1190,13 @@ public class CompetitionsController(
     private static void Apply(Competition c, SaveCompetitionRequest r)
     {
         c.CompetitionName = r.CompetitionName.Trim();
-        c.CompetitionFormat = (DropShot.Models.CompetitionFormat)r.CompetitionFormat;
+        c.CompetitionFormat = (CompetitionFormat)r.CompetitionFormat;
         c.MaxParticipants = r.MaxParticipants;
         c.StartDate = r.StartDate;
         c.EndDate = r.EndDate;
         c.MaxAge = r.MaxAge;
         c.MinAge = r.MinAge;
-        c.EligibleSex = (DropShot.Models.PlayerSex?)r.EligibleSex;
+        c.EligibleSex = (PlayerSex?)r.EligibleSex;
         // HostClubId/CreatorUserId are set explicitly at Create time and are immutable thereafter.
         c.RulesSetId = r.RulesSetId;
         c.EventId = r.EventId;
@@ -1242,16 +1243,16 @@ public class CompetitionsController(
         f.Player2Id = r.Player2Id;
         f.Player3Id = r.Player3Id;
         f.Player4Id = r.Player4Id;
-        f.Status = (DropShot.Models.FixtureStatus)r.Status;
+        f.Status = (FixtureStatus)r.Status;
         if (r.ResultSummary != null) f.ResultSummary = r.ResultSummary;
         if (r.WinnerPlayerId != null) f.WinnerPlayerId = r.WinnerPlayerId;
     }
 
     private static CompetitionDto ToDto(Competition c) => new(
         c.CompetitionID, c.CompetitionName,
-        (DropShot.Shared.CompetitionFormat)c.CompetitionFormat,
+        c.CompetitionFormat,
         c.MaxParticipants, c.StartDate, c.EndDate, c.MaxAge, c.MinAge,
-        (DropShot.Shared.PlayerSex?)c.EligibleSex,
+        c.EligibleSex,
         c.HostClubId, c.HostClub?.Name, c.RulesSetId, c.Rules?.Name,
         c.EventId, c.Event?.Name, c.IsArchived, c.IsStarted,
         c.CreatorUserId, c.IsRestricted, c.RegisterByDate);
@@ -1260,7 +1261,7 @@ public class CompetitionsController(
         f.CompetitionFixtureId, f.CompetitionId,
         f.CompetitionStageId, f.Stage?.Name,
         f.CourtId, f.Court?.Name,
-        f.ScheduledAt, (DropShot.Shared.FixtureStatus)f.Status,
+        f.ScheduledAt, f.Status,
         f.FixtureLabel, f.RoundNumber,
         f.Player1Id, f.Player1?.DisplayName,
         f.Player2Id, f.Player2?.DisplayName,
@@ -1320,7 +1321,7 @@ public class CompetitionsController(
 
         var members = await db.CompetitionParticipants
             .Where(cp => cp.CompetitionId == id && cp.TeamId == teamId
-                && cp.Status == DropShot.Models.ParticipantStatus.FullPlayer)
+                && cp.Status == ParticipantStatus.FullPlayer)
             .Include(cp => cp.Player)
             .ToListAsync();
 
@@ -1571,10 +1572,10 @@ public class CompetitionsController(
         await using var db = dbFactory.CreateDbContext();
 
         var comp = await db.Competition.AsNoTracking().FirstOrDefaultAsync(c => c.CompetitionID == id);
-        var scoringMode = comp?.LeagueScoring ?? DropShot.Models.LeagueScoringMode.WinPoints;
+        var scoringMode = comp?.LeagueScoring ?? LeagueScoringMode.WinPoints;
 
         var rrStageIds = await db.CompetitionStages
-            .Where(s => s.CompetitionId == id && s.StageType == DropShot.Models.StageType.RoundRobin)
+            .Where(s => s.CompetitionId == id && s.StageType == StageType.RoundRobin)
             .Select(s => s.CompetitionStageId)
             .ToListAsync();
 
@@ -1590,7 +1591,7 @@ public class CompetitionsController(
             .Where(f => f.CompetitionId == id
                 && f.CompetitionStageId != null
                 && rrStageIds.Contains(f.CompetitionStageId!.Value)
-                && f.Status == DropShot.Models.FixtureStatus.Completed
+                && f.Status == FixtureStatus.Completed
                 && f.HomeTeamId != null && f.AwayTeamId != null
                 && teamIds.Contains(f.HomeTeamId.Value)
                 && teamIds.Contains(f.AwayTeamId.Value))
@@ -1609,8 +1610,8 @@ public class CompetitionsController(
 
         string unitLabel = scoringMode switch
         {
-            DropShot.Models.LeagueScoringMode.SetsWon  => "sets",
-            DropShot.Models.LeagueScoringMode.GamesWon => "games",
+            LeagueScoringMode.SetsWon  => "sets",
+            LeagueScoringMode.GamesWon => "games",
             _                                          => "rubbers",
         };
 
@@ -1637,8 +1638,8 @@ public class CompetitionsController(
 
             (int homeFor, int awayFor) = scoringMode switch
             {
-                DropShot.Models.LeagueScoringMode.SetsWon  => (homeSets, awaySets),
-                DropShot.Models.LeagueScoringMode.GamesWon => (homeGames, awayGames),
+                LeagueScoringMode.SetsWon  => (homeSets, awaySets),
+                LeagueScoringMode.GamesWon => (homeGames, awayGames),
                 _                                          => (homeRubbers, awayRubbers),
             };
             scoringFor[homeId] += homeFor;
@@ -1654,8 +1655,8 @@ public class CompetitionsController(
 
             (int homePts, int awayPts) = scoringMode switch
             {
-                DropShot.Models.LeagueScoringMode.SetsWon  => (homeSets, awaySets),
-                DropShot.Models.LeagueScoringMode.GamesWon => (homeGames, awayGames),
+                LeagueScoringMode.SetsWon  => (homeSets, awaySets),
+                LeagueScoringMode.GamesWon => (homeGames, awayGames),
                 _ => (homeWin ? 3 : (!awayWin ? 1 : 0),
                       awayWin ? 3 : (!homeWin ? 1 : 0)),
             };
@@ -1925,8 +1926,8 @@ public class CompetitionsController(
                     });
                     int points = scoringMode switch
                     {
-                        Models.LeagueScoringMode.SetsWon  => sets,
-                        Models.LeagueScoringMode.GamesWon => games,
+                        LeagueScoringMode.SetsWon  => sets,
+                        LeagueScoringMode.GamesWon => games,
                         _ => won * 3, // approx — this is per-player not per-fixture
                     };
                     return (PlayerId: p.PlayerId, Played: played, Won: won, Points: points);
@@ -1948,13 +1949,13 @@ public class CompetitionsController(
         return result;
     }
 
-    private static string StageDisplayName(Models.StageType type) => type switch
+    private static string StageDisplayName(StageType type) => type switch
     {
-        Models.StageType.RoundRobin   => "Round Robin",
-        Models.StageType.Knockout     => "Knockout",
-        Models.StageType.QuarterFinal => "Quarter-Final",
-        Models.StageType.SemiFinal    => "Semi-Final",
-        Models.StageType.Final        => "Final",
+        StageType.RoundRobin   => "Round Robin",
+        StageType.Knockout     => "Knockout",
+        StageType.QuarterFinal => "Quarter-Final",
+        StageType.SemiFinal    => "Semi-Final",
+        StageType.Final        => "Final",
         _                             => type.ToString()
     };
 }

--- a/DropShot/Controllers/EventsController.cs
+++ b/DropShot/Controllers/EventsController.cs
@@ -52,7 +52,7 @@ public class EventsController(
             e.HostClubId, e.HostClub?.Name,
             e.Competitions.Select(c => new CompetitionDto(
                 c.CompetitionID, c.CompetitionName,
-                (DropShot.Shared.CompetitionFormat)c.CompetitionFormat,
+                c.CompetitionFormat,
                 c.MaxParticipants, c.StartDate, c.EndDate, c.MaxAge, c.MinAge,
                 (DropShot.Shared.PlayerSex?)c.EligibleSex,
                 c.HostClubId, c.HostClub?.Name, c.RulesSetId, c.Rules?.Name,
@@ -131,8 +131,8 @@ public class EventsController(
             var comp = new Competition
             {
                 CompetitionName = t.CompetitionName.Trim(),
-                CompetitionFormat = (DropShot.Models.CompetitionFormat)t.CompetitionFormat,
-                EligibleSex = (DropShot.Models.PlayerSex?)t.EligibleSex,
+                CompetitionFormat = t.CompetitionFormat,
+                EligibleSex = t.EligibleSex,
                 MaxAge = t.MaxAge,
                 MinAge = t.MinAge,
                 EventId = id,
@@ -147,7 +147,7 @@ public class EventsController(
 
         return created.Select(c => new CompetitionDto(
             c.CompetitionID, c.CompetitionName,
-            (DropShot.Shared.CompetitionFormat)c.CompetitionFormat,
+            c.CompetitionFormat,
             c.MaxParticipants, c.StartDate, c.EndDate, c.MaxAge, c.MinAge,
             (DropShot.Shared.PlayerSex?)c.EligibleSex,
             c.HostClubId, null, c.RulesSetId, null,

--- a/DropShot/Controllers/PlayersController.cs
+++ b/DropShot/Controllers/PlayersController.cs
@@ -75,7 +75,7 @@ public class PlayersController(
             LastName = req.LastName,
             Email = req.Email,
             DateOfBirth = req.DateOfBirth,
-            Sex = (DropShot.Models.PlayerSex?)req.Sex,
+            Sex = req.Sex,
             ContactPreferences = req.ContactPreferences,
             MobileNumber = req.MobileNumber
         };
@@ -104,7 +104,7 @@ public class PlayersController(
         p.LastName = req.LastName;
         p.Email = req.Email;
         p.DateOfBirth = req.DateOfBirth;
-        p.Sex = (DropShot.Models.PlayerSex?)req.Sex;
+        p.Sex = req.Sex;
         p.ContactPreferences = req.ContactPreferences;
         p.MobileNumber = req.MobileNumber;
         await db.SaveChangesAsync();

--- a/DropShot/Models/Competition.cs
+++ b/DropShot/Models/Competition.cs
@@ -1,27 +1,7 @@
-﻿namespace DropShot.Models
+﻿using DropShot.Shared;
+
+namespace DropShot.Models
 {
-    public enum MatchFormatType : byte
-    {
-        BestOf = 1,
-        FixedSets = 2
-    }
-
-    public enum LeagueScoringMode : byte
-    {
-        WinPoints = 1,
-        SetsWon = 2,
-        GamesWon = 3
-    }
-
-    public enum CompetitionFormat
-    {
-        Singles = 1,
-        Doubles = 2,
-        Team = 3,
-        MixedDoubles = 4,
-        TeamMatch = 5
-    }
-
     public class Competition
     {
         public int CompetitionID { get; set; }

--- a/DropShot/Models/CompetitionFixture.cs
+++ b/DropShot/Models/CompetitionFixture.cs
@@ -1,14 +1,6 @@
-namespace DropShot.Models;
+using DropShot.Shared;
 
-public enum FixtureStatus : byte
-{
-    Scheduled = 1,
-    InProgress = 2,
-    Completed = 3,
-    Cancelled = 4,
-    Walkover = 5,
-    AwaitingVerification = 6
-}
+namespace DropShot.Models;
 
 public class CompetitionFixture
 {

--- a/DropShot/Models/CompetitionParticipant.cs
+++ b/DropShot/Models/CompetitionParticipant.cs
@@ -1,13 +1,6 @@
-namespace DropShot.Models;
+using DropShot.Shared;
 
-public enum ParticipantStatus : byte
-{
-    Registered   = 1,  // Added by admin but player has not yet confirmed participation
-    FullPlayer   = 2,  // Active full participant (was Confirmed — byte value unchanged)
-    Withdrawn    = 3,
-    Disqualified = 4,
-    Substitute   = 5,  // Available as a substitute, not in a team
-}
+namespace DropShot.Models;
 
 public class CompetitionParticipant
 {

--- a/DropShot/Models/CompetitionStage.cs
+++ b/DropShot/Models/CompetitionStage.cs
@@ -1,13 +1,6 @@
-namespace DropShot.Models;
+using DropShot.Shared;
 
-public enum StageType : byte
-{
-    RoundRobin   = 1,
-    Knockout     = 2,   // full auto-bracket (generates all rounds automatically)
-    Final        = 3,
-    QuarterFinal = 4,   // top 8 players — 4 matches
-    SemiFinal    = 5,   // top 4 players (or QF winners) — 2 matches
-}
+namespace DropShot.Models;
 
 public class CompetitionStage
 {

--- a/DropShot/Models/Player.cs
+++ b/DropShot/Models/Player.cs
@@ -1,13 +1,7 @@
 using DropShot.Data;
+using DropShot.Shared;
 
 namespace DropShot.Models;
-
-public enum PlayerSex : byte
-{
-    Male = 1,
-    Female = 2,
-    Other = 3
-}
 
 public class Player
 {

--- a/DropShot/Models/PlayerFriend.cs
+++ b/DropShot/Models/PlayerFriend.cs
@@ -1,11 +1,6 @@
-namespace DropShot.Models;
+using DropShot.Shared;
 
-public enum FriendStatus : byte
-{
-    Pending = 1,
-    Accepted = 2,
-    Blocked = 3
-}
+namespace DropShot.Models;
 
 public class PlayerFriend
 {

--- a/DropShot/Models/SchedulingModels.cs
+++ b/DropShot/Models/SchedulingModels.cs
@@ -1,3 +1,5 @@
+using DropShot.Shared;
+
 namespace DropShot.Models;
 
 public class CompetitionMatchWindow

--- a/DropShot/Models/TennisMatchState.cs
+++ b/DropShot/Models/TennisMatchState.cs
@@ -2,14 +2,6 @@ using DropShot.Shared;
 
 namespace DropShot.Models;
 
-public enum SetWinMode : byte
-{
-    /// <summary>Standard tennis — win by 2 games, tie-break at GamesFirstTo all.</summary>
-    WinBy2 = 0,
-    /// <summary>First player to reach GamesFirstTo wins the set (no tie-break).</summary>
-    FirstTo = 1
-}
-
 public class TennisMatchState
 {
     // Scores

--- a/DropShot/Services/ClubAuthorizationService.cs
+++ b/DropShot/Services/ClubAuthorizationService.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using DropShot.Data;
 using DropShot.Models;
+using DropShot.Shared;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 

--- a/DropShot/Services/CompetitionProgressionService.cs
+++ b/DropShot/Services/CompetitionProgressionService.cs
@@ -1,5 +1,6 @@
 using DropShot.Data;
 using DropShot.Models;
+using DropShot.Shared;
 using Microsoft.EntityFrameworkCore;
 
 namespace DropShot.Services;

--- a/DropShot/Services/CompetitionSchedulerService.cs
+++ b/DropShot/Services/CompetitionSchedulerService.cs
@@ -1,5 +1,6 @@
 using DropShot.Data;
 using DropShot.Models;
+using DropShot.Shared;
 using Microsoft.EntityFrameworkCore;
 
 namespace DropShot.Services;

--- a/DropShot/Services/EligibilityEvaluator.cs
+++ b/DropShot/Services/EligibilityEvaluator.cs
@@ -1,4 +1,5 @@
 using DropShot.Models;
+using DropShot.Shared;
 
 namespace DropShot.Services;
 

--- a/DropShot/Services/FixtureSimulationService.cs
+++ b/DropShot/Services/FixtureSimulationService.cs
@@ -1,5 +1,6 @@
 using DropShot.Data;
 using DropShot.Models;
+using DropShot.Shared;
 using Microsoft.EntityFrameworkCore;
 
 namespace DropShot.Services;

--- a/DropShot/Services/PlayerStatsService.cs
+++ b/DropShot/Services/PlayerStatsService.cs
@@ -1,5 +1,6 @@
 using DropShot.Data;
 using DropShot.Models;
+using DropShot.Shared;
 using Microsoft.EntityFrameworkCore;
 
 namespace DropShot.Services;

--- a/DropShot/Services/RubberResolutionService.cs
+++ b/DropShot/Services/RubberResolutionService.cs
@@ -1,8 +1,8 @@
 using DropShot.Data;
 using DropShot.Models;
+using DropShot.Shared;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
-using RubberTieBreakMode = DropShot.Shared.RubberTieBreakMode;
 
 namespace DropShot.Services;
 

--- a/DropShot/Services/RubberTemplateRegistry.cs
+++ b/DropShot/Services/RubberTemplateRegistry.cs
@@ -1,4 +1,5 @@
 using DropShot.Models;
+using DropShot.Shared;
 
 namespace DropShot.Services;
 

--- a/DropShot/Services/TennisScoreService.cs
+++ b/DropShot/Services/TennisScoreService.cs
@@ -1,4 +1,5 @@
 using DropShot.Models;
+using DropShot.Shared;
 
 namespace DropShot.Services;
 

--- a/DropShot/Services/WebCompetitionService.cs
+++ b/DropShot/Services/WebCompetitionService.cs
@@ -1,5 +1,6 @@
 using DropShot.Data;
 using DropShot.Models;
+using DropShot.Shared;
 using DropShot.Shared.Dtos;
 using DropShot.UI.Services;
 using DropShot.UI.Services.Auth;
@@ -100,21 +101,21 @@ public sealed class WebCompetitionService(
 
         return new CompetitionDetailDto(
             c.CompetitionID, c.CompetitionName,
-            (DropShot.Shared.CompetitionFormat)c.CompetitionFormat,
+            c.CompetitionFormat,
             c.MaxParticipants, c.StartDate, c.EndDate, c.MaxAge, c.MinAge,
-            (DropShot.Shared.PlayerSex?)c.EligibleSex,
+            c.EligibleSex,
             c.HostClubId, c.HostClub?.Name, c.RulesSetId, c.Rules?.Name,
             c.EventId, c.Event?.Name,
             c.Stages.Select(s => new CompetitionStageDto(
                 s.CompetitionStageId, s.Name, s.StageOrder,
-                (DropShot.Shared.StageType)s.StageType)).ToList(),
+                s.StageType)).ToList(),
             c.Participants.Select(p => new CompetitionParticipantDto(
                 p.PlayerId, p.Player?.DisplayName ?? "",
-                (DropShot.Shared.ParticipantStatus)p.Status,
+                p.Status,
                 p.RegisteredAt, p.TeamId, p.Team?.Name,
                 p.Player?.MobileNumber,
                 p.Role,
-                (DropShot.Shared.PlayerSex?)p.Player?.Sex,
+                p.Player?.Sex,
                 p.CompetitionDivisionId,
                 p.Division?.Name)).ToList(),
             c.IsArchived,
@@ -141,7 +142,7 @@ public sealed class WebCompetitionService(
                 cp.Court1Id, cp.Court1.Name,
                 cp.Court2Id, cp.Court2.Name,
                 cp.Name)).ToList(),
-            (DropShot.Shared.LeagueScoringMode)c.LeagueScoring,
+            c.LeagueScoring,
             myPlayerId);
     }
 
@@ -149,7 +150,7 @@ public sealed class WebCompetitionService(
         f.CompetitionFixtureId, f.CompetitionId,
         f.CompetitionStageId, f.Stage?.Name,
         f.CourtId, f.Court?.Name,
-        f.ScheduledAt, (DropShot.Shared.FixtureStatus)f.Status,
+        f.ScheduledAt, f.Status,
         f.FixtureLabel, f.RoundNumber,
         f.Player1Id, f.Player1?.DisplayName,
         f.Player2Id, f.Player2?.DisplayName,
@@ -192,7 +193,7 @@ public sealed class WebCompetitionService(
         {
             CompetitionId = competitionId,
             PlayerId = player.PlayerId,
-            Status = (DropShot.Models.ParticipantStatus)status,
+            Status = status,
             RegisteredAt = DateTime.UtcNow
         });
         await db.SaveChangesAsync(ct);
@@ -209,7 +210,7 @@ public sealed class WebCompetitionService(
                 && cp.Player!.UserId == currentUser.UserId, ct)
             ?? throw new KeyNotFoundException("Could not find your participant record.");
 
-        participant.Status = (DropShot.Models.ParticipantStatus)status;
+        participant.Status = status;
         await db.SaveChangesAsync(ct);
     }
 
@@ -235,7 +236,7 @@ public sealed class WebCompetitionService(
             fx.AwayGamesTotal = o.AwayGamesTotal;
         }
 
-        fx.Status = DropShot.Models.FixtureStatus.Completed;
+        fx.Status = FixtureStatus.Completed;
         fx.CompletedAt = DateTime.UtcNow;
         fx.VerificationToken = null;
 
@@ -273,12 +274,12 @@ public sealed class WebCompetitionService(
         bool requireVerification = !request.AdminOverride && (fx.Competition?.RequireVerification ?? false);
         if (requireVerification)
         {
-            fx.Status = DropShot.Models.FixtureStatus.AwaitingVerification;
+            fx.Status = FixtureStatus.AwaitingVerification;
             fx.VerificationToken = Guid.NewGuid();
         }
         else
         {
-            fx.Status = DropShot.Models.FixtureStatus.Completed;
+            fx.Status = FixtureStatus.Completed;
             fx.VerificationToken = null;
         }
         fx.CompletedAt = DateTime.UtcNow;
@@ -371,16 +372,16 @@ public sealed class WebCompetitionService(
             fx.AwayTeamId,
             fx.HomeTeam?.Name ?? "Home",
             fx.AwayTeam?.Name ?? "Away",
-            (DropShot.Shared.MatchFormatType)(comp?.MatchFormat ?? DropShot.Models.MatchFormatType.BestOf),
+            comp?.MatchFormat ?? MatchFormatType.BestOf,
             comp?.BestOf ?? 3,
             comp?.NumberOfSets ?? 3,
             comp?.GamesPerSet ?? 6,
-            (DropShot.Shared.SetWinMode)(comp?.SetWinMode ?? DropShot.Models.SetWinMode.WinBy2),
+            comp?.SetWinMode ?? SetWinMode.WinBy2,
             comp?.RequireVerification ?? false,
-            fx.Status == DropShot.Models.FixtureStatus.AwaitingVerification
-                || fx.Status == DropShot.Models.FixtureStatus.Completed,
+            fx.Status == FixtureStatus.AwaitingVerification
+                || fx.Status == FixtureStatus.Completed,
             rubbers,
-            (DropShot.Shared.LeagueScoringMode)(comp?.LeagueScoring ?? DropShot.Models.LeagueScoringMode.WinPoints),
+            comp?.LeagueScoring ?? LeagueScoringMode.WinPoints,
             comp?.HostClubId);
     }
 
@@ -452,8 +453,8 @@ public sealed class WebCompetitionService(
             var (homeScore, awayScore) = RubberResolutionService.ComputeScore(
                 allRubbers, fx.HomeTeamId.Value, fx.AwayTeamId.Value);
 
-            bool alreadyFinalised = fx.Status == DropShot.Models.FixtureStatus.AwaitingVerification
-                || fx.Status == DropShot.Models.FixtureStatus.Completed;
+            bool alreadyFinalised = fx.Status == FixtureStatus.AwaitingVerification
+                || fx.Status == FixtureStatus.Completed;
 
             fx.ResultSummary = $"{homeScore}-{awayScore}";
             int? winner = homeScore > awayScore ? fx.HomeTeamId
@@ -482,7 +483,7 @@ public sealed class WebCompetitionService(
 
             if (requireVerification)
             {
-                fx.Status = DropShot.Models.FixtureStatus.AwaitingVerification;
+                fx.Status = FixtureStatus.AwaitingVerification;
                 fx.VerificationToken = Guid.NewGuid();
                 await db.SaveChangesAsync(ct);
 
@@ -509,7 +510,7 @@ public sealed class WebCompetitionService(
             }
             else
             {
-                fx.Status = DropShot.Models.FixtureStatus.Completed;
+                fx.Status = FixtureStatus.Completed;
                 await db.SaveChangesAsync(ct);
 
                 var savedFixtureId = fx.CompetitionFixtureId;
@@ -539,9 +540,9 @@ public sealed class WebCompetitionService(
             // Rubbers are in progress but not all done yet — flip Scheduled →
             // InProgress now that the first score has been recorded. EnsureRubbersAsync
             // deliberately leaves Scheduled until an actual score lands.
-            if (fx.Status == DropShot.Models.FixtureStatus.Scheduled)
+            if (fx.Status == FixtureStatus.Scheduled)
             {
-                fx.Status = DropShot.Models.FixtureStatus.InProgress;
+                fx.Status = FixtureStatus.InProgress;
                 await db.SaveChangesAsync(ct);
             }
         }
@@ -549,9 +550,9 @@ public sealed class WebCompetitionService(
 
     private static CompetitionDto ToDto(Competition c) => new(
         c.CompetitionID, c.CompetitionName,
-        (DropShot.Shared.CompetitionFormat)c.CompetitionFormat,
+        c.CompetitionFormat,
         c.MaxParticipants, c.StartDate, c.EndDate, c.MaxAge, c.MinAge,
-        (DropShot.Shared.PlayerSex?)c.EligibleSex,
+        c.EligibleSex,
         c.HostClubId, c.HostClub?.Name, c.RulesSetId, c.Rules?.Name,
         c.EventId, c.Event?.Name, c.IsArchived, c.IsStarted,
         c.CreatorUserId, c.IsRestricted, c.RegisterByDate);
@@ -611,7 +612,7 @@ public sealed class WebCompetitionService(
             .Include(f => f.Player1).Include(f => f.Player2)
             .Include(f => f.Player3).Include(f => f.Player4)
             .Include(f => f.HomeTeam).Include(f => f.AwayTeam)
-            .Where(f => f.Status == DropShot.Models.FixtureStatus.AwaitingVerification
+            .Where(f => f.Status == FixtureStatus.AwaitingVerification
                 && (isAdmin
                     || (f.Competition.HostClubId.HasValue && editableClubIds.Contains(f.Competition.HostClubId.Value))
                     || competitionAdminIds.Contains(f.CompetitionId)))
@@ -638,8 +639,8 @@ public sealed class WebCompetitionService(
                              || f.Player3Id == pid || f.Player4Id == pid
                              || (f.HomeTeamId.HasValue && myTeamIds.Contains(f.HomeTeamId.Value))
                              || (f.AwayTeamId.HasValue && myTeamIds.Contains(f.AwayTeamId.Value)))
-                         && (f.Status == DropShot.Models.FixtureStatus.Scheduled
-                             || f.Status == DropShot.Models.FixtureStatus.InProgress))
+                         && (f.Status == FixtureStatus.Scheduled
+                             || f.Status == FixtureStatus.InProgress))
                 .OrderBy(f => f.ScheduledAt)
                 .ToListAsync(ct);
 
@@ -666,7 +667,7 @@ public sealed class WebCompetitionService(
                              || f.Player3Id == pid || f.Player4Id == pid
                              || (f.HomeTeamId.HasValue && myTeamIds.Contains(f.HomeTeamId.Value))
                              || (f.AwayTeamId.HasValue && myTeamIds.Contains(f.AwayTeamId.Value)))
-                         && f.Status == DropShot.Models.FixtureStatus.Completed
+                         && f.Status == FixtureStatus.Completed
                          && f.ResultSummary != null)
                 .OrderByDescending(f => f.CompletedAt ?? f.ScheduledAt)
                 .Take(safeLimit)
@@ -792,7 +793,7 @@ public sealed class WebCompetitionService(
             CompetitionId = competitionId,
             PlayerId = player.PlayerId,
             RegisteredAt = DateTime.UtcNow,
-            Status = DropShot.Models.ParticipantStatus.Registered
+            Status = ParticipantStatus.Registered
         });
         await db.SaveChangesAsync(ct);
     }

--- a/DropShot/Services/WebEventService.cs
+++ b/DropShot/Services/WebEventService.cs
@@ -50,7 +50,7 @@ public sealed class WebEventService(
             e.HostClubId, e.HostClub?.Name,
             e.Competitions.Select(c => new CompetitionDto(
                 c.CompetitionID, c.CompetitionName,
-                (DropShot.Shared.CompetitionFormat)c.CompetitionFormat,
+                c.CompetitionFormat,
                 c.MaxParticipants, c.StartDate, c.EndDate, c.MaxAge, c.MinAge,
                 (DropShot.Shared.PlayerSex?)c.EligibleSex,
                 c.HostClubId, c.HostClub?.Name, c.RulesSetId, c.Rules?.Name,
@@ -98,8 +98,8 @@ public sealed class WebEventService(
             var comp = new Competition
             {
                 CompetitionName = t.CompetitionName.Trim(),
-                CompetitionFormat = (DropShot.Models.CompetitionFormat)t.CompetitionFormat,
-                EligibleSex = (DropShot.Models.PlayerSex?)t.EligibleSex,
+                CompetitionFormat = t.CompetitionFormat,
+                EligibleSex = t.EligibleSex,
                 MaxAge = t.MaxAge,
                 MinAge = t.MinAge,
                 EventId = eventId,
@@ -114,7 +114,7 @@ public sealed class WebEventService(
 
         return created.Select(c => new CompetitionDto(
             c.CompetitionID, c.CompetitionName,
-            (DropShot.Shared.CompetitionFormat)c.CompetitionFormat,
+            c.CompetitionFormat,
             c.MaxParticipants, c.StartDate, c.EndDate, c.MaxAge, c.MinAge,
             (DropShot.Shared.PlayerSex?)c.EligibleSex,
             c.HostClubId, null, c.RulesSetId, null,

--- a/DropShot/Services/WebPlayerService.cs
+++ b/DropShot/Services/WebPlayerService.cs
@@ -112,7 +112,7 @@ public sealed class WebPlayerService(
             Email = NullIfEmpty(request.Email),
             MobileNumber = NullIfEmpty(request.MobileNumber),
             DateOfBirth = request.DateOfBirth,
-            Sex = (DropShot.Models.PlayerSex?)request.Sex,
+            Sex = request.Sex,
             ContactPreferences = NullIfEmpty(request.ContactPreferences),
             IsLight = request.IsLight,
             CreatedByUserId = currentUser.UserId
@@ -134,7 +134,7 @@ public sealed class WebPlayerService(
         p.Email = NullIfEmpty(request.Email);
         p.MobileNumber = NullIfEmpty(request.MobileNumber);
         p.DateOfBirth = request.DateOfBirth;
-        p.Sex = (DropShot.Models.PlayerSex?)request.Sex;
+        p.Sex = request.Sex;
         p.ContactPreferences = NullIfEmpty(request.ContactPreferences);
         await db.SaveChangesAsync(ct);
         return ToDto(p);
@@ -204,7 +204,7 @@ public sealed class WebPlayerService(
             Email = NullIfEmpty(request.Email),
             MobileNumber = NullIfEmpty(request.MobileNumber),
             DateOfBirth = request.DateOfBirth,
-            Sex = (DropShot.Models.PlayerSex?)request.Sex,
+            Sex = request.Sex,
             IsLight = true,
             CreatedByClubId = clubId,
             CreatedByUserId = currentUser.UserId
@@ -233,7 +233,7 @@ public sealed class WebPlayerService(
         p.Email = NullIfEmpty(request.Email);
         p.MobileNumber = NullIfEmpty(request.MobileNumber);
         p.DateOfBirth = request.DateOfBirth;
-        p.Sex = (DropShot.Models.PlayerSex?)request.Sex;
+        p.Sex = request.Sex;
         await db.SaveChangesAsync(ct);
         return ToDto(p);
     }
@@ -330,7 +330,7 @@ public sealed class WebPlayerService(
             LastName = NullIfEmpty(request.LastName),
             Email = NullIfEmpty(request.Email),
             MobileNumber = NullIfEmpty(request.MobileNumber),
-            Sex = (DropShot.Models.PlayerSex?)request.Sex,
+            Sex = request.Sex,
             IsLight = true,
             CreatedByUserId = currentUser.UserId
         };
@@ -356,7 +356,7 @@ public sealed class WebPlayerService(
         p.LastName = NullIfEmpty(request.LastName);
         p.Email = NullIfEmpty(request.Email);
         p.MobileNumber = NullIfEmpty(request.MobileNumber);
-        p.Sex = (DropShot.Models.PlayerSex?)request.Sex;
+        p.Sex = request.Sex;
         await db.SaveChangesAsync(ct);
         return ToDto(p);
     }


### PR DESCRIPTION
## Summary

Removes the duplicate copies of nine enums from \`DropShot.Models\`. They've been defined identically (same byte values) in both \`DropShot.Models\` and \`DropShot.Shared\`; everything now points at the \`DropShot.Shared\` definitions.

Enums consolidated:
- \`CompetitionFormat\`, \`LeagueScoringMode\`, \`MatchFormatType\` (were in \`DropShot.Models.Competition.cs\`)
- \`FixtureStatus\` (was in \`DropShot.Models.CompetitionFixture.cs\`)
- \`ParticipantStatus\` (was in \`DropShot.Models.CompetitionParticipant.cs\`)
- \`StageType\` (was in \`DropShot.Models.CompetitionStage.cs\`)
- \`PlayerSex\` (was in \`DropShot.Models.Player.cs\`)
- \`FriendStatus\` (was in \`DropShot.Models.PlayerFriend.cs\`)
- \`SetWinMode\` (was in \`DropShot.Models.TennisMatchState.cs\`)

EF migrations are unaffected — column type stays \`byte\` either way.

Code changes are mostly mechanical:
1. Delete the duplicate enum definitions (keep the entity classes)
2. Add \`using DropShot.Shared;\` (or \`@using DropShot.Shared\`) to the ~20 files that referenced the removed enums
3. Drop now-redundant identity casts and explicit \`DropShot.Models.X\` qualifications. \`WebCompetitionService\` / \`WebEventService\` / \`CompetitionsController\` / \`EventsController\` / \`PlayersController\` / \`WebPlayerService\` all simplify their projection expressions

## Why this PR

Investigated this dedup while planning the TennisScore.razor migration (PR 7c-f). Lifting \`Match\` and \`TennisMatchState\` from \`DropShot.Models\` to \`DropShot.Shared\` (which TennisScore needs to be reachable from \`DropShot.UI\`) requires call sites to add \`using DropShot.Shared;\` — and that surfaces ambiguous-reference errors on every duplicate enum in those files. This PR clears that blocker.

## Test plan

- [x] \`dotnet build DropShot.sln\` clean (0 errors; 5 pre-existing warnings, 2 fewer than before since some collapsed identity casts cleared their warnings)
- [x] \`dotnet test DropShot.Tests\` — all 28 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)