### PR TITLE
Fix iOS TestFlight: install matching simulator runtime

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -43,6 +43,16 @@ jobs:
           sudo xcode-select -s "$XCODE"
           xcodebuild -version
 
+      - name: Install matching iOS Simulator runtime
+        run: |
+          # actool validates the asset catalog against the iphonesimulator SDK
+          # bundled with the selected Xcode (e.g. iOS 18.1 for Xcode 16.1).
+          # macos-15 runner only ships iOS 18.5+/19.x runtimes; download the
+          # matching one for the selected Xcode.
+          sudo xcodebuild -downloadPlatform iOS
+          echo "=== Available simulator runtimes after download ==="
+          xcrun simctl list runtimes | grep -i ios
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:


### PR DESCRIPTION
## Summary
Build now reaches actool with proper output. New error from #542's run:

> No simulator runtime version from [22F77, 22G86, 23A8464, 23B86, 23C54] available to use with iphonesimulator SDK version 22B74

actool validates asset catalogs against the iphonesimulator SDK bundled with the selected Xcode (iOS 18.1 = 22B74 for Xcode 16.1). The macos-15 runner only ships iOS 18.5+ and 19.x runtimes — none match.

Add a step that downloads the matching simulator runtime via \`xcodebuild -downloadPlatform iOS\`. Adds ~5 min to the workflow.

**Bonus from #542's run:** the codesign step confirmed all secrets are valid — cert detected, "DropShot App Store" profile loaded, App ID \`Y9A56DJ9X9.tennis.ds.dropshot\` matches.

## Test plan
- [ ] Re-trigger workflow
- [ ] "Install matching iOS Simulator runtime" step completes (5–10 min download)
- [ ] Publish IPA proceeds past actool
- [ ] Upload to TestFlight runs
- [ ] Build appears in App Store Connect TestFlight as "Processing"