### PR TITLE
Phase 7 PR 7N: stand up ICompetitionAdminService (read side + simple writes)

### DIFF
--- a/DropShot.Maui/MauiProgram.cs
+++ b/DropShot.Maui/MauiProgram.cs
@@ -53,6 +53,7 @@ public static class MauiProgram
         builder.Services.AddScoped<IClubService, HttpClubService>();
         builder.Services.AddScoped<IEventService, HttpEventService>();
         builder.Services.AddScoped<ICompetitionService, HttpCompetitionService>();
+        builder.Services.AddScoped<ICompetitionAdminService, HttpCompetitionAdminService>();
         builder.Services.AddScoped<IRulesSetService, HttpRulesSetService>();
         builder.Services.AddScoped<ISiteSettingsService, HttpSiteSettingsService>();
         builder.Services.AddScoped<IInvitationService, HttpInvitationService>();

--- a/DropShot.Maui/Services/HttpCompetitionAdminService.cs
+++ b/DropShot.Maui/Services/HttpCompetitionAdminService.cs
@@ -1,0 +1,185 @@
+using System.Net.Http.Json;
+using DropShot.Shared;
+using DropShot.Shared.Dtos;
+using DropShot.UI.Services;
+
+namespace DropShot.Maui.Services;
+
+public sealed class HttpCompetitionAdminService(HttpClient http) : ICompetitionAdminService
+{
+    // ── Read ─────────────────────────────────────────────────────────────────
+
+    public async Task<CompetitionEditDto?> GetCompetitionForEditAsync(int? competitionId, CancellationToken ct = default)
+    {
+        var url = competitionId.HasValue && competitionId.Value > 0
+            ? $"api/competitions/admin/{competitionId.Value}/edit"
+            : "api/competitions/admin/new/edit";
+        return await http.GetFromJsonAsync<CompetitionEditDto>(url, ct);
+    }
+
+    public async Task<List<CompetitionSeedSourceDto>> GetSeedSourceCandidatesAsync(
+        int? excludeCompetitionId, CompetitionFormat format, int? hostClubId, CancellationToken ct = default)
+    {
+        var qs = $"format={format}";
+        if (excludeCompetitionId.HasValue) qs += $"&excludeCompetitionId={excludeCompetitionId.Value}";
+        if (hostClubId.HasValue) qs += $"&hostClubId={hostClubId.Value}";
+        return await http.GetFromJsonAsync<List<CompetitionSeedSourceDto>>(
+            $"api/competitions/admin/seed-source-candidates?{qs}", ct) ?? [];
+    }
+
+    public async Task<List<ClubSchedulingTemplateDto>> GetClubTemplatesAsync(int clubId, CancellationToken ct = default)
+        => await http.GetFromJsonAsync<List<ClubSchedulingTemplateDto>>(
+            $"api/competitions/admin/clubs/{clubId}/scheduling-templates", ct) ?? [];
+
+    public async Task<List<ClubEmailTemplateDto>> GetEmailTemplatesAsync(int clubId, CancellationToken ct = default)
+        => await http.GetFromJsonAsync<List<ClubEmailTemplateDto>>(
+            $"api/competitions/admin/clubs/{clubId}/email-templates", ct) ?? [];
+
+    public async Task<bool> CanEditCompetitionAsync(int? competitionId, CancellationToken ct = default)
+    {
+        var qs = competitionId.HasValue ? $"?competitionId={competitionId.Value}" : "";
+        return await http.GetFromJsonAsync<bool>($"api/competitions/admin/can-edit{qs}", ct);
+    }
+
+    public async Task<bool> IsSuperAdminAsync(CancellationToken ct = default)
+        => await http.GetFromJsonAsync<bool>("api/competitions/admin/is-super-admin", ct);
+
+    public async Task<List<CompetitionAdminRowDto>> GetCompetitionAdminsAsync(int competitionId, CancellationToken ct = default)
+        => await http.GetFromJsonAsync<List<CompetitionAdminRowDto>>(
+            $"api/competitions/admin/{competitionId}/admins", ct) ?? [];
+
+    // ── Competition lifecycle ────────────────────────────────────────────────
+
+    public async Task<int> SaveCompetitionAsync(
+        int? competitionId, SaveCompetitionEditRequest request, CancellationToken ct = default)
+    {
+        var resp = competitionId.HasValue && competitionId.Value > 0
+            ? await http.PutAsJsonAsync($"api/competitions/admin/{competitionId.Value}", request, ct)
+            : await http.PostAsJsonAsync("api/competitions/admin", request, ct);
+        if (!resp.IsSuccessStatusCode)
+        {
+            var body = await resp.Content.ReadAsStringAsync(ct);
+            throw new InvalidOperationException(string.IsNullOrEmpty(body) ? resp.ReasonPhrase ?? "Save failed." : body);
+        }
+        return await resp.Content.ReadFromJsonAsync<int>(cancellationToken: ct);
+    }
+
+    public async Task<CloneCompetitionResultDto> CloneCompetitionAsync(
+        int sourceCompetitionId, CloneCompetitionRequest request, CancellationToken ct = default)
+    {
+        var resp = await http.PostAsJsonAsync(
+            $"api/competitions/admin/{sourceCompetitionId}/clone", request, ct);
+        resp.EnsureSuccessStatusCode();
+        return (await resp.Content.ReadFromJsonAsync<CloneCompetitionResultDto>(cancellationToken: ct))!;
+    }
+
+    public async Task<bool> ToggleStartedAsync(int competitionId, CancellationToken ct = default)
+    {
+        var resp = await http.PostAsync($"api/competitions/admin/{competitionId}/toggle-started", null, ct);
+        resp.EnsureSuccessStatusCode();
+        return await resp.Content.ReadFromJsonAsync<bool>(cancellationToken: ct);
+    }
+
+    // ── Stages ───────────────────────────────────────────────────────────────
+
+    public async Task ApplyStageFollowUpAsync(
+        int competitionId, ApplyStageFollowUpRequest request, CancellationToken ct = default)
+    {
+        var resp = await http.PostAsJsonAsync(
+            $"api/competitions/admin/{competitionId}/stages/follow-up", request, ct);
+        resp.EnsureSuccessStatusCode();
+    }
+
+    // ── Admins ───────────────────────────────────────────────────────────────
+
+    public async Task AddCompetitionAdminAsync(
+        int competitionId, AddCompetitionAdminRequest request, CancellationToken ct = default)
+    {
+        var resp = await http.PostAsJsonAsync(
+            $"api/competitions/admin/{competitionId}/admins", request, ct);
+        if (!resp.IsSuccessStatusCode)
+        {
+            var body = await resp.Content.ReadAsStringAsync(ct);
+            throw new InvalidOperationException(string.IsNullOrEmpty(body) ? resp.ReasonPhrase ?? "Failed to add admin." : body);
+        }
+    }
+
+    public async Task RemoveCompetitionAdminAsync(int competitionId, string userId, CancellationToken ct = default)
+    {
+        var resp = await http.DeleteAsync(
+            $"api/competitions/admin/{competitionId}/admins/{Uri.EscapeDataString(userId)}", ct);
+        resp.EnsureSuccessStatusCode();
+    }
+
+    // ── Rubber template ──────────────────────────────────────────────────────
+
+    public async Task<RubberTemplateStateDto> LoadRubberTemplateStateAsync(int competitionId, CancellationToken ct = default)
+    {
+        var dto = await http.GetFromJsonAsync<RubberTemplateStateDto>(
+            $"api/competitions/admin/{competitionId}/rubber-template", ct)
+            ?? throw new InvalidOperationException("Rubber template not found.");
+        return dto;
+    }
+
+    public async Task ApplyRubberPresetAsync(
+        int competitionId, ApplyRubberPresetRequest request, CancellationToken ct = default)
+    {
+        var resp = await http.PostAsJsonAsync(
+            $"api/competitions/admin/{competitionId}/rubber-template/preset", request, ct);
+        resp.EnsureSuccessStatusCode();
+    }
+
+    public async Task ConvertToCustomTemplateAsync(int competitionId, CancellationToken ct = default)
+    {
+        var resp = await http.PostAsync(
+            $"api/competitions/admin/{competitionId}/rubber-template/convert-to-custom", null, ct);
+        resp.EnsureSuccessStatusCode();
+    }
+
+    public async Task AddCustomRubberRowAsync(int competitionId, CancellationToken ct = default)
+    {
+        var resp = await http.PostAsync(
+            $"api/competitions/admin/{competitionId}/rubber-template/rows", null, ct);
+        resp.EnsureSuccessStatusCode();
+    }
+
+    public async Task SaveRubberRowAsync(
+        int competitionId, SaveRubberRowRequest request, CancellationToken ct = default)
+    {
+        var resp = await http.PutAsJsonAsync(
+            $"api/competitions/admin/{competitionId}/rubber-template/rows", request, ct);
+        resp.EnsureSuccessStatusCode();
+    }
+
+    public async Task DeleteCustomRubberRowAsync(int competitionId, int order, CancellationToken ct = default)
+    {
+        var resp = await http.DeleteAsync(
+            $"api/competitions/admin/{competitionId}/rubber-template/rows/{order}", ct);
+        resp.EnsureSuccessStatusCode();
+    }
+
+    public async Task RevertToDefaultTemplateAsync(int competitionId, CancellationToken ct = default)
+    {
+        var resp = await http.PostAsync(
+            $"api/competitions/admin/{competitionId}/rubber-template/revert", null, ct);
+        resp.EnsureSuccessStatusCode();
+    }
+
+    // ── Email ────────────────────────────────────────────────────────────────
+
+    public async Task SendMatchEmailAsync(
+        int competitionId, SendMatchEmailRequest request, CancellationToken ct = default)
+    {
+        var resp = await http.PostAsJsonAsync(
+            $"api/competitions/admin/{competitionId}/email/match", request, ct);
+        resp.EnsureSuccessStatusCode();
+    }
+
+    public async Task SendCompetitionEmailAsync(
+        int competitionId, SendCompetitionEmailRequest request, CancellationToken ct = default)
+    {
+        var resp = await http.PostAsJsonAsync(
+            $"api/competitions/admin/{competitionId}/email/competition", request, ct);
+        resp.EnsureSuccessStatusCode();
+    }
+}

