### PR TITLE
Phase 7 PR 7S: lift TeamsSection + FixturesSection into DropShot.UI

### DIFF
--- a/DropShot.UI/Components/Competitions/Setup/FixturesSection.razor
+++ b/DropShot.UI/Components/Competitions/Setup/FixturesSection.razor
@@ -1,5 +1,5 @@
-@using DropShot.Models
 @using DropShot.Shared
+@using DropShot.Shared.Dtos
 
 <MudPaper id="section-fixtures" Class="pa-4 setup-section" Elevation="0"
      Style="background: rgba(255,255,255,0.08); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border: 1px solid rgba(255,255,255,0.12); border-radius: 12px; color: white;">
@@ -94,7 +94,7 @@
             <MudTh></MudTh>
         </HeaderContent>
         <RowTemplate>
-            <MudTd>@(!string.IsNullOrEmpty(context.FixtureLabel) ? context.FixtureLabel : context.Stage?.Name ?? "—")</MudTd>
+            <MudTd>@(!string.IsNullOrEmpty(context.FixtureLabel) ? context.FixtureLabel : context.StageName ?? "—")</MudTd>
             <MudTd>@(context.ScheduledAt?.ToString("dd MMM yyyy HH:mm") ?? "—")</MudTd>
             <MudTd>@FixturePlayers(context)</MudTd>
             <MudTd>@FixtureCourtLabel(context)</MudTd>
@@ -160,12 +160,12 @@
 </MudPaper>
 
 @code {
-    [Parameter, EditorRequired] public IReadOnlyList<CompetitionFixture> Fixtures { get; set; } = [];
-    [Parameter, EditorRequired] public IReadOnlyList<CompetitionStage> Stages { get; set; } = [];
+    [Parameter, EditorRequired] public IReadOnlyList<CompetitionFixtureDto> Fixtures { get; set; } = [];
+    [Parameter, EditorRequired] public IReadOnlyList<CompetitionStageDto> Stages { get; set; } = [];
     [Parameter] public bool CanEdit { get; set; }
-    [Parameter, EditorRequired] public Func<CompetitionFixture, string> FixturePlayers { get; set; } = _ => "";
-    [Parameter, EditorRequired] public Func<CompetitionFixture, string> FixtureCourtLabel { get; set; } = _ => "";
-    [Parameter, EditorRequired] public Func<CompetitionFixture, string> FixtureResultDisplay { get; set; } = _ => "";
+    [Parameter, EditorRequired] public Func<CompetitionFixtureDto, string> FixturePlayers { get; set; } = _ => "";
+    [Parameter, EditorRequired] public Func<CompetitionFixtureDto, string> FixtureCourtLabel { get; set; } = _ => "";
+    [Parameter, EditorRequired] public Func<CompetitionFixtureDto, string> FixtureResultDisplay { get; set; } = _ => "";
     [Parameter, EditorRequired] public Func<FixtureStatus, Color> StatusColor { get; set; } = _ => Color.Default;
 
     [Parameter] public bool ShowScheduleConfirm { get; set; }
@@ -186,9 +186,9 @@
     [Parameter] public EventCallback OnSchedule { get; set; }
     [Parameter] public EventCallback OnDeleteAll { get; set; }
     [Parameter] public EventCallback OnSimulate { get; set; }
-    [Parameter] public EventCallback<CompetitionFixture> OnSubmitScore { get; set; }
-    [Parameter] public EventCallback<CompetitionFixture> OnOverrideResult { get; set; }
-    [Parameter] public EventCallback<CompetitionFixture> OnShowQr { get; set; }
-    [Parameter] public EventCallback<CompetitionFixture> OnOpenEditDialog { get; set; }
-    [Parameter] public EventCallback<CompetitionFixture> OnDeleteFixture { get; set; }
+    [Parameter] public EventCallback<CompetitionFixtureDto> OnSubmitScore { get; set; }
+    [Parameter] public EventCallback<CompetitionFixtureDto> OnOverrideResult { get; set; }
+    [Parameter] public EventCallback<CompetitionFixtureDto> OnShowQr { get; set; }
+    [Parameter] public EventCallback<CompetitionFixtureDto> OnOpenEditDialog { get; set; }
+    [Parameter] public EventCallback<CompetitionFixtureDto> OnDeleteFixture { get; set; }
 }

