### PR TITLE
Make MAUI #blazor-error-ui banner readable under dark theme

### DIFF
--- a/DropShot.Maui/wwwroot/css/app.css
+++ b/DropShot.Maui/wwwroot/css/app.css
@@ -14,8 +14,12 @@ html, body {
     -webkit-overflow-scrolling: touch;
 }
 
+/* Force dark text + visible link colour on the lightyellow background.
+   Without these the dark MudBlazor theme cascades white-ish text onto the
+   banner, making it look like an empty box at the bottom of the page. */
 #blazor-error-ui {
     background: lightyellow;
+    color: #1a1a1a;
     bottom: 0;
     box-shadow: 0 -1px 2px rgba(0, 0, 0, 0.2);
     display: none;
@@ -26,11 +30,18 @@ html, body {
     z-index: 1000;
 }
 
+    #blazor-error-ui a {
+        color: #1565c0;
+        text-decoration: underline;
+        margin-left: 0.75rem;
+    }
+
     #blazor-error-ui .dismiss {
         cursor: pointer;
         position: absolute;
         right: 0.75rem;
         top: 0.5rem;
+        color: #1a1a1a;
     }
 
 /* iOS safe-area support */


### PR DESCRIPTION
## Symptom

When an unhandled exception fires in the MAUI app (e.g. starting a new match), what looks like a blank yellow banner appears at the bottom of the screen. The banner *is* `<div id=\"blazor-error-ui\">` rendering — it contains static text (\"An unhandled error has occurred\" + reload/dismiss links) defined in `wwwroot/index.html` — but the dark MudBlazor theme cascades white-ish text colour onto the banner, so the text is invisible against `lightyellow`.

## Fix

Pin the banner's foreground colour to dark grey, give the reload/dismiss links a high-contrast blue. Pure CSS, MAUI-only.

## Caveat

This fixes the *visibility* of the banner, not the underlying exception. The static \"An unhandled error has occurred\" message doesn't include the exception detail; to see what's actually crashing, attach a debugger to the MAUI process and look at the IDE's Output window when the banner appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)