### PR TITLE
Fix iOS TestFlight: use full net9.0-ios18.0 TFM

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -69,12 +69,12 @@ jobs:
           echo "uuid=$UUID" >> "$GITHUB_OUTPUT"
 
       - name: Restore (iOS only)
-        run: dotnet restore DropShot.Maui/DropShot.Maui.csproj -p:TargetFramework=net9.0-ios
+        run: dotnet restore DropShot.Maui/DropShot.Maui.csproj -p:TargetFramework=net9.0-ios18.0
 
       - name: Publish IPA
         run: |
           dotnet publish DropShot.Maui/DropShot.Maui.csproj \
-            -f net9.0-ios \
+            -f net9.0-ios18.0 \
             -c Release \
             -p:RuntimeIdentifier=ios-arm64 \
             -p:ArchiveOnBuild=true \
@@ -86,7 +86,7 @@ jobs:
       - name: Locate IPA
         id: ipa
         run: |
-          IPA=$(find DropShot.Maui/bin/Release/net9.0-ios -name "*.ipa" | head -n 1)
+          IPA=$(find DropShot.Maui/bin/Release/net9.0-ios18.0 -name "*.ipa" | head -n 1)
           test -n "$IPA" || { echo "No IPA produced"; exit 1; }
           echo "path=$IPA" >> "$GITHUB_OUTPUT"
 
@@ -104,6 +104,6 @@ jobs:
         with:
           name: DropShot-ios-${{ steps.bn.outputs.build_number }}
           path: |
-            DropShot.Maui/bin/Release/net9.0-ios/ios-arm64/publish/*.ipa
-            DropShot.Maui/bin/Release/net9.0-ios/ios-arm64/**/*.dSYM/**
+            DropShot.Maui/bin/Release/net9.0-ios18.0/ios-arm64/publish/*.ipa
+            DropShot.Maui/bin/Release/net9.0-ios18.0/ios-arm64/**/*.dSYM/**
           retention-days: 14


### PR DESCRIPTION
## Summary
Third fix for the iOS TestFlight workflow. The csproj declares `net9.0-ios18.0` (explicit platform version), so MSBuild writes that exact TFM into `project.assets.json`. Passing `-f net9.0-ios` to publish fails with `NETSDK1005: Assets file ... doesn't have a target for 'net9.0-ios'` because the lookup is exact-match, not version-range.

Replaces all `net9.0-ios` with `net9.0-ios18.0` throughout the workflow — build flags, output paths, and artifact globs.

## Test plan
- [ ] Merge, re-trigger workflow
- [ ] Restore + Publish complete past the TFM error
- [ ] Reach the codesign step (real first test of secrets)