--- a/DropShot.UI/Components/Competitions/Setup/TeamsSection.razor
+++ b/DropShot.UI/Components/Competitions/Setup/TeamsSection.razor
@@ -1,5 +1,5 @@
-@using DropShot.Models
 @using DropShot.Shared
+@using DropShot.Shared.Dtos
 
 @{
     var isDoubles = Format is CompetitionFormat.Doubles or CompetitionFormat.MixedDoubles;
@@ -88,7 +88,7 @@
                                ValueChanged="@((int? pid) => OnAssignCaptain.InvokeAsync((context, pid)))">
                         @foreach (var p in Participants.Where(p => p.TeamId == context.CompetitionTeamId))
                         {
-                            <MudSelectItem T="int?" Value="@((int?)p.PlayerId)">@(p.Player?.DisplayName ?? "")</MudSelectItem>
+                            <MudSelectItem T="int?" Value="@((int?)p.PlayerId)">@p.DisplayName</MudSelectItem>
                         }
                     </MudSelect>
                 </MudTd>
@@ -98,7 +98,7 @@
                 {
                     @foreach (var p in Participants.Where(p => p.TeamId == context.CompetitionTeamId))
                     {
-                        var label = $"{p.Player?.DisplayName} ({p.Role ?? "—"})";
+                        var label = $"{p.DisplayName} ({p.Role ?? "—"})";
                         <MudChip T="string" Size="Size.Small" Variant="Variant.Text">@label</MudChip>
                     }
                 }
@@ -106,7 +106,7 @@
                 {
                     @string.Join(", ", Participants
                         .Where(p => p.TeamId == context.CompetitionTeamId)
-                        .Select(p => p.Player?.DisplayName ?? ""))
+                        .Select(p => p.DisplayName))
                 }
             </MudTd>
             @if (HasDivisions)
@@ -140,9 +140,9 @@
 </MudPaper>
 
 @code {
-    [Parameter, EditorRequired] public IReadOnlyList<CompetitionTeam> Teams { get; set; } = [];
-    [Parameter, EditorRequired] public IReadOnlyList<CompetitionParticipant> Participants { get; set; } = [];
-    [Parameter, EditorRequired] public IReadOnlyList<CompetitionDivision> Divisions { get; set; } = [];
+    [Parameter, EditorRequired] public IReadOnlyList<CompetitionTeamDto> Teams { get; set; } = [];
+    [Parameter, EditorRequired] public IReadOnlyList<CompetitionParticipantDto> Participants { get; set; } = [];
+    [Parameter, EditorRequired] public IReadOnlyList<CompetitionDivisionDto> Divisions { get; set; } = [];
     [Parameter, EditorRequired] public IReadOnlyList<string> AvailableRoles { get; set; } = [];
     [Parameter] public CompetitionFormat? Format { get; set; }
     [Parameter] public bool HasDivisions { get; set; }
@@ -154,9 +154,9 @@
     [Parameter] public EventCallback OnOpenGenerateDialog { get; set; }
     [Parameter] public EventCallback OnAutoAssignCaptains { get; set; }
     [Parameter] public EventCallback OnDeleteAllTeams { get; set; }
-    [Parameter] public EventCallback<(CompetitionTeam Team, int? PlayerId)> OnAssignCaptain { get; set; }
-    [Parameter] public EventCallback<(CompetitionTeam Team, int? DivisionId)> OnAssignTeamDivision { get; set; }
-    [Parameter] public EventCallback<CompetitionTeam> OnValidateTeam { get; set; }
-    [Parameter] public EventCallback<CompetitionTeam> OnOpenEditDialog { get; set; }
-    [Parameter] public EventCallback<CompetitionTeam> OnDeleteTeam { get; set; }
+    [Parameter] public EventCallback<(CompetitionTeamDto Team, int? PlayerId)> OnAssignCaptain { get; set; }
+    [Parameter] public EventCallback<(CompetitionTeamDto Team, int? DivisionId)> OnAssignTeamDivision { get; set; }
+    [Parameter] public EventCallback<CompetitionTeamDto> OnValidateTeam { get; set; }
+    [Parameter] public EventCallback<CompetitionTeamDto> OnOpenEditDialog { get; set; }
+    [Parameter] public EventCallback<CompetitionTeamDto> OnDeleteTeam { get; set; }
 }

