### PR TITLE
Upgrade to .NET 10 / MAUI 10 for iOS 26 SDK (Apple requirement)

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -17,26 +17,27 @@ concurrency:
 
 jobs:
   build-upload:
-    runs-on: macos-15
+    runs-on: macos-26
     timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Select Xcode (pin to MAUI-9-compatible version)
+      - name: Select Xcode 26
         run: |
-          # MAUI 9 iOS workload ships iOS 18.0 SDK pack. Xcode 16.4 (default on
-          # macos-15) ships iOS 18.4 SDK, which silently breaks actool. Pin to
-          # the lowest available 16.x (16.0-16.3); avoid 16.4+.
+          # Apple now requires builds with Xcode 26+ / iOS 26 SDK for App Store
+          # uploads. Pick the lowest available 26.x to match the .NET for iOS
+          # workload pack version (newer Xcodes may ship SDKs the pack doesn't
+          # know about yet).
           XCODE=""
-          for v in "16.1" "16.2" "16.1.0" "16.2.0" "16.0" "16.0.0" "16.3" "16.3.0"; do
+          for v in "26.0" "26.0.0" "26.1" "26.1.0" "26.2" "26.2.0" "26.3" "26.3.0"; do
             if [ -d "/Applications/Xcode_${v}.app" ]; then
               XCODE="/Applications/Xcode_${v}.app"
               break
             fi
           done
           if [ -z "$XCODE" ]; then
-            echo "No compatible Xcode (16.0-16.3) found. Available:"
+            echo "No Xcode 26.x found. Available:"
             ls -d /Applications/Xcode_*.app 2>/dev/null
             exit 1
           fi
@@ -46,9 +47,7 @@ jobs:
       - name: Install matching iOS Simulator runtime
         run: |
           # actool validates the asset catalog against the iphonesimulator SDK
-          # bundled with the selected Xcode (e.g. iOS 18.1 for Xcode 16.1).
-          # macos-15 runner only ships iOS 18.5+/19.x runtimes; download the
-          # matching one for the selected Xcode.
+          # bundled with the selected Xcode. Download the matching runtime.
           sudo xcodebuild -downloadPlatform iOS
           echo "=== Available simulator runtimes after download ==="
           xcrun simctl list runtimes | grep -i ios
@@ -92,12 +91,12 @@ jobs:
           echo "uuid=$UUID" >> "$GITHUB_OUTPUT"
 
       - name: Restore (iOS only)
-        run: dotnet restore DropShot.Maui/DropShot.Maui.csproj -p:TargetFramework=net9.0-ios18.0
+        run: dotnet restore DropShot.Maui/DropShot.Maui.csproj -p:TargetFramework=net10.0-ios26.0
 
       - name: Publish IPA
         run: |
           dotnet publish DropShot.Maui/DropShot.Maui.csproj \
-            -f net9.0-ios18.0 \
+            -f net10.0-ios26.0 \
             -c Release \
             -p:RuntimeIdentifier=ios-arm64 \
             -p:ArchiveOnBuild=true \
@@ -111,13 +110,13 @@ jobs:
         if: failure()
         run: |
           echo "=== actool dir contents ==="
-          ls -la DropShot.Maui/obj/Release/net9.0-ios18.0/ios-arm64/actool/ 2>/dev/null || echo "(no actool dir)"
+          ls -la DropShot.Maui/obj/Release/net10.0-ios26.0/ios-arm64/actool/ 2>/dev/null || echo "(no actool dir)"
           echo
           echo "=== asset-manifest.plist ==="
-          cat DropShot.Maui/obj/Release/net9.0-ios18.0/ios-arm64/actool/asset-manifest.plist 2>/dev/null || echo "(missing)"
+          cat DropShot.Maui/obj/Release/net10.0-ios26.0/ios-arm64/actool/asset-manifest.plist 2>/dev/null || echo "(missing)"
           echo
           echo "=== actool log files ==="
-          find DropShot.Maui/obj/Release/net9.0-ios18.0/ios-arm64/actool/ -type f -name "*.log" -exec sh -c 'echo "--- {} ---"; cat "{}"' \; 2>/dev/null || true
+          find DropShot.Maui/obj/Release/net10.0-ios26.0/ios-arm64/actool/ -type f -name "*.log" -exec sh -c 'echo "--- {} ---"; cat "{}"' \; 2>/dev/null || true
           echo
           echo "=== Xcode + actool version ==="
           xcode-select -p
@@ -129,7 +128,7 @@ jobs:
       - name: Locate IPA
         id: ipa
         run: |
-          IPA=$(find DropShot.Maui/bin/Release/net9.0-ios18.0 -name "*.ipa" | head -n 1)
+          IPA=$(find DropShot.Maui/bin/Release/net10.0-ios26.0 -name "*.ipa" | head -n 1)
           test -n "$IPA" || { echo "No IPA produced"; exit 1; }
           echo "path=$IPA" >> "$GITHUB_OUTPUT"
 
@@ -147,6 +146,6 @@ jobs:
         with:
           name: DropShot-ios-${{ steps.bn.outputs.build_number }}
           path: |
