### PR TITLE
Fix iOS workflow: bypass strict Xcode version check

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -110,12 +110,17 @@ jobs:
 
       - name: Publish IPA
         run: |
+          # IgnoreXcodeVersion=true: the .NET for iOS pack (26.0.11017) was
+          # built against Xcode 26.0 and strictly version-checks. Runner only
+          # has Xcode 26.0 (missing actool) or 26.1+. iOS 26.1 SDK is
+          # forward-compatible for our needs and Apple accepts any iOS 26+ SDK.
           dotnet publish DropShot.Maui/DropShot.Maui.csproj \
             -f net10.0-ios26.0 \
             -c Release \
             -p:RuntimeIdentifier=ios-arm64 \
             -p:ArchiveOnBuild=true \
             -p:OptimizePNGs=false \
+            -p:IgnoreXcodeVersion=true \
             -p:CodesignKey="${{ secrets.IOS_CODESIGN_KEY }}" \
             -p:CodesignProvision="${{ steps.profile.outputs.name }}" \
             -p:ApplicationVersion=${{ steps.bn.outputs.build_number }} \


### PR DESCRIPTION
## Summary
After PR #548 selects Xcode 26.1.1 (since 26.0 is missing actool on the macos-26 runner), the build now hits a strict version check from the .NET for iOS pack 26.0.11017:
> This version of .NET for iOS (26.0.11017) requires Xcode 26.0. The current version of Xcode is 26.1.1.

iOS 26.1 SDK is forward-compatible with the 26.0 pack for App Store builds. Apple's policy accepts "iOS 26 SDK or later". Bypass the check with \`-p:IgnoreXcodeVersion=true\`.

## Test plan
- [ ] Re-trigger workflow
- [ ] Publish IPA proceeds past the Xcode version check
- [ ] actool runs on Xcode 26.1
- [ ] Upload to TestFlight succeeds (Apple's iOS 26 gate clears with 26.1 SDK)