--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -752,10 +752,11 @@ else
             @* ── Teams / Pairings (hidden when HasDivisions — per-division UI in the Divisions section below) *@
             @if (!Model.HasDivisions && EffectivePersistedFormat() is CompetitionFormat.Team or CompetitionFormat.TeamMatch or CompetitionFormat.Doubles or CompetitionFormat.MixedDoubles)
             {
-                <DropShot.Components.Competitions.Setup.TeamsSection
-                    Teams="_teams"
-                    Participants="_participants"
-                    Divisions="_divisions"
+                <DropShot.UI.Components.Competitions.Setup.TeamsSection
+                    Teams="@_teams.Select(ToTeamDto).ToList()"
+                    Participants="@_participants.Select(ToParticipantDto).ToList()"
+                    Divisions="@_divisions.Select(d => new DropShot.Shared.Dtos.CompetitionDivisionDto(
+                        d.CompetitionDivisionId, d.CompetitionId, d.Rank, d.Name)).ToList()"
                     AvailableRoles="_availableRoles"
                     Format="EffectivePersistedFormat()"
                     HasDivisions="Model.HasDivisions"
@@ -767,25 +768,26 @@ else
                     OnOpenGenerateDialog="OpenGenerateDialog"
                     OnAutoAssignCaptains="AutoAssignCaptains"
                     OnDeleteAllTeams="DeleteAllTeams"
-                    OnAssignCaptain="@((args) => AssignCaptain(args.Team, args.PlayerId))"
-                    OnAssignTeamDivision="@((args) => AssignTeamDivision(args.Team, args.DivisionId))"
-                    OnValidateTeam="ValidateTeam"
-                    OnOpenEditDialog="OpenEditTeamDialog"
-                    OnDeleteTeam="DeleteTeam" />
+                    OnAssignCaptain="@((args) => AssignCaptainDto(args.Team, args.PlayerId))"
+                    OnAssignTeamDivision="@((args) => AssignTeamDivisionDto(args.Team, args.DivisionId))"
+                    OnValidateTeam="ValidateTeamDto"
+                    OnOpenEditDialog="OpenEditTeamDialogDto"
+                    OnDeleteTeam="DeleteTeamDto" />
             }
         </MudTabPanel>
 
         <MudTabPanel Text="Fixtures/Results">
             @if (!Model.HasDivisions)
             {
-                <DropShot.Components.Competitions.Setup.FixturesSection
-                    Fixtures="_fixtures"
-                    Stages="_stages"
+                <DropShot.UI.Components.Competitions.Setup.FixturesSection
+                    Fixtures="@_fixtures.Select(ToFixtureDto).ToList()"
+                    Stages="@_stages.Select(s => new DropShot.Shared.Dtos.CompetitionStageDto(
+                        s.CompetitionStageId, s.Name, s.StageOrder, s.StageType)).ToList()"
                     CanEdit="_canEdit"
                     IsSuperAdmin="_isSuperAdmin"
-                    FixturePlayers="FixturePlayers"
-                    FixtureCourtLabel="FixtureCourtLabel"
-                    FixtureResultDisplay="FixtureResultDisplay"
+                    FixturePlayers="FixturePlayersDto"
+                    FixtureCourtLabel="FixtureCourtLabelDto"
+                    FixtureResultDisplay="FixtureResultDisplayDto"
                     StatusColor="StatusColor"
                     ShowScheduleConfirm="_showScheduleConfirm"
                     ShowScheduleConfirmChanged="@(v => _showScheduleConfirm = v)"
