### PR TITLE
Phase 7 PR 7T: lift DivisionsSection into DropShot.UI

### DIFF
--- a/DropShot.Shared/Dtos/CompetitionAdminDtos.cs
+++ b/DropShot.Shared/Dtos/CompetitionAdminDtos.cs
@@ -109,13 +109,13 @@ public record CompetitionAdminRowDto(
 /// <c>CompetitionPage.DivisionWindowForm</c> type so DivisionsSection (post-RCL
 /// move) can bind to a Shared type instead of a parent-page nested class.
 /// </summary>
-public record DivisionWindowFormDto
+public class DivisionWindowFormDto
 {
-    public DayOfWeek Day { get; init; } = DayOfWeek.Monday;
-    public int? CourtId { get; init; }
-    public TimeSpan? Start { get; init; }
-    public TimeSpan? End { get; init; }
-    public int? EditingId { get; init; }
+    public DayOfWeek Day { get; set; } = DayOfWeek.Monday;
+    public int? CourtId { get; set; }
+    public TimeSpan? Start { get; set; }
+    public TimeSpan? End { get; set; }
+    public int? EditingId { get; set; }
 }
 
 public record ClubSchedulingTemplateDto(

--- a/DropShot.UI/Components/Competitions/Setup/DivisionsSection.razor
+++ b/DropShot.UI/Components/Competitions/Setup/DivisionsSection.razor
@@ -1,6 +1,5 @@
-@using DropShot.Components.Pages
-@using DropShot.Models
 @using DropShot.Shared
+@using DropShot.Shared.Dtos
 
 <MudPaper id="section-divisions" Class="pa-4 mb-4 setup-section" Elevation="0"
          Style="background: rgba(255,255,255,0.08); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border: 1px solid rgba(255,255,255,0.12); border-radius: 12px; color: white;">
@@ -133,7 +132,7 @@
                                                        ValueChanged="@((int? pid) => OnAssignCaptain.InvokeAsync((context, pid)))">
                                                 @foreach (var p in Participants.Where(p => p.TeamId == context.CompetitionTeamId))
                                                 {
-                                                    <MudSelectItem T="int?" Value="@((int?)p.PlayerId)">@(p.Player?.DisplayName ?? "")</MudSelectItem>
+                                                    <MudSelectItem T="int?" Value="@((int?)p.PlayerId)">@p.DisplayName</MudSelectItem>
                                                 }
                                             </MudSelect>
                                         </MudTd>
@@ -143,7 +142,7 @@
                                         {
                                             @foreach (var p in Participants.Where(p => p.TeamId == context.CompetitionTeamId))
                                             {
-                                                var label = $"{p.Player?.DisplayName} ({p.Role ?? "-"})";
+                                                var label = $"{p.DisplayName} ({p.Role ?? "-"})";
                                                 <MudChip T="string" Size="Size.Small" Variant="Variant.Text">@label</MudChip>
                                             }
                                         }
@@ -151,7 +150,7 @@
                                         {
                                             @string.Join(", ", Participants
                                                 .Where(p => p.TeamId == context.CompetitionTeamId)
-                                                .Select(p => p.Player?.DisplayName ?? ""))
+                                                .Select(p => p.DisplayName))
                                         }
                                     </MudTd>
                                     <MudTd>
@@ -227,7 +226,7 @@
                                     var isEditingWindow = windowForm.EditingId == w.CompetitionMatchWindowId;
                                     <tr style="@(isEditingWindow ? "background-color: rgba(255,193,7,0.15);" : "")">
                                         <td>@w.DayOfWeek</td>
-                                        <td>@(w.Court?.Name ?? "All courts")</td>
+                                        <td>@(w.CourtName ?? "All courts")</td>
                                         <td>@w.StartTime.ToString(@"hh\:mm")</td>
                                         <td>@w.EndTime.ToString(@"hh\:mm")</td>
                                         <td>
@@ -275,8 +274,8 @@
                        ValueChanged="@((int? v) => SeedSourceCompetitionIdChanged.InvokeAsync(v))" Class="mb-2">
                 @foreach (var c in SeedSourceCandidates)
                 {
-                    <MudSelectItem T="int?" Value="@((int?)c.CompetitionID)">
-                        @c.CompetitionName@(c.StartDate.HasValue ? $" ({c.StartDate:dd MMM yyyy})" : "")
+                    <MudSelectItem T="int?" Value="@((int?)c.CompetitionId)">
+                        @c.CompetitionName@(c.EndDate.HasValue ? $" ({c.EndDate:dd MMM yyyy})" : "")
                     </MudSelectItem>
                 }
             </MudSelect>
@@ -316,12 +315,12 @@
 }
 
 @code {
-    [Parameter, EditorRequired] public IReadOnlyList<CompetitionDivision> Divisions { get; set; } = [];
-    [Parameter, EditorRequired] public IReadOnlyList<CompetitionTeam> Teams { get; set; } = [];
-    [Parameter, EditorRequired] public IReadOnlyList<CompetitionParticipant> Participants { get; set; } = [];
-    [Parameter, EditorRequired] public IReadOnlyList<CompetitionMatchWindow> MatchWindows { get; set; } = [];
-    [Parameter, EditorRequired] public IReadOnlyList<Court> Courts { get; set; } = [];
-    [Parameter, EditorRequired] public IReadOnlyList<Competition> SeedSourceCandidates { get; set; } = [];
+    [Parameter, EditorRequired] public IReadOnlyList<CompetitionDivisionDto> Divisions { get; set; } = [];
+    [Parameter, EditorRequired] public IReadOnlyList<CompetitionTeamDto> Teams { get; set; } = [];
+    [Parameter, EditorRequired] public IReadOnlyList<CompetitionParticipantDto> Participants { get; set; } = [];
+    [Parameter, EditorRequired] public IReadOnlyList<CompetitionMatchWindowDto> MatchWindows { get; set; } = [];
+    [Parameter, EditorRequired] public IReadOnlyList<CourtDto> Courts { get; set; } = [];
+    [Parameter, EditorRequired] public IReadOnlyList<CompetitionSeedSourceDto> SeedSourceCandidates { get; set; } = [];
     [Parameter] public CompetitionFormat? Format { get; set; }
 
     [Parameter] public bool AddingDivision { get; set; }
@@ -353,24 +352,24 @@
 
     [Parameter] public bool SeedingDivisions { get; set; }
 
-    [Parameter, EditorRequired] public Func<int, CompetitionPage.DivisionWindowForm> GetDivisionWindowForm { get; set; } = _ => new();
+    [Parameter, EditorRequired] public Func<int, DivisionWindowFormDto> GetDivisionWindowForm { get; set; } = _ => new();
 
     [Parameter] public EventCallback OnStartAddDivision { get; set; }
     [Parameter] public EventCallback OnCancelAddDivision { get; set; }
     [Parameter] public EventCallback OnSaveDivision { get; set; }
-    [Parameter] public EventCallback<CompetitionDivision> OnStartInlineEditDivision { get; set; }
+    [Parameter] public EventCallback<CompetitionDivisionDto> OnStartInlineEditDivision { get; set; }
     [Parameter] public EventCallback OnCancelInlineEditDivision { get; set; }
-    [Parameter] public EventCallback<CompetitionDivision> OnDeleteDivision { get; set; }
+    [Parameter] public EventCallback<CompetitionDivisionDto> OnDeleteDivision { get; set; }
     [Parameter] public EventCallback OnOpenSeedDivisionsDialog { get; set; }
     [Parameter] public EventCallback OnRunSeedDivisions { get; set; }
     [Parameter] public EventCallback OnOpenGenerateDialog { get; set; }
     [Parameter] public EventCallback<int> OnAddDivisionMatchWindow { get; set; }
     [Parameter] public EventCallback<int> OnCancelEditDivisionMatchWindow { get; set; }
-    [Parameter] public EventCallback<CompetitionMatchWindow> OnCopyDivisionMatchWindowToForm { get; set; }
-    [Parameter] public EventCallback<CompetitionMatchWindow> OnEditDivisionMatchWindow { get; set; }
-    [Parameter] public EventCallback<CompetitionMatchWindow> OnDeleteMatchWindow { get; set; }
-    [Parameter] public EventCallback<(CompetitionTeam Team, int? PlayerId)> OnAssignCaptain { get; set; }
-    [Parameter] public EventCallback<CompetitionTeam> OnValidateTeam { get; set; }
-    [Parameter] public EventCallback<CompetitionTeam> OnOpenEditTeamDialog { get; set; }
-    [Parameter] public EventCallback<CompetitionTeam> OnDeleteTeam { get; set; }
+    [Parameter] public EventCallback<CompetitionMatchWindowDto> OnCopyDivisionMatchWindowToForm { get; set; }
+    [Parameter] public EventCallback<CompetitionMatchWindowDto> OnEditDivisionMatchWindow { get; set; }
+    [Parameter] public EventCallback<CompetitionMatchWindowDto> OnDeleteMatchWindow { get; set; }
+    [Parameter] public EventCallback<(CompetitionTeamDto Team, int? PlayerId)> OnAssignCaptain { get; set; }
+    [Parameter] public EventCallback<CompetitionTeamDto> OnValidateTeam { get; set; }
+    [Parameter] public EventCallback<CompetitionTeamDto> OnOpenEditTeamDialog { get; set; }
+    [Parameter] public EventCallback<CompetitionTeamDto> OnDeleteTeam { get; set; }
 }

