### PR TITLE
Phase 7 PR 7g: TennisScore web shim + drop @rendermode from RCL component

### DIFF
--- a/DropShot.Tests/Pages/TennisScoreTests.cs
+++ b/DropShot.Tests/Pages/TennisScoreTests.cs
@@ -1,7 +1,7 @@
 using Bunit;
+using DropShot.Components.Pages;
 using DropShot.Models;
 using DropShot.Tests.Helpers;
-using DropShot.UI.Components.Pages;
 using Xunit;
 
 namespace DropShot.Tests.Pages;

--- a/DropShot.UI/Components/Pages/TennisScore.razor
+++ b/DropShot.UI/Components/Pages/TennisScore.razor
@@ -12,11 +12,8 @@
 @using Newtonsoft.Json
 @using MudBlazor
 @using System.Threading
-@using System.Security.Claims
-@using Microsoft.AspNetCore.Components.Authorization
 
-@page "/tennisscore"
-@page "/match/{MatchId:int}"
+@* Routing + render mode + MudProviders supplied by host shims. *@
 
 @inject NavigationManager Navigation
 @inject UserState State
@@ -31,8 +28,6 @@
 @inject IJSRuntime JS
 
 @* FixtureId is passed as a query param when starting a match from a competition fixture *@
-
-<MudProviders />
 
 @if (_showServerSelect)
 {

--- a/DropShot/Components/Pages/TennisScore.razor
+++ b/DropShot/Components/Pages/TennisScore.razor
@@ -1,0 +1,11 @@
+@page "/tennisscore"
+@page "/match/{MatchId:int}"
+@rendermode InteractiveServer
+
+<MudProviders />
+
+<DropShot.UI.Components.Pages.TennisScore MatchId="@MatchId" />
+
+@code {
+    [Parameter] public int MatchId { get; set; }
+}


### PR DESCRIPTION
## Summary

PR 7f put the `@page` directives on the moved `DropShot.UI/.../TennisScore.razor` itself and dropped the `@rendermode` pin entirely, which left the web host serving the page in static SSR mode — no SignalR, no live scoring. Every other moved page in DropShot.UI follows the shim pattern: a tiny host-side Razor file owns the route + render mode + `MudProviders` and mounts the RCL component as a child.

This PR realigns TennisScore with that pattern.

## Changes

- `DropShot.UI/Components/Pages/TennisScore.razor`: drop the two `@page` directives and the inline `<MudProviders />`.
- `DropShot/Components/Pages/TennisScore.razor` (new web shim): `@page "/tennisscore"` + `@page "/match/{MatchId:int}"` + `@rendermode InteractiveServer` + `<MudProviders />` + mount of the RCL component passing `MatchId` through. Query params (`FixtureId`, `AutoStart`, `RubberId`, `BestOfOverride`, `ReturnUrl`) bind directly on the RCL component via its existing `[SupplyParameterFromQuery]` decorations — Blazor resolves those globally regardless of the route handler, mirroring how TeamMatchScoring's shim handles its `[SupplyParameterFromQuery(Name="edit")]`.
- `DropShot.Tests/Pages/TennisScoreTests.cs`: now renders `DropShot.Components.Pages.TennisScore` (the shim, which sets up `MudProviders`) instead of the RCL component directly. Mirrors HomeTests / Match shim usage and fixes the bUnit "`<MudPopoverProvider />` missing" failure introduced when `MudProviders` moved out of the RCL component.

## Test plan

- [x] `dotnet build DropShot.sln` — clean
- [x] `dotnet test DropShot.Tests` — 28/28 passing
- [ ] Manual web smoke: `/tennisscore` actually goes interactive (score a point, observe it persist + broadcast); `/match/0?fixtureId=...&autoStart=true` finalises with the SignalR hub connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)