### PR TITLE
Phase 7: lift Match + TennisMatchState into DropShot.Shared

### DIFF
--- a/DropShot.Shared/Match.cs
+++ b/DropShot.Shared/Match.cs
@@ -1,7 +1,10 @@
-using DropShot.Shared;
+namespace DropShot.Shared;
 
-namespace DropShot.Models;
-
+/// <summary>
+/// In-memory match state persisted as JSON inside <c>SavedMatch.MatchJson</c>.
+/// Lives in the shared assembly so the live-scoring page (TennisScore) can
+/// move into <c>DropShot.UI</c> without dragging the EF model graph.
+/// </summary>
 public class Match
 {
     public Stack<GameState> History { get; set; } = new Stack<GameState>();

--- a/DropShot.Shared/TennisMatchState.cs
+++ b/DropShot.Shared/TennisMatchState.cs
@@ -1,7 +1,11 @@
-using DropShot.Shared;
+namespace DropShot.Shared;
 
-namespace DropShot.Models;
-
+/// <summary>
+/// Mutable scoring state for the live-scoring page. Score-derivation logic
+/// lives in <c>TennisScoreService</c>; this is the data backing it. Lifted
+/// here from <c>DropShot.Models</c> alongside <see cref="Match"/> so the
+/// shared scoring pipeline can target the RCL.
+/// </summary>
 public class TennisMatchState
 {
     // Scores

--- a/DropShot/Components/ResultCard.razor
+++ b/DropShot/Components/ResultCard.razor
@@ -1,4 +1,5 @@
 @using DropShot.Models
+@using DropShot.Shared
 @using Newtonsoft.Json
 
 <div class="@CardClass">

--- a/DropShot/Models/UserState.cs
+++ b/DropShot/Models/UserState.cs
@@ -1,4 +1,5 @@
-﻿
+﻿using DropShot.Shared;
+
 namespace DropShot.Models
 {
     public class UserState

--- a/DropShot/Services/WebMatchService.cs
+++ b/DropShot/Services/WebMatchService.cs
@@ -1,5 +1,6 @@
 using DropShot.Data;
 using DropShot.Models;
+using DropShot.Shared;
 using DropShot.Shared.Dtos;
 using DropShot.UI.Services;
 using DropShot.UI.Services.Auth;

--- a/DropShot/Services/WebScoreboardService.cs
+++ b/DropShot/Services/WebScoreboardService.cs
@@ -103,7 +103,7 @@ public sealed class WebScoreboardService(
         if (string.IsNullOrWhiteSpace(matchJson)) return null;
         try
         {
-            var match = JsonConvert.DeserializeObject<DropShot.Models.Match>(matchJson);
+            var match = JsonConvert.DeserializeObject<Match>(matchJson);
             return match?.HistoryList?.LastOrDefault();
         }
         catch (JsonException) { return null; }


### PR DESCRIPTION
## Summary

Moves the two pure-data scoring types out of \`DropShot.Models\` and into \`DropShot.Shared\` so the TennisScore.razor page (later in the PR 7 sequence) can target the shared RCL without dragging the EF model graph. Both types only depended on \`DropShot.Shared\` types already (\`GameState\`, \`SetScore\`, \`SetWinMode\` after PR #505's dedup).

Now that PR #505 cleared the duplicate-enum blocker, the change is minimal:
- \`DropShot.Shared/Match.cs\` (moved verbatim from \`DropShot.Models\`)
- \`DropShot.Shared/TennisMatchState.cs\` (moved verbatim)
- \`UserState.cs\` gains \`using DropShot.Shared;\`
- \`WebMatchService.cs\` and \`ResultCard.razor\` add \`using DropShot.Shared\`
- \`WebScoreboardService.cs\` drops the now-redundant \`DropShot.Models.Match\` qualifier

6 files changed, +18/−8 lines.

## Why this PR (and what's next)

This is the final type-foundation step before TennisScore.razor's actual migration. The remaining sequence:

- **PR 7d** — \`IMatchScoringService\` interface + DTOs covering ~10 EF read/write operations (match-setup context, restore-incomplete-match, save-initial-match, persist-match-state, complete-fixture, complete-rubber, discard-match, save-player-settings, add-friend)
- **PR 7e** — MAUI \`HttpMatchScoringService\` + corresponding API endpoints
- **PR 7f** — The TennisScore.razor page move itself (~1,658 lines) with web/MAUI shims and tests

## Test plan

- [x] \`dotnet build DropShot.sln\` clean (0 errors; 5 pre-existing warnings)
- [x] \`dotnet test DropShot.Tests\` — all 28 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)