--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -700,13 +700,18 @@ else
             @* -- Divisions -- *@
             @if (Model.HasDivisions)
             {
-                <DropShot.Components.Competitions.Setup.DivisionsSection
-                    Divisions="_divisions"
-                    Teams="_teams"
-                    Participants="_participants"
-                    MatchWindows="_matchWindows"
-                    Courts="_courts"
-                    SeedSourceCandidates="_seedSourceCandidates"
+                <DropShot.UI.Components.Competitions.Setup.DivisionsSection
+                    Divisions="@_divisions.Select(d => new DropShot.Shared.Dtos.CompetitionDivisionDto(
+                        d.CompetitionDivisionId, d.CompetitionId, d.Rank, d.Name)).ToList()"
+                    Teams="@_teams.Select(ToTeamDto).ToList()"
+                    Participants="@_participants.Select(ToParticipantDto).ToList()"
+                    MatchWindows="@_matchWindows.Select(w => new DropShot.Shared.Dtos.CompetitionMatchWindowDto(
+                        w.CompetitionMatchWindowId, w.CompetitionId, w.CourtId, w.Court?.Name,
+                        w.CompetitionDivisionId, w.Division?.Name, w.DayOfWeek, w.StartTime, w.EndTime)).ToList()"
+                    Courts="@_courts.Select(c => new DropShot.Shared.Dtos.CourtDto(
+                        c.CourtId, c.ClubId, c.Name, (DropShot.Shared.CourtSurface)c.Surface, c.IsIndoor)).ToList()"
+                    SeedSourceCandidates="@_seedSourceCandidates.Select(c => new DropShot.Shared.Dtos.CompetitionSeedSourceDto(
+                        c.CompetitionID, c.CompetitionName, c.EndDate, c.Divisions?.Count ?? 0)).ToList()"
                     Format="EffectivePersistedFormat()"
                     AddingDivision="_addingDivision"
                     AddingDivisionChanged="@(v => _addingDivision = v)"
