### PR TITLE
Add missing MAUI route shims for TennisScore + CompetitionPage

### DIFF
--- a/DropShot.Maui/Components/Pages/CompetitionPage.razor
+++ b/DropShot.Maui/Components/Pages/CompetitionPage.razor
@@ -1,0 +1,9 @@
+@page "/competition/{Id:int}"
+@attribute [Authorize]
+@using Microsoft.AspNetCore.Authorization
+
+<DropShot.UI.Components.Pages.CompetitionPage Id="@Id" />
+
+@code {
+    [Parameter] public int Id { get; set; }
+}

--- a/DropShot.Maui/Components/Pages/TennisScore.razor
+++ b/DropShot.Maui/Components/Pages/TennisScore.razor
@@ -1,0 +1,10 @@
+@page "/tennisscore"
+@page "/match/{MatchId:int}"
+@attribute [Authorize]
+@using Microsoft.AspNetCore.Authorization
+
+<DropShot.UI.Components.Pages.TennisScore MatchId="@MatchId" />
+
+@code {
+    [Parameter] public int MatchId { get; set; }
+}


### PR DESCRIPTION
## Summary

The MAUI app was hitting "Page not found" when starting a new match. Cause: no route shim for `TennisScore.razor` (which owns `/tennisscore` and `/match/{MatchId:int}`). Same gap for `CompetitionPage.razor` after PR 7U lifted it to `DropShot.UI`.

`BlazorWebView`'s router only discovers `@page` directives in `DropShot.Maui/Components/Pages/`. Pages living in the RCL (`DropShot.UI`) need a thin shim in the MAUI Pages directory to register their routes — same pattern as the web app's `DropShot/Components/Pages/` shims, minus `@rendermode` and `<MudProviders />` (which only the web host needs).

## Files

- new `DropShot.Maui/Components/Pages/TennisScore.razor` — `/tennisscore` + `/match/{MatchId:int}`
- new `DropShot.Maui/Components/Pages/CompetitionPage.razor` — `/competition/{Id:int}`

## Test plan

- [x] `dotnet build DropShot.Maui` — 0 errors
- [ ] In MAUI: tap "Start a new match" — should land on the Active Matches list, not "Page not found"
- [ ] In MAUI: open a competition — `/competition/{id}` should render

🤖 Generated with [Claude Code](https://claude.com/claude-code)