### PR TITLE
Fix .NET 10 upgrade: bump AspNetCore packages to 10.0.1

### DIFF
--- a/DropShot.Maui/DropShot.Maui.csproj
+++ b/DropShot.Maui/DropShot.Maui.csproj
@@ -65,11 +65,11 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
         <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="$(MauiVersion)" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.1" />
         <PackageReference Include="MudBlazor" Version="9.4.0" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.4.0" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/DropShot.UI/DropShot.UI.csproj
+++ b/DropShot.UI/DropShot.UI.csproj
@@ -9,10 +9,10 @@
 
   <ItemGroup>
     <SupportedPlatform Include="browser" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.1" />
     <PackageReference Include="MudBlazor" Version="9.4.0" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
NU1605 from #544's run: MudBlazor 9.4.0 transitively requires \`Microsoft.AspNetCore.Components.Web >= 10.0.1\`, but we pinned \`10.0.0\`. NuGet treats this as a downgrade and fails with WarningAsError.

Bump all 10.0.0 package refs to 10.0.1 in both DropShot.Maui.csproj and DropShot.UI.csproj.

## Test plan
- [ ] Re-trigger workflow
- [ ] Restore step succeeds
- [ ] Build progresses to publish/codesign/upload