### PR TITLE
Bump MAUI ApplicationVersion 4 → 5 for Apple App Store

### DIFF
--- a/DropShot.Maui/DropShot.Maui.csproj
+++ b/DropShot.Maui/DropShot.Maui.csproj
@@ -31,7 +31,7 @@
 
         <!-- Versions -->
         <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
-        <ApplicationVersion>4</ApplicationVersion>
+        <ApplicationVersion>5</ApplicationVersion>
 
         <!-- To develop, package, and publish an app to the Microsoft Store, see: https://aka.ms/MauiTemplateUnpackaged -->
         <WindowsPackageType>None</WindowsPackageType>


### PR DESCRIPTION
App Store Connect rejected the previous upload:

> The bundle version must be higher than the previously uploaded version: '4'.

Bumps `<ApplicationVersion>` (CFBundleVersion) from 4 to 5. `<ApplicationDisplayVersion>` (1.0, user-facing) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)