### PR TITLE
Phase 7 PR 7O: ICompetitionAdminService coupled writes

### DIFF
--- a/DropShot.Maui/Services/HttpCompetitionAdminService.cs
+++ b/DropShot.Maui/Services/HttpCompetitionAdminService.cs
@@ -182,4 +182,313 @@ public sealed class HttpCompetitionAdminService(HttpClient http) : ICompetitionA
             $"api/competitions/admin/{competitionId}/email/competition", request, ct);
         resp.EnsureSuccessStatusCode();
     }
+
+    // ── Participants ─────────────────────────────────────────────────────────
+
+    public async Task<List<PlayerSearchResultDto>> SearchPlayersAsync(
+        int competitionId, SearchPlayersForAddRequest request, CancellationToken ct = default)
+    {
+        var resp = await http.PostAsJsonAsync(
+            $"api/competitions/admin/{competitionId}/participants/search", request, ct);
+        resp.EnsureSuccessStatusCode();
+        return await resp.Content.ReadFromJsonAsync<List<PlayerSearchResultDto>>(cancellationToken: ct) ?? [];
+    }
+
+    public async Task AddParticipantAsync(int competitionId, AddParticipantRequest request, CancellationToken ct = default)
+    {
+        var resp = await http.PostAsJsonAsync(
+            $"api/competitions/admin/{competitionId}/participants", request, ct);
+        if (!resp.IsSuccessStatusCode)
+        {
+            var body = await resp.Content.ReadAsStringAsync(ct);
+            throw new InvalidOperationException(string.IsNullOrEmpty(body) ? resp.ReasonPhrase ?? "Failed to add participant." : body);
+        }
+    }
+
+    public async Task RemoveParticipantAsync(int competitionId, int playerId, CancellationToken ct = default)
+    {
+        var resp = await http.DeleteAsync($"api/competitions/admin/{competitionId}/participants/{playerId}", ct);
+        resp.EnsureSuccessStatusCode();
+    }
+
+    public async Task UpdateParticipantStatusAsync(
+        int competitionId, int playerId, UpdateParticipantStatusRequest request, CancellationToken ct = default)
+    {
+        var resp = await http.PutAsJsonAsync(
+            $"api/competitions/admin/{competitionId}/participants/{playerId}/status", request, ct);
+        resp.EnsureSuccessStatusCode();
+    }
+
+    public async Task AssignParticipantTeamAsync(
+        int competitionId, int playerId, AssignParticipantTeamRequest request, CancellationToken ct = default)
+    {
+        var resp = await http.PutAsJsonAsync(
+            $"api/competitions/admin/{competitionId}/participants/{playerId}/team", request, ct);
+        resp.EnsureSuccessStatusCode();
+    }
+
+    public async Task AssignParticipantRoleAsync(
+        int competitionId, int playerId, SetParticipantRoleRequest request, CancellationToken ct = default)
+    {
+        var resp = await http.PutAsJsonAsync(
+            $"api/competitions/admin/{competitionId}/participants/{playerId}/role", request, ct);
+        resp.EnsureSuccessStatusCode();
+    }
+
+    public async Task AssignParticipantDivisionAsync(
+        int competitionId, int playerId, SetParticipantDivisionRequest request, CancellationToken ct = default)
+    {
+        var resp = await http.PutAsJsonAsync(
+            $"api/competitions/admin/{competitionId}/participants/{playerId}/division", request, ct);
+        resp.EnsureSuccessStatusCode();
+    }
+
+    public async Task<int> CreateLightPlayerAsync(
+        int competitionId, CreateLightPlayerForCompetitionRequest request, CancellationToken ct = default)
+    {
+        var resp = await http.PostAsJsonAsync(
+            $"api/competitions/admin/{competitionId}/light-players", request, ct);
+        if (!resp.IsSuccessStatusCode)
+        {
+            var body = await resp.Content.ReadAsStringAsync(ct);
+            throw new InvalidOperationException(string.IsNullOrEmpty(body) ? resp.ReasonPhrase ?? "Failed to create light player." : body);
+        }
+        return await resp.Content.ReadFromJsonAsync<int>(cancellationToken: ct);
+    }
+
+    public async Task SaveLightPlayerAsync(
+        int competitionId, int playerId, SaveLightPlayerRequest request, CancellationToken ct = default)
+    {
+        var resp = await http.PutAsJsonAsync(
+            $"api/competitions/admin/{competitionId}/light-players/{playerId}", request, ct);
+        resp.EnsureSuccessStatusCode();
+    }
+
+    // ── Divisions ────────────────────────────────────────────────────────────
+
+    public async Task<int> SaveDivisionAsync(
+        int competitionId, int? divisionId, SaveDivisionRequest request, CancellationToken ct = default)
+    {
+        var resp = divisionId.HasValue
+            ? await http.PutAsJsonAsync($"api/competitions/admin/{competitionId}/divisions/{divisionId.Value}", request, ct)
+            : await http.PostAsJsonAsync($"api/competitions/admin/{competitionId}/divisions", request, ct);
+        if (!resp.IsSuccessStatusCode)
+        {
+            var body = await resp.Content.ReadAsStringAsync(ct);
+            throw new InvalidOperationException(string.IsNullOrEmpty(body) ? resp.ReasonPhrase ?? "Failed to save division." : body);
+        }
+        return await resp.Content.ReadFromJsonAsync<int>(cancellationToken: ct);
+    }
+
+    public async Task DeleteDivisionAsync(int competitionId, int divisionId, CancellationToken ct = default)
+    {
+        var resp = await http.DeleteAsync(
+            $"api/competitions/admin/{competitionId}/divisions/{divisionId}", ct);
+        resp.EnsureSuccessStatusCode();
+    }
+
+    public async Task RunSeedDivisionsAsync(
+        int competitionId, SeedDivisionsFromPreviousRequest request, CancellationToken ct = default)
+    {
+        var resp = await http.PostAsJsonAsync(
+            $"api/competitions/admin/{competitionId}/divisions/seed", request, ct);
+        if (!resp.IsSuccessStatusCode)
+        {
+            var body = await resp.Content.ReadAsStringAsync(ct);
+            throw new InvalidOperationException(string.IsNullOrEmpty(body) ? resp.ReasonPhrase ?? "Failed to seed divisions." : body);
+        }
+    }
+
+    public async Task AssignTeamDivisionAsync(
+        int competitionId, int teamId, AssignTeamDivisionRequest request, CancellationToken ct = default)
+    {
+        var resp = await http.PutAsJsonAsync(
+            $"api/competitions/admin/{competitionId}/teams/{teamId}/division", request, ct);
+        resp.EnsureSuccessStatusCode();
+    }
+
+    // ── Teams ────────────────────────────────────────────────────────────────
+
+    public async Task<int> SaveTeamAsync(
+        int competitionId, int? teamId, SaveTeamRequest request, CancellationToken ct = default)
+    {
+        var resp = teamId.HasValue
+            ? await http.PutAsJsonAsync($"api/competitions/admin/{competitionId}/teams/{teamId.Value}", request, ct)
+            : await http.PostAsJsonAsync($"api/competitions/admin/{competitionId}/teams", request, ct);
+        if (!resp.IsSuccessStatusCode)
+        {
+            var body = await resp.Content.ReadAsStringAsync(ct);
+            throw new InvalidOperationException(string.IsNullOrEmpty(body) ? resp.ReasonPhrase ?? "Failed to save team." : body);
+        }
+        return await resp.Content.ReadFromJsonAsync<int>(cancellationToken: ct);
+    }
+
+    public async Task DeleteTeamAsync(int competitionId, int teamId, CancellationToken ct = default)
+    {
+        var resp = await http.DeleteAsync($"api/competitions/admin/{competitionId}/teams/{teamId}", ct);
+        resp.EnsureSuccessStatusCode();
+    }
+
+    public async Task DeleteAllTeamsAsync(int competitionId, CancellationToken ct = default)
+    {
+        var resp = await http.DeleteAsync($"api/competitions/admin/{competitionId}/teams", ct);
+        resp.EnsureSuccessStatusCode();
+    }
+
+    public async Task AssignCaptainAsync(
+        int competitionId, AssignCaptainRequest request, CancellationToken ct = default)
+    {
+        var resp = await http.PostAsJsonAsync(
+            $"api/competitions/admin/{competitionId}/teams/captain", request, ct);
+        resp.EnsureSuccessStatusCode();
+    }
+
+    public async Task<int> AutoAssignCaptainsAsync(int competitionId, CancellationToken ct = default)
+    {
+        var resp = await http.PostAsync($"api/competitions/admin/{competitionId}/teams/auto-captain", null, ct);
+        resp.EnsureSuccessStatusCode();
+        return await resp.Content.ReadFromJsonAsync<int>(cancellationToken: ct);
+    }
+
+    public async Task<GenerateTeamsResultDto> GenerateTeamsPreviewAsync(
+        int competitionId, GenerateTeamsRequest request, CancellationToken ct = default)
+    {
+        var resp = await http.PostAsJsonAsync(
+            $"api/competitions/admin/{competitionId}/teams/generate-preview", request, ct);
+        resp.EnsureSuccessStatusCode();
+        return (await resp.Content.ReadFromJsonAsync<GenerateTeamsResultDto>(cancellationToken: ct))!;
+    }
+
+    public async Task ConfirmGenerateTeamsAsync(
+        int competitionId, ConfirmGenerateTeamsRequest request, CancellationToken ct = default)
+    {
+        var resp = await http.PostAsJsonAsync(
+            $"api/competitions/admin/{competitionId}/teams/generate-confirm", request, ct);
+        resp.EnsureSuccessStatusCode();
+    }
+
+    public async Task<ValidateTeamResultDto> ValidateTeamAsync(
+        int competitionId, int teamId, CancellationToken ct = default)
+        => (await http.GetFromJsonAsync<ValidateTeamResultDto>(
+            $"api/competitions/admin/{competitionId}/teams/{teamId}/validate", ct))!;
+
+    // ── Fixtures ─────────────────────────────────────────────────────────────
+
+    public async Task<int> SaveFixtureAsync(
+        int competitionId, int? fixtureId, SaveFixtureRequest request, CancellationToken ct = default)
+    {
+        var resp = fixtureId.HasValue
+            ? await http.PutAsJsonAsync($"api/competitions/admin/{competitionId}/fixtures/{fixtureId.Value}", request, ct)
+            : await http.PostAsJsonAsync($"api/competitions/admin/{competitionId}/fixtures", request, ct);
+        if (!resp.IsSuccessStatusCode)
+        {
+            var body = await resp.Content.ReadAsStringAsync(ct);
+            throw new InvalidOperationException(string.IsNullOrEmpty(body) ? resp.ReasonPhrase ?? "Failed to save fixture." : body);
+        }
+        return await resp.Content.ReadFromJsonAsync<int>(cancellationToken: ct);
+    }
+
+    public async Task DeleteFixtureAsync(int competitionId, int fixtureId, CancellationToken ct = default)
+    {
+        var resp = await http.DeleteAsync($"api/competitions/admin/{competitionId}/fixtures/{fixtureId}", ct);
+        if (!resp.IsSuccessStatusCode)
+        {
+            var body = await resp.Content.ReadAsStringAsync(ct);
+            throw new InvalidOperationException(string.IsNullOrEmpty(body) ? resp.ReasonPhrase ?? "Failed to delete fixture." : body);
+        }
+    }
+
+    public async Task DeleteAllFixturesAsync(int competitionId, CancellationToken ct = default)
+    {
+        var resp = await http.DeleteAsync($"api/competitions/admin/{competitionId}/fixtures", ct);
+        resp.EnsureSuccessStatusCode();
+    }
+
+    public async Task<CompetitionFixtureDto?> LoadFixtureForDialogAsync(
+        int competitionId, int fixtureId, CancellationToken ct = default)
+    {
+        var resp = await http.GetAsync($"api/competitions/admin/{competitionId}/fixtures/{fixtureId}/dialog", ct);
+        if (resp.StatusCode == System.Net.HttpStatusCode.NotFound) return null;
+        resp.EnsureSuccessStatusCode();
+        return await resp.Content.ReadFromJsonAsync<CompetitionFixtureDto>(cancellationToken: ct);
+    }
+
+    public async Task<ConfirmFixtureAssignmentResultDto> ConfirmFixtureAssignmentAsync(
+        int competitionId, ConfirmFixtureAssignmentRequest request, CancellationToken ct = default)
+    {
+        var resp = await http.PostAsJsonAsync(
+            $"api/competitions/admin/{competitionId}/fixtures/confirm-assignment", request, ct);
+        resp.EnsureSuccessStatusCode();
+        return (await resp.Content.ReadFromJsonAsync<ConfirmFixtureAssignmentResultDto>(cancellationToken: ct))!;
+    }
+
+    public async Task<ScheduleFixturesResultDto> ScheduleFixturesAsync(
+        int competitionId, ScheduleFixturesAdminRequest request, CancellationToken ct = default)
+    {
+        var resp = await http.PostAsJsonAsync(
+            $"api/competitions/admin/{competitionId}/fixtures/schedule", request, ct);
+        resp.EnsureSuccessStatusCode();
+        return (await resp.Content.ReadFromJsonAsync<ScheduleFixturesResultDto>(cancellationToken: ct))!;
+    }
+
+    public async Task<SimulateRoundRobinResultDto> SimulateRoundRobinAsync(int competitionId, CancellationToken ct = default)
+    {
+        var resp = await http.PostAsync(
+            $"api/competitions/admin/{competitionId}/fixtures/simulate-rr", null, ct);
+        resp.EnsureSuccessStatusCode();
+        return (await resp.Content.ReadFromJsonAsync<SimulateRoundRobinResultDto>(cancellationToken: ct))!;
+    }
+
+    public async Task<SeedKnockoutFromStandingsResultDto> SeedKnockoutFromStandingsAsync(
+        int competitionId, CancellationToken ct = default)
+    {
+        var resp = await http.PostAsync(
+            $"api/competitions/admin/{competitionId}/fixtures/seed-knockout", null, ct);
+        resp.EnsureSuccessStatusCode();
+        return (await resp.Content.ReadFromJsonAsync<SeedKnockoutFromStandingsResultDto>(cancellationToken: ct))!;
+    }
+
+    // ── Match windows ────────────────────────────────────────────────────────
+
+    public async Task<int> AddMatchWindowAsync(
+        int competitionId, SaveMatchWindowRequest request, CancellationToken ct = default)
+    {
+        var resp = await http.PostAsJsonAsync(
+            $"api/competitions/admin/{competitionId}/match-windows", request, ct);
+        if (!resp.IsSuccessStatusCode)
+        {
+            var body = await resp.Content.ReadAsStringAsync(ct);
+            throw new InvalidOperationException(string.IsNullOrEmpty(body) ? resp.ReasonPhrase ?? "Failed to add window." : body);
+        }
+        return await resp.Content.ReadFromJsonAsync<int>(cancellationToken: ct);
+    }
+
+    public async Task DeleteMatchWindowAsync(int competitionId, int matchWindowId, CancellationToken ct = default)
+    {
+        var resp = await http.DeleteAsync(
+            $"api/competitions/admin/{competitionId}/match-windows/{matchWindowId}", ct);
+        resp.EnsureSuccessStatusCode();
+    }
+
+    public async Task<int> AddDivisionMatchWindowAsync(
+        int competitionId, int divisionId, SaveMatchWindowRequest request, CancellationToken ct = default)
+    {
+        var resp = await http.PostAsJsonAsync(
+            $"api/competitions/admin/{competitionId}/divisions/{divisionId}/match-windows", request, ct);
+        if (!resp.IsSuccessStatusCode)
+        {
+            var body = await resp.Content.ReadAsStringAsync(ct);
+            throw new InvalidOperationException(string.IsNullOrEmpty(body) ? resp.ReasonPhrase ?? "Failed to add division window." : body);
+        }
+        return await resp.Content.ReadFromJsonAsync<int>(cancellationToken: ct);
+    }
+
+    public async Task<int> ImportMatchWindowsFromTemplateAsync(
+        int competitionId, ImportMatchWindowsFromTemplateRequest request, CancellationToken ct = default)
+    {
+        var resp = await http.PostAsJsonAsync(
+            $"api/competitions/admin/{competitionId}/match-windows/import-from-template", request, ct);
+        resp.EnsureSuccessStatusCode();
+        return await resp.Content.ReadFromJsonAsync<int>(cancellationToken: ct);
+    }
 }

