### PR TITLE
Phase 7 PR 7P: lift Templates + Stages + Admins sections into DropShot.UI

### DIFF
--- a/DropShot.UI/Components/Competitions/Setup/AdminsSection.razor
+++ b/DropShot.UI/Components/Competitions/Setup/AdminsSection.razor
@@ -1,4 +1,4 @@
-@using DropShot.Components.Pages
+@using DropShot.Shared.Dtos
 
 <MudPaper id="section-admins" Class="pa-4 mb-4 setup-section" Elevation="0"
      Style="background: rgba(255,255,255,0.08); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border: 1px solid rgba(255,255,255,0.12); border-radius: 12px; color: white;">
@@ -39,9 +39,9 @@
 </MudPaper>
 
 @code {
-    [Parameter, EditorRequired] public IReadOnlyList<CompetitionPage.CompetitionAdminRow> Admins { get; set; } = [];
+    [Parameter, EditorRequired] public IReadOnlyList<CompetitionAdminRowDto> Admins { get; set; } = [];
     [Parameter] public string NewAdminEmail { get; set; } = "";
     [Parameter] public EventCallback<string> NewAdminEmailChanged { get; set; }
     [Parameter] public EventCallback OnAddAdmin { get; set; }
-    [Parameter] public EventCallback<CompetitionPage.CompetitionAdminRow> OnRemoveAdmin { get; set; }
+    [Parameter] public EventCallback<CompetitionAdminRowDto> OnRemoveAdmin { get; set; }
 }

--- a/DropShot.UI/Components/Competitions/Setup/StagesSection.razor
+++ b/DropShot.UI/Components/Competitions/Setup/StagesSection.razor
@@ -1,5 +1,5 @@
-@using DropShot.Models
 @using DropShot.Shared
+@using DropShot.Shared.Dtos
 
 <MudPaper id="section-stages" Class="pa-4 mb-4 setup-section" Elevation="0"
      Style="background: rgba(255,255,255,0.08); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border: 1px solid rgba(255,255,255,0.12); border-radius: 12px; color: white;">
@@ -28,8 +28,8 @@
 </MudPaper>
 
 @code {
-    [Parameter, EditorRequired] public IReadOnlyList<CompetitionStage> Stages { get; set; } = [];
+    [Parameter, EditorRequired] public IReadOnlyList<CompetitionStageDto> Stages { get; set; } = [];
     [Parameter, EditorRequired] public Func<StageType, string> StageDisplayName { get; set; } = t => t.ToString();
     [Parameter] public EventCallback OnOpenAddDialog { get; set; }
-    [Parameter] public EventCallback<CompetitionStage> OnDeleteStage { get; set; }
+    [Parameter] public EventCallback<CompetitionStageDto> OnDeleteStage { get; set; }
 }

--- a/DropShot.UI/Components/Competitions/Setup/TemplatesSection.razor
+++ b/DropShot.UI/Components/Competitions/Setup/TemplatesSection.razor
@@ -1,4 +1,4 @@
-@using DropShot.Models
+@using DropShot.Shared.Dtos
 
 <MudPaper id="section-templates" Class="pa-4 mb-4 setup-section" Elevation="0"
      Style="background: rgba(255,255,255,0.08); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border: 1px solid rgba(255,255,255,0.12); border-radius: 12px; color: white;">
@@ -17,7 +17,7 @@
 </MudPaper>
 
 @code {
-    [Parameter, EditorRequired] public IReadOnlyList<CompetitionTemplate> Templates { get; set; } = [];
+    [Parameter, EditorRequired] public IReadOnlyList<CompetitionTemplateDto> Templates { get; set; } = [];
     [Parameter] public int? SelectedTemplateId { get; set; }
     [Parameter] public EventCallback<int?> OnApplyTemplate { get; set; }
 }

