### PR TITLE
Fix iOS TestFlight: mitigate actool failure

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -78,10 +78,30 @@ jobs:
             -c Release \
             -p:RuntimeIdentifier=ios-arm64 \
             -p:ArchiveOnBuild=true \
+            -p:OptimizePNGs=false \
             -p:CodesignKey="${{ secrets.IOS_CODESIGN_KEY }}" \
             -p:CodesignProvision="${{ steps.profile.outputs.name }}" \
             -p:ApplicationVersion=${{ steps.bn.outputs.build_number }} \
             -p:ApplicationDisplayVersion=1.0
+
+      - name: Dump actool diagnostics on failure
+        if: failure()
+        run: |
+          echo "=== actool dir contents ==="
+          ls -la DropShot.Maui/obj/Release/net9.0-ios18.0/ios-arm64/actool/ 2>/dev/null || echo "(no actool dir)"
+          echo
+          echo "=== asset-manifest.plist ==="
+          cat DropShot.Maui/obj/Release/net9.0-ios18.0/ios-arm64/actool/asset-manifest.plist 2>/dev/null || echo "(missing)"
+          echo
+          echo "=== actool log files ==="
+          find DropShot.Maui/obj/Release/net9.0-ios18.0/ios-arm64/actool/ -type f -name "*.log" -exec sh -c 'echo "--- {} ---"; cat "{}"' \; 2>/dev/null || true
+          echo
+          echo "=== Xcode + actool version ==="
+          xcode-select -p
+          xcrun actool --version 2>&1 || true
+          echo
+          echo "=== Resources/AppIcon contents ==="
+          ls -la DropShot.Maui/Resources/AppIcon/
 
       - name: Locate IPA
         id: ipa


### PR DESCRIPTION
## Summary
Build now reaches actool (Apple asset compiler) but actool crashes before writing \`asset-manifest.plist\`, then MAUI tooling fails parsing the empty file with "Root element is missing".

Two changes:
1. \`OptimizePNGs=false\` — known cause of actool plist corruption. PNG optimization via pngcrush sometimes produces output actool can't manifest properly.
2. Diagnostic step on failure — dumps actool dir contents, log files, and tool versions so the real error surfaces if (1) doesn't fix it.

## Test plan
- [ ] Re-trigger workflow
- [ ] If publish succeeds, codesign step gets to test secrets
- [ ] If still failing, the diagnostic dump tells us what actool actually said