### PR TITLE
Fix MAUI UriFormatException when starting a new match — wire App:BaseUrl into IConfiguration

### DIFF
--- a/DropShot.Maui/MauiProgram.cs
+++ b/DropShot.Maui/MauiProgram.cs
@@ -3,6 +3,7 @@ using DropShot.Shared;
 using DropShot.UI.Services;
 using DropShot.UI.Services.Auth;
 using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using MudBlazor.Services;
 
@@ -33,6 +34,16 @@ public static class MauiProgram
         builder.Services.AddBlazorWebViewDeveloperTools();
         builder.Logging.AddDebug();
 #endif
+
+        // Expose ApiBaseUrl as IConfiguration["App:BaseUrl"] so any code that
+        // reads that key (HttpScoreboardHubFactory, Upgrade.razor, etc.) gets
+        // the right absolute URL on MAUI. Without this, services that build
+        // SignalR hub URLs from $"{baseUrl}/chathub" produce relative URIs
+        // and SignalR throws System.UriFormatException.
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["App:BaseUrl"] = ApiBaseUrl,
+        });
 
         // ── Shared HttpClient ────────────────────────────────────────────────
         // Both AuthService and ApiService share the same scoped HttpClient so


### PR DESCRIPTION
## Symptom

Starting a new match in MAUI throws `System.UriFormatException` from `System.Private.Uri.dll`. The dark-text fix in #532 made the error banner visible at the bottom of the screen.

## Cause

`HttpScoreboardHubFactory` (`DropShot.Maui/Services/HttpScoreboardHubFactory.cs:19`) reads `config["App:BaseUrl"]` to build the SignalR hub URL:

```csharp
var baseUrl = config["App:BaseUrl"]?.TrimEnd('/') ?? "";
var hubUrl = $"{baseUrl}/chathub";
```

`MauiProgram.cs` never registered an `App:BaseUrl` value in `IConfiguration`, so the lookup returned null, `baseUrl` became `""`, and the hub URL became `/chathub` — a relative URI. `SignalR.HubConnectionBuilder.WithUrl(string)` calls `new Uri(url)` internally, which throws `UriFormatException` for a relative URI without a base.

The bug has been latent. PR #527 (which added the `/match/{int}` MAUI route shim) just exposed `TennisScore`'s hub-connection path for the first time.

## Fix

Register an in-memory configuration source that maps `App:BaseUrl` to the same `ApiBaseUrl` const that already backs the `HttpClient` base address. One source of truth — both the HTTP services and the SignalR hub now point at the same server.

Same fix also benefits `Upgrade.razor` and any future code that reads `App:BaseUrl` on MAUI.

## Test plan

- [x] `dotnet build DropShot.sln` — 0 CS compile errors
- [ ] Stop the running MAUI process, rebuild, launch
- [ ] Tap "Start a new match" — should land on the match-setup wizard, no error banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)