--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -372,7 +372,7 @@ else
         @* ── Competition Admins ───────────────────────────── *@
         @if (IsEdit && _canEdit)
         {
-            <DropShot.Components.Competitions.Setup.AdminsSection
+            <DropShot.UI.Components.Competitions.Setup.AdminsSection
                 Admins="_competitionAdmins"
                 NewAdminEmail="@_newAdminEmail"
                 NewAdminEmailChanged="@(v => _newAdminEmail = v)"
@@ -383,11 +383,11 @@ else
         @* ── Stages ─────────────────────────────────────────── *@
         @if (IsEdit)
         {
-            <DropShot.Components.Competitions.Setup.StagesSection
-                Stages="_stages"
+            <DropShot.UI.Components.Competitions.Setup.StagesSection
+                Stages="@_stages.Select(s => new DropShot.Shared.Dtos.CompetitionStageDto(s.CompetitionStageId, s.Name, s.StageOrder, s.StageType)).ToList()"
                 StageDisplayName="StageDisplayName"
                 OnOpenAddDialog="OpenAddStageDialog"
-                OnDeleteStage="DeleteStage" />
+                OnDeleteStage="DeleteStageDto" />
 
             @* ── Match Windows (hidden when HasDivisions — per-division UI lives in the Divisions section below) *@
             @if (!Model.HasDivisions)
@@ -452,8 +452,11 @@ else
             @* ── Apply Competition Template ───────────────────── *@
             @if (_competitionTemplates.Count > 0)
             {
-                <DropShot.Components.Competitions.Setup.TemplatesSection
-                    Templates="_competitionTemplates"
+                <DropShot.UI.Components.Competitions.Setup.TemplatesSection
+                    Templates="@_competitionTemplates.Select(t => new DropShot.Shared.Dtos.CompetitionTemplateDto(
+                        t.CompetitionTemplateId, t.ClubId, t.Name, t.Format, t.RulesSetId, t.BestOf, t.MaxAge, t.EligibleSex,
+                        t.Windows.Select(w => new DropShot.Shared.Dtos.CompetitionTemplateWindowDto(
+                            w.CompetitionTemplateWindowId, w.DayOfWeek, w.StartTime, w.EndTime)).ToList())).ToList()"
                     SelectedTemplateId="_selectedCompetitionTemplateId"
                     OnApplyTemplate="ApplyCompetitionTemplate" />
             }
@@ -1663,8 +1666,7 @@ else
     private bool _templateWindowsApplied;
 
     // Competition admins
-    public record CompetitionAdminRow(string UserId, string UserEmail, DateTime AssignedAt);
-    private List<CompetitionAdminRow> _competitionAdmins = [];
+    private List<DropShot.Shared.Dtos.CompetitionAdminRowDto> _competitionAdmins = [];
     private string _newAdminEmail = "";
 
     // Send Email
@@ -2397,6 +2399,12 @@ else
         await db.SaveChangesAsync();
         _showStageFollowUpDialog = false;
         Snackbar.Add($"{stages.Count} stage(s) added.", Severity.Success);
+    }
+
+    private async Task DeleteStageDto(DropShot.Shared.Dtos.CompetitionStageDto dto)
+    {
+        var stage = _stages.FirstOrDefault(s => s.CompetitionStageId == dto.CompetitionStageId);
+        if (stage is not null) await DeleteStage(stage);
     }
 
     private async Task DeleteStage(CompetitionStage stage)
@@ -4500,7 +4508,7 @@ else
         _competitionAdmins = await db.CompetitionAdmins
             .Where(ca => ca.CompetitionId == Id)
             .Join(db.Users, ca => ca.UserId, u => u.Id,
-                  (ca, u) => new CompetitionAdminRow(ca.UserId, u.Email ?? "", ca.AssignedAt))
+                  (ca, u) => new DropShot.Shared.Dtos.CompetitionAdminRowDto(ca.UserId, u.Email ?? "", ca.AssignedAt))
             .ToListAsync();
     }
 
@@ -4518,7 +4526,7 @@ else
         Snackbar.Add("Admin added.", Severity.Success);
     }
 
-    private async Task RemoveCompetitionAdmin(CompetitionAdminRow row)
+    private async Task RemoveCompetitionAdmin(DropShot.Shared.Dtos.CompetitionAdminRowDto row)
     {
         await using var db = DbFactory.CreateDbContext();
         var ca = await db.CompetitionAdmins.FindAsync(Id, row.UserId);


### PR DESCRIPTION
## Summary

- Moves three small section components (TemplatesSection, StagesSection, AdminsSection) from `DropShot/Components/Competitions/Setup/` to `DropShot.UI/Components/Competitions/Setup/`.
- Section parameters swap from EF entities (`CompetitionTemplate`, `CompetitionStage`, nested `CompetitionPage.CompetitionAdminRow`) to Shared DTOs (`CompetitionTemplateDto`, `CompetitionStageDto`, `CompetitionAdminRowDto`).
- Drops the nested `CompetitionAdminRow` type from `CompetitionPage` — the page now stores `List<CompetitionAdminRowDto>` directly.

## Design notes

- **Inline projection at the call site.** Parent `CompetitionPage.razor` projects EF entities to DTOs in the markup. These are tab-1 sections so the projection runs on tab navigation only — negligible cost.
- **`DeleteStageDto` bridge.** A thin `private async Task DeleteStageDto(CompetitionStageDto)` helper maps the new DTO-typed callback back to the existing entity-typed `DeleteStage` handler. Bridge collapses into a service-tier call when 7U lifts the parent into the RCL.
- Combined as one PR per the master plan — three small sections (23/35/47 lines), each with non-overlapping DTOs.

## Test plan

- [x] `dotnet build DropShot.sln` — 0 errors
- [x] `dotnet test DropShot.Tests` — 28/28 passing
- [x] `dotnet build DropShot.Maui/DropShot.Maui.csproj` — clean across all 4 TFMs
- [ ] Manual smoke after merge: open a competition page, apply a template, add/delete a stage, add/remove a competition admin

🤖 Generated with [Claude Code](https://claude.com/claude-code)