### PR TITLE
Fix iOS TestFlight: SDK pinning + full maui workload

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -35,8 +35,11 @@ jobs:
         with:
           global-json-file: DropShot.Maui/global.json
 
-      - name: Install MAUI iOS workload
-        run: dotnet workload install maui-ios
+      - name: Pin SDK at repo root
+        run: cp DropShot.Maui/global.json global.json
+
+      - name: Install MAUI workload
+        run: dotnet workload install maui
 
       - name: Compute build number
         id: bn


### PR DESCRIPTION
## Summary
Fixes two errors from the first iOS TestFlight CI run:

1. **Wrong SDK** — runner picked .NET 10.0.203 instead of pinned 9.0.100. `global.json` lives at `DropShot.Maui/global.json`; `dotnet` CLI walks up from cwd (repo root) and never finds it. Now copied to repo root at runtime.
2. **Missing android workload** — `dotnet publish -f net9.0-ios` still does an outer-build pass over the csproj's full `<TargetFrameworks>` list. Swapped `maui-ios` for the full `maui` meta-workload to cover android + maccatalyst evaluation. Adds ~2 min per run.

## Test plan
- [ ] Merge, then re-trigger the iOS TestFlight workflow
- [ ] Verify Setup .NET resolves to 9.0.1xx (not 10.x)
- [ ] Verify Install MAUI workload completes successfully
- [ ] Verify Publish IPA completes without NETSDK1147 errors