### PR TITLE
Phase 7 PR 7Q: lift RubberTemplateSection into DropShot.UI

### DIFF
--- a/DropShot.UI/Components/Competitions/Setup/RubberTemplateSection.razor
+++ b/DropShot.UI/Components/Competitions/Setup/RubberTemplateSection.razor
@@ -1,4 +1,5 @@
 @using DropShot.Shared
+@using DropShot.Shared.Dtos
 
 @{
     var isCustom = Source == "custom";
@@ -98,7 +99,7 @@
 
 @code {
     [Parameter, EditorRequired] public IReadOnlyList<RubberDef> Defs { get; set; } = [];
-    [Parameter, EditorRequired] public IReadOnlyList<(string Key, string Label)> Presets { get; set; } = [];
+    [Parameter, EditorRequired] public IReadOnlyList<RubberPresetDto> Presets { get; set; } = [];
     [Parameter, EditorRequired] public IReadOnlyList<string> AvailableRoles { get; set; } = [];
     [Parameter] public string Source { get; set; } = "default";
     [Parameter] public string? SelectedPresetKey { get; set; }

--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -417,9 +417,9 @@ else
             @* ── Rubber Template ─────────────────────────────── *@
             @if (EffectivePersistedFormat() == CompetitionFormat.TeamMatch)
             {
-                <DropShot.Components.Competitions.Setup.RubberTemplateSection
+                <DropShot.UI.Components.Competitions.Setup.RubberTemplateSection
                     Defs="_rubberTemplateDefs"
-                    Presets="_rubberPresets"
+                    Presets="@_rubberPresets.Select(p => new DropShot.Shared.Dtos.RubberPresetDto(p.Key, p.Label)).ToList()"
                     AvailableRoles="_availableRoles"
                     Source="_rubberTemplateSource"
                     SelectedPresetKey="@_selectedRubberPresetKey"


### PR DESCRIPTION
## Summary

- Moves `RubberTemplateSection.razor` from `DropShot/Components/Competitions/Setup/` to `DropShot.UI/Components/Competitions/Setup/`.
- `Presets` parameter swaps from a local tuple type (`List<(string Key, string Label)>`) to `RubberPresetDto` (already defined in `DropShot.Shared/Dtos/CompetitionDtos.cs`).
- `RubberDef` and `RubberTemplateRegistry` are already in `DropShot.Shared` (PR 7L), so the section now has no `DropShot.*` references.

## Test plan

- [x] `dotnet build DropShot.sln` — 0 errors
- [x] `dotnet test DropShot.Tests` — 28/28
- [x] `dotnet build DropShot.Maui` — 4 TFMs clean
- [ ] Manual smoke after merge: open a TeamMatch competition; load preset; convert to custom; edit a row; revert to default

🤖 Generated with [Claude Code](https://claude.com/claude-code)