-            DropShot.Maui/bin/Release/net9.0-ios18.0/ios-arm64/publish/*.ipa
-            DropShot.Maui/bin/Release/net9.0-ios18.0/ios-arm64/**/*.dSYM/**
+            DropShot.Maui/bin/Release/net10.0-ios26.0/ios-arm64/publish/*.ipa
+            DropShot.Maui/bin/Release/net10.0-ios26.0/ios-arm64/**/*.dSYM/**
           retention-days: 14

--- a/DropShot.Maui/DropShot.Maui.csproj
+++ b/DropShot.Maui/DropShot.Maui.csproj
@@ -1,12 +1,12 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
+<Project Sdk="Microsoft.NET.Sdk.Razor">
 
     <PropertyGroup>
-        <TargetFrameworks>net9.0-android35.0;net9.0-ios18.0;net9.0-maccatalyst18.0</TargetFrameworks>
-        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0</TargetFrameworks>
+        <TargetFrameworks>net10.0-android36.0;net10.0-ios26.0;net10.0-maccatalyst26.0</TargetFrameworks>
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
         <CheckEolTargetFramework>false</CheckEolTargetFramework>
-        <MauiVersion Condition="'$(MauiVersion)' == ''">9.0.0</MauiVersion>
+        <MauiVersion Condition="'$(MauiVersion)' == ''">10.0.60</MauiVersion>
         <!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
-        <!-- <TargetFrameworks>$(TargetFrameworks);net9.0-tizen</TargetFrameworks> -->
+        <!-- <TargetFrameworks>$(TargetFrameworks);net10.0-tizen</TargetFrameworks> -->
 
         <!-- Note for MacCatalyst:
             The default runtime is maccatalyst-x64, except in Release config, in which case the default is maccatalyst-x64;maccatalyst-arm64.
@@ -65,11 +65,11 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
         <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="$(MauiVersion)" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.8" />
-        <PackageReference Include="MudBlazor" Version="9.2.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
+        <PackageReference Include="MudBlazor" Version="9.4.0" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.4.0" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/DropShot.Maui/global.json
+++ b/DropShot.Maui/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.100",
+    "version": "10.0.100",
     "rollForward": "latestFeature"
   }
 }

--- a/DropShot.Shared/DropShot.Shared.csproj
+++ b/DropShot.Shared/DropShot.Shared.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/DropShot.UI/DropShot.UI.csproj
+++ b/DropShot.UI/DropShot.UI.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <AddRazorSupportForMvc>false</AddRazorSupportForMvc>
@@ -9,10 +9,10 @@
 
   <ItemGroup>
     <SupportedPlatform Include="browser" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="9.0.1" />
-    <PackageReference Include="MudBlazor" Version="9.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.0" />
+    <PackageReference Include="MudBlazor" Version="9.4.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
Apple now requires builds with iOS 26 SDK / Xcode 26+ for App Store and TestFlight uploads. The previous PR chain (#538-#543) got the .NET 9 build working end-to-end through codesign, but the upload step now hits HTTP 409:

> SDK version issue. This app was built with the iOS 18.1 SDK. All iOS and iPadOS apps must be built with the iOS 26 SDK or later, included in Xcode 26 or later.

This PR upgrades the project from .NET 9 / MAUI 9 / iOS 18 -> .NET 10 / MAUI 10 / iOS 26.

## Changes

**Project files:**
- `DropShot.Maui/global.json`: SDK 9.0.100 -> 10.0.100 (latestFeature)
- `DropShot.Maui/DropShot.Maui.csproj`: TFMs net9.0-* -> net10.0-* (android36.0, ios26.0, maccatalyst26.0); MauiVersion 9.0.0 -> 10.0.60; AspNetCore packages 9.x -> 10.0.0; MudBlazor 9.2.0 -> 9.4.0 (already supports .NET 10)
- `DropShot.UI/DropShot.UI.csproj`: TargetFramework net9.0 -> net10.0; matching package bumps
- `DropShot.Shared/DropShot.Shared.csproj`: TargetFramework net9.0 -> net10.0

**Workflow:**
- Runner: macos-15 -> macos-26 (GA since Feb 2026, ships Xcode 26)
- Xcode pin: 16.0-16.3 -> 26.0-26.3
- TFM and output paths: net9.0-ios18.0 -> net10.0-ios26.0 throughout

## Risks
- **Library compatibility:** MudBlazor 9.4.0 is confirmed to support .NET 10. Other packages bumped to 10.0.0 stable. No code changes anticipated.
- **MAUI 10 breaking changes:** Several APIs are deprecated (FadeTo -> FadeToAsync, ListView, TableView, MessagingCenter made internal). Repo doesn't use these on a quick scan, but compile errors would surface during build.
- **Backend deploy.yml unchanged:** Already uses dotnet-version 10.0.x, so net10.0 shared lib should work.

## Test plan
- [ ] Re-trigger iOS TestFlight workflow
- [ ] Verify .NET 10 SDK resolves
- [ ] Verify Xcode 26.x is selected
- [ ] Verify Publish IPA produces a .ipa (this is where previous .NET 10 attempts failed per user's recollection)
- [ ] Verify Upload to TestFlight succeeds (Apple's iOS 26 SDK gate)
- [ ] Confirm build appears in App Store Connect TestFlight