@@ -803,11 +805,11 @@ else
                     OnSchedule="ScheduleFixtures"
                     OnDeleteAll="DeleteAllFixtures"
                     OnSimulate="SimulateRoundRobinAsync"
-                    OnSubmitScore="OpenSubmitScoreAsync"
-                    OnOverrideResult="OpenOverrideResultAsync"
-                    OnShowQr="ShowQrCode"
-                    OnOpenEditDialog="OpenEditFixtureDialog"
-                    OnDeleteFixture="DeleteFixture" />
+                    OnSubmitScore="OpenSubmitScoreAsyncDto"
+                    OnOverrideResult="OpenOverrideResultAsyncDto"
+                    OnShowQr="ShowQrCodeDto"
+                    OnOpenEditDialog="OpenEditFixtureDialogDto"
+                    OnDeleteFixture="DeleteFixtureDto" />
             }
             else
             {
@@ -2405,6 +2407,96 @@ else
         await db.SaveChangesAsync();
         _showStageFollowUpDialog = false;
         Snackbar.Add($"{stages.Count} stage(s) added.", Severity.Success);
+    }
+
+    // ── DTO bridges (moved sections call DTO-typed callbacks; bridges look up
+    // the EF entity by id and forward to the existing entity-based handlers,
+    // until 7U lifts the parent into the RCL).
+    private static DropShot.Shared.Dtos.CompetitionTeamDto ToTeamDto(CompetitionTeam t) =>
+        new(t.CompetitionTeamId, t.CompetitionId, t.Name, t.CaptainPlayerId,
+            t.Captain?.DisplayName, t.CompetitionDivisionId);
+
+    private static DropShot.Shared.Dtos.CompetitionParticipantDto ToParticipantDto(CompetitionParticipant p) =>
+        new(p.PlayerId, p.Player?.DisplayName ?? "", p.Status, p.RegisteredAt,
+            p.TeamId, p.Team?.Name, p.Player?.MobileNumber, p.Role, p.Player?.Sex,
+            p.CompetitionDivisionId, p.Division?.Name);
+
+    private async Task AssignCaptainDto(DropShot.Shared.Dtos.CompetitionTeamDto dto, int? playerId)
+    {
+        var team = _teams.FirstOrDefault(t => t.CompetitionTeamId == dto.CompetitionTeamId);
+        if (team is not null) await AssignCaptain(team, playerId);
+    }
+
+    private async Task AssignTeamDivisionDto(DropShot.Shared.Dtos.CompetitionTeamDto dto, int? divisionId)
+    {
+        var team = _teams.FirstOrDefault(t => t.CompetitionTeamId == dto.CompetitionTeamId);
+        if (team is not null) await AssignTeamDivision(team, divisionId);
+    }
+
+    private async Task ValidateTeamDto(DropShot.Shared.Dtos.CompetitionTeamDto dto)
+    {
+        var team = _teams.FirstOrDefault(t => t.CompetitionTeamId == dto.CompetitionTeamId);
+        if (team is not null) await ValidateTeam(team);
+    }
+
+    private void OpenEditTeamDialogDto(DropShot.Shared.Dtos.CompetitionTeamDto dto)
+    {
+        var team = _teams.FirstOrDefault(t => t.CompetitionTeamId == dto.CompetitionTeamId);
+        if (team is not null) OpenEditTeamDialog(team);
+    }
+
+    private async Task DeleteTeamDto(DropShot.Shared.Dtos.CompetitionTeamDto dto)
+    {
+        var team = _teams.FirstOrDefault(t => t.CompetitionTeamId == dto.CompetitionTeamId);
+        if (team is not null) await DeleteTeam(team);
+    }
+
+    private string FixturePlayersDto(DropShot.Shared.Dtos.CompetitionFixtureDto dto)
+    {
+        var fx = _fixtures.FirstOrDefault(f => f.CompetitionFixtureId == dto.CompetitionFixtureId);
+        return fx is null ? "" : FixturePlayers(fx);
+    }
+
+    private string FixtureCourtLabelDto(DropShot.Shared.Dtos.CompetitionFixtureDto dto)
+    {
+        var fx = _fixtures.FirstOrDefault(f => f.CompetitionFixtureId == dto.CompetitionFixtureId);
+        return fx is null ? "" : FixtureCourtLabel(fx);
+    }
+
+    private string FixtureResultDisplayDto(DropShot.Shared.Dtos.CompetitionFixtureDto dto)
+    {
+        var fx = _fixtures.FirstOrDefault(f => f.CompetitionFixtureId == dto.CompetitionFixtureId);
+        return fx is null ? "" : FixtureResultDisplay(fx);
+    }
+
+    private async Task OpenSubmitScoreAsyncDto(DropShot.Shared.Dtos.CompetitionFixtureDto dto)
+    {
+        var fx = _fixtures.FirstOrDefault(f => f.CompetitionFixtureId == dto.CompetitionFixtureId);
+        if (fx is not null) await OpenSubmitScoreAsync(fx);
+    }
+
+    private async Task OpenOverrideResultAsyncDto(DropShot.Shared.Dtos.CompetitionFixtureDto dto)
+    {
+        var fx = _fixtures.FirstOrDefault(f => f.CompetitionFixtureId == dto.CompetitionFixtureId);
+        if (fx is not null) await OpenOverrideResultAsync(fx);
+    }
+
+    private void ShowQrCodeDto(DropShot.Shared.Dtos.CompetitionFixtureDto dto)
+    {
+        var fx = _fixtures.FirstOrDefault(f => f.CompetitionFixtureId == dto.CompetitionFixtureId);
+        if (fx is not null) ShowQrCode(fx);
+    }
+
+    private void OpenEditFixtureDialogDto(DropShot.Shared.Dtos.CompetitionFixtureDto dto)
+    {
+        var fx = _fixtures.FirstOrDefault(f => f.CompetitionFixtureId == dto.CompetitionFixtureId);
+        if (fx is not null) OpenEditFixtureDialog(fx);
+    }
+
+    private async Task DeleteFixtureDto(DropShot.Shared.Dtos.CompetitionFixtureDto dto)
+    {
+        var fx = _fixtures.FirstOrDefault(f => f.CompetitionFixtureId == dto.CompetitionFixtureId);
+        if (fx is not null) await DeleteFixture(fx);
     }
 
     private async Task DeleteStageDto(DropShot.Shared.Dtos.CompetitionStageDto dto)


