### PR TITLE
Fix iOS workflow: prefer Xcode 26.1+, verify actool

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -25,12 +25,12 @@ jobs:
 
       - name: Select Xcode 26
         run: |
-          # Apple now requires builds with Xcode 26+ / iOS 26 SDK for App Store
-          # uploads. Pick the lowest available 26.x to match the .NET for iOS
-          # workload pack version (newer Xcodes may ship SDKs the pack doesn't
-          # know about yet).
+          # Apple requires Xcode 26+ / iOS 26 SDK for App Store uploads.
+          # Prefer 26.1/26.2 — Xcode 26.0 on macos-26 was missing actool in
+          # one image revision (xcrun -find actool fails). Newer 26.x are
+          # complete builds.
           XCODE=""
-          for v in "26.0" "26.0.0" "26.1" "26.1.0" "26.2" "26.2.0" "26.3" "26.3.0"; do
+          for v in "26.1" "26.1.0" "26.2" "26.2.0" "26.3" "26.3.0" "26.0" "26.0.0"; do
             if [ -d "/Applications/Xcode_${v}.app" ]; then
               XCODE="/Applications/Xcode_${v}.app"
               break
@@ -43,6 +43,14 @@ jobs:
           fi
           sudo xcode-select -s "$XCODE"
           xcodebuild -version
+          # First-launch unpacks bundled tools (actool, ibtool, etc.).
+          sudo xcodebuild -runFirstLaunch
+          echo "=== verifying actool is findable ==="
+          xcrun -find actool || {
+            echo "actool not found in selected Xcode. Listing developer/usr/bin:"
+            ls "$(xcode-select -p)/usr/bin/" | head -50
+            exit 1
+          }
 
       - name: Ensure iOS Simulator runtime present
         run: |


### PR DESCRIPTION
## Summary
.NET 10 / Xcode 26 build now restores, builds, and codesigns successfully. New error from latest run:
> xcrun: error: unable to find utility \"actool\", not a developer tool or in PATH

Xcode 26.0 on the macos-26 runner had an incomplete tool install (actool missing). Three changes to the Xcode selection step:

1. Prefer Xcode 26.1/26.2/26.3 over 26.0 (newer point releases are complete builds)
2. Run \`xcodebuild -runFirstLaunch\` after selection — unpacks bundled tools
3. Verify \`xcrun -find actool\` succeeds before publish; if not, dump dev tool dir for diagnosis

## Test plan
- [ ] Re-trigger workflow
- [ ] Xcode selection prints 26.1/26.2/26.3 (not 26.0)
- [ ] actool verification succeeds
- [ ] Publish IPA progresses through actool