### PR TITLE
Fix iOS TFM: route to net10.0-ios26.2 pack

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -126,12 +126,12 @@ jobs:
           echo "uuid=$UUID" >> "$GITHUB_OUTPUT"
 
       - name: Restore (iOS only)
-        run: dotnet restore DropShot.Maui/DropShot.Maui.csproj -p:TargetFramework=net10.0-ios26.0
+        run: dotnet restore DropShot.Maui/DropShot.Maui.csproj -p:TargetFramework=net10.0-ios26.2
 
       - name: Publish IPA
         run: |
           dotnet publish DropShot.Maui/DropShot.Maui.csproj \
-            -f net10.0-ios26.0 \
+            -f net10.0-ios26.2 \
             -c Release \
             -p:RuntimeIdentifier=ios-arm64 \
             -p:ArchiveOnBuild=true \
@@ -145,13 +145,13 @@ jobs:
         if: failure()
         run: |
           echo "=== actool dir contents ==="
-          ls -la DropShot.Maui/obj/Release/net10.0-ios26.0/ios-arm64/actool/ 2>/dev/null || echo "(no actool dir)"
+          ls -la DropShot.Maui/obj/Release/net10.0-ios26.2/ios-arm64/actool/ 2>/dev/null || echo "(no actool dir)"
           echo
           echo "=== asset-manifest.plist ==="
-          cat DropShot.Maui/obj/Release/net10.0-ios26.0/ios-arm64/actool/asset-manifest.plist 2>/dev/null || echo "(missing)"
+          cat DropShot.Maui/obj/Release/net10.0-ios26.2/ios-arm64/actool/asset-manifest.plist 2>/dev/null || echo "(missing)"
           echo
           echo "=== actool log files ==="
-          find DropShot.Maui/obj/Release/net10.0-ios26.0/ios-arm64/actool/ -type f -name "*.log" -exec sh -c 'echo "--- {} ---"; cat "{}"' \; 2>/dev/null || true
+          find DropShot.Maui/obj/Release/net10.0-ios26.2/ios-arm64/actool/ -type f -name "*.log" -exec sh -c 'echo "--- {} ---"; cat "{}"' \; 2>/dev/null || true
           echo
           echo "=== Xcode + actool version ==="
           xcode-select -p
@@ -163,7 +163,7 @@ jobs:
       - name: Locate IPA
         id: ipa
         run: |
-          IPA=$(find DropShot.Maui/bin/Release/net10.0-ios26.0 -name "*.ipa" | head -n 1)
+          IPA=$(find DropShot.Maui/bin/Release/net10.0-ios26.2 -name "*.ipa" | head -n 1)
           test -n "$IPA" || { echo "No IPA produced"; exit 1; }
           echo "path=$IPA" >> "$GITHUB_OUTPUT"
 
@@ -181,6 +181,6 @@ jobs:
         with:
           name: DropShot-ios-${{ steps.bn.outputs.build_number }}
           path: |
-            DropShot.Maui/bin/Release/net10.0-ios26.0/ios-arm64/publish/*.ipa
-            DropShot.Maui/bin/Release/net10.0-ios26.0/ios-arm64/**/*.dSYM/**
+            DropShot.Maui/bin/Release/net10.0-ios26.2/ios-arm64/publish/*.ipa
+            DropShot.Maui/bin/Release/net10.0-ios26.2/ios-arm64/**/*.dSYM/**
           retention-days: 14

--- a/DropShot.Maui/DropShot.Maui.csproj
+++ b/DropShot.Maui/DropShot.Maui.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
     <PropertyGroup>
-        <TargetFrameworks>net10.0-android36.0;net10.0-ios26.0;net10.0-maccatalyst26.0</TargetFrameworks>
+        <TargetFrameworks>net10.0-android36.0;net10.0-ios26.2;net10.0-maccatalyst26.2</TargetFrameworks>
         <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
         <CheckEolTargetFramework>false</CheckEolTargetFramework>
         <MauiVersion Condition="'$(MauiVersion)' == ''">10.0.60</MauiVersion>


### PR DESCRIPTION
## Summary
Diagnostic from #551's run revealed the workload install puts BOTH packs on disk:
\`\`\`
Installing pack Microsoft.iOS.Sdk.net10.0_26.2 version 26.2.10233...   <- supports Xcode 26.2/26.3
Installing pack Microsoft.iOS.Sdk.net10.0_26.0 version 26.0.11017...   <- strict Xcode 26.0
\`\`\`

The TFM determines which pack the build resolves. \`net10.0-ios26.0\` was routing to the strict 26.0 pack — hence the "requires Xcode 26.0" error even with Xcode 26.2 selected.

Switch TFM to \`net10.0-ios26.2\` (and \`maccatalyst26.2\`) so the build picks the 26.2 pack.

## Test plan
- [ ] Workflow auto-fires on push (still in temp mode)
- [ ] Restore + Publish use \`Microsoft.iOS.Sdk.net10.0_26.2/26.2.10233\` pack
- [ ] Version check passes
- [ ] Reach codesign + upload