@@ -731,21 +736,21 @@ else
                     OnStartAddDivision="StartAddDivision"
                     OnCancelAddDivision="CancelAddDivision"
                     OnSaveDivision="SaveDivisionDialog"
-                    OnStartInlineEditDivision="StartInlineEditDivision"
+                    OnStartInlineEditDivision="StartInlineEditDivisionDto"
                     OnCancelInlineEditDivision="CancelInlineEditDivision"
-                    OnDeleteDivision="DeleteDivision"
+                    OnDeleteDivision="DeleteDivisionDto"
                     OnOpenSeedDivisionsDialog="OpenSeedDivisionsDialog"
                     OnRunSeedDivisions="RunSeedDivisions"
                     OnOpenGenerateDialog="OpenGenerateDialog"
                     OnAddDivisionMatchWindow="AddDivisionMatchWindow"
                     OnCancelEditDivisionMatchWindow="CancelEditDivisionMatchWindow"
-                    OnCopyDivisionMatchWindowToForm="CopyDivisionMatchWindowToForm"
-                    OnEditDivisionMatchWindow="EditDivisionMatchWindow"
-                    OnDeleteMatchWindow="DeleteMatchWindow"
-                    OnAssignCaptain="@((args) => AssignCaptain(args.Team, args.PlayerId))"
-                    OnValidateTeam="ValidateTeam"
-                    OnOpenEditTeamDialog="OpenEditTeamDialog"
-                    OnDeleteTeam="DeleteTeam" />
+                    OnCopyDivisionMatchWindowToForm="CopyDivisionMatchWindowToFormDto"
+                    OnEditDivisionMatchWindow="EditDivisionMatchWindowDto"
+                    OnDeleteMatchWindow="DeleteMatchWindowDto"
+                    OnAssignCaptain="@((args) => AssignCaptainDto(args.Team, args.PlayerId))"
+                    OnValidateTeam="ValidateTeamDto"
+                    OnOpenEditTeamDialog="OpenEditTeamDialogDto"
+                    OnDeleteTeam="DeleteTeamDto" />
             }
 
 
