### PR TITLE
Share MudBlazor theme between web and MAUI hosts

### DIFF
--- a/DropShot.Maui/Components/Layout/LoginLayout.razor
+++ b/DropShot.Maui/Components/Layout/LoginLayout.razor
@@ -1,6 +1,6 @@
 @inherits LayoutComponentBase
 
-<MudThemeProvider />
+<MudThemeProvider IsDarkMode="true" Theme="DropShot.UI.Theme.DropShotTheme.Default" />
 <MudPopoverProvider />
 
 <MudContainer MaxWidth="MaxWidth.Small" Class="mt-8">

--- a/DropShot.Maui/Components/Layout/MainLayout.razor
+++ b/DropShot.Maui/Components/Layout/MainLayout.razor
@@ -5,7 +5,7 @@
 @inject ISnackbar Snackbar
 @inject NavigationManager Nav
 
-<MudThemeProvider />
+<MudThemeProvider IsDarkMode="true" Theme="DropShot.UI.Theme.DropShotTheme.Default" />
 <MudPopoverProvider />
 <MudDialogProvider FullWidth="true" MaxWidth="MaxWidth.Small" />
 <MudSnackbarProvider />

--- a/DropShot.UI/Theme/DropShotTheme.cs
+++ b/DropShot.UI/Theme/DropShotTheme.cs
@@ -1,0 +1,22 @@
+using MudBlazor;
+
+namespace DropShot.UI.Theme;
+
+/// <summary>
+/// Shared MudBlazor theme for both the web (DropShot) and MAUI (DropShot.Maui)
+/// hosts. Defined once here so the two app shells can't drift — MAUI was
+/// shipping with the stock purple palette while the web had moved to teal.
+/// </summary>
+public static class DropShotTheme
+{
+    public static MudTheme Default { get; } = new()
+    {
+        PaletteDark = new PaletteDark
+        {
+            Primary        = "#00897b",
+            PrimaryDarken  = "#00695c",
+            PrimaryLighten = "#4db6ac",
+            Secondary      = "#26a69a",
+        }
+    };
+}

--- a/DropShot/Components/Layout/MainLayout.razor
+++ b/DropShot/Components/Layout/MainLayout.razor
@@ -1,7 +1,7 @@
  <meta name="viewport" content="width=device-width, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
 @inherits LayoutComponentBase
 @inject DropShot.Services.SiteSettingsService SiteSettings
-<MudThemeProvider IsDarkMode="true" Theme="_theme" />
+<MudThemeProvider IsDarkMode="true" Theme="DropShot.UI.Theme.DropShotTheme.Default" />
 <style>:root { --ds-content-max-width: @(_contentMaxWidthPx)px; }</style>
 @* Popover/Dialog/Snackbar providers are intentionally NOT here.
    Each @rendermode InteractiveServer page injects <MudProviders /> directly
@@ -29,17 +29,6 @@
 </div>
 
 @code {
-    private MudTheme _theme = new()
-    {
-        PaletteDark = new PaletteDark
-        {
-            Primary = "#00897b",
-            PrimaryDarken = "#00695c",
-            PrimaryLighten = "#4db6ac",
-            Secondary = "#26a69a",
-        }
-    };
-
     private int _contentMaxWidthPx = SiteSettingsService.ContentMaxWidthPxDefault;
 
     protected override async Task OnInitializedAsync()


### PR DESCRIPTION
## Summary

The MAUI app was rendering with the stock MudBlazor purple palette because `DropShot.Maui/Components/Layout/MainLayout.razor` and `LoginLayout.razor` both used `<MudThemeProvider />` with no `Theme` parameter. The web app long ago moved to a teal palette via a `MudTheme` defined inline in `DropShot/Components/Layout/MainLayout.razor`. The two hosts had drifted.

## Fix

- New `DropShot.UI/Theme/DropShotTheme.cs` exposes the `MudTheme` as `DropShotTheme.Default` (static, single source of truth).
- Web `MainLayout.razor` drops the local `_theme` field and references `DropShot.UI.Theme.DropShotTheme.Default`.
- MAUI `MainLayout.razor` and `LoginLayout.razor` swap `<MudThemeProvider />` for `<MudThemeProvider IsDarkMode="true" Theme="DropShot.UI.Theme.DropShotTheme.Default" />`.

Going forward, both hosts can't drift — any palette change lands once in `DropShot.UI/Theme/DropShotTheme.cs`.

## Test plan

- [ ] Run the MAUI app — app bar and primary controls should be teal (`#00897b`), not purple
- [ ] Run the web app — palette unchanged
- [ ] `dotnet build DropShot.sln` clean

## Note

Independent of in-flight PR 7U (CompetitionPage parent lift). No conflict expected — this PR only touches `DropShot.UI/Theme/`, the two MAUI layouts, and the web `MainLayout.razor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)