### PR TITLE
Phase 7 PR 7R: lift MatchWindowsSection into DropShot.UI

### DIFF
--- a/DropShot.UI/Components/Competitions/Setup/MatchWindowsSection.razor
+++ b/DropShot.UI/Components/Competitions/Setup/MatchWindowsSection.razor
@@ -1,4 +1,4 @@
-@using DropShot.Models
+@using DropShot.Shared.Dtos
 
 <MudPaper id="section-match-windows" Class="pa-4 mb-4 setup-section" Elevation="0"
      Style="background: rgba(255,255,255,0.08); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border: 1px solid rgba(255,255,255,0.12); border-radius: 12px; color: white;">
@@ -68,7 +68,7 @@
                     var isEditing = EditingWindowId == w.CompetitionMatchWindowId;
                     <tr style="@(isEditing ? "background-color: rgba(255,193,7,0.15);" : "")">
                         <td>@w.DayOfWeek</td>
-                        <td>@(w.Court?.Name ?? "All courts")</td>
+                        <td>@(w.CourtName ?? "All courts")</td>
                         <td>@w.StartTime.ToString(@"hh\:mm")</td>
                         <td>@w.EndTime.ToString(@"hh\:mm")</td>
                         <td>
@@ -109,9 +109,9 @@
 </MudPaper>
 
 @code {
-    [Parameter, EditorRequired] public IReadOnlyList<CompetitionMatchWindow> Windows { get; set; } = [];
-    [Parameter, EditorRequired] public IReadOnlyList<Court> Courts { get; set; } = [];
-    [Parameter, EditorRequired] public IReadOnlyList<ClubSchedulingTemplate> ClubTemplates { get; set; } = [];
+    [Parameter, EditorRequired] public IReadOnlyList<CompetitionMatchWindowDto> Windows { get; set; } = [];
+    [Parameter, EditorRequired] public IReadOnlyList<CourtDto> Courts { get; set; } = [];
+    [Parameter, EditorRequired] public IReadOnlyList<ClubSchedulingTemplateDto> ClubTemplates { get; set; } = [];
     [Parameter] public int? SelectedTemplateId { get; set; }
     [Parameter] public DayOfWeek NewWindowDay { get; set; }
     [Parameter] public EventCallback<DayOfWeek> NewWindowDayChanged { get; set; }
@@ -124,8 +124,8 @@
     [Parameter] public int? EditingWindowId { get; set; }
     [Parameter] public EventCallback OnAdd { get; set; }
     [Parameter] public EventCallback OnCancelEdit { get; set; }
-    [Parameter] public EventCallback<CompetitionMatchWindow> OnCopyToForm { get; set; }
-    [Parameter] public EventCallback<CompetitionMatchWindow> OnEdit { get; set; }
-    [Parameter] public EventCallback<CompetitionMatchWindow> OnDelete { get; set; }
+    [Parameter] public EventCallback<CompetitionMatchWindowDto> OnCopyToForm { get; set; }
+    [Parameter] public EventCallback<CompetitionMatchWindowDto> OnEdit { get; set; }
+    [Parameter] public EventCallback<CompetitionMatchWindowDto> OnDelete { get; set; }
     [Parameter] public EventCallback<int?> OnImportFromTemplate { get; set; }
 }

