### PR TITLE
Phase 7 PR 7L: lift RubberDef + RubberTemplateRegistry to DropShot.Shared

### DIFF
--- a/DropShot.Shared/RubberTemplateRegistry.cs
+++ b/DropShot.Shared/RubberTemplateRegistry.cs
@@ -1,7 +1,4 @@
-using DropShot.Models;
-using DropShot.Shared;
-
-namespace DropShot.Services;
+namespace DropShot.Shared;
 
 public record RubberDef(
     int Order,
@@ -12,8 +9,8 @@ public record RubberDef(
 
 /// <summary>
 /// Code-default rubber templates. A competition can override these by attaching a
-/// <see cref="CompetitionRubberTemplate"/> row or by selecting a non-default preset
-/// via <c>Competition.RubberTemplateKey</c>.
+/// custom rubber template row or by selecting a non-default preset via
+/// <c>Competition.RubberTemplateKey</c>.
 /// </summary>
 public static class RubberTemplateRegistry
 {

--- a/DropShot/Components/Competitions/Setup/RubberTemplateSection.razor
+++ b/DropShot/Components/Competitions/Setup/RubberTemplateSection.razor
@@ -1,4 +1,4 @@
-@using DropShot.Services
+@using DropShot.Shared
 
 @{
     var isCustom = Source == "custom";

--- a/DropShot/Services/ICompetitionRubberTemplateProvider.cs
+++ b/DropShot/Services/ICompetitionRubberTemplateProvider.cs
@@ -1,5 +1,6 @@
 using DropShot.Data;
 using DropShot.Models;
+using DropShot.Shared;
 using Microsoft.EntityFrameworkCore;
 
 namespace DropShot.Services;


### PR DESCRIPTION
## Summary

Lift `RubberDef` and `RubberTemplateRegistry` from `DropShot.Services` to `DropShot.Shared` ahead of the `CompetitionPage` RCL extraction.

`RubberDef` is a parameter type for `RubberTemplateSection`, so it must live in `DropShot.Shared` before that section can move into the RCL (planned in PR 7Q).

## Design notes

- Pure mechanical namespace flip — no behaviour change.
- `PlayerSex` and `CompetitionFormat` already live in `DropShot.Shared/Enums.cs`, so the lift is clean (no transitive lifts).
- The xmldoc `<see cref=""CompetitionRubberTemplate""/>` becomes plain `<c>` text since `DropShot.Shared` cannot reference `DropShot.Models`.
- `using` updates: `DropShot.Services/ICompetitionRubberTemplateProvider.cs` adds `using DropShot.Shared;`; `DropShot/Components/Competitions/Setup/RubberTemplateSection.razor` swaps `@using DropShot.Services` → `@using DropShot.Shared`. All other call sites already imported `DropShot.Shared`.

## Test plan

- [x] `dotnet build DropShot.sln` — 0 errors.
- [x] `dotnet test DropShot.Tests` — 28/28 pass.
- [x] `DropShot.Maui` builds across all 4 TFMs (covered by sln build).

This is the first PR in the multi-PR `CompetitionPage.razor` migration (the last unmigrated page in the Phase 7 web → RCL extraction). Plan: 7L → 7M (admin DTOs) → 7N/7O (admin service) → 7P–7T (section moves) → 7U (parent move + shim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)