### PR TITLE
Fix MAUI iOS TestFlight startup crash — explicit Configuration.Memory PackageReference

### DIFF
--- a/DropShot.Maui/DropShot.Maui.csproj
+++ b/DropShot.Maui/DropShot.Maui.csproj
@@ -67,6 +67,15 @@
         <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="$(MauiVersion)" />
         <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="9.0.1" />
         <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.8" />
+        <!-- Hard-root Configuration.Memory so the iOS AOT/trimmer keeps it.
+             MauiProgram.CreateMauiApp calls builder.Configuration.AddInMemoryCollection(...);
+             the in-memory provider is only a transitive dep, so without an
+             explicit PackageReference the iOS Release publisher strips the
+             assembly and the runtime aborts during init when it can't load
+             the AOT module. Crash signature: SIGABRT in
+             mono_runtime_init_checked → mono_assembly_request_byname →
+             load_aot_module on a TestFlight device build. -->
+        <PackageReference Include="Microsoft.Extensions.Configuration.Memory" Version="9.0.8" />
         <PackageReference Include="MudBlazor" Version="9.2.0" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.4.0" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.0" />


### PR DESCRIPTION
## Symptom

TestFlight build 5 crashes immediately on iOS device: `EXC_CRASH (SIGABRT) — abort() called`. Lifetime ~0.4s, before any UI renders.

## Root cause

PR #533 added `builder.Configuration.AddInMemoryCollection(...)` to `MauiProgram.CreateMauiApp`. The extension method lives in `Microsoft.Extensions.Configuration.Memory.dll`, which until now was only a transitive dependency.

iOS Release publishes with full AOT + trimming. Without an explicit `PackageReference` the trimmer treated the assembly as unused and stripped it. The mono runtime then aborts during init when `load_aot_module` can't open the missing module:

```
mono_runtime_init_checked (appdomain.c:283)      ← OOM exception prototype
  mono_exception_from_name_two_strings_checked
    create_exception_two_strings
      mono_runtime_invoke_checked
        mono_jit_compile_method_with_opt
          mono_aot_get_method
            load_aot_module                       ← FAILS
              mono_assembly_request_byname
                xamarin_assembly_preload_hook
g_log (fatal severity) → abort
```

## Diagnostic

Symbolicated `.ips` against the matching dSYM (UUID `7B4FAE70-2F90-31FA-A83A-D024E86CDA8E`) — confirmed the abort is in mono runtime init before user code runs. Built the same source for iOS Simulator (interpreter mode, no AOT) — app launches cleanly, no abort. The simulator-vs-device asymmetry is the smoking gun for an AOT/trimmer issue.

## Fix

Add an explicit `<PackageReference Include="Microsoft.Extensions.Configuration.Memory" Version="9.0.8" />` to `DropShot.Maui.csproj` so the trimmer is forced to keep it.

## Test plan

- [ ] Re-publish for iOS Release on the cloud Mac (after merging this)
- [ ] Bump `<ApplicationVersion>` to 6
- [ ] Upload to App Store Connect, install via TestFlight
- [ ] App launches without the SIGABRT
- [ ] Web app unchanged (no MAUI files affected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)