--- a/DropShot.Shared/Dtos/CompetitionAdminDtos.cs
+++ b/DropShot.Shared/Dtos/CompetitionAdminDtos.cs
@@ -289,3 +289,62 @@ public record SearchPlayersForAddRequest(
     string Query,
     int? HostClubId,
     int? MaxResults = 20);
+
+// ── Phase 7O additions: roster / divisions / teams / fixtures / match windows ──
+//
+// Several admin requests reuse DTOs already defined in CompetitionDtos.cs
+// (AddParticipantRequest, UpdateParticipantStatusRequest, AssignParticipantTeamRequest,
+// SetParticipantRoleRequest, SetParticipantDivisionRequest, SaveDivisionRequest,
+// SaveTeamRequest, SaveFixtureRequest, SeedDivisionsFromPreviousRequest,
+// SeedDivisionsResultDto). The records below are admin-only types not present in
+// the player-facing surface.
+
+/// <summary>
+/// One row in the player-search results returned by
+/// <c>ICompetitionAdminService.SearchPlayersAsync</c>. Tight subset of the Player
+/// row — just enough for the add-participant search list.
+/// </summary>
+public record PlayerSearchResultDto(
+    int PlayerId,
+    string DisplayName,
+    PlayerSex? Sex,
+    DateTime? DateOfBirth,
+    string? ClubName,
+    bool IsLight);
+
+/// <summary>
+/// Set the division a team belongs to (or unassign with null). Distinct from
+/// <see cref="SetParticipantDivisionRequest"/>, which sets a participant's
+/// division — same shape, different semantics, kept as separate types so the
+/// route surface reads naturally.
+/// </summary>
+public record AssignTeamDivisionRequest(int? CompetitionDivisionId);
+
+/// <summary>
+/// Assign (or unassign with <c>PlayerId == null</c>) a captain on a team.
+/// Distinct from <c>SetTeamCaptainRequest</c> which only supports setting.
+/// </summary>
+public record AssignCaptainRequest(int CompetitionTeamId, int? PlayerId);
+
+public record ValidateTeamResultDto(
+    IReadOnlyList<string> Errors,
+    IReadOnlyList<string> Warnings);
+
+/// <summary>
+/// Pure-validator request: ask the service "would this assignment violate
+/// eligibility rules?" without persisting. Lets the caller decide whether to
+/// show a confirm dialog before saving.
+/// </summary>
+public record ConfirmFixtureAssignmentRequest(
+    int? Player1Id,
+    int? Player2Id,
+    int? Player3Id,
+    int? Player4Id,
+    int? HomeTeamId,
+    int? AwayTeamId);
+
+public record ConfirmFixtureAssignmentResultDto(
+    bool IsValid,
+    IReadOnlyList<string> Violations);
+
+

--- a/DropShot.Shared/Dtos/CompetitionDtos.cs
+++ b/DropShot.Shared/Dtos/CompetitionDtos.cs
@@ -214,7 +214,10 @@ public record SaveFixtureRequest(
     FixtureStatus Status,
     string? ResultSummary = null,
     int? WinnerPlayerId = null,
-    bool Force = false);
+    bool Force = false,
+    int? HomeTeamId = null,
+    int? AwayTeamId = null,
+    int? CourtPairId = null);
 
 public record SaveTeamRequest(string Name);
 

--- a/DropShot.UI/Services/ICompetitionAdminService.cs
+++ b/DropShot.UI/Services/ICompetitionAdminService.cs
@@ -135,4 +135,197 @@ public interface ICompetitionAdminService
     /// <summary>Send the configured email to every participant of the competition.</summary>
     Task SendCompetitionEmailAsync(
         int competitionId, SendCompetitionEmailRequest request, CancellationToken ct = default);