### PR DESCRIPTION
## Summary

- Moves TeamsSection and FixturesSection (paired per master plan) from `DropShot/Components/Competitions/Setup/` to `DropShot.UI/Components/Competitions/Setup/`.
- TeamsSection params swap to DTOs: `CompetitionTeam` → `CompetitionTeamDto`, `CompetitionParticipant` → `CompetitionParticipantDto`, `CompetitionDivision` → `CompetitionDivisionDto`.
- FixturesSection params swap to DTOs: `CompetitionFixture` → `CompetitionFixtureDto`, `CompetitionStage` → `CompetitionStageDto`. Formatter `Func<>` types retyped to take the DTO.
- Parent projects via `ToTeamDto` / `ToParticipantDto` static helpers + inline LINQ; ~12 thin DTO bridges forward to the existing entity handlers.

## Paired rationale

`AssignCaptain` is called from both TeamsSection and (in 7T) DivisionsSection — moving them together cements the captain workflow's parameter projection in one design conversation. Both sections operate on the same entity surface (Team / Participant / Fixture). Bridges collapse into service-tier calls when 7U lifts the parent.

## Test plan

- [x] `dotnet build DropShot.sln` — 0 errors
- [x] `dotnet test DropShot.Tests` — 28/28
- [x] `dotnet build DropShot.Maui` — 4 TFMs clean
- [ ] Manual smoke: add team, auto-assign captains, generate teams, submit fixture score, override result, delete fixture, delete all fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)