### PR TITLE
Bypass IConfiguration for App:BaseUrl on MAUI — fixes iOS TestFlight crash

### DIFF
--- a/DropShot.Maui/Components/Pages/Upgrade.razor
+++ b/DropShot.Maui/Components/Pages/Upgrade.razor
@@ -1,5 +1,4 @@
 @page "/upgrade"
-@inject Microsoft.Extensions.Configuration.IConfiguration Configuration
 
 <DropShot.UI.Components.Pages.Upgrade>
     <CheckoutControls>
@@ -18,7 +17,7 @@
 @code {
     private async Task OpenWebUpgradeAsync()
     {
-        var baseUrl = Configuration["App:BaseUrl"]?.TrimEnd('/') ?? "";
+        var baseUrl = MauiProgram.ApiBaseUrl.TrimEnd('/');
         var url = $"{baseUrl}/upgrade";
         await Browser.Default.OpenAsync(url, BrowserLaunchMode.External);
     }

--- a/DropShot.Maui/DropShot.Maui.csproj
+++ b/DropShot.Maui/DropShot.Maui.csproj
@@ -31,7 +31,7 @@
 
         <!-- Versions -->
         <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
-        <ApplicationVersion>5</ApplicationVersion>
+        <ApplicationVersion>6</ApplicationVersion>
 
         <!-- To develop, package, and publish an app to the Microsoft Store, see: https://aka.ms/MauiTemplateUnpackaged -->
         <WindowsPackageType>None</WindowsPackageType>
@@ -67,15 +67,6 @@
         <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="$(MauiVersion)" />
         <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="9.0.1" />
         <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.8" />
-        <!-- Hard-root Configuration.Memory so the iOS AOT/trimmer keeps it.
-             MauiProgram.CreateMauiApp calls builder.Configuration.AddInMemoryCollection(...);
-             the in-memory provider is only a transitive dep, so without an
-             explicit PackageReference the iOS Release publisher strips the
-             assembly and the runtime aborts during init when it can't load
-             the AOT module. Crash signature: SIGABRT in
-             mono_runtime_init_checked → mono_assembly_request_byname →
-             load_aot_module on a TestFlight device build. -->
-        <PackageReference Include="Microsoft.Extensions.Configuration.Memory" Version="9.0.8" />
         <PackageReference Include="MudBlazor" Version="9.2.0" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.4.0" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.0" />

--- a/DropShot.Maui/MauiProgram.cs
+++ b/DropShot.Maui/MauiProgram.cs
@@ -3,7 +3,6 @@ using DropShot.Shared;
 using DropShot.UI.Services;
 using DropShot.UI.Services.Auth;
 using Microsoft.AspNetCore.Components.Authorization;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using MudBlazor.Services;
 
@@ -34,16 +33,6 @@ public static class MauiProgram
         builder.Services.AddBlazorWebViewDeveloperTools();
         builder.Logging.AddDebug();
 #endif
-
-        // Expose ApiBaseUrl as IConfiguration["App:BaseUrl"] so any code that
-        // reads that key (HttpScoreboardHubFactory, Upgrade.razor, etc.) gets
-        // the right absolute URL on MAUI. Without this, services that build
-        // SignalR hub URLs from $"{baseUrl}/chathub" produce relative URIs
-        // and SignalR throws System.UriFormatException.
-        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
-        {
-            ["App:BaseUrl"] = ApiBaseUrl,
-        });
 
         // ── Shared HttpClient ────────────────────────────────────────────────
         // Both AuthService and ApiService share the same scoped HttpClient so

--- a/DropShot.Maui/Services/HttpScoreboardHubFactory.cs
+++ b/DropShot.Maui/Services/HttpScoreboardHubFactory.cs
@@ -16,7 +16,13 @@ public sealed class HttpScoreboardHubFactory(
 {
     public HubConnection Create()
     {
-        var baseUrl = config["App:BaseUrl"]?.TrimEnd('/') ?? "";
+        // Prefer App:BaseUrl from IConfiguration when present (web-style),
+        // but no provider populates that key on MAUI — fall back to the
+        // ApiBaseUrl const that already backs the HttpClient. Building a
+        // relative URL here would throw UriFormatException inside SignalR.
+        var baseUrl = config["App:BaseUrl"]?.TrimEnd('/');
+        if (string.IsNullOrEmpty(baseUrl))
+            baseUrl = MauiProgram.ApiBaseUrl.TrimEnd('/');
         var hubUrl = $"{baseUrl}/chathub";
 
         return new HubConnectionBuilder()


### PR DESCRIPTION
## Why this PR

Cloud-Mac NuGet can't resolve `Microsoft.Extensions.Configuration.Memory` (network/proxy issue specific to that environment), so the explicit `PackageReference` added in #536 can't be restored. Switching tactic: drop the IConfiguration plumbing entirely on MAUI so the package isn't needed.

## What changed

- **`MauiProgram.cs`**: drop `AddInMemoryCollection` + the `Microsoft.Extensions.Configuration` using; revert to the original `MauiProgram` shape.
- **`HttpScoreboardHubFactory`**: prefer `config[\"App:BaseUrl\"]` when present (so any future configuration source still wins), but fall back to `MauiProgram.ApiBaseUrl` directly when the key is empty. This is what actually happens on MAUI today and avoids the relative-URL + `UriFormatException` crash inside SignalR.
- **`DropShot.Maui/Components/Pages/Upgrade.razor`**: drop the IConfiguration inject; read `MauiProgram.ApiBaseUrl` directly. Same idea.
- **`DropShot.Maui.csproj`**:
  - remove the `Microsoft.Extensions.Configuration.Memory` PackageReference (no longer needed)
  - bump `<ApplicationVersion>` 5 → 6 for the next TestFlight upload

## Net effect

- ✅ PR #533's SignalR `UriFormatException` is still fixed (HubFactory now has a guaranteed non-empty baseUrl).
- ✅ PR #536's AOT/trimmer dependency on Configuration.Memory is gone (we no longer call `AddInMemoryCollection`).
- ✅ The TestFlight startup `SIGABRT` (`mono_runtime_init_checked` → `load_aot_module` failing on the trimmed-out Memory assembly) goes away.

## Test plan

- [x] `dotnet build DropShot.sln` — 0 errors, 0 warnings on the .NET side
- [x] iOS Simulator launch already confirmed working in the diagnostic build (PR #536 verification)
- [ ] On the cloud Mac: `git pull && dotnet publish DropShot.Maui/DropShot.Maui.csproj -f net9.0-ios18.0 -c Release -p:ArchiveOnBuild=true -p:CodesignKey=\"Apple Distribution: Alan Beattie (Y9A56DJ9X9)\"`
- [ ] Upload as build 6, install via TestFlight
- [ ] App launches without SIGABRT
- [ ] Tap \"Start a new match\" → MatchSetupWizard renders, fuzzy player search works, hub connects

🤖 Generated with [Claude Code](https://claude.com/claude-code)