### PR TITLE
Hotfix: add EnumNamespaceMove migration to fix deploy

### DIFF
--- a/DropShot/Data/Migrations/20260502110002_EnumNamespaceMove.Designer.cs
+++ b/DropShot/Data/Migrations/20260502110002_EnumNamespaceMove.Designer.cs
@@ -4,16 +4,19 @@ using DropShot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace DropShot.Migrations
+namespace DropShot.Data.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260502110002_EnumNamespaceMove")]
+    partial class EnumNamespaceMove
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DropShot/Data/Migrations/20260502110002_EnumNamespaceMove.cs
+++ b/DropShot/Data/Migrations/20260502110002_EnumNamespaceMove.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropShot.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class EnumNamespaceMove : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<byte>(
+                name: "CompetitionFormat",
+                table: "Competition",
+                type: "tinyint",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "CompetitionFormat",
+                table: "Competition",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(byte),
+                oldType: "tinyint");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Deploy has been failing since PR #505 (enum dedup) with EF's \`PendingModelChangesWarning\`. This PR adds the migration that PR #505 should have included.

## Root cause

\`DropShot.Models.CompetitionFormat\` was implicitly \`int\`-backed (no \`: byte\` underlying-type specifier), while \`DropShot.Shared.CompetitionFormat\` is \`byte\`-backed. When PR #505 deleted the \`DropShot.Models\` copy and pointed everything at \`DropShot.Shared\`, EF correctly detected this as a real schema change: \`Competition.CompetitionFormat\` column needs to go from \`int\` (4 bytes) to \`tinyint\` (1 byte).

The other 8 consolidated enums were already \`: byte\` in both namespaces, so no other column changes are needed.

## What's in this migration

\`Up\`: \`ALTER COLUMN Competition.CompetitionFormat int → tinyint\`. Existing values are 1–5 (per the enum members \`Singles\`, \`Doubles\`, \`Team\`, \`MixedDoubles\`, \`TeamMatch\`), all of which fit safely in \`tinyint\`. No data loss.

\`Down\`: reverses to \`int\` (only relevant if rolling back the enum dedup, which we wouldn't).

## Test plan

- [x] \`dotnet build DropShot.sln\` clean (0 errors)
- [ ] CI deploy succeeds (will verify after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)