### PR TITLE
Phase 8 PR 8a: anonymous Home in MAUI

### DIFF
--- a/DropShot.Maui/Components/Pages/Home.razor
+++ b/DropShot.Maui/Components/Pages/Home.razor
@@ -1,9 +1,8 @@
 @page "/"
-@attribute [Authorize]
 
-@* MAUI shim. No <MudProviders /> (MainLayout owns them) and no
-   AnonymousQrPanel slot — MAUI doesn't have a QR-login flow, and
-   [Authorize] redirects unauthenticated users to login before they
-   could see Home anyway. *@
+@* MAUI shim. Intentionally NOT [Authorize]-gated so the app launches at Home
+   for anonymous users (matching the web). LoginUrl points at MAUI's own
+   bearer-token login page; MagicLinkUrl is empty so the magic-link button is
+   hidden — magic link is a web-Identity feature MAUI doesn't have. *@
 
-<DropShot.UI.Components.Pages.Home />
+<DropShot.UI.Components.Pages.Home LoginUrl="/login" MagicLinkUrl="" />

--- a/DropShot.UI/Components/Pages/Home.razor
+++ b/DropShot.UI/Components/Pages/Home.razor
@@ -121,23 +121,26 @@
                     {
                         <MudText Typo="Typo.body1" Class="mt-2 d-none d-md-block">
                             Scan the QR code with your phone to log in, or
-                            <MudLink Href="/Account/Login">use email and password</MudLink>.
+                            <MudLink Href="@LoginUrl">use email and password</MudLink>.
                         </MudText>
                         <MudText Typo="Typo.body1" Class="mt-2 d-md-none">
-                            <MudLink Href="/Account/Login">Log in with email and password</MudLink> to get started.
+                            <MudLink Href="@LoginUrl">Log in with email and password</MudLink> to get started.
                         </MudText>
                     }
                     else
                     {
                         <MudText Typo="Typo.body1" Class="mt-2">
-                            <MudLink Href="/Account/Login">Log in with email and password</MudLink> to get started.
+                            <MudLink Href="@LoginUrl">Log in with email and password</MudLink> to get started.
                         </MudText>
                     }
-                    <MudButton Variant="Variant.Outlined" Color="Color.Primary" Class="mt-3"
-                               StartIcon="@Icons.Material.Filled.AutoFixHigh"
-                               Href="/Account/LoginMagicLink">
-                        Sign in with magic link
-                    </MudButton>
+                    @if (!string.IsNullOrEmpty(MagicLinkUrl))
+                    {
+                        <MudButton Variant="Variant.Outlined" Color="Color.Primary" Class="mt-3"
+                                   StartIcon="@Icons.Material.Filled.AutoFixHigh"
+                                   Href="@MagicLinkUrl">
+                            Sign in with magic link
+                        </MudButton>
+                    }
                 </MudItem>
                 @if (AnonymousQrPanel is not null)
                 {
@@ -312,10 +315,23 @@
 
     /// <summary>
     /// Server-only QR-login panel passed by the web host shim. MAUI omits
-    /// the slot (no QR-login flow on mobile, and [Authorize] redirects
-    /// unauthenticated users to login before they could see Home anyway).
+    /// the slot — no QR-login flow on mobile.
     /// </summary>
     [Parameter] public RenderFragment? AnonymousQrPanel { get; set; }
+
+    /// <summary>
+    /// URL the "Log in with email and password" links navigate to. Defaults
+    /// to the web's ASP.NET Identity scaffolded route; MAUI overrides to
+    /// "/login" (its own bearer-token login page).
+    /// </summary>
+    [Parameter] public string LoginUrl { get; set; } = "/Account/Login";
+
+    /// <summary>
+    /// URL for the "Sign in with magic link" button. Defaults to the web's
+    /// scaffolded route. MAUI passes empty/null to hide the button — magic
+    /// link is a web-Identity feature MAUI doesn't have.
+    /// </summary>
+    [Parameter] public string? MagicLinkUrl { get; set; } = "/Account/LoginMagicLink";
 
     private List<CompetitionFixtureDto> _upcomingFixtures = [];
     private List<CompetitionFixtureDto> _pendingReviews = [];


### PR DESCRIPTION
## Summary

The MAUI app was always landing on `/login` instead of `/` because the `Home.razor` shim had `@attribute [Authorize]`, which caused `Routes.razor`'s `<NotAuthorized>` branch to redirect unauthenticated users to login. Now Home renders for anyone — same behaviour as the web. Every other authorized page keeps its own `[Authorize]` and continues redirecting.

## Changes

1. **`DropShot.Maui/Components/Pages/Home.razor`** — drop `[Authorize]`. Pass `LoginUrl="/login"` and `MagicLinkUrl=""` to the inner RCL component.
2. **`DropShot.UI/Components/Pages/Home.razor`** — parameterize the sign-in URLs:
   - `LoginUrl` (default `/Account/Login` for web; MAUI passes `/login`)
   - `MagicLinkUrl` (default `/Account/LoginMagicLink` for web; MAUI passes empty so the magic-link button is hidden — that flow is web-Identity only)

Web shim is unchanged — defaults match today's behaviour.

## Test plan

- [x] `dotnet build DropShot.sln` — 0 errors
- [x] `dotnet test DropShot.Tests` — 28/28 passing
- [x] `dotnet build DropShot.Maui` — 4 TFMs clean
- [ ] Launch MAUI clean — should land on Home with the "Welcome to DropShot" anonymous panel (sign-in pitch + email/password link, no magic-link button)
- [ ] Tap "Log in with email and password" — navigates to `/login`
- [ ] Log in successfully — Home re-renders with the authenticated dashboard
- [ ] Web app — Home unchanged (sign-in panel still shows the magic-link button + the QR panel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)