### PR TITLE
Fix iOS workflow: bump SDK band to 10.0.200 for Xcode 26.1 support

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -110,17 +110,12 @@ jobs:
 
       - name: Publish IPA
         run: |
-          # IgnoreXcodeVersion=true: the .NET for iOS pack (26.0.11017) was
-          # built against Xcode 26.0 and strictly version-checks. Runner only
-          # has Xcode 26.0 (missing actool) or 26.1+. iOS 26.1 SDK is
-          # forward-compatible for our needs and Apple accepts any iOS 26+ SDK.
           dotnet publish DropShot.Maui/DropShot.Maui.csproj \
             -f net10.0-ios26.0 \
             -c Release \
             -p:RuntimeIdentifier=ios-arm64 \
             -p:ArchiveOnBuild=true \
             -p:OptimizePNGs=false \
-            -p:IgnoreXcodeVersion=true \
             -p:CodesignKey="${{ secrets.IOS_CODESIGN_KEY }}" \
             -p:CodesignProvision="${{ steps.profile.outputs.name }}" \
             -p:ApplicationVersion=${{ steps.bn.outputs.build_number }} \

--- a/DropShot.Maui/global.json
+++ b/DropShot.Maui/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.100",
+    "version": "10.0.200",
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
## Summary
Per Microsoft docs (aka.ms/xcode-requirement), there is **no override property** for the .NET for iOS Xcode version check — \`IgnoreXcodeVersion=true\` doesn't exist (my mistake in #549). Supported fixes are: install matching Xcode, or install a workload version that supports your Xcode.

The newer iOS workload that supports Xcode 26.1 ships with SDK 10.0.20x. Our \`global.json\` was pinned to 10.0.100 with \`latestFeature\` rollforward — that only walks within 10.0.1xx and won't cross into 10.0.2xx.

Bumping the baseline pulls the newer workload via the existing \`dotnet workload install maui\` step.

Also removes \`-p:IgnoreXcodeVersion=true\` since it's not a real property.

## Test plan
- [ ] Setup .NET resolves to a 10.0.2xx SDK
- [ ] Install MAUI workload pulls a newer iOS pack (>26.0.11017)
- [ ] Publish IPA proceeds — Xcode 26.1.1 now accepted by the new pack
- [ ] Build reaches codesign + upload