@@ -2497,6 +2502,30 @@ else
     {
         var fx = _fixtures.FirstOrDefault(f => f.CompetitionFixtureId == dto.CompetitionFixtureId);
         if (fx is not null) await DeleteFixture(fx);
+    }
+
+    private void StartInlineEditDivisionDto(DropShot.Shared.Dtos.CompetitionDivisionDto dto)
+    {
+        var div = _divisions.FirstOrDefault(d => d.CompetitionDivisionId == dto.CompetitionDivisionId);
+        if (div is not null) StartInlineEditDivision(div);
+    }
+
+    private async Task DeleteDivisionDto(DropShot.Shared.Dtos.CompetitionDivisionDto dto)
+    {
+        var div = _divisions.FirstOrDefault(d => d.CompetitionDivisionId == dto.CompetitionDivisionId);
+        if (div is not null) await DeleteDivision(div);
+    }
+
+    private void CopyDivisionMatchWindowToFormDto(DropShot.Shared.Dtos.CompetitionMatchWindowDto dto)
+    {
+        var w = _matchWindows.FirstOrDefault(x => x.CompetitionMatchWindowId == dto.CompetitionMatchWindowId);
+        if (w is not null) CopyDivisionMatchWindowToForm(w);
+    }
+
+    private void EditDivisionMatchWindowDto(DropShot.Shared.Dtos.CompetitionMatchWindowDto dto)
+    {
+        var w = _matchWindows.FirstOrDefault(x => x.CompetitionMatchWindowId == dto.CompetitionMatchWindowId);
+        if (w is not null) EditDivisionMatchWindow(w);
     }
 
     private async Task DeleteStageDto(DropShot.Shared.Dtos.CompetitionStageDto dto)
@@ -4257,21 +4286,13 @@ else
     }
 
     // ── Per-division match windows ──────────────────────────────────────────
-    public class DivisionWindowForm
-    {
-        public DayOfWeek Day { get; set; } = DayOfWeek.Monday;
-        public int? CourtId { get; set; }
-        public TimeSpan? Start { get; set; }
-        public TimeSpan? End { get; set; }
-        public int? EditingId { get; set; }
-    }
-    private readonly Dictionary<int, DivisionWindowForm> _divisionWindowForms = [];
+    private readonly Dictionary<int, DropShot.Shared.Dtos.DivisionWindowFormDto> _divisionWindowForms = [];
 
-    private DivisionWindowForm GetDivisionWindowForm(int divisionId)
+    private DropShot.Shared.Dtos.DivisionWindowFormDto GetDivisionWindowForm(int divisionId)
     {
         if (!_divisionWindowForms.TryGetValue(divisionId, out var form))
         {
-            form = new DivisionWindowForm();
+            form = new DropShot.Shared.Dtos.DivisionWindowFormDto();
             _divisionWindowForms[divisionId] = form;
         }
         return form;


### PR DESCRIPTION
## Summary

- Moves DivisionsSection (the largest setup section, 376 lines, 7 model types) from `DropShot/Components/Competitions/Setup/` to `DropShot.UI/Components/Competitions/Setup/`.
- Parameter types swap to Shared DTOs (`CompetitionDivisionDto`, `CompetitionTeamDto`, `CompetitionParticipantDto`, `CompetitionMatchWindowDto`, `CourtDto`, `CompetitionSeedSourceDto`).
- `DivisionWindowFormDto` switched from `record`/`init` to `class`/`set` so the section's `@bind-Value` form binding works; nested `CompetitionPage.DivisionWindowForm` type removed entirely.
- Bridge handlers added: `StartInlineEditDivisionDto`, `DeleteDivisionDto`, `CopyDivisionMatchWindowToFormDto`, `EditDivisionMatchWindowDto`. AssignCaptain/ValidateTeam/Open/Delete reuse 7S bridges.

## Status

After this PR all 8 setup sections live in `DropShot.UI`. **7U** is the final move that lifts the parent `CompetitionPage` into the RCL and creates the thin web shim.

## Test plan

- [x] `dotnet build DropShot.sln` — 0 errors
- [x] `dotnet test DropShot.Tests` — 28/28
- [x] `dotnet build DropShot.Maui` — 4 TFMs clean
- [ ] Manual smoke: add division; inline-edit; delete; seed divisions from a previous competition (with promote/demote); add per-division match window; assign captain to a team within a division

🤖 Generated with [Claude Code](https://claude.com/claude-code)