### PR TITLE
Persist MAUI login across app restarts (iOS)

### DIFF
--- a/DropShot.Maui/Components/Routes.razor
+++ b/DropShot.Maui/Components/Routes.razor
@@ -1,13 +1,35 @@
+@inject AuthService Auth
+
 <CascadingAuthenticationState>
-    <Router AppAssembly="@typeof(MauiProgram).Assembly"
-            AdditionalAssemblies="@(new[] { typeof(DropShot.UI.Services.Auth.ICurrentUser).Assembly })">
-        <Found Context="routeData">
-            <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(Layout.MainLayout)">
-                <NotAuthorized>
-                    <RedirectToLogin />
-                </NotAuthorized>
-            </AuthorizeRouteView>
-            <FocusOnNavigate RouteData="@routeData" Selector="h1" />
-        </Found>
-    </Router>
+    @if (!_sessionRestored)
+    {
+        <MudThemeProvider IsDarkMode="true" Theme="DropShot.UI.Theme.DropShotTheme.Default" />
+        <div style="display:flex;align-items:center;justify-content:center;height:100vh;">
+            <MudProgressCircular Color="Color.Primary" Indeterminate="true" Size="Size.Large" />
+        </div>
+    }
+    else
+    {
+        <Router AppAssembly="@typeof(MauiProgram).Assembly"
+                AdditionalAssemblies="@(new[] { typeof(DropShot.UI.Services.Auth.ICurrentUser).Assembly })">
+            <Found Context="routeData">
+                <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(Layout.MainLayout)">
+                    <NotAuthorized>
+                        <RedirectToLogin />
+                    </NotAuthorized>
+                </AuthorizeRouteView>
+                <FocusOnNavigate RouteData="@routeData" Selector="h1" />
+            </Found>
+        </Router>
+    }
 </CascadingAuthenticationState>
+
+@code {
+    private bool _sessionRestored;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await Auth.TryRestoreSessionAsync();
+        _sessionRestored = true;
+    }
+}


### PR DESCRIPTION
## Summary
- iOS users were being kicked to `/login` on every cold app start even though their JWT was already cached in `SecureStorage` (Keychain) — `AuthService.TryRestoreSessionAsync()` was implemented but never invoked on startup
- Wired the existing restore method into `Routes.razor` via a one-shot `OnInitializedAsync` gate so the cached token is reloaded and the auth state is rehydrated before the router decides to render `<RedirectToLogin>`
- Added a brief centred `MudProgressCircular` while restore is in flight so the login page does not flash before the restore completes
- No changes to `AuthService` itself — its existing catch-and-logout path already handles expired tokens, network failures, and missing tokens

## Test plan
- [ ] Cold-start logged-out: launch fresh, expect login page
- [ ] Cold-start logged-in (the fix): log in, fully close the app, relaunch — expect spinner then authenticated home page, no login redirect
- [ ] Expired token: relaunch with a stale JWT — expect login page, no stuck spinner, console clean
- [ ] Logout still clears the token: logout, relaunch, expect login page
- [ ] No regression on web host (`DropShot.Web` has its own `Routes.razor`, untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)