--- a/DropShot.Shared/Dtos/CompetitionAdminDtos.cs
+++ b/DropShot.Shared/Dtos/CompetitionAdminDtos.cs
@@ -58,7 +58,7 @@ public record CompetitionEditDto(
     IReadOnlyList<CompetitionMatchWindowDto> MatchWindows,
     IReadOnlyList<CourtPairDto> CourtPairs,
     IReadOnlyList<CompetitionAdminRowDto> Admins,
-    RubberTemplateDto? RubberTemplate,
+    RubberTemplateStateDto? RubberTemplate,
     IReadOnlyList<CompetitionSeedSourceDto> SeedSourceCandidates,
     IReadOnlyList<ClubSchedulingTemplateDto> ClubTemplates,
     IReadOnlyList<CompetitionTemplateDto> CompetitionTemplates,

--- a/DropShot.Tests/Helpers/DropShotTestContext.cs
+++ b/DropShot.Tests/Helpers/DropShotTestContext.cs
@@ -124,6 +124,7 @@ public class DropShotTestContext : BunitContext
         Services.AddScoped<IClubService, WebClubService>();
         Services.AddScoped<IEventService, WebEventService>();
         Services.AddScoped<ICompetitionService, WebCompetitionService>();
+        Services.AddScoped<ICompetitionAdminService, WebCompetitionAdminService>();
         Services.AddScoped<IRulesSetService, WebRulesSetService>();
         Services.AddScoped<ISiteSettingsService, WebSiteSettingsService>();
         Services.AddScoped<IInvitationService, WebInvitationService>();

--- a/DropShot.UI/Services/ICompetitionAdminService.cs
+++ b/DropShot.UI/Services/ICompetitionAdminService.cs
@@ -1,0 +1,138 @@
+using DropShot.Shared;
+using DropShot.Shared.Dtos;
+
+namespace DropShot.UI.Services;
+
+/// <summary>
+/// Admin-side competition operations for the CompetitionPage. Sibling of
+/// <see cref="ICompetitionService"/>; that one is the player-facing read /
+/// scoring surface, this one wraps every server-only dependency the
+/// CompetitionPage previously injected directly (DbContext, ClubAuthorizationService,
+/// UserManager, AdminEmailService, CompetitionSchedulerService,
+/// FixtureSimulationService, ICompetitionRubberTemplateProvider).
+///
+/// Phase 7 PR 7N adds the read side + simple/independent writes (stages,
+/// admins, clone, comp-save, email, rubber template). Phase 7 PR 7O adds the
+/// coupled writes (participants, divisions, teams, match windows, fixtures,
+/// scheduler, simulator).
+/// </summary>
+public interface ICompetitionAdminService
+{
+    // ── Read ─────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// One-shot fat aggregate for the CompetitionPage initial load. When
+    /// <paramref name="competitionId"/> is null or 0, returns a create-mode
+    /// payload (defaults + lookup tables, no entity data). When set, returns
+    /// the full edit-mode payload (competition + stages + participants +
+    /// divisions + teams + fixtures + match windows + court pairs + rubber
+    /// template state + admins + clone-source candidates + lookup tables).
+    /// Returns null in edit mode if the competition doesn't exist or the
+    /// caller can't view it.
+    /// </summary>
+    Task<CompetitionEditDto?> GetCompetitionForEditAsync(int? competitionId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Candidate competitions to seed divisions from: same format + host club,
+    /// finished, has divisions. Used by the seed-divisions dialog after the
+    /// host club changes mid-edit.
+    /// </summary>
+    Task<List<CompetitionSeedSourceDto>> GetSeedSourceCandidatesAsync(
+        int? excludeCompetitionId, CompetitionFormat format, int? hostClubId, CancellationToken ct = default);
+
+    Task<List<ClubSchedulingTemplateDto>> GetClubTemplatesAsync(int clubId, CancellationToken ct = default);
+    Task<List<ClubEmailTemplateDto>> GetEmailTemplatesAsync(int clubId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Whether the current user is allowed to edit the given competition.
+    /// When <paramref name="competitionId"/> is null, returns whether the
+    /// user can create any competition at all (subscribed user, club admin,
+    /// or system admin).
+    /// </summary>
+    Task<bool> CanEditCompetitionAsync(int? competitionId, CancellationToken ct = default);
+
+    Task<bool> IsSuperAdminAsync(CancellationToken ct = default);
+
+    Task<List<CompetitionAdminRowDto>> GetCompetitionAdminsAsync(int competitionId, CancellationToken ct = default);
+
+    // ── Competition lifecycle ────────────────────────────────────────────────
+
+    /// <summary>
+    /// Create or update a competition. Returns the saved competition's id (new
+    /// or existing). Throws <see cref="InvalidOperationException"/> on duplicate
+    /// name. When <paramref name="competitionId"/> is null, a new row is created
+    /// and the creator user id is stamped on user-owned competitions (no host club).
+    /// </summary>
+    Task<int> SaveCompetitionAsync(
+        int? competitionId, SaveCompetitionEditRequest request, CancellationToken ct = default);
+
+    Task<CloneCompetitionResultDto> CloneCompetitionAsync(
+        int sourceCompetitionId, CloneCompetitionRequest request, CancellationToken ct = default);
+
+    /// <summary>Toggles the <c>IsStarted</c> flag and returns the new value.</summary>
+    Task<bool> ToggleStartedAsync(int competitionId, CancellationToken ct = default);
+
+    // ── Stages ───────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Bulk-add follow-on stages (e.g. SF + Final after a Knockout). Reorders
+    /// the resulting stage list by natural type order.
+    /// </summary>
+    Task ApplyStageFollowUpAsync(
+        int competitionId, ApplyStageFollowUpRequest request, CancellationToken ct = default);
+
+    // ── Admins ───────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Add a competition-scoped admin by email. Throws
+    /// <see cref="KeyNotFoundException"/> when no user with that email exists,
+    /// and <see cref="InvalidOperationException"/> when the user is already an admin.
+    /// </summary>
+    Task AddCompetitionAdminAsync(
+        int competitionId, AddCompetitionAdminRequest request, CancellationToken ct = default);
+
+    Task RemoveCompetitionAdminAsync(int competitionId, string userId, CancellationToken ct = default);
+
+    // ── Rubber template ──────────────────────────────────────────────────────
+
+    Task<RubberTemplateStateDto> LoadRubberTemplateStateAsync(int competitionId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Set the competition's rubber preset key (or clear it with a null key)
+    /// and remove any custom template so the preset takes effect.
+    /// </summary>
+    Task ApplyRubberPresetAsync(
+        int competitionId, ApplyRubberPresetRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Snapshot the currently-resolved template into a DB-backed custom one,
+    /// so the user can edit individual rows. No-op if the resolved template is empty.
+    /// </summary>
+    Task ConvertToCustomTemplateAsync(int competitionId, CancellationToken ct = default);
+
+    /// <summary>Append an empty row to the custom template, picking the next order.</summary>
+    Task AddCustomRubberRowAsync(int competitionId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Update a row in the custom template, identified by its (competition, order)
+    /// pair. <see cref="SaveRubberRowRequest.RowId"/> is unused here for parity
+    /// with the existing page UI which addresses rows by Order.
+    /// </summary>
+    Task SaveRubberRowAsync(
+        int competitionId, SaveRubberRowRequest request, CancellationToken ct = default);
+
+    Task DeleteCustomRubberRowAsync(int competitionId, int order, CancellationToken ct = default);
+
+    /// <summary>Clear the custom template and the preset key — falls back to format default.</summary>
+    Task RevertToDefaultTemplateAsync(int competitionId, CancellationToken ct = default);
+
+    // ── Email ────────────────────────────────────────────────────────────────
+
+    /// <summary>Send the configured email to every player on the named fixture.</summary>
+    Task SendMatchEmailAsync(
+        int competitionId, SendMatchEmailRequest request, CancellationToken ct = default);
+
+    /// <summary>Send the configured email to every participant of the competition.</summary>
+    Task SendCompetitionEmailAsync(
+        int competitionId, SendCompetitionEmailRequest request, CancellationToken ct = default);
+}

--- a/DropShot/Controllers/CompetitionsAdminController.cs
+++ b/DropShot/Controllers/CompetitionsAdminController.cs
@@ -1,0 +1,213 @@
+using DropShot.Shared;
+using DropShot.Shared.Dtos;
+using DropShot.UI.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DropShot.Controllers;
+
+/// <summary>
+/// Admin/edit endpoints for the CompetitionPage. Sibling of
+/// <see cref="CompetitionsController"/>; that one is the player-facing
+/// read+scoring API, this one wraps server-only operations behind
+/// <see cref="ICompetitionAdminService"/>.
+/// </summary>
+[ApiController]
+[Route("api/competitions/admin")]
+[Authorize(AuthenticationSchemes = "Bearer")]
+public class CompetitionsAdminController(
+    ICompetitionAdminService admin,
+    ILogger<CompetitionsAdminController> logger) : ControllerBase
+{
+    // ── Read ─────────────────────────────────────────────────────────────────
+
+    [HttpGet("{id:int}/edit")]
+    public async Task<ActionResult<CompetitionEditDto>> GetForEdit(int id, CancellationToken ct)
+    {
+        var dto = await admin.GetCompetitionForEditAsync(id, ct);
+        return dto is null ? NotFound() : Ok(dto);
+    }
+
+    [HttpGet("new/edit")]
+    public async Task<ActionResult<CompetitionEditDto>> GetForCreate(CancellationToken ct)
+    {
+        var dto = await admin.GetCompetitionForEditAsync(null, ct);
+        return dto is null ? Forbid() : Ok(dto);
+    }
+
+    [HttpGet("seed-source-candidates")]
+    public async Task<ActionResult<List<CompetitionSeedSourceDto>>> GetSeedCandidates(
+        [FromQuery] int? excludeCompetitionId,
+        [FromQuery] CompetitionFormat format,
+        [FromQuery] int? hostClubId,
+        CancellationToken ct)
+        => await admin.GetSeedSourceCandidatesAsync(excludeCompetitionId, format, hostClubId, ct);
+
+    [HttpGet("clubs/{clubId:int}/scheduling-templates")]
+    public async Task<ActionResult<List<ClubSchedulingTemplateDto>>> GetClubTemplates(int clubId, CancellationToken ct)
+        => await admin.GetClubTemplatesAsync(clubId, ct);
+
+    [HttpGet("clubs/{clubId:int}/email-templates")]
+    public async Task<ActionResult<List<ClubEmailTemplateDto>>> GetEmailTemplates(int clubId, CancellationToken ct)
+        => await admin.GetEmailTemplatesAsync(clubId, ct);
+
+    [HttpGet("can-edit")]
+    public async Task<ActionResult<bool>> CanEdit([FromQuery] int? competitionId, CancellationToken ct)
+        => await admin.CanEditCompetitionAsync(competitionId, ct);
+
+    [HttpGet("is-super-admin")]
+    public async Task<ActionResult<bool>> IsSuperAdmin(CancellationToken ct)
+        => await admin.IsSuperAdminAsync(ct);
+
+    [HttpGet("{id:int}/admins")]
+    public async Task<ActionResult<List<CompetitionAdminRowDto>>> GetAdmins(int id, CancellationToken ct)
+        => await admin.GetCompetitionAdminsAsync(id, ct);
+
+    // ── Competition lifecycle ────────────────────────────────────────────────
+
+    [HttpPost]
+    public async Task<ActionResult<int>> Create([FromBody] SaveCompetitionEditRequest req, CancellationToken ct)
+    {
+        try { return await admin.SaveCompetitionAsync(null, req, ct); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (InvalidOperationException ex) { return BadRequest(new { message = ex.Message }); }
+    }
+
+    [HttpPut("{id:int}")]
+    public async Task<ActionResult<int>> Update(
+        int id, [FromBody] SaveCompetitionEditRequest req, CancellationToken ct)
+    {
+        try { return await admin.SaveCompetitionAsync(id, req, ct); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+        catch (InvalidOperationException ex) { return BadRequest(new { message = ex.Message }); }
+    }
+
+    [HttpPost("{id:int}/clone")]
+    public async Task<ActionResult<CloneCompetitionResultDto>> Clone(
+        int id, [FromBody] CloneCompetitionRequest req, CancellationToken ct)
+    {
+        try { return await admin.CloneCompetitionAsync(id, req, ct); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+    }
+
+    [HttpPost("{id:int}/toggle-started")]
+    public async Task<ActionResult<bool>> ToggleStarted(int id, CancellationToken ct)
+    {
+        try { return await admin.ToggleStartedAsync(id, ct); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+    }
+
+    // ── Stages ───────────────────────────────────────────────────────────────
+
+    [HttpPost("{id:int}/stages/follow-up")]
+    public async Task<IActionResult> ApplyStageFollowUp(
+        int id, [FromBody] ApplyStageFollowUpRequest req, CancellationToken ct)
+    {
+        try { await admin.ApplyStageFollowUpAsync(id, req, ct); return NoContent(); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+    }
+
+    // ── Admins ───────────────────────────────────────────────────────────────
+
+    [HttpPost("{id:int}/admins")]
+    public async Task<IActionResult> AddAdmin(
+        int id, [FromBody] AddCompetitionAdminRequest req, CancellationToken ct)
+    {
+        try { await admin.AddCompetitionAdminAsync(id, req, ct); return NoContent(); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException ex) { return NotFound(new { message = ex.Message }); }
+        catch (InvalidOperationException ex) { return BadRequest(new { message = ex.Message }); }
+    }
+
+    [HttpDelete("{id:int}/admins/{userId}")]
+    public async Task<IActionResult> RemoveAdmin(int id, string userId, CancellationToken ct)
+    {
+        try { await admin.RemoveCompetitionAdminAsync(id, userId, ct); return NoContent(); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+    }
+
+    // ── Rubber template ──────────────────────────────────────────────────────
+
+    [HttpGet("{id:int}/rubber-template")]
+    public async Task<ActionResult<RubberTemplateStateDto>> GetRubberTemplate(int id, CancellationToken ct)
+    {
+        try { return await admin.LoadRubberTemplateStateAsync(id, ct); }
+        catch (KeyNotFoundException) { return NotFound(); }
+    }
+
+    [HttpPost("{id:int}/rubber-template/preset")]
+    public async Task<IActionResult> ApplyPreset(
+        int id, [FromBody] ApplyRubberPresetRequest req, CancellationToken ct)
+    {
+        try { await admin.ApplyRubberPresetAsync(id, req, ct); return NoContent(); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+    }
+
+    [HttpPost("{id:int}/rubber-template/convert-to-custom")]
+    public async Task<IActionResult> ConvertToCustom(int id, CancellationToken ct)
+    {
+        try { await admin.ConvertToCustomTemplateAsync(id, ct); return NoContent(); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+    }
+
+    [HttpPost("{id:int}/rubber-template/rows")]
+    public async Task<IActionResult> AddCustomRow(int id, CancellationToken ct)
+    {
+        try { await admin.AddCustomRubberRowAsync(id, ct); return NoContent(); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+        catch (InvalidOperationException ex) { return BadRequest(new { message = ex.Message }); }
+    }
+
+    [HttpPut("{id:int}/rubber-template/rows")]
+    public async Task<IActionResult> SaveCustomRow(
+        int id, [FromBody] SaveRubberRowRequest req, CancellationToken ct)
+    {
+        try { await admin.SaveRubberRowAsync(id, req, ct); return NoContent(); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+    }
+
+    [HttpDelete("{id:int}/rubber-template/rows/{order:int}")]
+    public async Task<IActionResult> DeleteCustomRow(int id, int order, CancellationToken ct)
+    {
+        try { await admin.DeleteCustomRubberRowAsync(id, order, ct); return NoContent(); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+    }
+
+    [HttpPost("{id:int}/rubber-template/revert")]
+    public async Task<IActionResult> RevertToDefault(int id, CancellationToken ct)
+    {
+        try { await admin.RevertToDefaultTemplateAsync(id, ct); return NoContent(); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+    }
+
+    // ── Email ────────────────────────────────────────────────────────────────
+
+    [HttpPost("{id:int}/email/match")]
+    public async Task<IActionResult> SendMatchEmail(
+        int id, [FromBody] SendMatchEmailRequest req, CancellationToken ct)
+    {
+        try { await admin.SendMatchEmailAsync(id, req, ct); return NoContent(); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+    }
+
+    [HttpPost("{id:int}/email/competition")]
+    public async Task<IActionResult> SendCompetitionEmail(
+        int id, [FromBody] SendCompetitionEmailRequest req, CancellationToken ct)
+    {
+        try { await admin.SendCompetitionEmailAsync(id, req, ct); return NoContent(); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+    }
+}

--- a/DropShot/Program.cs
+++ b/DropShot/Program.cs
@@ -128,6 +128,7 @@ builder.Services.AddScoped<IPlayerService, WebPlayerService>();
 builder.Services.AddScoped<IClubService, WebClubService>();
 builder.Services.AddScoped<IEventService, WebEventService>();
 builder.Services.AddScoped<ICompetitionService, WebCompetitionService>();
+builder.Services.AddScoped<ICompetitionAdminService, WebCompetitionAdminService>();
 builder.Services.AddScoped<IRulesSetService, WebRulesSetService>();
 builder.Services.AddScoped<ISiteSettingsService, WebSiteSettingsService>();
 builder.Services.AddScoped<IInvitationService, WebInvitationService>();

--- a/DropShot/Services/WebCompetitionAdminService.cs
+++ b/DropShot/Services/WebCompetitionAdminService.cs
@@ -1,0 +1,847 @@
+using System.Security.Claims;
+using DropShot.Data;
+using DropShot.Models;
+using DropShot.Shared;
+using DropShot.Shared.Dtos;
+using DropShot.UI.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+
+namespace DropShot.Services;
+
+public sealed class WebCompetitionAdminService(
+    IDbContextFactory<MyDbContext> dbFactory,
+    ClubAuthorizationService authzService,
+    IHttpContextAccessor httpContextAccessor,
+    UserManager<ApplicationUser> userManager,
+    ICompetitionRubberTemplateProvider rubberTemplateProvider,
+    AdminEmailService adminEmailService) : ICompetitionAdminService
+{
+    private ClaimsPrincipal CurrentUser =>
+        httpContextAccessor.HttpContext?.User ?? new ClaimsPrincipal();
+
+    // ── Read ─────────────────────────────────────────────────────────────────
+
+    public async Task<CompetitionEditDto?> GetCompetitionForEditAsync(int? competitionId, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+
+        var clubs = await db.Clubs.AsNoTracking().OrderBy(c => c.Name)
+            .Select(c => new ClubDto(c.ClubId, c.Name, c.AddressLine1, c.AddressLine2, c.Town, c.Postcode,
+                c.Phone, c.Email, c.Website, c.Courts.Count))
+            .ToListAsync(ct);
+        var rulesSets = await db.RulesSets.AsNoTracking().OrderBy(r => r.Name)
+            .Select(r => new RulesSetDto(r.RulesSetId, r.Name, r.Description, r.Items.Count))
+            .ToListAsync(ct);
+        var events = await db.Events.AsNoTracking().OrderBy(e => e.Name)
+            .Select(e => new EventDto(e.EventId, e.Name, e.Description, e.StartDate, e.EndDate,
+                e.HostClubId, e.HostClub != null ? e.HostClub.Name : null,
+                e.Competitions.Count))
+            .ToListAsync(ct);
+
+        if (!competitionId.HasValue || competitionId.Value <= 0)
+        {
+            // Create-mode payload: lookups + authz flags, no entity data.
+            var canCreate = await CanEditCompetitionAsync(null, ct);
+            var isSuperAdminCreate = authzService.IsSuperAdmin(CurrentUser);
+            return new CompetitionEditDto(
+                CompetitionId: null,
+                CompetitionName: "",
+                CompetitionFormat: null,
+                MaxParticipants: null,
+                StartDate: null, EndDate: null, RegisterByDate: null,
+                MaxAge: null, MinAge: null, EligibleSex: null,
+                RulesSetId: null, HostClubId: null, HostClubName: null,
+                EventId: null, EventName: null,
+                BestOf: 3, RequireVerification: false, IsArchived: false, IsStarted: false,
+                CreatorUserId: null, IsRestricted: false,
+                TeamSize: null, RubberTemplateKey: null,
+                MatchFormat: MatchFormatType.BestOf, NumberOfSets: 3, GamesPerSet: 6,
+                SetWinMode: SetWinMode.WinBy2, LeagueScoring: LeagueScoringMode.WinPoints,
+                RubberTieBreak: RubberTieBreakMode.AdminDecides,
+                MinDaysBetweenPlayerMatches: null, HasDivisions: false,
+                SeededFromCompetitionId: null,
+                Stages: [], Participants: [], Divisions: [], Teams: [], Fixtures: [],
+                MatchWindows: [], CourtPairs: [], Admins: [],
+                RubberTemplate: null,
+                SeedSourceCandidates: [],
+                ClubTemplates: [], CompetitionTemplates: [], EmailTemplates: [],
+                HostClubCourts: [],
+                Clubs: clubs, RulesSets: rulesSets, Events: events,
+                AllowedPlayerIds: [],
+                CanEdit: canCreate,
+                IsSuperAdmin: isSuperAdminCreate);
+        }
+
+        var id = competitionId.Value;
+        var comp = await db.Competition
+            .Include(c => c.HostClub)
+            .Include(c => c.Rules)
+            .Include(c => c.Event)
+            .Include(c => c.Stages.OrderBy(s => s.StageOrder))
+            .Include(c => c.Participants).ThenInclude(p => p.Player)
+            .Include(c => c.Participants).ThenInclude(p => p.Team)
+            .Include(c => c.Participants).ThenInclude(p => p.Division)
+            .Include(c => c.Fixtures).ThenInclude(f => f.Stage)
+            .Include(c => c.Fixtures).ThenInclude(f => f.Court)
+            .Include(c => c.Fixtures).ThenInclude(f => f.Player1)
+            .Include(c => c.Fixtures).ThenInclude(f => f.Player2)
+            .Include(c => c.Fixtures).ThenInclude(f => f.Player3)
+            .Include(c => c.Fixtures).ThenInclude(f => f.Player4)
+            .Include(c => c.Fixtures).ThenInclude(f => f.HomeTeam)
+            .Include(c => c.Fixtures).ThenInclude(f => f.AwayTeam)
+            .Include(c => c.Fixtures).ThenInclude(f => f.CourtPair).ThenInclude(cp => cp!.Court1)
+            .Include(c => c.Fixtures).ThenInclude(f => f.CourtPair).ThenInclude(cp => cp!.Court2)
+            .Include(c => c.Teams).ThenInclude(t => t.Captain)
+            .Include(c => c.MatchWindows).ThenInclude(w => w.Court)
+            .Include(c => c.MatchWindows).ThenInclude(w => w.Division)
+            .Include(c => c.Divisions)
+            .Include(c => c.AllowedPlayers)
+            .AsSplitQuery()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(c => c.CompetitionID == id, ct);
+
+        if (comp is null) return null;
+
+        if (!await authzService.CanEditCompetitionAsync(CurrentUser, comp.HostClubId, id))
+            return null;
+
+        var canEdit = true;
+        var isSuperAdmin = authzService.IsSuperAdmin(CurrentUser);
+
+        var courtPairs = await db.CourtPairs.AsNoTracking()
+            .Where(cp => cp.CompetitionId == id)
+            .Include(cp => cp.Court1).Include(cp => cp.Court2)
+            .OrderBy(cp => cp.Name)
+            .Select(cp => new CourtPairDto(
+                cp.CourtPairId, cp.CompetitionId,
+                cp.Court1Id, cp.Court1!.Name, cp.Court2Id, cp.Court2!.Name, cp.Name))
+            .ToListAsync(ct);
+
+        var seedCandidates = await db.Competition.AsNoTracking()
+            .Where(c => c.CompetitionID != id
+                        && c.CompetitionFormat == comp.CompetitionFormat
+                        && c.HostClubId == comp.HostClubId
+                        && c.Divisions.Any())
+            .OrderByDescending(c => c.StartDate)
+            .ThenBy(c => c.CompetitionName)
+            .Select(c => new CompetitionSeedSourceDto(
+                c.CompetitionID, c.CompetitionName, c.EndDate, c.Divisions.Count))
+            .ToListAsync(ct);
+
+        var hostClubCourts = new List<CourtDto>();
+        var clubTemplates = new List<ClubSchedulingTemplateDto>();
+        var competitionTemplates = new List<CompetitionTemplateDto>();
+        var emailTemplates = new List<ClubEmailTemplateDto>();
+        if (comp.HostClubId.HasValue)
+        {
+            hostClubCourts = await db.Courts.AsNoTracking()
+                .Where(c => c.ClubId == comp.HostClubId.Value)
+                .OrderBy(c => c.Name)
+                .Select(c => new CourtDto(c.CourtId, c.ClubId, c.Name, (DropShot.Shared.CourtSurface)c.Surface, c.IsIndoor))
+                .ToListAsync(ct);
+
+            clubTemplates = await db.ClubSchedulingTemplates.AsNoTracking()
+                .Include(t => t.Windows)
+                .Where(t => t.ClubId == comp.HostClubId.Value)
+                .OrderBy(t => t.Name)
+                .Select(t => new ClubSchedulingTemplateDto(
+                    t.ClubSchedulingTemplateId, t.ClubId, t.Name,
+                    t.Windows.Select(w => new ClubSchedulingTemplateWindowDto(
+                        w.ClubSchedulingTemplateWindowId, w.DayOfWeek, w.StartTime, w.EndTime)).ToList()))
+                .ToListAsync(ct);
+
+            competitionTemplates = await db.CompetitionTemplates.AsNoTracking()
+                .Include(t => t.Windows)
+                .Where(t => t.ClubId == comp.HostClubId.Value)
+                .OrderBy(t => t.Name)
+                .Select(t => new CompetitionTemplateDto(
+                    t.CompetitionTemplateId, t.ClubId, t.Name, t.Format, t.RulesSetId, t.BestOf,
+                    t.MaxAge, t.EligibleSex,
+                    t.Windows.Select(w => new CompetitionTemplateWindowDto(
+                        w.CompetitionTemplateWindowId, w.DayOfWeek, w.StartTime, w.EndTime)).ToList()))
+                .ToListAsync(ct);
+
+            emailTemplates = await db.ClubEmailTemplates.AsNoTracking()
+                .Where(t => t.ClubId == comp.HostClubId.Value)
+                .OrderBy(t => t.Name)
+                .Select(t => new ClubEmailTemplateDto(
+                    t.ClubEmailTemplateId, t.ClubId, t.Name, t.Subject, t.Body))
+                .ToListAsync(ct);
+        }
+
+        var admins = await GetCompetitionAdminsInternalAsync(db, id, ct);
+        var rubberTemplate = await LoadRubberTemplateStateInternalAsync(db, comp, ct);
+
+        return new CompetitionEditDto(
+            CompetitionId: comp.CompetitionID,
+            CompetitionName: comp.CompetitionName,
+            CompetitionFormat: comp.CompetitionFormat,
+            MaxParticipants: comp.MaxParticipants,
+            StartDate: comp.StartDate, EndDate: comp.EndDate, RegisterByDate: comp.RegisterByDate,
+            MaxAge: comp.MaxAge, MinAge: comp.MinAge, EligibleSex: comp.EligibleSex,
+            RulesSetId: comp.RulesSetId, HostClubId: comp.HostClubId, HostClubName: comp.HostClub?.Name,
+            EventId: comp.EventId, EventName: comp.Event?.Name,
+            BestOf: comp.BestOf, RequireVerification: comp.RequireVerification,
+            IsArchived: comp.IsArchived, IsStarted: comp.IsStarted,
+            CreatorUserId: comp.CreatorUserId, IsRestricted: comp.IsRestricted,
+            TeamSize: comp.TeamSize, RubberTemplateKey: comp.RubberTemplateKey,
+            MatchFormat: comp.MatchFormat, NumberOfSets: comp.NumberOfSets, GamesPerSet: comp.GamesPerSet,
+            SetWinMode: comp.SetWinMode, LeagueScoring: comp.LeagueScoring,
+            RubberTieBreak: comp.RubberTieBreak,
+            MinDaysBetweenPlayerMatches: comp.MinDaysBetweenPlayerMatches,
+            HasDivisions: comp.HasDivisions,
+            SeededFromCompetitionId: comp.SeededFromCompetitionId,
+            Stages: comp.Stages.Select(ToStageDto).ToList(),
+            Participants: comp.Participants.Select(ToParticipantDto).ToList(),
+            Divisions: comp.Divisions.OrderBy(d => d.Rank).Select(ToDivisionDto).ToList(),
+            Teams: comp.Teams.OrderBy(t => t.Name).Select(ToTeamDto).ToList(),
+            Fixtures: comp.Fixtures
+                .OrderBy(f => f.RoundNumber).ThenBy(f => f.ScheduledAt)
+                .Select(ToFixtureDto).ToList(),
+            MatchWindows: comp.MatchWindows
+                .OrderBy(w => w.DayOfWeek).ThenBy(w => w.StartTime)
+                .Select(ToMatchWindowDto).ToList(),
+            CourtPairs: courtPairs,
+            Admins: admins,
+            RubberTemplate: rubberTemplate,
+            SeedSourceCandidates: seedCandidates,
+            ClubTemplates: clubTemplates,
+            CompetitionTemplates: competitionTemplates,
+            EmailTemplates: emailTemplates,
+            HostClubCourts: hostClubCourts,
+            Clubs: clubs, RulesSets: rulesSets, Events: events,
+            AllowedPlayerIds: comp.AllowedPlayers.Select(ap => ap.PlayerId).ToList(),
+            CanEdit: canEdit,
+            IsSuperAdmin: isSuperAdmin);
+    }
+
+    public async Task<List<CompetitionSeedSourceDto>> GetSeedSourceCandidatesAsync(
+        int? excludeCompetitionId, CompetitionFormat format, int? hostClubId, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        return await db.Competition.AsNoTracking()
+            .Where(c => (!excludeCompetitionId.HasValue || c.CompetitionID != excludeCompetitionId.Value)
+                        && c.CompetitionFormat == format
+                        && c.HostClubId == hostClubId
+                        && c.Divisions.Any())
+            .OrderByDescending(c => c.StartDate)
+            .ThenBy(c => c.CompetitionName)
+            .Select(c => new CompetitionSeedSourceDto(
+                c.CompetitionID, c.CompetitionName, c.EndDate, c.Divisions.Count))
+            .ToListAsync(ct);
+    }
+
+    public async Task<List<ClubSchedulingTemplateDto>> GetClubTemplatesAsync(int clubId, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        return await db.ClubSchedulingTemplates.AsNoTracking()
+            .Include(t => t.Windows)
+            .Where(t => t.ClubId == clubId)
+            .OrderBy(t => t.Name)
+            .Select(t => new ClubSchedulingTemplateDto(
+                t.ClubSchedulingTemplateId, t.ClubId, t.Name,
+                t.Windows.Select(w => new ClubSchedulingTemplateWindowDto(
+                    w.ClubSchedulingTemplateWindowId, w.DayOfWeek, w.StartTime, w.EndTime)).ToList()))
+            .ToListAsync(ct);
+    }
+
+    public async Task<List<ClubEmailTemplateDto>> GetEmailTemplatesAsync(int clubId, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        return await db.ClubEmailTemplates.AsNoTracking()
+            .Where(t => t.ClubId == clubId)
+            .OrderBy(t => t.Name)
+            .Select(t => new ClubEmailTemplateDto(
+                t.ClubEmailTemplateId, t.ClubId, t.Name, t.Subject, t.Body))
+            .ToListAsync(ct);
+    }
+
+    public async Task<bool> CanEditCompetitionAsync(int? competitionId, CancellationToken ct = default)
+    {
+        if (competitionId.HasValue && competitionId.Value > 0)
+        {
+            await using var db = await dbFactory.CreateDbContextAsync(ct);
+            var hostClubId = await db.Competition.AsNoTracking()
+                .Where(c => c.CompetitionID == competitionId.Value)
+                .Select(c => c.HostClubId)
+                .FirstOrDefaultAsync(ct);
+            return await authzService.CanEditCompetitionAsync(CurrentUser, hostClubId, competitionId.Value);
+        }
+
+        var appUser = await userManager.GetUserAsync(CurrentUser);
+        var canCreateUserComp = authzService.CanCreateUserCompetition(CurrentUser, appUser);
+        var isAdmin = await authzService.IsAdminAsync(CurrentUser);
+        var adminClubIds = await authzService.GetAdminClubIdsAsync(CurrentUser);
+        return isAdmin || adminClubIds.Count > 0 || canCreateUserComp;
+    }
+
+    public Task<bool> IsSuperAdminAsync(CancellationToken ct = default)
+        => Task.FromResult(authzService.IsSuperAdmin(CurrentUser));
+
+    public async Task<List<CompetitionAdminRowDto>> GetCompetitionAdminsAsync(int competitionId, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        return await GetCompetitionAdminsInternalAsync(db, competitionId, ct);
+    }
+
+    private static Task<List<CompetitionAdminRowDto>> GetCompetitionAdminsInternalAsync(
+        MyDbContext db, int competitionId, CancellationToken ct)
+        => db.CompetitionAdmins.AsNoTracking()
+            .Where(ca => ca.CompetitionId == competitionId)
+            .Join(db.Users, ca => ca.UserId, u => u.Id,
+                  (ca, u) => new CompetitionAdminRowDto(ca.UserId, u.Email ?? "", ca.AssignedAt))
+            .ToListAsync(ct);
+
+    // ── Competition lifecycle ────────────────────────────────────────────────
+
+    public async Task<int> SaveCompetitionAsync(
+        int? competitionId, SaveCompetitionEditRequest request, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var name = request.CompetitionName.Trim();
+
+        var nameExists = await db.Competition.AsNoTracking()
+            .AnyAsync(c => (!competitionId.HasValue || c.CompetitionID != competitionId.Value)
+                           && c.CompetitionName.Trim().ToLower() == name.ToLower(), ct);
+        if (nameExists)
+            throw new InvalidOperationException($"A competition named \"{name}\" already exists.");
+
+        if (competitionId.HasValue && competitionId.Value > 0)
+        {
+            var comp = await db.Competition.FirstOrDefaultAsync(c => c.CompetitionID == competitionId.Value, ct)
+                ?? throw new KeyNotFoundException("Competition not found.");
+
+            if (!await authzService.CanEditCompetitionAsync(CurrentUser, comp.HostClubId, comp.CompetitionID))
+                throw new UnauthorizedAccessException("You can't edit this competition.");
+
+            ApplyRequestToEntity(comp, request, name);
+            await db.SaveChangesAsync(ct);
+            return comp.CompetitionID;
+        }
+        else
+        {
+            if (!await CanEditCompetitionAsync(null, ct))
+                throw new UnauthorizedAccessException("You can't create a competition.");
+
+            var comp = new Competition();
+            ApplyRequestToEntity(comp, request, name);
+            if (comp.HostClubId is null)
+                comp.CreatorUserId = userManager.GetUserId(CurrentUser);
+            else
+                comp.CreatorUserId = null;
+
+            db.Competition.Add(comp);
+            await db.SaveChangesAsync(ct);
+            return comp.CompetitionID;
+        }
+    }
+
+    private static void ApplyRequestToEntity(Competition comp, SaveCompetitionEditRequest req, string name)
+    {
+        comp.CompetitionName = name;
+        comp.CompetitionFormat = req.CompetitionFormat;
+        comp.EligibleSex = req.EligibleSex;
+        comp.MaxParticipants = req.MaxParticipants;
+        comp.StartDate = req.StartDate;
+        comp.EndDate = req.EndDate;
+        comp.RegisterByDate = req.RegisterByDate;
+        comp.MaxAge = req.MaxAge;
+        comp.MinAge = req.MinAge;
+        comp.HostClubId = req.HostClubId;
+        comp.RulesSetId = req.RulesSetId;
+        comp.EventId = req.EventId;
+        comp.BestOf = req.BestOf;
+        comp.RequireVerification = req.RequireVerification;
+        comp.TeamSize = req.TeamSize;
+        comp.RubberTemplateKey = req.RubberTemplateKey;
+        comp.MatchFormat = req.MatchFormat;
+        comp.NumberOfSets = req.NumberOfSets;
+        comp.GamesPerSet = req.GamesPerSet;
+        comp.SetWinMode = req.SetWinMode;
+        comp.LeagueScoring = req.LeagueScoring;
+        comp.RubberTieBreak = req.RubberTieBreak;
+        comp.MinDaysBetweenPlayerMatches = req.MinDaysBetweenPlayerMatches;
+        comp.HasDivisions = req.HasDivisions;
+        comp.SeededFromCompetitionId = req.SeededFromCompetitionId;
+        comp.IsRestricted = req.IsRestricted;
+    }
+
+    public async Task<CloneCompetitionResultDto> CloneCompetitionAsync(
+        int sourceCompetitionId, CloneCompetitionRequest request, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var source = await db.Competition
+            .Include(c => c.Stages)
+            .Include(c => c.RubberTemplate!).ThenInclude(rt => rt.Rubbers)
+            .FirstOrDefaultAsync(c => c.CompetitionID == sourceCompetitionId, ct)
+            ?? throw new KeyNotFoundException("Source competition not found.");
+
+        if (!await authzService.CanEditCompetitionAsync(CurrentUser, source.HostClubId, sourceCompetitionId))
+            throw new UnauthorizedAccessException("You can't clone this competition.");
+
+        var newComp = new Competition
+        {
+            CompetitionName             = request.NewName.Trim(),
+            CompetitionFormat           = source.CompetitionFormat,
+            HostClubId                  = source.HostClubId,
+            CreatorUserId               = source.HostClubId == null ? source.CreatorUserId : null,
+            MaxParticipants             = source.MaxParticipants,
+            MaxAge                      = source.MaxAge,
+            MinAge                      = source.MinAge,
+            EligibleSex                 = source.EligibleSex,
+            RulesSetId                  = source.RulesSetId,
+            EventId                     = source.EventId,
+            HasDivisions                = source.HasDivisions,
+            BestOf                      = source.BestOf,
+            MatchFormat                 = source.MatchFormat,
+            NumberOfSets                = source.NumberOfSets,
+            GamesPerSet                 = source.GamesPerSet,
+            SetWinMode                  = source.SetWinMode,
+            LeagueScoring               = source.LeagueScoring,
+            RubberTieBreak              = source.RubberTieBreak,
+            MinDaysBetweenPlayerMatches = source.MinDaysBetweenPlayerMatches,
+            TeamSize                    = source.TeamSize,
+            RubberTemplateKey           = source.RubberTemplateKey,
+            RequireVerification         = source.RequireVerification,
+            IsRestricted                = source.IsRestricted,
+            SeededFromCompetitionId     = sourceCompetitionId,
+        };
+        db.Competition.Add(newComp);
+        await db.SaveChangesAsync(ct);
+
+        foreach (var stage in source.Stages.OrderBy(s => s.StageOrder))
+        {
+            db.CompetitionStages.Add(new CompetitionStage
+            {
+                CompetitionId = newComp.CompetitionID,
+                Name          = stage.Name,
+                StageOrder    = stage.StageOrder,
+                StageType     = stage.StageType,
+            });
+        }
+
+        if (source.RubberTemplate?.Rubbers.Count > 0)
+        {
+            var newTemplate = new CompetitionRubberTemplate { CompetitionId = newComp.CompetitionID };
+            db.CompetitionRubberTemplates.Add(newTemplate);
+            await db.SaveChangesAsync(ct);
+            foreach (var r in source.RubberTemplate.Rubbers.OrderBy(r => r.Order))
+            {
+                db.RubberTemplateRubbers.Add(new RubberTemplateRubber
+                {
+                    CompetitionRubberTemplateId = newTemplate.CompetitionRubberTemplateId,
+                    Order         = r.Order,
+                    Name          = r.Name,
+                    CourtNumber   = r.CourtNumber,
+                    HomeRolesJson = r.HomeRolesJson,
+                    AwayRolesJson = r.AwayRolesJson,
+                });
+            }
+        }
+
+        if (request.CopyParticipants)
+        {
+            var toClone = await db.CompetitionParticipants
+                .Where(p => p.CompetitionId == sourceCompetitionId
+                            && p.Status != ParticipantStatus.Withdrawn
+                            && p.Status != ParticipantStatus.Disqualified)
+                .ToListAsync(ct);
+            foreach (var p in toClone)
+            {
+                db.CompetitionParticipants.Add(new CompetitionParticipant
+                {
+                    CompetitionId = newComp.CompetitionID,
+                    PlayerId      = p.PlayerId,
+                    RegisteredAt  = DateTime.UtcNow,
+                    Status        = ParticipantStatus.Registered,
+                });
+            }
+        }
+
+        await db.SaveChangesAsync(ct);
+        return new CloneCompetitionResultDto(newComp.CompetitionID);
+    }
+
+    public async Task<bool> ToggleStartedAsync(int competitionId, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var comp = await db.Competition.FindAsync([competitionId], ct)
+            ?? throw new KeyNotFoundException("Competition not found.");
+
+        if (!await authzService.CanEditCompetitionAsync(CurrentUser, comp.HostClubId, competitionId))
+            throw new UnauthorizedAccessException("You can't edit this competition.");
+
+        comp.IsStarted = !comp.IsStarted;
+        await db.SaveChangesAsync(ct);
+        return comp.IsStarted;
+    }
+
+    // ── Stages ───────────────────────────────────────────────────────────────
+
+    public async Task ApplyStageFollowUpAsync(
+        int competitionId, ApplyStageFollowUpRequest request, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var comp = await db.Competition
+            .Include(c => c.Stages)
+            .FirstOrDefaultAsync(c => c.CompetitionID == competitionId, ct)
+            ?? throw new KeyNotFoundException("Competition not found.");
+
+        if (!await authzService.CanEditCompetitionAsync(CurrentUser, comp.HostClubId, competitionId))
+            throw new UnauthorizedAccessException("You can't edit this competition.");
+
+        foreach (var type in request.StageTypes)
+        {
+            db.CompetitionStages.Add(new CompetitionStage
+            {
+                CompetitionId = competitionId,
+                Name          = StageDisplayName(type),
+                StageOrder    = 0,
+                StageType     = type,
+            });
+        }
+        await db.SaveChangesAsync(ct);
+
+        var stages = await db.CompetitionStages
+            .Where(s => s.CompetitionId == competitionId)
+            .ToListAsync(ct);
+        var ordered = stages.OrderBy(s => StageTypeSortKey(s.StageType)).ToList();
+        for (int i = 0; i < ordered.Count; i++) ordered[i].StageOrder = i;
+        await db.SaveChangesAsync(ct);
+    }
+
+    // ── Admins ───────────────────────────────────────────────────────────────
+
+    public async Task AddCompetitionAdminAsync(
+        int competitionId, AddCompetitionAdminRequest request, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var comp = await db.Competition.AsNoTracking()
+            .FirstOrDefaultAsync(c => c.CompetitionID == competitionId, ct)
+            ?? throw new KeyNotFoundException("Competition not found.");
+        if (!await authzService.CanEditCompetitionAsync(CurrentUser, comp.HostClubId, competitionId))
+            throw new UnauthorizedAccessException("You can't manage admins for this competition.");
+
+        var email = request.Email.Trim();
+        var user = await db.Users.FirstOrDefaultAsync(u => u.Email == email, ct)
+            ?? throw new KeyNotFoundException("No user with that email.");
+        var alreadyAdmin = await db.CompetitionAdmins
+            .AnyAsync(ca => ca.CompetitionId == competitionId && ca.UserId == user.Id, ct);
+        if (alreadyAdmin)
+            throw new InvalidOperationException("That user is already an admin of this competition.");
+
+        db.CompetitionAdmins.Add(new CompetitionAdmin
+        {
+            CompetitionId = competitionId,
+            UserId        = user.Id,
+            AssignedAt    = DateTime.UtcNow,
+        });
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task RemoveCompetitionAdminAsync(int competitionId, string userId, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var comp = await db.Competition.AsNoTracking()
+            .FirstOrDefaultAsync(c => c.CompetitionID == competitionId, ct)
+            ?? throw new KeyNotFoundException("Competition not found.");
+        if (!await authzService.CanEditCompetitionAsync(CurrentUser, comp.HostClubId, competitionId))
+            throw new UnauthorizedAccessException("You can't manage admins for this competition.");
+
+        var ca = await db.CompetitionAdmins.FindAsync([competitionId, userId], ct);
+        if (ca is null) return;
+        db.CompetitionAdmins.Remove(ca);
+        await db.SaveChangesAsync(ct);
+    }
+
+    // ── Rubber template ──────────────────────────────────────────────────────
+
+    public async Task<RubberTemplateStateDto> LoadRubberTemplateStateAsync(int competitionId, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var comp = await db.Competition.AsNoTracking()
+            .Include(c => c.RubberTemplate).ThenInclude(t => t!.Rubbers)
+            .FirstOrDefaultAsync(c => c.CompetitionID == competitionId, ct)
+            ?? throw new KeyNotFoundException("Competition not found.");
+        return await LoadRubberTemplateStateInternalAsync(db, comp, ct);
+    }
+
+    private async Task<RubberTemplateStateDto> LoadRubberTemplateStateInternalAsync(
+        MyDbContext db, Competition comp, CancellationToken ct)
+    {
+        string source;
+        string? selectedKey;
+        if (comp.RubberTemplate is { Rubbers.Count: > 0 })
+        {
+            source = "custom";
+            selectedKey = null;
+        }
+        else if (!string.IsNullOrEmpty(comp.RubberTemplateKey))
+        {
+            source = "preset";
+            selectedKey = comp.RubberTemplateKey;
+        }
+        else
+        {
+            source = "default";
+            selectedKey = null;
+        }
+
+        var template = await rubberTemplateProvider.GetAsync(db, comp.CompetitionID);
+        var defs = template?.ToList() ?? [];
+        var roles = RubberTemplateRegistry.GetRoleSet(template).ToList();
+        var presets = RubberTemplateRegistry.AvailablePresets()
+            .Select(p => new RubberPresetDto(p.Key, p.Label))
+            .ToList();
+        return new RubberTemplateStateDto(source, selectedKey, defs, presets, roles);
+    }
+
+    public async Task ApplyRubberPresetAsync(
+        int competitionId, ApplyRubberPresetRequest request, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var comp = await db.Competition
+            .FirstOrDefaultAsync(c => c.CompetitionID == competitionId, ct)
+            ?? throw new KeyNotFoundException("Competition not found.");
+        if (!await authzService.CanEditCompetitionAsync(CurrentUser, comp.HostClubId, competitionId))
+            throw new UnauthorizedAccessException("You can't edit this competition.");
+
+        comp.RubberTemplateKey = string.IsNullOrWhiteSpace(request.PresetKey) ? null : request.PresetKey;
+        var custom = await db.CompetitionRubberTemplates
+            .FirstOrDefaultAsync(t => t.CompetitionId == competitionId, ct);
+        if (custom is not null) db.CompetitionRubberTemplates.Remove(custom);
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task ConvertToCustomTemplateAsync(int competitionId, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var comp = await db.Competition
+            .Include(c => c.RubberTemplate).ThenInclude(t => t!.Rubbers)
+            .FirstOrDefaultAsync(c => c.CompetitionID == competitionId, ct)
+            ?? throw new KeyNotFoundException("Competition not found.");
+        if (!await authzService.CanEditCompetitionAsync(CurrentUser, comp.HostClubId, competitionId))
+            throw new UnauthorizedAccessException("You can't edit this competition.");
+
+        var resolved = await rubberTemplateProvider.GetAsync(db, competitionId);
+        if (resolved is null || resolved.Count == 0) return;
+
+        if (comp.RubberTemplate is null)
+        {
+            comp.RubberTemplate = new CompetitionRubberTemplate { CompetitionId = competitionId };
+            db.CompetitionRubberTemplates.Add(comp.RubberTemplate);
+        }
+        else
+        {
+            db.RubberTemplateRubbers.RemoveRange(comp.RubberTemplate.Rubbers);
+            comp.RubberTemplate.Rubbers.Clear();
+        }
+
+        int order = 1;
+        foreach (var def in resolved)
+        {
+            comp.RubberTemplate.Rubbers.Add(new RubberTemplateRubber
+            {
+                Order       = order++,
+                Name        = def.Name,
+                CourtNumber = def.CourtNumber,
+                HomeRoles   = def.HomeRoles.ToList(),
+                AwayRoles   = def.AwayRoles.ToList(),
+            });
+        }
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task AddCustomRubberRowAsync(int competitionId, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var comp = await db.Competition.AsNoTracking()
+            .FirstOrDefaultAsync(c => c.CompetitionID == competitionId, ct)
+            ?? throw new KeyNotFoundException("Competition not found.");
+        if (!await authzService.CanEditCompetitionAsync(CurrentUser, comp.HostClubId, competitionId))
+            throw new UnauthorizedAccessException("You can't edit this competition.");
+
+        var template = await db.CompetitionRubberTemplates
+            .Include(t => t.Rubbers)
+            .FirstOrDefaultAsync(t => t.CompetitionId == competitionId, ct)
+            ?? throw new InvalidOperationException("No custom template — convert first.");
+
+        int nextOrder = template.Rubbers.Count == 0 ? 1 : template.Rubbers.Max(r => r.Order) + 1;
+        template.Rubbers.Add(new RubberTemplateRubber
+        {
+            Order       = nextOrder,
+            Name        = "Rubber " + nextOrder,
+            CourtNumber = 1,
+            HomeRoles   = ["A"],
+            AwayRoles   = ["A"],
+        });
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task SaveRubberRowAsync(
+        int competitionId, SaveRubberRowRequest request, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var comp = await db.Competition.AsNoTracking()
+            .FirstOrDefaultAsync(c => c.CompetitionID == competitionId, ct)
+            ?? throw new KeyNotFoundException("Competition not found.");
+        if (!await authzService.CanEditCompetitionAsync(CurrentUser, comp.HostClubId, competitionId))
+            throw new UnauthorizedAccessException("You can't edit this competition.");
+
+        var row = await db.RubberTemplateRubbers
+            .Include(r => r.Template)
+            .FirstOrDefaultAsync(r =>
+                r.Template.CompetitionId == competitionId && r.Order == request.Order, ct)
+            ?? throw new KeyNotFoundException("Rubber row not found.");
+
+        row.Name        = string.IsNullOrWhiteSpace(request.Name) ? row.Name : request.Name.Trim();
+        row.CourtNumber = request.CourtNumber < 1 ? 1 : request.CourtNumber;
+        row.HomeRoles   = request.HomeRoles.ToList();
+        row.AwayRoles   = request.AwayRoles.ToList();
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task DeleteCustomRubberRowAsync(int competitionId, int order, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var comp = await db.Competition.AsNoTracking()
+            .FirstOrDefaultAsync(c => c.CompetitionID == competitionId, ct)
+            ?? throw new KeyNotFoundException("Competition not found.");
+        if (!await authzService.CanEditCompetitionAsync(CurrentUser, comp.HostClubId, competitionId))
+            throw new UnauthorizedAccessException("You can't edit this competition.");
+
+        var row = await db.RubberTemplateRubbers
+            .Include(r => r.Template)
+            .FirstOrDefaultAsync(r => r.Template.CompetitionId == competitionId && r.Order == order, ct);
+        if (row is null) return;
+        db.RubberTemplateRubbers.Remove(row);
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task RevertToDefaultTemplateAsync(int competitionId, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var comp = await db.Competition
+            .FirstOrDefaultAsync(c => c.CompetitionID == competitionId, ct)
+            ?? throw new KeyNotFoundException("Competition not found.");
+        if (!await authzService.CanEditCompetitionAsync(CurrentUser, comp.HostClubId, competitionId))
+            throw new UnauthorizedAccessException("You can't edit this competition.");
+
+        comp.RubberTemplateKey = null;
+        var custom = await db.CompetitionRubberTemplates
+            .FirstOrDefaultAsync(t => t.CompetitionId == competitionId, ct);
+        if (custom is not null) db.CompetitionRubberTemplates.Remove(custom);
+        await db.SaveChangesAsync(ct);
+    }
+
+    // ── Email ────────────────────────────────────────────────────────────────
+
+    public async Task SendMatchEmailAsync(
+        int competitionId, SendMatchEmailRequest request, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var comp = await db.Competition.AsNoTracking()
+            .FirstOrDefaultAsync(c => c.CompetitionID == competitionId, ct)
+            ?? throw new KeyNotFoundException("Competition not found.");
+        if (!await authzService.CanEditCompetitionAsync(CurrentUser, comp.HostClubId, competitionId))
+            throw new UnauthorizedAccessException("You can't email for this competition.");
+
+        var fixture = await db.CompetitionFixtures
+            .Include(f => f.Competition)
+            .Include(f => f.Player1).Include(f => f.Player2)
+            .Include(f => f.Player3).Include(f => f.Player4)
+            .FirstOrDefaultAsync(f => f.CompetitionFixtureId == request.FixtureId
+                                      && f.CompetitionId == competitionId, ct)
+            ?? throw new KeyNotFoundException("Fixture not found.");
+
+        await adminEmailService.SendMatchEmailAsync(fixture, request.Subject, request.Body);
+    }
+
+    public async Task SendCompetitionEmailAsync(
+        int competitionId, SendCompetitionEmailRequest request, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var comp = await db.Competition.AsNoTracking()
+            .FirstOrDefaultAsync(c => c.CompetitionID == competitionId, ct)
+            ?? throw new KeyNotFoundException("Competition not found.");
+        if (!await authzService.CanEditCompetitionAsync(CurrentUser, comp.HostClubId, competitionId))
+            throw new UnauthorizedAccessException("You can't email for this competition.");
+
+        var participants = await db.CompetitionParticipants
+            .Where(cp => cp.CompetitionId == competitionId)
+            .Include(cp => cp.Player)
+            .Select(cp => cp.Player!)
+            .Where(p => p != null && p.Email != null)
+            .ToListAsync(ct);
+
+        await adminEmailService.SendCompetitionEmailAsync(
+            participants, comp.CompetitionName, request.Subject, request.Body, competitionId);
+    }
+
+    // ── Projection helpers ───────────────────────────────────────────────────
+
+    private static CompetitionStageDto ToStageDto(CompetitionStage s) =>
+        new(s.CompetitionStageId, s.Name, s.StageOrder, s.StageType);
+
+    private static CompetitionParticipantDto ToParticipantDto(CompetitionParticipant p) =>
+        new(p.PlayerId, p.Player?.DisplayName ?? "", p.Status, p.RegisteredAt,
+            p.TeamId, p.Team?.Name, p.Player?.MobileNumber, p.Role, p.Player?.Sex,
+            p.CompetitionDivisionId, p.Division?.Name);
+
+    private static CompetitionDivisionDto ToDivisionDto(CompetitionDivision d) =>
+        new(d.CompetitionDivisionId, d.CompetitionId, d.Rank, d.Name);
+
+    private static CompetitionTeamDto ToTeamDto(CompetitionTeam t) =>
+        new(t.CompetitionTeamId, t.CompetitionId, t.Name,
+            t.CaptainPlayerId, t.Captain?.DisplayName, t.CompetitionDivisionId);
+
+    private static CompetitionMatchWindowDto ToMatchWindowDto(CompetitionMatchWindow w) =>
+        new(w.CompetitionMatchWindowId, w.CompetitionId,
+            w.CourtId, w.Court?.Name, w.CompetitionDivisionId, w.Division?.Name,
+            w.DayOfWeek, w.StartTime, w.EndTime);
+
+    private static CompetitionFixtureDto ToFixtureDto(CompetitionFixture f) =>
+        new(f.CompetitionFixtureId, f.CompetitionId,
+            f.CompetitionStageId, f.Stage?.Name,
+            f.CourtId, f.Court?.Name,
+            f.ScheduledAt, f.Status, f.FixtureLabel, f.RoundNumber,
+            f.Player1Id, f.Player1?.DisplayName,
+            f.Player2Id, f.Player2?.DisplayName,
+            f.Player3Id, f.Player3?.DisplayName,
+            f.Player4Id, f.Player4?.DisplayName,
+            f.ResultSummary, f.WinnerPlayerId,
+            f.HomeTeamId, f.HomeTeam?.Name,
+            f.AwayTeamId, f.AwayTeam?.Name,
+            f.WinnerTeamId,
+            f.CourtPairId,
+            f.CourtPair != null
+                ? (f.CourtPair.Name ?? $"{f.CourtPair.Court1?.Name} + {f.CourtPair.Court2?.Name}")
+                : null,
+            null, // Rubbers — admin view doesn't need them at this granularity
+            f.CompletedAt,
+            f.OriginalResultSummary,
+            f.ResultModifiedByAdmin,
+            f.Competition?.CompetitionName);
+
+    private static string StageDisplayName(StageType type) => type switch
+    {
+        StageType.RoundRobin   => "Round Robin",
+        StageType.Knockout     => "Knockout",
+        StageType.QuarterFinal => "Quarter-Final",
+        StageType.SemiFinal    => "Semi-Final",
+        StageType.Final        => "Final",
+        _                      => type.ToString(),
+    };
+
+    private static int StageTypeSortKey(StageType type) => type switch
+    {
+        StageType.RoundRobin   => 0,
+        StageType.QuarterFinal => 1,
+        StageType.SemiFinal    => 2,
+        StageType.Knockout     => 3,
+        StageType.Final        => 4,
+        _                      => 99,
+    };
+}


### PR DESCRIPTION
## Summary

The architectural commit for the CompetitionPage migration. Stands up a new admin-side service tier sibling to ``ICompetitionService``, with read-side queries (fat ``GetCompetitionForEditAsync``, lookups, authz flags) plus the writes that don't share entities with other sections (stages, admins, clone, comp-save, rubber template, email).

PR 7O follows with the coupled writes (participants, divisions, teams, fixtures, scheduler, simulator).

## Design notes

- New service ``ICompetitionAdminService`` lives alongside ``ICompetitionService`` in ``DropShot.UI/Services/``. Splitting by audience keeps the player-facing service at 21 methods instead of pushing it past 50 with ~30 admin methods. Also matches the new ``/api/competitions/admin/*`` route prefix.
- ``GetCompetitionForEditAsync(int? id)`` returns a fat ``CompetitionEditDto`` that bundles every list the page needs at initial load: competition + stages + participants + divisions + teams + fixtures + match windows + court pairs + rubber template state + admins + clone-source candidates + lookup tables (clubs, rules sets, events, host-club courts, club templates, competition templates, email templates). One round-trip mirrors the page's current EF block.
- When ``id`` is null/0, returns a create-mode payload (defaults + lookup tables, no entity data).
- ``WebCompetitionAdminService`` injects ``IDbContextFactory<MyDbContext>``, ``ClubAuthorizationService``, ``IHttpContextAccessor``, ``UserManager<ApplicationUser>``, ``ICompetitionRubberTemplateProvider``, ``AdminEmailService`` — the six server-only dependencies the page currently injects directly. After PR 7U the page injects only ``ICompetitionAdminService``.
- ``HttpCompetitionAdminService`` follows the existing ``HttpCompetitionService`` pattern: ``HttpClient`` injection only, ``GetFromJsonAsync`` / ``PostAsJsonAsync`` / ``EnsureSuccessStatusCode``.
- ``CompetitionsAdminController`` is a sibling to ``CompetitionsController`` rather than an extension — simpler review, cleaner separation. Authorization is delegated to the service (which throws ``UnauthorizedAccessException``); the controller catches and returns ``Forbid()``.
- One DTO tightening (carry-over from PR 7M scaffolding): ``CompetitionEditDto.RubberTemplate`` field type changed from ``RubberTemplateDto?`` to ``RubberTemplateStateDto?`` — the new admin-rich shape includes the available presets list + role set, which the rubber template section needs.

## Methods on the new service

**Read:** ``GetCompetitionForEditAsync``, ``GetSeedSourceCandidatesAsync``, ``GetClubTemplatesAsync``, ``GetEmailTemplatesAsync``, ``GetCompetitionAdminsAsync``, ``CanEditCompetitionAsync``, ``IsSuperAdminAsync``.

**Lifecycle:** ``SaveCompetitionAsync`` (create + update), ``CloneCompetitionAsync``, ``ToggleStartedAsync``.

**Stages:** ``ApplyStageFollowUpAsync``.

**Admins:** ``AddCompetitionAdminAsync``, ``RemoveCompetitionAdminAsync``.

**Rubber template:** ``LoadRubberTemplateStateAsync``, ``ApplyRubberPresetAsync``, ``ConvertToCustomTemplateAsync``, ``AddCustomRubberRowAsync``, ``SaveRubberRowAsync``, ``DeleteCustomRubberRowAsync``, ``RevertToDefaultTemplateAsync``.

**Email:** ``SendMatchEmailAsync``, ``SendCompetitionEmailAsync``.

## Test plan

- [x] ``dotnet build DropShot.sln`` — 0 errors.
- [x] ``dotnet test DropShot.Tests`` — 28/28 pass.
- [x] ``DropShot.Maui`` builds across all 4 TFMs (covered by sln build).

The page still uses its existing EF code paths — nothing consumes ``ICompetitionAdminService`` yet. Section moves (PR 7P–7T) and parent move (PR 7U) start consuming it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)