+
+    // ── Participants ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Search the player pool for the add-participant flow. When the
+    /// competition has a host club, results are restricted to that club's
+    /// roster; otherwise the global player set is searched. Excludes players
+    /// already enrolled in this competition. Honours competition gender / age
+    /// restrictions.
+    /// </summary>
+    Task<List<PlayerSearchResultDto>> SearchPlayersAsync(
+        int competitionId, SearchPlayersForAddRequest request, CancellationToken ct = default);
+
+    Task AddParticipantAsync(int competitionId, AddParticipantRequest request, CancellationToken ct = default);
+    Task RemoveParticipantAsync(int competitionId, int playerId, CancellationToken ct = default);
+
+    Task UpdateParticipantStatusAsync(
+        int competitionId, int playerId, UpdateParticipantStatusRequest request, CancellationToken ct = default);
+
+    Task AssignParticipantTeamAsync(
+        int competitionId, int playerId, AssignParticipantTeamRequest request, CancellationToken ct = default);
+
+    Task AssignParticipantRoleAsync(
+        int competitionId, int playerId, SetParticipantRoleRequest request, CancellationToken ct = default);
+
+    Task AssignParticipantDivisionAsync(
+        int competitionId, int playerId, SetParticipantDivisionRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Create a "light" Player (no user account) and immediately enrol them as
+    /// a participant. Returns the new playerId. <see cref="CreateLightPlayerForCompetitionRequest.HostClubId"/>
+    /// is required because light players are scoped to a club.
+    /// </summary>
+    Task<int> CreateLightPlayerAsync(
+        int competitionId, CreateLightPlayerForCompetitionRequest request, CancellationToken ct = default);
+
+    /// <summary>Update an existing light player's profile fields.</summary>
+    Task SaveLightPlayerAsync(
+        int competitionId, int playerId, SaveLightPlayerRequest request, CancellationToken ct = default);
+
+    // ── Divisions ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Create or update a division. Returns the saved division's id. Also
+    /// flips the competition's <c>HasDivisions</c> flag on first insert.
+    /// </summary>
+    Task<int> SaveDivisionAsync(
+        int competitionId, int? divisionId, SaveDivisionRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Delete a division. Nullifies the division reference on participants and
+    /// teams, deletes any division-scoped match windows, and removes the
+    /// division row.
+    /// </summary>
+    Task DeleteDivisionAsync(int competitionId, int divisionId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Seed divisions from a previously-completed competition: copy division
+    /// rows, then assign participants by their previous-competition rank.
+    /// When <c>ApplyPromotion</c> is true, also promote the top
+    /// <c>PromoteCount</c> finishers up one division and demote the bottom
+    /// <c>DemoteCount</c> down one.
+    /// </summary>
+    Task RunSeedDivisionsAsync(
+        int competitionId, SeedDivisionsFromPreviousRequest request, CancellationToken ct = default);
+
+    Task AssignTeamDivisionAsync(
+        int competitionId, int teamId, AssignTeamDivisionRequest request, CancellationToken ct = default);
+
+    // ── Teams ────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Create or update a team's name. Captain and division are managed via
+    /// dedicated methods (<see cref="AssignCaptainAsync"/> /
+    /// <see cref="AssignTeamDivisionAsync"/>).
+    /// </summary>
+    Task<int> SaveTeamAsync(
+        int competitionId, int? teamId, SaveTeamRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Delete a team. Nullifies <c>TeamId</c> on its participants (FK is
+    /// no-action) and removes the team row.
+    /// </summary>
+    Task DeleteTeamAsync(int competitionId, int teamId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Delete every team in the competition. Nullifies all
+    /// participant/fixture team refs and deletes any rubbers attached to
+    /// fixtures that lose both teams.
+    /// </summary>
+    Task DeleteAllTeamsAsync(int competitionId, CancellationToken ct = default);
+
+    Task AssignCaptainAsync(
+        int competitionId, AssignCaptainRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// For every captain-less team, pick a random <c>FullPlayer</c> participant
+    /// on that team and assign them as captain. Returns the number of teams
+    /// updated.
+    /// </summary>
+    Task<int> AutoAssignCaptainsAsync(int competitionId, CancellationToken ct = default);
+
+    Task<GenerateTeamsResultDto> GenerateTeamsPreviewAsync(
+        int competitionId, GenerateTeamsRequest request, CancellationToken ct = default);
+
+    Task ConfirmGenerateTeamsAsync(
+        int competitionId, ConfirmGenerateTeamsRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Validate a team's role assignments: every required role from the
+    /// competition's rubber template must be filled, with no duplicates and no
+    /// blanks. Pure read — no mutations.
+    /// </summary>
+    Task<ValidateTeamResultDto> ValidateTeamAsync(
+        int competitionId, int teamId, CancellationToken ct = default);
+
+    // ── Fixtures ─────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Create or update a fixture. Caller is responsible for validation —
+    /// call <see cref="ConfirmFixtureAssignmentAsync"/> first when the user
+    /// has changed the assignment.
+    /// </summary>
+    Task<int> SaveFixtureAsync(
+        int competitionId, int? fixtureId, SaveFixtureRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Delete a fixture. Cascades into its rubbers and saved-match rows. If
+    /// the fixture has a recorded result, downstream knockout fixtures that
+    /// inherited a winner from it are reset.
+    /// </summary>
+    Task DeleteFixtureAsync(int competitionId, int fixtureId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Delete every fixture in the competition. Cascades into rubbers and
+    /// saved matches.
+    /// </summary>
+    Task DeleteAllFixturesAsync(int competitionId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Load a single fixture for the edit dialog. Returns null when the
+    /// fixture doesn't exist or doesn't belong to this competition.
+    /// </summary>
+    Task<CompetitionFixtureDto?> LoadFixtureForDialogAsync(
+        int competitionId, int fixtureId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Validate a proposed fixture assignment without persisting. Returns
+    /// <c>IsValid=true</c> when no eligibility / pairing rules are violated;
+    /// otherwise the violation list explains why so the caller can prompt
+    /// the user to override.
+    /// </summary>
+    Task<ConfirmFixtureAssignmentResultDto> ConfirmFixtureAssignmentAsync(
+        int competitionId, ConfirmFixtureAssignmentRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Auto-schedule fixtures for the competition. Wraps
+    /// <c>CompetitionSchedulerService</c>; the request's <c>DeleteExistingUnscheduled</c>
+    /// flag maps to the scheduler's <c>UnscheduledOnly</c> delete mode.
+    /// </summary>
+    Task<ScheduleFixturesResultDto> ScheduleFixturesAsync(
+        int competitionId, ScheduleFixturesAdminRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Generate plausible random results for every incomplete round-robin
+    /// fixture. Super-admin only — wraps <c>FixtureSimulationService</c>.
+    /// </summary>
+    Task<SimulateRoundRobinResultDto> SimulateRoundRobinAsync(int competitionId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Populate the first round of the knockout stage by ranking participants
+    /// by their round-robin standings (or registration order when no RR
+    /// results exist). Pairs top seeds against bottom seeds in bracket order.
+    /// </summary>
+    Task<SeedKnockoutFromStandingsResultDto> SeedKnockoutFromStandingsAsync(
+        int competitionId, CancellationToken ct = default);
+
+    // ── Match windows ────────────────────────────────────────────────────────
+
+    Task<int> AddMatchWindowAsync(
+        int competitionId, SaveMatchWindowRequest request, CancellationToken ct = default);
+
+    Task DeleteMatchWindowAsync(int competitionId, int matchWindowId, CancellationToken ct = default);
+
+    Task<int> AddDivisionMatchWindowAsync(
+        int competitionId, int divisionId, SaveMatchWindowRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Append windows from a club scheduling template, skipping any (day,
+    /// start, end) tuple already present. Returns the number of windows added.
+    /// </summary>
+    Task<int> ImportMatchWindowsFromTemplateAsync(
+        int competitionId, ImportMatchWindowsFromTemplateRequest request, CancellationToken ct = default);
 }

--- a/DropShot/Controllers/CompetitionsAdminController.cs
+++ b/DropShot/Controllers/CompetitionsAdminController.cs
@@ -210,4 +210,344 @@ public class CompetitionsAdminController(
         catch (UnauthorizedAccessException) { return Forbid(); }
         catch (KeyNotFoundException) { return NotFound(); }
     }
+
+    // ── Participants ─────────────────────────────────────────────────────────
+
+    [HttpPost("{id:int}/participants/search")]
+    public async Task<ActionResult<List<PlayerSearchResultDto>>> SearchPlayers(
+        int id, [FromBody] SearchPlayersForAddRequest req, CancellationToken ct)
+    {
+        try { return await admin.SearchPlayersAsync(id, req, ct); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+    }
+
+    [HttpPost("{id:int}/participants")]
+    public async Task<IActionResult> AddParticipant(
+        int id, [FromBody] AddParticipantRequest req, CancellationToken ct)
+    {
+        try { await admin.AddParticipantAsync(id, req, ct); return NoContent(); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException ex) { return NotFound(new { message = ex.Message }); }
+        catch (InvalidOperationException ex) { return BadRequest(new { message = ex.Message }); }
+    }
+
+    [HttpDelete("{id:int}/participants/{playerId:int}")]
+    public async Task<IActionResult> RemoveParticipant(int id, int playerId, CancellationToken ct)
+    {
+        try { await admin.RemoveParticipantAsync(id, playerId, ct); return NoContent(); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+    }
+
+    [HttpPut("{id:int}/participants/{playerId:int}/status")]
+    public async Task<IActionResult> UpdateParticipantStatus(
+        int id, int playerId, [FromBody] UpdateParticipantStatusRequest req, CancellationToken ct)
+    {
+        try { await admin.UpdateParticipantStatusAsync(id, playerId, req, ct); return NoContent(); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+    }
+
+    [HttpPut("{id:int}/participants/{playerId:int}/team")]
+    public async Task<IActionResult> AssignParticipantTeam(
+        int id, int playerId, [FromBody] AssignParticipantTeamRequest req, CancellationToken ct)
+    {
+        try { await admin.AssignParticipantTeamAsync(id, playerId, req, ct); return NoContent(); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+    }
+
+    [HttpPut("{id:int}/participants/{playerId:int}/role")]
+    public async Task<IActionResult> AssignParticipantRole(
+        int id, int playerId, [FromBody] SetParticipantRoleRequest req, CancellationToken ct)
+    {
+        try { await admin.AssignParticipantRoleAsync(id, playerId, req, ct); return NoContent(); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+    }
+
+    [HttpPut("{id:int}/participants/{playerId:int}/division")]
+    public async Task<IActionResult> AssignParticipantDivision(
+        int id, int playerId, [FromBody] SetParticipantDivisionRequest req, CancellationToken ct)
+    {
+        try { await admin.AssignParticipantDivisionAsync(id, playerId, req, ct); return NoContent(); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+    }
+
+    [HttpPost("{id:int}/light-players")]
+    public async Task<ActionResult<int>> CreateLightPlayer(
+        int id, [FromBody] CreateLightPlayerForCompetitionRequest req, CancellationToken ct)
+    {
+        try { return await admin.CreateLightPlayerAsync(id, req, ct); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+        catch (InvalidOperationException ex) { return BadRequest(new { message = ex.Message }); }
+    }
+
+    [HttpPut("{id:int}/light-players/{playerId:int}")]
+    public async Task<IActionResult> SaveLightPlayer(
+        int id, int playerId, [FromBody] SaveLightPlayerRequest req, CancellationToken ct)
+    {
+        try { await admin.SaveLightPlayerAsync(id, playerId, req, ct); return NoContent(); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+        catch (InvalidOperationException ex) { return BadRequest(new { message = ex.Message }); }
+    }
+
+    // ── Divisions ────────────────────────────────────────────────────────────
+
+    [HttpPost("{id:int}/divisions")]
+    public async Task<ActionResult<int>> CreateDivision(
+        int id, [FromBody] SaveDivisionRequest req, CancellationToken ct)
+    {
+        try { return await admin.SaveDivisionAsync(id, null, req, ct); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+        catch (InvalidOperationException ex) { return BadRequest(new { message = ex.Message }); }
+    }
+
+    [HttpPut("{id:int}/divisions/{divisionId:int}")]
+    public async Task<ActionResult<int>> UpdateDivision(
+        int id, int divisionId, [FromBody] SaveDivisionRequest req, CancellationToken ct)
+    {
+        try { return await admin.SaveDivisionAsync(id, divisionId, req, ct); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+        catch (InvalidOperationException ex) { return BadRequest(new { message = ex.Message }); }
+    }
+
+    [HttpDelete("{id:int}/divisions/{divisionId:int}")]
+    public async Task<IActionResult> DeleteDivision(int id, int divisionId, CancellationToken ct)
+    {
+        try { await admin.DeleteDivisionAsync(id, divisionId, ct); return NoContent(); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+    }
+
+    [HttpPost("{id:int}/divisions/seed")]
+    public async Task<IActionResult> SeedDivisions(
+        int id, [FromBody] SeedDivisionsFromPreviousRequest req, CancellationToken ct)
+    {
+        try { await admin.RunSeedDivisionsAsync(id, req, ct); return NoContent(); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException ex) { return NotFound(new { message = ex.Message }); }
+        catch (InvalidOperationException ex) { return BadRequest(new { message = ex.Message }); }
+    }
+
+    [HttpPut("{id:int}/teams/{teamId:int}/division")]
+    public async Task<IActionResult> AssignTeamDivision(
+        int id, int teamId, [FromBody] AssignTeamDivisionRequest req, CancellationToken ct)
+    {
+        try { await admin.AssignTeamDivisionAsync(id, teamId, req, ct); return NoContent(); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+        catch (InvalidOperationException ex) { return BadRequest(new { message = ex.Message }); }
+    }
+
+    // ── Teams ────────────────────────────────────────────────────────────────
+
+    [HttpPost("{id:int}/teams")]
+    public async Task<ActionResult<int>> CreateTeam(
+        int id, [FromBody] SaveTeamRequest req, CancellationToken ct)
+    {
+        try { return await admin.SaveTeamAsync(id, null, req, ct); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+        catch (InvalidOperationException ex) { return BadRequest(new { message = ex.Message }); }
+    }
+
+    [HttpPut("{id:int}/teams/{teamId:int}")]
+    public async Task<ActionResult<int>> UpdateTeam(
+        int id, int teamId, [FromBody] SaveTeamRequest req, CancellationToken ct)
+    {
+        try { return await admin.SaveTeamAsync(id, teamId, req, ct); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+        catch (InvalidOperationException ex) { return BadRequest(new { message = ex.Message }); }
+    }
+
+    [HttpDelete("{id:int}/teams/{teamId:int}")]
+    public async Task<IActionResult> DeleteTeam(int id, int teamId, CancellationToken ct)
+    {
+        try { await admin.DeleteTeamAsync(id, teamId, ct); return NoContent(); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+    }
+
+    [HttpDelete("{id:int}/teams")]
+    public async Task<IActionResult> DeleteAllTeams(int id, CancellationToken ct)
+    {
+        try { await admin.DeleteAllTeamsAsync(id, ct); return NoContent(); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+    }
+
+    [HttpPost("{id:int}/teams/captain")]
+    public async Task<IActionResult> AssignCaptain(
+        int id, [FromBody] AssignCaptainRequest req, CancellationToken ct)
+    {
+        try { await admin.AssignCaptainAsync(id, req, ct); return NoContent(); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+        catch (InvalidOperationException ex) { return BadRequest(new { message = ex.Message }); }
+    }
+
+    [HttpPost("{id:int}/teams/auto-captain")]
+    public async Task<ActionResult<int>> AutoAssignCaptains(int id, CancellationToken ct)
+    {
+        try { return await admin.AutoAssignCaptainsAsync(id, ct); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+    }
+
+    [HttpPost("{id:int}/teams/generate-preview")]
+    public async Task<ActionResult<GenerateTeamsResultDto>> GenerateTeamsPreview(
+        int id, [FromBody] GenerateTeamsRequest req, CancellationToken ct)
+    {
+        try { return await admin.GenerateTeamsPreviewAsync(id, req, ct); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+    }
+
+    [HttpPost("{id:int}/teams/generate-confirm")]
+    public async Task<IActionResult> ConfirmGenerateTeams(
+        int id, [FromBody] ConfirmGenerateTeamsRequest req, CancellationToken ct)
+    {
+        try { await admin.ConfirmGenerateTeamsAsync(id, req, ct); return NoContent(); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+    }
+
+    [HttpGet("{id:int}/teams/{teamId:int}/validate")]
+    public async Task<ActionResult<ValidateTeamResultDto>> ValidateTeam(int id, int teamId, CancellationToken ct)
+    {
+        try { return await admin.ValidateTeamAsync(id, teamId, ct); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+    }
+
+    // ── Fixtures ─────────────────────────────────────────────────────────────
+
+    [HttpPost("{id:int}/fixtures")]
+    public async Task<ActionResult<int>> CreateFixture(
+        int id, [FromBody] SaveFixtureRequest req, CancellationToken ct)
+    {
+        try { return await admin.SaveFixtureAsync(id, null, req, ct); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+        catch (InvalidOperationException ex) { return BadRequest(new { message = ex.Message }); }
+    }
+
+    [HttpPut("{id:int}/fixtures/{fixtureId:int}")]
+    public async Task<ActionResult<int>> UpdateFixture(
+        int id, int fixtureId, [FromBody] SaveFixtureRequest req, CancellationToken ct)
+    {
+        try { return await admin.SaveFixtureAsync(id, fixtureId, req, ct); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+        catch (InvalidOperationException ex) { return BadRequest(new { message = ex.Message }); }
+    }
+
+    [HttpDelete("{id:int}/fixtures/{fixtureId:int}")]
+    public async Task<IActionResult> DeleteFixture(int id, int fixtureId, CancellationToken ct)
+    {
+        try { await admin.DeleteFixtureAsync(id, fixtureId, ct); return NoContent(); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+        catch (InvalidOperationException ex) { return BadRequest(new { message = ex.Message }); }
+    }
+
+    [HttpDelete("{id:int}/fixtures")]
+    public async Task<IActionResult> DeleteAllFixtures(int id, CancellationToken ct)
+    {
+        try { await admin.DeleteAllFixturesAsync(id, ct); return NoContent(); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+    }
+
+    [HttpGet("{id:int}/fixtures/{fixtureId:int}/dialog")]
+    public async Task<ActionResult<CompetitionFixtureDto>> LoadFixtureForDialog(int id, int fixtureId, CancellationToken ct)
+    {
+        try
+        {
+            var dto = await admin.LoadFixtureForDialogAsync(id, fixtureId, ct);
+            return dto is null ? NotFound() : Ok(dto);
+        }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+    }
+
+    [HttpPost("{id:int}/fixtures/confirm-assignment")]
+    public async Task<ActionResult<ConfirmFixtureAssignmentResultDto>> ConfirmFixtureAssignment(
+        int id, [FromBody] ConfirmFixtureAssignmentRequest req, CancellationToken ct)
+    {
+        try { return await admin.ConfirmFixtureAssignmentAsync(id, req, ct); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+    }
+
+    [HttpPost("{id:int}/fixtures/schedule")]
+    public async Task<ActionResult<ScheduleFixturesResultDto>> ScheduleFixtures(
+        int id, [FromBody] ScheduleFixturesAdminRequest req, CancellationToken ct)
+    {
+        try { return await admin.ScheduleFixturesAsync(id, req, ct); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+    }
+
+    [HttpPost("{id:int}/fixtures/simulate-rr")]
+    public async Task<ActionResult<SimulateRoundRobinResultDto>> SimulateRoundRobin(int id, CancellationToken ct)
+    {
+        try { return await admin.SimulateRoundRobinAsync(id, ct); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+    }
+
+    [HttpPost("{id:int}/fixtures/seed-knockout")]
+    public async Task<ActionResult<SeedKnockoutFromStandingsResultDto>> SeedKnockoutFromStandings(int id, CancellationToken ct)
+    {
+        try { return await admin.SeedKnockoutFromStandingsAsync(id, ct); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+    }
+
+    // ── Match windows ────────────────────────────────────────────────────────
+
+    [HttpPost("{id:int}/match-windows")]
+    public async Task<ActionResult<int>> AddMatchWindow(
+        int id, [FromBody] SaveMatchWindowRequest req, CancellationToken ct)
+    {
+        try { return await admin.AddMatchWindowAsync(id, req, ct); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+        catch (InvalidOperationException ex) { return BadRequest(new { message = ex.Message }); }
+    }
+
+    [HttpDelete("{id:int}/match-windows/{matchWindowId:int}")]
+    public async Task<IActionResult> DeleteMatchWindow(int id, int matchWindowId, CancellationToken ct)
+    {
+        try { await admin.DeleteMatchWindowAsync(id, matchWindowId, ct); return NoContent(); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+    }
+
+    [HttpPost("{id:int}/divisions/{divisionId:int}/match-windows")]
+    public async Task<ActionResult<int>> AddDivisionMatchWindow(
+        int id, int divisionId, [FromBody] SaveMatchWindowRequest req, CancellationToken ct)
+    {
+        try { return await admin.AddDivisionMatchWindowAsync(id, divisionId, req, ct); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+        catch (InvalidOperationException ex) { return BadRequest(new { message = ex.Message }); }
+    }
+
+    [HttpPost("{id:int}/match-windows/import-from-template")]
+    public async Task<ActionResult<int>> ImportMatchWindowsFromTemplate(
+        int id, [FromBody] ImportMatchWindowsFromTemplateRequest req, CancellationToken ct)
+    {
+        try { return await admin.ImportMatchWindowsFromTemplateAsync(id, req, ct); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+    }
 }

--- a/DropShot/Services/WebCompetitionAdminService.cs
+++ b/DropShot/Services/WebCompetitionAdminService.cs
@@ -16,7 +16,9 @@ public sealed class WebCompetitionAdminService(
     IHttpContextAccessor httpContextAccessor,
     UserManager<ApplicationUser> userManager,
     ICompetitionRubberTemplateProvider rubberTemplateProvider,
-    AdminEmailService adminEmailService) : ICompetitionAdminService
+    AdminEmailService adminEmailService,
+    CompetitionSchedulerService scheduler,
+    FixtureSimulationService fixtureSimulator) : ICompetitionAdminService
 {
     private ClaimsPrincipal CurrentUser =>
         httpContextAccessor.HttpContext?.User ?? new ClaimsPrincipal();
@@ -844,4 +846,1331 @@ public sealed class WebCompetitionAdminService(
         StageType.Final        => 4,
         _                      => 99,
     };
+
+    // ── Auth helper ──────────────────────────────────────────────────────────
+
+    private async Task<Competition> LoadAndAuthorizeAsync(MyDbContext db, int competitionId, CancellationToken ct)
+    {
+        var comp = await db.Competition.AsNoTracking()
+            .Where(c => c.CompetitionID == competitionId)
+            .Select(c => new Competition
+            {
+                CompetitionID  = c.CompetitionID,
+                HostClubId     = c.HostClubId,
+                CompetitionFormat = c.CompetitionFormat,
+                EligibleSex    = c.EligibleSex,
+                MaxAge         = c.MaxAge,
+                MinAge         = c.MinAge,
+                MaxParticipants = c.MaxParticipants,
+                LeagueScoring  = c.LeagueScoring,
+                HasDivisions   = c.HasDivisions,
+            })
+            .FirstOrDefaultAsync(ct)
+            ?? throw new KeyNotFoundException("Competition not found.");
+        if (!await authzService.CanEditCompetitionAsync(CurrentUser, comp.HostClubId, competitionId))
+            throw new UnauthorizedAccessException("You can't edit this competition.");
+        return comp;
+    }
+
+    // ── Participants ─────────────────────────────────────────────────────────
+
+    public async Task<List<PlayerSearchResultDto>> SearchPlayersAsync(
+        int competitionId, SearchPlayersForAddRequest request, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var meta = await LoadAndAuthorizeAsync(db, competitionId, ct);
+
+        var alreadyIn = await db.CompetitionParticipants.AsNoTracking()
+            .Where(p => p.CompetitionId == competitionId)
+            .Select(p => p.PlayerId)
+            .ToListAsync(ct);
+        var alreadyInSet = alreadyIn.ToHashSet();
+
+        var hostClubId = meta.HostClubId;
+        var query = hostClubId.HasValue
+            ? db.Players.AsNoTracking().Where(p => db.ClubPlayers.Any(cp => cp.ClubId == hostClubId.Value && cp.PlayerId == p.PlayerId))
+            : db.Players.AsNoTracking();
+
+        if (!string.IsNullOrWhiteSpace(request.Query))
+            query = query.Where(p => p.DisplayName.Contains(request.Query));
+
+        var candidates = await query
+            .Select(p => new
+            {
+                p.PlayerId,
+                p.DisplayName,
+                p.Sex,
+                p.DateOfBirth,
+                p.IsLight,
+                ClubName = hostClubId.HasValue
+                    ? db.Clubs.Where(c => c.ClubId == hostClubId.Value).Select(c => c.Name).FirstOrDefault()
+                    : null
+            })
+            .Take((request.MaxResults ?? 20) * 4) // overfetch a little so post-filter still has room
+            .ToListAsync(ct);
+
+        var today = DateOnly.FromDateTime(DateTime.Today);
+        var results = new List<PlayerSearchResultDto>();
+        foreach (var p in candidates)
+        {
+            if (alreadyInSet.Contains(p.PlayerId)) continue;
+
+            // Gender filter — skip players whose sex doesn't match (allow null/unset through)
+            if (meta.EligibleSex.HasValue && p.Sex.HasValue && p.Sex != meta.EligibleSex) continue;
+
+            // Age filter — only apply if player has a date of birth
+            if (p.DateOfBirth.HasValue)
+            {
+                int age = today.Year - p.DateOfBirth.Value.Year;
+                if (p.DateOfBirth.Value.AddYears(age) > today) age--;
+                if (meta.MaxAge.HasValue && age >= meta.MaxAge.Value) continue;
+                if (meta.MinAge.HasValue && age < meta.MinAge.Value) continue;
+            }
+
+            results.Add(new PlayerSearchResultDto(
+                p.PlayerId, p.DisplayName, p.Sex,
+                p.DateOfBirth?.ToDateTime(TimeOnly.MinValue),
+                p.ClubName, p.IsLight));
+            if (results.Count >= (request.MaxResults ?? 20)) break;
+        }
+        return results;
+    }
+
+    public async Task AddParticipantAsync(int competitionId, AddParticipantRequest request, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var comp = await db.Competition
+            .Include(c => c.AllowedPlayers)
+            .Include(c => c.Participants)
+            .FirstOrDefaultAsync(c => c.CompetitionID == competitionId, ct)
+            ?? throw new KeyNotFoundException("Competition not found.");
+        if (!await authzService.CanEditCompetitionAsync(CurrentUser, comp.HostClubId, competitionId))
+            throw new UnauthorizedAccessException("You can't edit this competition.");
+
+        if (comp.Participants.Any(p => p.PlayerId == request.PlayerId))
+            throw new InvalidOperationException("Player is already a participant.");
+        if (comp.MaxParticipants.HasValue && comp.Participants.Count >= comp.MaxParticipants.Value)
+            throw new InvalidOperationException($"Maximum of {comp.MaxParticipants.Value} participants reached.");
+
+        var player = await db.Players.FirstOrDefaultAsync(p => p.PlayerId == request.PlayerId, ct)
+            ?? throw new KeyNotFoundException("Player not found.");
+        // The page logs eligibility violations as admin overrides; mirror that by
+        // computing them up-front. The service does NOT block on violations —
+        // the caller already accepted them through the page-level dialog.
+        _ = EligibilityEvaluator.Evaluate(comp, player);
+
+        db.CompetitionParticipants.Add(new CompetitionParticipant
+        {
+            CompetitionId = competitionId,
+            PlayerId      = request.PlayerId,
+            RegisteredAt  = DateTime.UtcNow,
+            Status        = ParticipantStatus.Registered,
+        });
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task RemoveParticipantAsync(int competitionId, int playerId, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        await LoadAndAuthorizeAsync(db, competitionId, ct);
+        var row = await db.CompetitionParticipants.FindAsync([competitionId, playerId], ct);
+        if (row is null) return;
+        db.CompetitionParticipants.Remove(row);
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task UpdateParticipantStatusAsync(
+        int competitionId, int playerId, UpdateParticipantStatusRequest request, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        await LoadAndAuthorizeAsync(db, competitionId, ct);
+        var row = await db.CompetitionParticipants.FindAsync([competitionId, playerId], ct)
+            ?? throw new KeyNotFoundException("Participant not found.");
+        row.Status = request.Status;
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task AssignParticipantTeamAsync(
+        int competitionId, int playerId, AssignParticipantTeamRequest request, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        await LoadAndAuthorizeAsync(db, competitionId, ct);
+        var row = await db.CompetitionParticipants.FindAsync([competitionId, playerId], ct)
+            ?? throw new KeyNotFoundException("Participant not found.");
+        row.TeamId = request.TeamId;
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task AssignParticipantRoleAsync(
+        int competitionId, int playerId, SetParticipantRoleRequest request, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        await LoadAndAuthorizeAsync(db, competitionId, ct);
+        var row = await db.CompetitionParticipants.FindAsync([competitionId, playerId], ct)
+            ?? throw new KeyNotFoundException("Participant not found.");
+        row.Role = string.IsNullOrWhiteSpace(request.Role) ? null : request.Role;
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task AssignParticipantDivisionAsync(
+        int competitionId, int playerId, SetParticipantDivisionRequest request, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        await LoadAndAuthorizeAsync(db, competitionId, ct);
+        var row = await db.CompetitionParticipants.FindAsync([competitionId, playerId], ct)
+            ?? throw new KeyNotFoundException("Participant not found.");
+        row.CompetitionDivisionId = request.CompetitionDivisionId;
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task<int> CreateLightPlayerAsync(
+        int competitionId, CreateLightPlayerForCompetitionRequest request, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        await LoadAndAuthorizeAsync(db, competitionId, ct);
+
+        if (string.IsNullOrWhiteSpace(request.DisplayName))
+            throw new InvalidOperationException("Display name is required.");
+        if (!request.HostClubId.HasValue)
+            throw new InvalidOperationException("Light players must be scoped to a host club.");
+
+        var clubId = request.HostClubId.Value;
+        var player = new Player
+        {
+            DisplayName     = request.DisplayName.Trim(),
+            FirstName       = string.IsNullOrWhiteSpace(request.FirstName) ? null : request.FirstName!.Trim(),
+            LastName        = string.IsNullOrWhiteSpace(request.LastName)  ? null : request.LastName!.Trim(),
+            Email           = string.IsNullOrWhiteSpace(request.Email)     ? null : request.Email!.Trim(),
+            MobileNumber    = string.IsNullOrWhiteSpace(request.MobileNumber) ? null : request.MobileNumber!.Trim(),
+            Sex             = request.Sex,
+            DateOfBirth     = request.DateOfBirth.HasValue ? DateOnly.FromDateTime(request.DateOfBirth.Value) : null,
+            IsLight         = true,
+            CreatedByClubId = clubId,
+        };
+        db.Players.Add(player);
+        await db.SaveChangesAsync(ct);
+
+        db.ClubPlayers.Add(new ClubPlayer { ClubId = clubId, PlayerId = player.PlayerId });
+        db.CompetitionParticipants.Add(new CompetitionParticipant
+        {
+            CompetitionId = competitionId,
+            PlayerId      = player.PlayerId,
+            RegisteredAt  = DateTime.UtcNow,
+            Status        = ParticipantStatus.Registered,
+        });
+        await db.SaveChangesAsync(ct);
+        return player.PlayerId;
+    }
+
+    public async Task SaveLightPlayerAsync(
+        int competitionId, int playerId, SaveLightPlayerRequest request, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        await LoadAndAuthorizeAsync(db, competitionId, ct);
+
+        var player = await db.Players.FindAsync([playerId], ct)
+            ?? throw new KeyNotFoundException("Player not found.");
+        if (!player.IsLight)
+            throw new InvalidOperationException("Only light players can be edited from this dialog.");
+
+        player.DisplayName  = request.DisplayName.Trim();
+        player.FirstName    = string.IsNullOrWhiteSpace(request.FirstName) ? null : request.FirstName!.Trim();
+        player.LastName     = string.IsNullOrWhiteSpace(request.LastName)  ? null : request.LastName!.Trim();
+        player.Email        = string.IsNullOrWhiteSpace(request.Email)     ? null : request.Email!.Trim();
+        player.MobileNumber = string.IsNullOrWhiteSpace(request.MobileNumber) ? null : request.MobileNumber!.Trim();
+        player.Sex          = request.Sex;
+        player.DateOfBirth  = request.DateOfBirth.HasValue ? DateOnly.FromDateTime(request.DateOfBirth.Value) : null;
+        await db.SaveChangesAsync(ct);
+    }
+
+    // ── Divisions ────────────────────────────────────────────────────────────
+
+    public async Task<int> SaveDivisionAsync(
+        int competitionId, int? divisionId, SaveDivisionRequest request, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(request.Name))
+            throw new InvalidOperationException("Division name is required.");
+
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var comp = await db.Competition.FirstOrDefaultAsync(c => c.CompetitionID == competitionId, ct)
+            ?? throw new KeyNotFoundException("Competition not found.");
+        if (!await authzService.CanEditCompetitionAsync(CurrentUser, comp.HostClubId, competitionId))
+            throw new UnauthorizedAccessException("You can't edit this competition.");
+
+        if (divisionId is null)
+        {
+            if (await db.CompetitionDivisions.AnyAsync(d => d.CompetitionId == competitionId && d.Rank == request.Rank, ct))
+                throw new InvalidOperationException($"Division rank {request.Rank} already exists.");
+            var div = new CompetitionDivision
+            {
+                CompetitionId = competitionId,
+                Name          = request.Name.Trim(),
+                Rank          = request.Rank,
+            };
+            db.CompetitionDivisions.Add(div);
+            if (!comp.HasDivisions) comp.HasDivisions = true;
+            await db.SaveChangesAsync(ct);
+            return div.CompetitionDivisionId;
+        }
+        else
+        {
+            var row = await db.CompetitionDivisions.FindAsync([divisionId.Value], ct)
+                ?? throw new KeyNotFoundException("Division not found.");
+            if (row.CompetitionId != competitionId)
+                throw new InvalidOperationException("Division belongs to a different competition.");
+            if (row.Rank != request.Rank
+                && await db.CompetitionDivisions.AnyAsync(
+                    x => x.CompetitionId == competitionId && x.Rank == request.Rank
+                         && x.CompetitionDivisionId != row.CompetitionDivisionId, ct))
+                throw new InvalidOperationException($"Division rank {request.Rank} already exists.");
+            row.Name = request.Name.Trim();
+            row.Rank = request.Rank;
+            await db.SaveChangesAsync(ct);
+            return row.CompetitionDivisionId;
+        }
+    }
+
+    public async Task DeleteDivisionAsync(int competitionId, int divisionId, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        await LoadAndAuthorizeAsync(db, competitionId, ct);
+
+        var participants = await db.CompetitionParticipants
+            .Where(p => p.CompetitionId == competitionId && p.CompetitionDivisionId == divisionId).ToListAsync(ct);
+        foreach (var p in participants) p.CompetitionDivisionId = null;
+
+        var teams = await db.CompetitionTeams
+            .Where(t => t.CompetitionId == competitionId && t.CompetitionDivisionId == divisionId).ToListAsync(ct);
+        foreach (var t in teams) t.CompetitionDivisionId = null;
+
+        var divWindows = await db.CompetitionMatchWindows
+            .Where(w => w.CompetitionId == competitionId && w.CompetitionDivisionId == divisionId).ToListAsync(ct);
+        if (divWindows.Count > 0) db.CompetitionMatchWindows.RemoveRange(divWindows);
+
+        var row = await db.CompetitionDivisions.FindAsync([divisionId], ct);
+        if (row is not null && row.CompetitionId == competitionId)
+            db.CompetitionDivisions.Remove(row);
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task RunSeedDivisionsAsync(
+        int competitionId, SeedDivisionsFromPreviousRequest request, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var comp = await db.Competition
+            .Include(c => c.Divisions)
+            .Include(c => c.Participants)
+            .FirstOrDefaultAsync(c => c.CompetitionID == competitionId, ct)
+            ?? throw new KeyNotFoundException("Competition not found.");
+        if (!await authzService.CanEditCompetitionAsync(CurrentUser, comp.HostClubId, competitionId))
+            throw new UnauthorizedAccessException("You can't edit this competition.");
+
+        var previous = await db.Competition
+            .Include(c => c.Divisions)
+            .Include(c => c.Participants)
+            .FirstOrDefaultAsync(c => c.CompetitionID == request.PreviousCompetitionId, ct)
+            ?? throw new KeyNotFoundException("Source competition not found.");
+
+        if (comp.Divisions.Any())
+            throw new InvalidOperationException("This competition already has divisions — clear them first.");
+
+        var byRank = new Dictionary<byte, CompetitionDivision>();
+        foreach (var prev in previous.Divisions.OrderBy(d => d.Rank))
+        {
+            var nd = new CompetitionDivision
+            {
+                CompetitionId = competitionId,
+                Rank          = prev.Rank,
+                Name          = prev.Name,
+            };
+            db.CompetitionDivisions.Add(nd);
+            byRank[prev.Rank] = nd;
+        }
+        comp.HasDivisions = true;
+        comp.SeededFromCompetitionId = previous.CompetitionID;
+        await db.SaveChangesAsync(ct);
+
+        var previousRankByPlayer = previous.Participants
+            .Where(p => p.CompetitionDivisionId.HasValue)
+            .ToDictionary(
+                p => p.PlayerId,
+                p => previous.Divisions.First(d => d.CompetitionDivisionId == p.CompetitionDivisionId).Rank);
+
+        if (request.ApplyPromotion && (request.PromoteCount > 0 || request.DemoteCount > 0)
+            && previous.Divisions.Count > 0)
+        {
+            byte minRank = previous.Divisions.Min(d => d.Rank);
+            byte maxRank = previous.Divisions.Max(d => d.Rank);
+            var stats = await PlayerStatsService.ComputeAsync(
+                db, [previous.CompetitionID], previous.LeagueScoring);
+            foreach (var div in previous.Divisions)
+            {
+                var ranked = previous.Participants
+                    .Where(p => p.CompetitionDivisionId == div.CompetitionDivisionId)
+                    .Select(p => new { p.PlayerId, Points = stats.TryGetValue(p.PlayerId, out var s) ? s.LeaguePoints : 0 })
+                    .OrderByDescending(x => x.Points)
+                    .ToList();
+                if (div.Rank > minRank)
+                    foreach (var promo in ranked.Take(request.PromoteCount))
+                        previousRankByPlayer[promo.PlayerId] = (byte)(div.Rank - 1);
+                if (div.Rank < maxRank)
+                    foreach (var demo in ranked.AsEnumerable().Reverse().Take(request.DemoteCount))
+                        previousRankByPlayer[demo.PlayerId] = (byte)(div.Rank + 1);
+            }
+        }
+
+        foreach (var cp in comp.Participants)
+        {
+            if (!previousRankByPlayer.TryGetValue(cp.PlayerId, out var nextRank)) continue;
+            if (!byRank.TryGetValue(nextRank, out var div)) continue;
+            cp.CompetitionDivisionId = div.CompetitionDivisionId;
+        }
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task AssignTeamDivisionAsync(
+        int competitionId, int teamId, AssignTeamDivisionRequest request, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        await LoadAndAuthorizeAsync(db, competitionId, ct);
+        var team = await db.CompetitionTeams.FindAsync([teamId], ct)
+            ?? throw new KeyNotFoundException("Team not found.");
+        if (team.CompetitionId != competitionId)
+            throw new InvalidOperationException("Team belongs to a different competition.");
+        team.CompetitionDivisionId = request.CompetitionDivisionId;
+        await db.SaveChangesAsync(ct);
+    }
+
+    // ── Teams ────────────────────────────────────────────────────────────────
+
+    public async Task<int> SaveTeamAsync(
+        int competitionId, int? teamId, SaveTeamRequest request, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(request.Name))
+            throw new InvalidOperationException("Team name is required.");
+
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        await LoadAndAuthorizeAsync(db, competitionId, ct);
+
+        if (teamId is null)
+        {
+            var team = new CompetitionTeam { CompetitionId = competitionId, Name = request.Name.Trim() };
+            db.CompetitionTeams.Add(team);
+            await db.SaveChangesAsync(ct);
+            return team.CompetitionTeamId;
+        }
+        else
+        {
+            var row = await db.CompetitionTeams.FindAsync([teamId.Value], ct)
+                ?? throw new KeyNotFoundException("Team not found.");
+            if (row.CompetitionId != competitionId)
+                throw new InvalidOperationException("Team belongs to a different competition.");
+            row.Name = request.Name.Trim();
+            await db.SaveChangesAsync(ct);
+            return row.CompetitionTeamId;
+        }
+    }
+
+    public async Task DeleteTeamAsync(int competitionId, int teamId, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        await LoadAndAuthorizeAsync(db, competitionId, ct);
+
+        var members = await db.CompetitionParticipants
+            .Where(cp => cp.CompetitionId == competitionId && cp.TeamId == teamId).ToListAsync(ct);
+        foreach (var m in members) m.TeamId = null;
+
+        var row = await db.CompetitionTeams.FindAsync([teamId], ct);
+        if (row is not null && row.CompetitionId == competitionId)
+            db.CompetitionTeams.Remove(row);
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task DeleteAllTeamsAsync(int competitionId, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        await LoadAndAuthorizeAsync(db, competitionId, ct);
+
+        var participants = await db.CompetitionParticipants
+            .Where(cp => cp.CompetitionId == competitionId && cp.TeamId != null).ToListAsync(ct);
+        foreach (var cp in participants) cp.TeamId = null;
+
+        var fixtures = await db.CompetitionFixtures
+            .Where(f => f.CompetitionId == competitionId
+                     && (f.HomeTeamId != null || f.AwayTeamId != null || f.WinnerTeamId != null))
+            .ToListAsync(ct);
+        var fixtureIds = fixtures.Select(f => f.CompetitionFixtureId).ToList();
+        foreach (var f in fixtures)
+        {
+            f.HomeTeamId = null;
+            f.AwayTeamId = null;
+            f.WinnerTeamId = null;
+        }
+        if (fixtureIds.Count > 0)
+        {
+            var rubbers = await db.Rubbers
+                .Where(r => fixtureIds.Contains(r.CompetitionFixtureId) && r.WinnerTeamId != null)
+                .ToListAsync(ct);
+            foreach (var r in rubbers) r.WinnerTeamId = null;
+        }
+
+        var teams = await db.CompetitionTeams.Where(t => t.CompetitionId == competitionId).ToListAsync(ct);
+        db.CompetitionTeams.RemoveRange(teams);
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task AssignCaptainAsync(
+        int competitionId, AssignCaptainRequest request, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        await LoadAndAuthorizeAsync(db, competitionId, ct);
+        var team = await db.CompetitionTeams.FindAsync([request.CompetitionTeamId], ct)
+            ?? throw new KeyNotFoundException("Team not found.");
+        if (team.CompetitionId != competitionId)
+            throw new InvalidOperationException("Team belongs to a different competition.");
+        team.CaptainPlayerId = request.PlayerId;
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task<int> AutoAssignCaptainsAsync(int competitionId, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        await LoadAndAuthorizeAsync(db, competitionId, ct);
+
+        var teams = await db.CompetitionTeams
+            .Where(t => t.CompetitionId == competitionId && t.CaptainPlayerId == null)
+            .ToListAsync(ct);
+        if (teams.Count == 0) return 0;
+
+        var participants = await db.CompetitionParticipants.AsNoTracking()
+            .Where(p => p.CompetitionId == competitionId
+                        && p.Status == ParticipantStatus.FullPlayer
+                        && p.TeamId != null)
+            .Select(p => new { p.PlayerId, p.TeamId })
+            .ToListAsync(ct);
+
+        var byTeam = participants.GroupBy(p => p.TeamId!.Value)
+                                 .ToDictionary(g => g.Key, g => g.Select(x => x.PlayerId).ToList());
+        var rng = new Random();
+        int assigned = 0;
+        foreach (var team in teams)
+        {
+            if (!byTeam.TryGetValue(team.CompetitionTeamId, out var ids) || ids.Count == 0) continue;
+            team.CaptainPlayerId = ids[rng.Next(ids.Count)];
+            assigned++;
+        }
+        if (assigned > 0) await db.SaveChangesAsync(ct);
+        return assigned;
+    }
+
+    public async Task<GenerateTeamsResultDto> GenerateTeamsPreviewAsync(
+        int competitionId, GenerateTeamsRequest request, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var comp = await db.Competition
+            .Include(c => c.Divisions)
+            .FirstOrDefaultAsync(c => c.CompetitionID == competitionId, ct)
+            ?? throw new KeyNotFoundException("Competition not found.");
+        if (!await authzService.CanEditCompetitionAsync(CurrentUser, comp.HostClubId, competitionId))
+            throw new UnauthorizedAccessException("You can't edit this competition.");
+
+        var participants = await db.CompetitionParticipants.AsNoTracking()
+            .Include(p => p.Player)
+            .Where(p => p.CompetitionId == competitionId)
+            .ToListAsync(ct);
+
+        var warnings = new List<string>();
+        var preview = new List<GeneratedTeamPreviewDto>();
+
+        var active = participants.Where(p => p.Status == ParticipantStatus.FullPlayer).ToList();
+        var skippedRegistered = participants.Count(p => p.Status == ParticipantStatus.Registered);
+        var skippedDisqualified = participants.Count(p => p.Status == ParticipantStatus.Disqualified);
+        if (skippedRegistered > 0)
+            warnings.Add($"{skippedRegistered} participant(s) with status 'Registered' will be skipped — only Full Players are included.");
+        if (skippedDisqualified > 0)
+            warnings.Add($"{skippedDisqualified} disqualified participant(s) will be skipped.");
+        if (active.Count == 0)
+        {
+            warnings.Add("No Full Players to generate from.");
+            return new GenerateTeamsResultDto(preview, warnings);
+        }
+
+        var format = comp.CompetitionFormat;
+        var isDoubles = format is CompetitionFormat.Doubles or CompetitionFormat.MixedDoubles;
+        var isTeamMatch = format == CompetitionFormat.TeamMatch;
+        var itemLabel = isDoubles ? "Pair" : "Team";
+        var teamSize = request.TeamSize ?? comp.TeamSize ?? (isDoubles ? 2 : 4);
+
+        // For TeamMatch, derive role assigner from the persisted preset key (or
+        // the format default). The page also looks at the in-memory rubber
+        // template state; here we use the source-of-truth columns on Competition.
+        RubberTemplateRegistry.RoleAssigner? assigner = null;
+        if (isTeamMatch)
+        {
+            var presetKey = !string.IsNullOrEmpty(comp.RubberTemplateKey)
+                ? comp.RubberTemplateKey
+                : RubberTemplateRegistry.GetFormatDefaultKey(format);
+            assigner = RubberTemplateRegistry.GetRoleAssigner(presetKey);
+        }
+
+        var useMttSplit = isTeamMatch
+            && (comp.RubberTemplateKey == RubberTemplateRegistry.MttKey
+                || string.IsNullOrEmpty(comp.RubberTemplateKey));
+
+        List<(int? DivisionId, string? DivisionName, List<CompetitionParticipant> Members)> buckets;
+        if (comp.HasDivisions && comp.Divisions.Count > 0)
+        {
+            // Filter by requested division if specified.
+            var divs = request.CompetitionDivisionId.HasValue
+                ? comp.Divisions.Where(d => d.CompetitionDivisionId == request.CompetitionDivisionId.Value).ToList()
+                : comp.Divisions.OrderBy(d => d.Rank).ToList();
+            var assigned = active.Where(p => p.CompetitionDivisionId.HasValue).ToList();
+            var unassigned = active.Count - assigned.Count;
+            if (unassigned > 0 && !request.CompetitionDivisionId.HasValue)
+                warnings.Add($"{unassigned} participant(s) have no division set and will be skipped.");
+
+            buckets = divs
+                .Select(d => ((int?)d.CompetitionDivisionId, (string?)d.Name,
+                              assigned.Where(p => p.CompetitionDivisionId == d.CompetitionDivisionId).ToList()))
+                .Where(t => t.Item3.Count > 0)
+                .ToList();
+            if (buckets.Count == 0)
+            {
+                warnings.Add("No participants are assigned to any division — nothing to generate.");
+                return new GenerateTeamsResultDto(preview, warnings);
+            }
+        }
+        else
+        {
+            buckets = [(null, null, active)];
+        }
+
+        var rng = new Random();
+        foreach (var (divId, divName, bucketMembers) in buckets)
+        {
+            GenerateBucket(bucketMembers, divId, divName, format,
+                useMttSplit || (request.BalanceByGender && format == CompetitionFormat.MixedDoubles),
+                teamSize, itemLabel, assigner, rng, preview, warnings);
+        }
+        return new GenerateTeamsResultDto(preview, warnings);
+    }
+
+    private static void GenerateBucket(
+        List<CompetitionParticipant> bucketMembers,
+        int? divisionId, string? divisionName,
+        CompetitionFormat? format, bool splitByGender,
+        int teamSize, string itemLabel,
+        RubberTemplateRegistry.RoleAssigner? assigner, Random rng,
+        List<GeneratedTeamPreviewDto> preview, List<string> warnings)
+    {
+        string TeamName(int idx) => $"{itemLabel} {(char)('A' + idx)}";
+        string BucketPrefix() => divisionName is null ? "" : $"[{divisionName}] ";
+
+        if (splitByGender)
+        {
+            var males   = bucketMembers.Where(p => p.Player?.Sex == PlayerSex.Male).OrderBy(_ => rng.Next()).ToList();
+            var females = bucketMembers.Where(p => p.Player?.Sex == PlayerSex.Female).OrderBy(_ => rng.Next()).ToList();
+            var noSex   = bucketMembers.Where(p => p.Player?.Sex is null or PlayerSex.Other).ToList();
+
+            if (noSex.Count > 0)
+                warnings.Add($"{BucketPrefix()}{noSex.Count} player(s) have no gender set and will be skipped.");
+
+            var perGender = teamSize / 2;
+            if (teamSize % 2 != 0)
+                warnings.Add($"{BucketPrefix()}Team size {teamSize} is odd — using {perGender} of each gender.");
+
+            var teamCount = Math.Min(males.Count / perGender, females.Count / perGender);
+            if (teamCount == 0)
+            {
+                warnings.Add($"{BucketPrefix()}Not enough players: {males.Count} male(s), {females.Count} female(s) for teams of {teamSize}.");
+                return;
+            }
+            var leftoverM = males.Count - (teamCount * perGender);
+            var leftoverF = females.Count - (teamCount * perGender);
+            if (leftoverM > 0 || leftoverF > 0)
+                warnings.Add($"{BucketPrefix()}{leftoverM + leftoverF} player(s) will be unassigned ({leftoverM} male, {leftoverF} female).");
+
+            for (int i = 0; i < teamCount; i++)
+            {
+                var members = new List<CompetitionParticipant>();
+                members.AddRange(males.Skip(i * perGender).Take(perGender));
+                members.AddRange(females.Skip(i * perGender).Take(perGender));
+                preview.Add(new GeneratedTeamPreviewDto(
+                    TeamName(i),
+                    members.Select(m => m.PlayerId).ToList(),
+                    AssignRoles(assigner, members),
+                    divisionId, divisionName));
+            }
+        }
+        else
+        {
+            var shuffled = bucketMembers.OrderBy(_ => rng.Next()).ToList();
+            var teamCount = shuffled.Count / teamSize;
+            var leftover = shuffled.Count % teamSize;
+            if (teamCount == 0)
+            {
+                warnings.Add($"{BucketPrefix()}Not enough players ({shuffled.Count}) for teams of {teamSize}.");
+                return;
+            }
+            if (leftover > 0)
+                warnings.Add($"{BucketPrefix()}{leftover} player(s) will be unassigned.");
+            for (int i = 0; i < teamCount; i++)
+            {
+                var members = shuffled.Skip(i * teamSize).Take(teamSize).ToList();
+                preview.Add(new GeneratedTeamPreviewDto(
+                    TeamName(i),
+                    members.Select(m => m.PlayerId).ToList(),
+                    AssignRoles(assigner, members),
+                    divisionId, divisionName));
+            }
+        }
+    }
+
+    private static IReadOnlyDictionary<int, string> AssignRoles(
+        RubberTemplateRegistry.RoleAssigner? assigner, List<CompetitionParticipant> members)
+    {
+        if (assigner is null) return new Dictionary<int, string>();
+        var candidates = members
+            .Select(m => new RubberTemplateRegistry.AssignmentCandidate(
+                m.PlayerId, m.Player?.DisplayName ?? "", m.Player?.Sex))
+            .ToList();
+        return assigner(candidates).ToDictionary(kv => kv.Key, kv => kv.Value);
+    }
+
+    public async Task ConfirmGenerateTeamsAsync(
+        int competitionId, ConfirmGenerateTeamsRequest request, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var comp = await db.Competition.FirstOrDefaultAsync(c => c.CompetitionID == competitionId, ct)
+            ?? throw new KeyNotFoundException("Competition not found.");
+        if (!await authzService.CanEditCompetitionAsync(CurrentUser, comp.HostClubId, competitionId))
+            throw new UnauthorizedAccessException("You can't edit this competition.");
+
+        var existingTeams = await db.CompetitionTeams.Where(t => t.CompetitionId == competitionId).ToListAsync(ct);
+        if (existingTeams.Count > 0)
+        {
+            var existingMembers = await db.CompetitionParticipants
+                .Where(cp => cp.CompetitionId == competitionId && cp.TeamId != null)
+                .ToListAsync(ct);
+            foreach (var m in existingMembers) m.TeamId = null;
+            db.CompetitionTeams.RemoveRange(existingTeams);
+            await db.SaveChangesAsync(ct);
+        }
+
+        int? appliedTeamSize = null;
+        foreach (var preview in request.Teams)
+        {
+            var team = new CompetitionTeam
+            {
+                CompetitionId         = competitionId,
+                Name                  = preview.Name,
+                CompetitionDivisionId = preview.DivisionId,
+            };
+            db.CompetitionTeams.Add(team);
+            await db.SaveChangesAsync(ct);
+
+            foreach (var memberId in preview.MemberPlayerIds)
+            {
+                var cp = await db.CompetitionParticipants.FindAsync([competitionId, memberId], ct);
+                if (cp is null) continue;
+                cp.TeamId = team.CompetitionTeamId;
+                if (preview.Roles.TryGetValue(memberId, out var role)) cp.Role = role;
+            }
+            appliedTeamSize ??= preview.MemberPlayerIds.Count;
+            await db.SaveChangesAsync(ct);
+        }
+
+        if (appliedTeamSize.HasValue && comp.TeamSize != appliedTeamSize.Value)
+        {
+            comp.TeamSize = appliedTeamSize.Value;
+            await db.SaveChangesAsync(ct);
+        }
+    }
+
+    public async Task<ValidateTeamResultDto> ValidateTeamAsync(
+        int competitionId, int teamId, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var comp = await db.Competition.AsNoTracking()
+            .FirstOrDefaultAsync(c => c.CompetitionID == competitionId, ct)
+            ?? throw new KeyNotFoundException("Competition not found.");
+        if (!await authzService.CanEditCompetitionAsync(CurrentUser, comp.HostClubId, competitionId))
+            throw new UnauthorizedAccessException("You can't edit this competition.");
+
+        var team = await db.CompetitionTeams.AsNoTracking()
+            .FirstOrDefaultAsync(t => t.CompetitionTeamId == teamId && t.CompetitionId == competitionId, ct)
+            ?? throw new KeyNotFoundException("Team not found.");
+
+        var members = await db.CompetitionParticipants.AsNoTracking()
+            .Include(p => p.Player)
+            .Where(p => p.CompetitionId == competitionId
+                        && p.TeamId == teamId
+                        && p.Status == ParticipantStatus.FullPlayer)
+            .ToListAsync(ct);
+
+        var resolved = await rubberTemplateProvider.GetAsync(db, competitionId);
+        var requiredRoles = RubberTemplateRegistry.GetRoleSet(resolved).ToList();
+
+        var errors = new List<string>();
+        var warnings = new List<string>();
+        if (requiredRoles.Count > 0)
+        {
+            foreach (var role in requiredRoles)
+            {
+                int count = members.Count(m => m.Role == role);
+                if (count == 0) errors.Add($"Missing role {role}");
+                else if (count > 1) errors.Add($"Duplicate role {role}");
+            }
+            foreach (var m in members.Where(m => string.IsNullOrEmpty(m.Role)))
+                errors.Add($"{m.Player?.DisplayName}: no role");
+        }
+        return new ValidateTeamResultDto(errors, warnings);
+    }
+
+    // ── Fixtures ─────────────────────────────────────────────────────────────
+
+    public async Task<int> SaveFixtureAsync(
+        int competitionId, int? fixtureId, SaveFixtureRequest request, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var comp = await db.Competition.AsNoTracking()
+            .FirstOrDefaultAsync(c => c.CompetitionID == competitionId, ct)
+            ?? throw new KeyNotFoundException("Competition not found.");
+        if (!await authzService.CanEditCompetitionAsync(CurrentUser, comp.HostClubId, competitionId))
+            throw new UnauthorizedAccessException("You can't edit this competition.");
+
+        var side1 = new[] { request.Player1Id, request.Player3Id }.Where(id => id.HasValue).Select(id => id!.Value).ToHashSet();
+        var side2 = new[] { request.Player2Id, request.Player4Id }.Where(id => id.HasValue).Select(id => id!.Value).ToHashSet();
+        if (side1.Overlaps(side2))
+            throw new InvalidOperationException("A player cannot appear on both sides of a fixture.");
+
+        bool isTeamMatch = comp.CompetitionFormat == CompetitionFormat.TeamMatch;
+
+        if (fixtureId is null)
+        {
+            var f = new CompetitionFixture { CompetitionId = competitionId };
+            ApplyFixtureRequest(f, request, isTeamMatch);
+            db.CompetitionFixtures.Add(f);
+            await db.SaveChangesAsync(ct);
+            return f.CompetitionFixtureId;
+        }
+        else
+        {
+            var f = await db.CompetitionFixtures.FindAsync([fixtureId.Value], ct)
+                ?? throw new KeyNotFoundException("Fixture not found.");
+            if (f.CompetitionId != competitionId)
+                throw new InvalidOperationException("Fixture belongs to a different competition.");
+            ApplyFixtureRequest(f, request, isTeamMatch);
+            await db.SaveChangesAsync(ct);
+            return f.CompetitionFixtureId;
+        }
+    }
+
+    private static void ApplyFixtureRequest(CompetitionFixture f, SaveFixtureRequest req, bool isTeamMatch)
+    {
+        f.CompetitionStageId = req.CompetitionStageId;
+        f.FixtureLabel       = req.FixtureLabel;
+        f.ScheduledAt        = req.ScheduledAt;
+        f.Player1Id          = req.Player1Id;
+        f.Player2Id          = req.Player2Id;
+        f.Player3Id          = req.Player3Id;
+        f.Player4Id          = req.Player4Id;
+        f.HomeTeamId         = req.HomeTeamId;
+        f.AwayTeamId         = req.AwayTeamId;
+        if (req.RoundNumber.HasValue) f.RoundNumber = req.RoundNumber.Value;
+        f.Status             = req.Status;
+        if (isTeamMatch)
+        {
+            f.CourtPairId = req.CourtPairId;
+            f.CourtId     = null;
+        }
+        else
+        {
+            f.CourtId     = req.CourtId;
+            f.CourtPairId = null;
+        }
+    }
+
+    public async Task DeleteFixtureAsync(int competitionId, int fixtureId, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        await LoadAndAuthorizeAsync(db, competitionId, ct);
+
+        var fx = await db.CompetitionFixtures
+            .Include(f => f.Stage)
+            .FirstOrDefaultAsync(f => f.CompetitionFixtureId == fixtureId, ct);
+        if (fx is null || fx.CompetitionId != competitionId) return;
+
+        bool hasResult = fx.Status == FixtureStatus.Completed
+                      || fx.Status == FixtureStatus.AwaitingVerification;
+
+        if (!hasResult)
+        {
+            db.CompetitionFixtures.Remove(fx);
+            await db.SaveChangesAsync(ct);
+            return;
+        }
+
+        // Has a result: keep the row, but reset to Scheduled and cascade across
+        // any downstream fixtures that inherited a winner from this one.
+        var oldWinnerPlayerId = fx.WinnerPlayerId;
+        var oldWinnerTeamId   = fx.WinnerTeamId;
+        bool isTeamFixture    = fx.HomeTeamId.HasValue;
+        var currentStageOrder = fx.Stage?.StageOrder;
+        var currentRound      = fx.RoundNumber;
+
+        bool IsDownstream(CompetitionFixture f)
+        {
+            if (currentStageOrder.HasValue && f.Stage != null && f.Stage.StageOrder > currentStageOrder.Value) return true;
+            if (f.CompetitionStageId == fx.CompetitionStageId
+                && currentRound.HasValue && f.RoundNumber.HasValue
+                && f.RoundNumber.Value > currentRound.Value) return true;
+            return false;
+        }
+
+        if (oldWinnerPlayerId.HasValue || oldWinnerTeamId.HasValue)
+        {
+            var downstream = await db.CompetitionFixtures
+                .Include(f => f.Stage)
+                .Where(f => f.CompetitionId == fx.CompetitionId
+                    && f.CompetitionFixtureId != fx.CompetitionFixtureId
+                    && (f.Status == FixtureStatus.InProgress || f.Status == FixtureStatus.Completed
+                        || f.Status == FixtureStatus.AwaitingVerification))
+                .ToListAsync(ct);
+            bool blocked = isTeamFixture
+                ? downstream.Any(f => IsDownstream(f) && (f.HomeTeamId == oldWinnerTeamId || f.AwayTeamId == oldWinnerTeamId))
+                : downstream.Any(f => IsDownstream(f) && (f.Player1Id == oldWinnerPlayerId || f.Player2Id == oldWinnerPlayerId));
+            if (blocked)
+                throw new InvalidOperationException(
+                    "Cannot delete: the winner has a downstream match that is in progress or completed. Delete that result first.");
+        }
+
+        if (oldWinnerPlayerId.HasValue)
+        {
+            var nextFixtures = await db.CompetitionFixtures
+                .Include(f => f.Stage)
+                .Where(f => f.CompetitionId == fx.CompetitionId
+                    && f.CompetitionFixtureId != fx.CompetitionFixtureId
+                    && f.Status == FixtureStatus.Scheduled
+                    && (f.Player1Id == oldWinnerPlayerId || f.Player2Id == oldWinnerPlayerId))
+                .ToListAsync(ct);
+            foreach (var nf in nextFixtures)
+            {
+                if (!IsDownstream(nf)) continue;
+                if (nf.Player1Id == oldWinnerPlayerId) nf.Player1Id = null;
+                if (nf.Player2Id == oldWinnerPlayerId) nf.Player2Id = null;
+            }
+        }
+
+        if (oldWinnerTeamId.HasValue)
+        {
+            var nextFixtures = await db.CompetitionFixtures
+                .Include(f => f.Stage)
+                .Include(f => f.Rubbers)
+                .Where(f => f.CompetitionId == fx.CompetitionId
+                    && f.CompetitionFixtureId != fx.CompetitionFixtureId
+                    && f.Status == FixtureStatus.Scheduled
+                    && (f.HomeTeamId == oldWinnerTeamId || f.AwayTeamId == oldWinnerTeamId))
+                .ToListAsync(ct);
+            foreach (var nf in nextFixtures)
+            {
+                if (!IsDownstream(nf)) continue;
+                if (nf.HomeTeamId == oldWinnerTeamId) nf.HomeTeamId = null;
+                if (nf.AwayTeamId == oldWinnerTeamId) nf.AwayTeamId = null;
+                if (nf.Rubbers.Any()) db.Rubbers.RemoveRange(nf.Rubbers);
+            }
+        }
+
+        if (fx.SavedMatchId.HasValue)
+        {
+            var savedMatch = await db.SavedMatch.FindAsync([fx.SavedMatchId.Value], ct);
+            if (savedMatch is not null) db.SavedMatch.Remove(savedMatch);
+            fx.SavedMatchId = null;
+        }
+
+        if (isTeamFixture)
+        {
+            var rubbers = await db.Rubbers
+                .Where(r => r.CompetitionFixtureId == fx.CompetitionFixtureId)
+                .ToListAsync(ct);
+            var rubberSavedMatchIds = rubbers
+                .Where(r => r.SavedMatchId.HasValue)
+                .Select(r => r.SavedMatchId!.Value)
+                .ToList();
+            if (rubberSavedMatchIds.Count > 0)
+            {
+                var perRubberSavedMatches = await db.SavedMatch
+                    .Where(m => rubberSavedMatchIds.Contains(m.SavedMatchId))
+                    .ToListAsync(ct);
+                db.SavedMatch.RemoveRange(perRubberSavedMatches);
+            }
+            foreach (var r in rubbers)
+            {
+                r.IsComplete       = false;
+                r.WinnerTeamId     = null;
+                r.HomeSetsWon      = null;
+                r.AwaySetsWon      = null;
+                r.HomeGames        = null;
+                r.AwayGames        = null;
+                r.HomeGamesTotal   = null;
+                r.AwayGamesTotal   = null;
+                r.SavedMatchId     = null;
+            }
+        }
+
+        fx.Status                 = FixtureStatus.Scheduled;
+        fx.CompletedAt            = null;
+        fx.ResultSummary          = null;
+        fx.WinnerPlayerId         = null;
+        fx.WinnerTeamId           = null;
+        fx.VerificationToken      = null;
+        fx.OriginalResultSummary  = null;
+        fx.OriginalWinnerPlayerId = null;
+        fx.ResultModifiedByAdmin  = false;
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task DeleteAllFixturesAsync(int competitionId, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        await LoadAndAuthorizeAsync(db, competitionId, ct);
+
+        var fixtures = await db.CompetitionFixtures
+            .Where(f => f.CompetitionId == competitionId).ToListAsync(ct);
+        var fixtureIds = fixtures.Select(f => f.CompetitionFixtureId).ToList();
+
+        var rubbers = await db.Rubbers.Where(r => fixtureIds.Contains(r.CompetitionFixtureId)).ToListAsync(ct);
+        var rubberSavedMatchIds = rubbers
+            .Where(r => r.SavedMatchId.HasValue)
+            .Select(r => r.SavedMatchId!.Value)
+            .ToList();
+        if (rubbers.Count > 0) db.Rubbers.RemoveRange(rubbers);
+
+        var directSavedMatchIds = fixtures.Where(f => f.SavedMatchId.HasValue).Select(f => f.SavedMatchId!.Value);
+        var savedMatchIds = directSavedMatchIds.Concat(rubberSavedMatchIds).Distinct().ToList();
+        if (savedMatchIds.Count > 0)
+        {
+            var savedMatches = await db.SavedMatch.Where(m => savedMatchIds.Contains(m.SavedMatchId)).ToListAsync(ct);
+            if (savedMatches.Count > 0) db.SavedMatch.RemoveRange(savedMatches);
+        }
+
+        db.CompetitionFixtures.RemoveRange(fixtures);
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task<CompetitionFixtureDto?> LoadFixtureForDialogAsync(
+        int competitionId, int fixtureId, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var comp = await db.Competition.AsNoTracking()
+            .FirstOrDefaultAsync(c => c.CompetitionID == competitionId, ct);
+        if (comp is null) return null;
+        if (!await authzService.CanEditCompetitionAsync(CurrentUser, comp.HostClubId, competitionId))
+            throw new UnauthorizedAccessException("You can't view this competition's fixtures.");
+
+        var f = await db.CompetitionFixtures.AsNoTracking()
+            .Include(f => f.Stage)
+            .Include(f => f.Court)
+            .Include(f => f.CourtPair).ThenInclude(cp => cp!.Court1)
+            .Include(f => f.CourtPair).ThenInclude(cp => cp!.Court2)
+            .Include(f => f.Player1)
+            .Include(f => f.Player2)
+            .Include(f => f.Player3)
+            .Include(f => f.Player4)
+            .Include(f => f.HomeTeam)
+            .Include(f => f.AwayTeam)
+            .Include(f => f.Competition)
+            .FirstOrDefaultAsync(f => f.CompetitionFixtureId == fixtureId && f.CompetitionId == competitionId, ct);
+        return f is null ? null : ToFixtureDto(f);
+    }
+
+    public async Task<ConfirmFixtureAssignmentResultDto> ConfirmFixtureAssignmentAsync(
+        int competitionId, ConfirmFixtureAssignmentRequest request, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var comp = await db.Competition.AsNoTracking()
+            .Include(c => c.AllowedPlayers)
+            .FirstOrDefaultAsync(c => c.CompetitionID == competitionId, ct)
+            ?? throw new KeyNotFoundException("Competition not found.");
+        if (!await authzService.CanEditCompetitionAsync(CurrentUser, comp.HostClubId, competitionId))
+            throw new UnauthorizedAccessException("You can't edit this competition.");
+
+        var playerIds = new[] { request.Player1Id, request.Player2Id, request.Player3Id, request.Player4Id }
+            .Where(id => id.HasValue).Select(id => id!.Value).Distinct().ToList();
+        if (playerIds.Count == 0)
+            return new ConfirmFixtureAssignmentResultDto(true, []);
+
+        var participantIds = await db.CompetitionParticipants.AsNoTracking()
+            .Where(p => p.CompetitionId == competitionId && p.Status == ParticipantStatus.FullPlayer)
+            .Select(p => p.PlayerId).ToListAsync(ct);
+        var participantSet = participantIds.ToHashSet();
+        var missing = playerIds.Where(pid => !participantSet.Contains(pid)).ToList();
+        var violations = new List<string>();
+        if (missing.Count > 0)
+        {
+            var names = await db.Players.AsNoTracking()
+                .Where(p => missing.Contains(p.PlayerId))
+                .Select(p => p.DisplayName)
+                .ToListAsync(ct);
+            violations.Add($"Player(s) {string.Join(", ", names)} are not registered Full Player participants of this competition.");
+            return new ConfirmFixtureAssignmentResultDto(false, violations);
+        }
+
+        var players = await db.Players.AsNoTracking().Where(p => playerIds.Contains(p.PlayerId)).ToListAsync(ct);
+        foreach (var p in players)
+            foreach (var v in EligibilityEvaluator.Evaluate(comp, p))
+                violations.Add($"{p.DisplayName}: {v.Message}");
+
+        if (comp.CompetitionFormat == CompetitionFormat.MixedDoubles)
+        {
+            void CheckPair(int? aId, int? bId, string label)
+            {
+                if (!aId.HasValue || !bId.HasValue) return;
+                var a = players.FirstOrDefault(p => p.PlayerId == aId.Value);
+                var b = players.FirstOrDefault(p => p.PlayerId == bId.Value);
+                if (a is null || b is null) return;
+                if (a.Sex.HasValue && b.Sex.HasValue && a.Sex == b.Sex)
+                    violations.Add($"{label} is two {(a.Sex == PlayerSex.Male ? "males" : "females")}; mixed doubles requires one male + one female.");
+            }
+            CheckPair(request.Player1Id, request.Player3Id, "Home pair");
+            CheckPair(request.Player2Id, request.Player4Id, "Away pair");
+        }
+
+        return new ConfirmFixtureAssignmentResultDto(violations.Count == 0, violations);
+    }
+
+    public async Task<ScheduleFixturesResultDto> ScheduleFixturesAsync(
+        int competitionId, ScheduleFixturesAdminRequest request, CancellationToken ct = default)
+    {
+        await using (var db = await dbFactory.CreateDbContextAsync(ct))
+            await LoadAndAuthorizeAsync(db, competitionId, ct);
+
+        var mode = request.DeleteExistingUnscheduled
+            ? ScheduleDeleteMode.UnscheduledOnly
+            : ScheduleDeleteMode.None;
+        var result = await scheduler.ScheduleAsync(competitionId, new ScheduleFixturesRequest(mode));
+        return new ScheduleFixturesResultDto(
+            result.FixturesCreated, result.Unscheduled, result.UnconfirmedParticipants);
+    }
+
+    public async Task<SimulateRoundRobinResultDto> SimulateRoundRobinAsync(int competitionId, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        await LoadAndAuthorizeAsync(db, competitionId, ct);
+        if (!authzService.IsSuperAdmin(CurrentUser))
+            throw new UnauthorizedAccessException("Only super admins can simulate fixtures.");
+
+        var outcome = await fixtureSimulator.SimulateRoundRobinAsync(db, competitionId);
+        return new SimulateRoundRobinResultDto(outcome.FixturesSimulated);
+    }
+
+    public async Task<SeedKnockoutFromStandingsResultDto> SeedKnockoutFromStandingsAsync(
+        int competitionId, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var comp = await db.Competition
+            .Include(c => c.Stages)
+            .Include(c => c.Participants)
+            .FirstOrDefaultAsync(c => c.CompetitionID == competitionId, ct)
+            ?? throw new KeyNotFoundException("Competition not found.");
+        if (!await authzService.CanEditCompetitionAsync(CurrentUser, comp.HostClubId, competitionId))
+            throw new UnauthorizedAccessException("You can't edit this competition.");
+
+        var warnings = new List<string>();
+        var knockoutStageIds = comp.Stages
+            .Where(s => s.StageType is StageType.Knockout or StageType.QuarterFinal)
+            .Select(s => s.CompetitionStageId)
+            .ToHashSet();
+
+        var firstRoundFixtures = await db.CompetitionFixtures
+            .Where(f => f.CompetitionId == competitionId
+                     && f.Status != FixtureStatus.Completed
+                     && f.CompetitionStageId.HasValue
+                     && knockoutStageIds.Contains(f.CompetitionStageId.Value)
+                     && f.RoundNumber == 1)
+            .OrderBy(f => f.FixtureLabel)
+            .ToListAsync(ct);
+
+        if (firstRoundFixtures.Count == 0)
+        {
+            warnings.Add("No unseeded knockout fixtures found.");
+            return new SeedKnockoutFromStandingsResultDto(0, warnings);
+        }
+
+        var rrStageIds = comp.Stages
+            .Where(s => s.StageType == StageType.RoundRobin)
+            .Select(s => s.CompetitionStageId)
+            .ToHashSet();
+
+        var activePlayers = comp.Participants
+            .Where(p => p.Status == ParticipantStatus.FullPlayer)
+            .Select(p => p.PlayerId)
+            .ToList();
+
+        List<int> seededPlayers;
+        var rrFixtures = await db.CompetitionFixtures
+            .Where(f => f.CompetitionId == competitionId
+                     && f.CompetitionStageId != null
+                     && rrStageIds.Contains(f.CompetitionStageId!.Value)
+                     && f.Status == FixtureStatus.Completed
+                     && f.WinnerPlayerId != null)
+            .ToListAsync(ct);
+
+        if (rrFixtures.Count == 0)
+        {
+            seededPlayers = activePlayers.Take(firstRoundFixtures.Count * 2).ToList();
+        }
+        else
+        {
+            var pts = activePlayers.ToDictionary(pid => pid, _ => (Points: 0, Won: 0));
+            foreach (var f in rrFixtures)
+            {
+                var pids = new[] { f.Player1Id, f.Player2Id, f.Player3Id, f.Player4Id }
+                    .Where(pid => pid.HasValue && pts.ContainsKey(pid.Value))
+                    .Select(pid => pid!.Value).Distinct();
+                foreach (var pid in pids)
+                {
+                    bool win = pid == f.WinnerPlayerId;
+                    int points = comp.LeagueScoring switch
+                    {
+                        LeagueScoringMode.SetsWon  => ParseSetsWon(f.ResultSummary, pid == f.Player1Id || pid == f.Player3Id),
+                        LeagueScoringMode.GamesWon => ParseGamesWon(f.ResultSummary, pid == f.Player1Id || pid == f.Player3Id),
+                        _ => win ? 3 : (!f.WinnerPlayerId.HasValue ? 1 : 0),
+                    };
+                    var cur = pts[pid];
+                    pts[pid] = (cur.Points + points, cur.Won + (win ? 1 : 0));
+                }
+            }
+            seededPlayers = pts
+                .OrderByDescending(kv => kv.Value.Points)
+                .ThenByDescending(kv => kv.Value.Won)
+                .Take(firstRoundFixtures.Count * 2)
+                .Select(kv => kv.Key)
+                .ToList();
+        }
+
+        CompetitionProgressionService.AssignWinners(firstRoundFixtures, seededPlayers);
+        await db.SaveChangesAsync(ct);
+        return new SeedKnockoutFromStandingsResultDto(firstRoundFixtures.Count, warnings);
+    }
+
+    private static int ParseSetsWon(string? resultSummary, bool isSide1)
+    {
+        if (string.IsNullOrWhiteSpace(resultSummary)) return 0;
+        int count = 0;
+        foreach (var set in resultSummary.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var parts = set.Split('-');
+            if (parts.Length != 2 || !int.TryParse(parts[0], out var g1) || !int.TryParse(parts[1], out var g2)) continue;
+            if (isSide1 && g1 > g2) count++;
+            else if (!isSide1 && g2 > g1) count++;
+        }
+        return count;
+    }
+
+    private static int ParseGamesWon(string? resultSummary, bool isSide1)
+    {
+        if (string.IsNullOrWhiteSpace(resultSummary)) return 0;
+        int total = 0;
+        foreach (var set in resultSummary.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var parts = set.Split('-');
+            if (parts.Length != 2 || !int.TryParse(parts[0], out var g1) || !int.TryParse(parts[1], out var g2)) continue;
+            total += isSide1 ? g1 : g2;
+        }
+        return total;
+    }
+
+    // ── Match windows ────────────────────────────────────────────────────────
+
+    public async Task<int> AddMatchWindowAsync(
+        int competitionId, SaveMatchWindowRequest request, CancellationToken ct = default)
+    {
+        if (request.EndTime <= request.StartTime)
+            throw new InvalidOperationException("End time must be after start time.");
+
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        await LoadAndAuthorizeAsync(db, competitionId, ct);
+
+        var w = new CompetitionMatchWindow
+        {
+            CompetitionId         = competitionId,
+            CourtId               = request.CourtId,
+            CompetitionDivisionId = request.CompetitionDivisionId,
+            DayOfWeek             = request.DayOfWeek,
+            StartTime             = request.StartTime,
+            EndTime               = request.EndTime,
+        };
+        db.CompetitionMatchWindows.Add(w);
+        await db.SaveChangesAsync(ct);
+        return w.CompetitionMatchWindowId;
+    }
+
+    public async Task DeleteMatchWindowAsync(int competitionId, int matchWindowId, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        await LoadAndAuthorizeAsync(db, competitionId, ct);
+
+        var w = await db.CompetitionMatchWindows.FindAsync([matchWindowId], ct);
+        if (w is null || w.CompetitionId != competitionId) return;
+        db.CompetitionMatchWindows.Remove(w);
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task<int> AddDivisionMatchWindowAsync(
+        int competitionId, int divisionId, SaveMatchWindowRequest request, CancellationToken ct = default)
+    {
+        if (request.EndTime <= request.StartTime)
+            throw new InvalidOperationException("End time must be after start time.");
+
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        await LoadAndAuthorizeAsync(db, competitionId, ct);
+
+        var w = new CompetitionMatchWindow
+        {
+            CompetitionId         = competitionId,
+            CompetitionDivisionId = divisionId,
+            CourtId               = request.CourtId,
+            DayOfWeek             = request.DayOfWeek,
+            StartTime             = request.StartTime,
+            EndTime               = request.EndTime,
+        };
+        db.CompetitionMatchWindows.Add(w);
+        await db.SaveChangesAsync(ct);
+        return w.CompetitionMatchWindowId;
+    }
+
+    public async Task<int> ImportMatchWindowsFromTemplateAsync(
+        int competitionId, ImportMatchWindowsFromTemplateRequest request, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        await LoadAndAuthorizeAsync(db, competitionId, ct);
+
+        var template = await db.ClubSchedulingTemplates.AsNoTracking()
+            .Include(t => t.Windows)
+            .FirstOrDefaultAsync(t => t.ClubSchedulingTemplateId == request.ClubSchedulingTemplateId, ct)
+            ?? throw new KeyNotFoundException("Template not found.");
+
+        var existing = await db.CompetitionMatchWindows.AsNoTracking()
+            .Where(w => w.CompetitionId == competitionId)
+            .Select(w => new { w.DayOfWeek, w.StartTime, w.EndTime })
+            .ToListAsync(ct);
+        var existingKeys = existing.Select(e => (e.DayOfWeek, e.StartTime, e.EndTime)).ToHashSet();
+
+        var toAdd = template.Windows
+            .Where(tw => !existingKeys.Contains((tw.DayOfWeek, tw.StartTime, tw.EndTime)))
+            .Select(tw => new CompetitionMatchWindow
+            {
+                CompetitionId = competitionId,
+                DayOfWeek     = tw.DayOfWeek,
+                StartTime     = tw.StartTime,
+                EndTime       = tw.EndTime,
+            })
+            .ToList();
+        if (toAdd.Count == 0) return 0;
+
+        db.CompetitionMatchWindows.AddRange(toAdd);
+        await db.SaveChangesAsync(ct);
+        return toAdd.Count;
+    }
 }


### PR DESCRIPTION
## Summary

- Second half of the `ICompetitionAdminService` build-out started in 7N. Adds 33 methods covering every remaining server-only mutation the `CompetitionPage` performs today: participants, divisions, teams, fixtures, match windows, scheduler, simulator.
- Injects `CompetitionSchedulerService` and `FixtureSimulationService` into `WebCompetitionAdminService`. Server-only services stay server-only — Maui/HTTP never sees them.
- Reuses existing DTOs from `CompetitionDtos.cs` where shapes already match (`AddParticipantRequest`, `SaveDivisionRequest`, `SaveTeamRequest`, `SaveFixtureRequest`, `UpdateParticipantStatusRequest`, `AssignParticipantTeamRequest`, `SetParticipantRoleRequest`, `SetParticipantDivisionRequest`, `SeedDivisionsFromPreviousRequest`). `SaveFixtureRequest` gains optional `HomeTeamId`/`AwayTeamId`/`CourtPairId` trailing fields (additive). New admin-only DTOs added to `CompetitionAdminDtos.cs`: `PlayerSearchResultDto`, `AssignTeamDivisionRequest`, `AssignCaptainRequest`, `ValidateTeamResultDto`, `ConfirmFixtureAssignmentRequest`, `ConfirmFixtureAssignmentResultDto`.

## Design notes

- **Page is untouched in this PR.** Its 51 EF `DbFactory.CreateDbContextAsync` blocks stay as-is. 7U lifts the parent into the RCL and replaces every one of them with an `Admin.*Async` call. This matches the 7N pattern (rubber-template service surface shipped before the page consumed it).
- **No DI changes.** `ICompetitionAdminService` is already registered in `Program.cs`, `MauiProgram.cs`, and `DropShotTestContext`. `CompetitionSchedulerService` and `FixtureSimulationService` are already registered in the Web composition root (and the test context).
- **Authorization is per-method.** Every write goes through `authzService.CanEditCompetitionAsync` — no auth bypasses; `SimulateRoundRobinAsync` additionally checks `IsSuperAdmin`. The new private `LoadAndAuthorizeAsync` helper consolidates the load-comp + auth-check prelude.
- **`ConfirmFixtureAssignmentAsync` is a pure validator** — it returns a `ConfirmFixtureAssignmentResultDto(IsValid, Violations)` without persisting, so the caller can decide whether to show a confirm dialog before calling `SaveFixtureAsync`.
- **Page algorithms preserved.** `GenerateTeamsPreviewAsync` mirrors the page's per-bucket gender-split + role-assigner logic (lifted into a private `GenerateBucket` helper). `SeedKnockoutFromStandingsAsync` lifts the league-scoring logic and the `ParseSetsWon` / `ParseGamesWon` parsers.

## Test plan

- [x] `dotnet build DropShot.sln` — 0 errors
- [x] `dotnet test DropShot.Tests` — 28/28 passing
- [x] `dotnet build DropShot.Maui/DropShot.Maui.csproj` — clean across all 4 TFMs (windows, ios, maccatalyst, android)
- [x] Verified `CompetitionPage.razor` still has its 51 `DbFactory.CreateDbContextAsync` references (no page changes in 7O)
- [ ] Manual smoke after merge: existing competition admin UI continues to work end-to-end (purely additive on the service tier)

🤖 Generated with [Claude Code](https://claude.com/claude-code)