### PR TITLE
Fix backend deploy: bump MudBlazor to 9.4.0

### DIFF
--- a/DropShot/DropShot.csproj
+++ b/DropShot/DropShot.csproj
@@ -24,7 +24,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.*" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.*" />
-    <PackageReference Include="MudBlazor" Version="9.2.0" />
+    <PackageReference Include="MudBlazor" Version="9.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
Backend deploy.yml broke after #544/#545 with NU1605:

> Detected package downgrade: MudBlazor from 9.4.0 to 9.2.0
> DropShot -> DropShot.UI -> MudBlazor (>= 9.4.0)
> DropShot -> MudBlazor (>= 9.2.0)

DropShot.UI now requires MudBlazor 9.4.0 (for .NET 10 support), but the backend csproj directly pins 9.2.0. Bump backend to match.

Backend DropShot.csproj was already on net10.0 with all AspNetCore packages on 10.0.*, so no other changes needed.

## Test plan
- [ ] Backend deploy.yml restore step succeeds
- [ ] Build + EF migrations + Azure deploy complete