--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -392,10 +392,16 @@ else
             @* ── Match Windows (hidden when HasDivisions — per-division UI lives in the Divisions section below) *@
             @if (!Model.HasDivisions)
             {
-                <DropShot.Components.Competitions.Setup.MatchWindowsSection
-                    Windows="_matchWindows"
-                    Courts="_courts"
-                    ClubTemplates="_clubTemplates"
+                <DropShot.UI.Components.Competitions.Setup.MatchWindowsSection
+                    Windows="@_matchWindows.Select(w => new DropShot.Shared.Dtos.CompetitionMatchWindowDto(
+                        w.CompetitionMatchWindowId, w.CompetitionId, w.CourtId, w.Court?.Name,
+                        w.CompetitionDivisionId, w.Division?.Name, w.DayOfWeek, w.StartTime, w.EndTime)).ToList()"
+                    Courts="@_courts.Select(c => new DropShot.Shared.Dtos.CourtDto(
+                        c.CourtId, c.ClubId, c.Name, (DropShot.Shared.CourtSurface)c.Surface, c.IsIndoor)).ToList()"
+                    ClubTemplates="@_clubTemplates.Select(t => new DropShot.Shared.Dtos.ClubSchedulingTemplateDto(
+                        t.ClubSchedulingTemplateId, t.ClubId, t.Name,
+                        t.Windows.Select(w => new DropShot.Shared.Dtos.ClubSchedulingTemplateWindowDto(
+                            w.ClubSchedulingTemplateWindowId, w.DayOfWeek, w.StartTime, w.EndTime)).ToList())).ToList()"
                     SelectedTemplateId="_selectedTemplateId"
                     NewWindowDay="_newMatchWindowDay"
                     NewWindowDayChanged="@(v => _newMatchWindowDay = v)"
@@ -408,9 +414,9 @@ else
                     EditingWindowId="_editingMatchWindowId"
                     OnAdd="AddMatchWindow"
                     OnCancelEdit="CancelEditMatchWindow"
-                    OnCopyToForm="CopyMatchWindowToForm"
-                    OnEdit="EditMatchWindow"
-                    OnDelete="DeleteMatchWindow"
+                    OnCopyToForm="CopyMatchWindowToFormDto"
+                    OnEdit="EditMatchWindowDto"
+                    OnDelete="DeleteMatchWindowDto"
                     OnImportFromTemplate="ImportFromTemplate" />
             }
 
@@ -4099,6 +4105,24 @@ else
         // Intentionally do NOT clear the form — admins often add multiple similar
         // windows differing in only one field (different day, different court).
         Snackbar.Add("Window added.", Severity.Success);
+    }
+
+    private void CopyMatchWindowToFormDto(DropShot.Shared.Dtos.CompetitionMatchWindowDto dto)
+    {
+        var w = _matchWindows.FirstOrDefault(x => x.CompetitionMatchWindowId == dto.CompetitionMatchWindowId);
+        if (w is not null) CopyMatchWindowToForm(w);
+    }
+
+    private void EditMatchWindowDto(DropShot.Shared.Dtos.CompetitionMatchWindowDto dto)
+    {
+        var w = _matchWindows.FirstOrDefault(x => x.CompetitionMatchWindowId == dto.CompetitionMatchWindowId);
+        if (w is not null) EditMatchWindow(w);
+    }
+
+    private async Task DeleteMatchWindowDto(DropShot.Shared.Dtos.CompetitionMatchWindowDto dto)
+    {
+        var w = _matchWindows.FirstOrDefault(x => x.CompetitionMatchWindowId == dto.CompetitionMatchWindowId);
+        if (w is not null) await DeleteMatchWindow(w);
     }
 
     private void CopyMatchWindowToForm(CompetitionMatchWindow w)


### PR DESCRIPTION
## Summary

- Moves `MatchWindowsSection.razor` from `DropShot/Components/Competitions/Setup/` to `DropShot.UI/Components/Competitions/Setup/`.
- Parameter swap: `CompetitionMatchWindow` → `CompetitionMatchWindowDto`, `Court` → `CourtDto`, `ClubSchedulingTemplate` → `ClubSchedulingTemplateDto`.
- Parent projects EF entities to DTOs at the call site; three thin bridge handlers (`CopyMatchWindowToFormDto`, `EditMatchWindowDto`, `DeleteMatchWindowDto`) forward to the existing entity-based handlers.

## Test plan

- [x] `dotnet build DropShot.sln` — 0 errors
- [x] `dotnet test DropShot.Tests` — 28/28
- [x] `dotnet build DropShot.Maui` — 4 TFMs clean
- [ ] Manual smoke: add a window, edit, delete, import from a club scheduling template

🤖 Generated with [Claude Code](https://claude.com/claude-code)