### PR TITLE
Revert iOS workflow to manual trigger only

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -7,16 +7,6 @@ on:
         description: "What to test (shown in TestFlight)"
         required: false
         default: "Internal build"
-  # TEMP: auto-fire on push to main during initial debugging.
-  # Remove once the workflow reliably reaches TestFlight upload — manual
-  # triggers are preferable to avoid burning TestFlight build numbers.
-  push:
-    branches: [main]
-    paths:
-      - '.github/workflows/ios-testflight.yml'
-      - 'DropShot.Maui/**'
-      - 'DropShot.UI/**'
-      - 'DropShot.Shared/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
The iOS TestFlight workflow is now reliably reaching the upload step. Reverting the temporary push trigger from #551 — back to manual \`workflow_dispatch\` only.

## Test plan
- [ ] Workflow does NOT auto-fire on the next merge to main
- [ ] Workflow can still be triggered manually from Actions tab