### PR TITLE
Fix iOS TestFlight: pin Xcode to 16.0-16.3

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -23,10 +23,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Select Xcode 16.x
+      - name: Select Xcode (pin to MAUI-9-compatible version)
         run: |
-          XCODE=$(ls -d /Applications/Xcode_16*.app 2>/dev/null | sort -V | tail -n 1)
-          test -n "$XCODE" || { echo "No Xcode 16 found"; exit 1; }
+          # MAUI 9 iOS workload ships iOS 18.0 SDK pack. Xcode 16.4 (default on
+          # macos-15) ships iOS 18.4 SDK, which silently breaks actool. Pin to
+          # the lowest available 16.x (16.0-16.3); avoid 16.4+.
+          XCODE=""
+          for v in "16.1" "16.2" "16.1.0" "16.2.0" "16.0" "16.0.0" "16.3" "16.3.0"; do
+            if [ -d "/Applications/Xcode_${v}.app" ]; then
+              XCODE="/Applications/Xcode_${v}.app"
+              break
+            fi
+          done
+          if [ -z "$XCODE" ]; then
+            echo "No compatible Xcode (16.0-16.3) found. Available:"
+            ls -d /Applications/Xcode_*.app 2>/dev/null
+            exit 1
+          fi
           sudo xcode-select -s "$XCODE"
           xcodebuild -version
 


### PR DESCRIPTION
## Summary
Diagnostic dump from #541 revealed the actool failure root cause: Xcode 16.4 (default on macos-15 runner) ships iOS 18.4 SDK, but the .NET MAUI 9 iOS workload ships \`Microsoft.iOS.Sdk.net9.0_18.0/18.0.9617\` which expects iOS 18.0 SDK. MAUI's MSBuild targets silently bail before invoking actool when the SDK versions mismatch — empty bundle dir, no log files, just a downstream parse error on the missing manifest.

Pin Xcode selection to the lowest available 16.0-16.3 instead of grabbing the highest 16.x.

## Test plan
- [ ] Re-trigger workflow
- [ ] Xcode selection step prints 16.0/16.1/16.2/16.3 (not 16.4)
- [ ] Publish IPA completes — actool runs, produces a manifest
- [ ] Codesign + TestFlight upload steps run (real first test of secrets)