### PR TITLE
Ship responsive nav drawer + drawer-hosted user info + player picker fallback

### DIFF
--- a/DropShot.Maui/Components/Layout/MainLayout.razor
+++ b/DropShot.Maui/Components/Layout/MainLayout.razor
@@ -1,9 +1,6 @@
 @inherits LayoutComponentBase
 @implements IDisposable
-@inject AuthService Auth
 @inject ICurrentUser CurrentUser
-@inject ISnackbar Snackbar
-@inject NavigationManager Nav
 
 <MudThemeProvider IsDarkMode="true" Theme="DropShot.UI.Theme.DropShotTheme.Default" />
 <MudPopoverProvider />
@@ -12,33 +9,13 @@
 
 <MudLayout>
     <MudAppBar Elevation="1" Color="Color.Primary">
-        <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit"
-                       Edge="Edge.Start" OnClick="@ToggleDrawer" />
-        <MudText Typo="Typo.h6" Class="ml-2">DropShot</MudText>
+        <MudText Typo="Typo.h6">DropShot</MudText>
         <MudSpacer />
-        <AuthorizeView>
-            <Authorized>
-                <CurrentUserBadge />
-                @if (CurrentUser.GrantedRoles.Count > 1)
-                {
-                    <MudMenu Icon="@Icons.Material.Filled.SwapHoriz" Color="Color.Inherit"
-                             Class="ml-1" Dense="true" aria-label="Switch role">
-                        @foreach (var role in CurrentUser.GrantedRoles)
-                        {
-                            <MudMenuItem OnClick="@(() => SwitchRoleAsync(role))"
-                                         Disabled="@(role == CurrentUser.ActiveRole)">
-                                @role
-                            </MudMenuItem>
-                        }
-                    </MudMenu>
-                }
-                <MudIconButton Icon="@Icons.Material.Filled.Logout" Color="Color.Inherit"
-                               OnClick="LogoutAsync" aria-label="Logout" Class="ml-2" />
-            </Authorized>
-        </AuthorizeView>
+        <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit"
+                       Edge="Edge.End" OnClick="@ToggleDrawer" />
     </MudAppBar>
 
-    <MudDrawer @bind-Open="_drawerOpen" Elevation="2" ClipMode="DrawerClipMode.Always">
+    <MudDrawer @bind-Open="_drawerOpen" Anchor="Anchor.End" Elevation="2" ClipMode="DrawerClipMode.Always">
         <NavMenu />
     </MudDrawer>
 
@@ -60,20 +37,6 @@
     private void OnCurrentUserChanged() => InvokeAsync(StateHasChanged);
 
     private void ToggleDrawer() => _drawerOpen = !_drawerOpen;
-
-    private async Task SwitchRoleAsync(string role)
-    {
-        var ok = await Auth.SwitchRoleAsync(role);
-        Snackbar.Add(
-            ok ? $"Switched to {role}." : $"Failed to switch to {role}.",
-            ok ? Severity.Success : Severity.Error);
-    }
-
-    private async Task LogoutAsync()
-    {
-        await Auth.LogoutAsync();
-        Nav.NavigateTo("/login", replace: true);
-    }
 
     public void Dispose()
     {

--- a/DropShot.Maui/Components/Layout/NavMenu.razor
+++ b/DropShot.Maui/Components/Layout/NavMenu.razor
@@ -1,7 +1,38 @@
+@implements IDisposable
+@using DropShot.Maui.Services
+@using DropShot.UI.Services.Auth
+@inject AuthService Auth
+@inject ICurrentUser CurrentUser
+@inject ISnackbar Snackbar
+@inject NavigationManager Nav
+
 <MudNavMenu>
+    <AuthorizeView>
+        <Authorized>
+            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="px-4 py-3">
+                <MudAvatar Color="Color.Primary" Size="Size.Medium">
+                    <MudIcon Icon="@Icons.Material.Filled.Person" />
+                </MudAvatar>
+                <MudStack Spacing="0">
+                    <MudText Typo="Typo.body1" Style="font-weight:600;">@CurrentUser.UserName</MudText>
+                    @if (!string.IsNullOrEmpty(CurrentUser.ActiveRole))
+                    {
+                        <MudText Typo="Typo.caption" Color="Color.Secondary">@CurrentUser.ActiveRole</MudText>
+                    }
+                </MudStack>
+            </MudStack>
+            <MudDivider />
+        </Authorized>
+    </AuthorizeView>
+
     <MudNavLink Href="/" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Home">
         Home
     </MudNavLink>
+    <AuthorizeView Roles="User">
+        <MudNavLink Href="/match" Icon="@Icons.Material.Filled.SportsTennis">
+            Match
+        </MudNavLink>
+    </AuthorizeView>
     <MudNavLink Href="/competitions" Icon="@Icons.Material.Filled.EmojiEvents">
         Competitions
     </MudNavLink>
@@ -21,4 +52,61 @@
             Players
         </MudNavLink>
     </AuthorizeView>
+
+    <AuthorizeView Roles="Admin,SuperAdmin,ClubAdmin">
+        <MudDivider Class="my-2" />
+        <MudNavLink Href="/score" Icon="@Icons.Material.Filled.Tv">
+            Scoreboard View
+        </MudNavLink>
+    </AuthorizeView>
+
+    <AuthorizeView>
+        <Authorized>
+            <MudDivider Class="my-2" />
+            @if (CurrentUser.GrantedRoles.Count > 1)
+            {
+                <MudText Typo="Typo.caption" Color="Color.Secondary" Class="px-4 pt-2">Switch role</MudText>
+                @foreach (var role in CurrentUser.GrantedRoles)
+                {
+                    <MudNavLink Icon="@Icons.Material.Filled.SwapHoriz"
+                                OnClick="@(() => SwitchRoleAsync(role))"
+                                Disabled="@(role == CurrentUser.ActiveRole)">
+                        @role
+                    </MudNavLink>
+                }
+                <MudDivider Class="my-2" />
+            }
+            <MudNavLink Icon="@Icons.Material.Filled.Logout" OnClick="LogoutAsync">
+                Logout
+            </MudNavLink>
+        </Authorized>
+    </AuthorizeView>
 </MudNavMenu>
+
+@code {
+    protected override void OnInitialized()
+    {
+        CurrentUser.Changed += OnCurrentUserChanged;
+    }
+
+    private void OnCurrentUserChanged() => InvokeAsync(StateHasChanged);
+
+    private async Task SwitchRoleAsync(string role)
+    {
+        var ok = await Auth.SwitchRoleAsync(role);
+        Snackbar.Add(
+            ok ? $"Switched to {role}." : $"Failed to switch to {role}.",
+            ok ? Severity.Success : Severity.Error);
+    }
+
+    private async Task LogoutAsync()
+    {
+        await Auth.LogoutAsync();
+        Nav.NavigateTo("/login", replace: true);
+    }
+
+    public void Dispose()
+    {
+        CurrentUser.Changed -= OnCurrentUserChanged;
+    }
+}

--- a/DropShot.UI/Components/Shared/MatchSetupWizard.razor
+++ b/DropShot.UI/Components/Shared/MatchSetupWizard.razor
@@ -825,23 +825,31 @@
         var excluded = GetAlreadySelectedPlayerIds();
 
         if (string.IsNullOrWhiteSpace(value))
-            return _searchablePlayers
-                .Where(p => !p.PlayerId.HasValue || !excluded.Contains(p.PlayerId.Value))
-                .Take(20);
+        {
+            if (_searchablePlayers.Count > 0)
+                return _searchablePlayers
+                    .Where(p => !p.PlayerId.HasValue || !excluded.Contains(p.PlayerId.Value))
+                    .Take(20);
+
+            // First-time users have no light/bookmarked players. Fall back to
+            // the fuzzy seed so the picker isn't empty before they type.
+            return _fuzzySeed
+                .Where(i => !excluded.Contains(i.PlayerId))
+                .Take(20)
+                .Select(FuzzyItemToSelection);
+        }
 
         List<PlayerSelection> results;
 
         if (_fuzzyInitialized)
         {
-            // Fuzzy index has all players, but autocomplete should only show my players
-            var myPlayerIds = _searchablePlayers
-                .Where(p => p.PlayerId.HasValue)
-                .Select(p => p.PlayerId!.Value)
-                .ToHashSet();
-
+            // Surface every verified player the fuzzy index knows about, not
+            // just the user's roster. StartMatch auto-bookmarks any verified
+            // pick (~line 1020), so widening the picker is intentional — do
+            // not re-add a "my players only" filter here.
             var fuzzyResults = await FuzzySearch.SearchAsync(value, 30);
             results = fuzzyResults
-                .Where(r => myPlayerIds.Contains(r.PlayerId) && !excluded.Contains(r.PlayerId))
+                .Where(r => !excluded.Contains(r.PlayerId))
                 .Take(14)
                 .Select(r => new PlayerSelection
                 {
@@ -852,13 +860,23 @@
                 })
                 .ToList();
         }
-        else
+        else if (_searchablePlayers.Count > 0)
         {
-            // Fallback before fuzzy index is ready
+            // Pre-init fallback for users with a roster: substring-search it.
             results = _searchablePlayers
                 .Where(p => p.DisplayName.Contains(value, StringComparison.OrdinalIgnoreCase)
                             && (!p.PlayerId.HasValue || !excluded.Contains(p.PlayerId.Value)))
                 .Take(14)
+                .ToList();
+        }
+        else
+        {
+            // Pre-init fallback for first-time users: substring-search the seed.
+            results = _fuzzySeed
+                .Where(i => i.DisplayName.Contains(value, StringComparison.OrdinalIgnoreCase)
+                            && !excluded.Contains(i.PlayerId))
+                .Take(14)
+                .Select(FuzzyItemToSelection)
                 .ToList();
         }
 
@@ -873,6 +891,14 @@
 
         return results;
     }
+
+    private PlayerSelection FuzzyItemToSelection(WizardFuzzyItemDto item) => new()
+    {
+        PlayerId = item.PlayerId,
+        DisplayName = item.DisplayName,
+        IsLight = item.IsLight,
+        ProfileImagePath = _playerAvatars.GetValueOrDefault(item.PlayerId)
+    };
 
     // ── Inline Light Player Creation ────────────────────────
 


### PR DESCRIPTION
## Summary
Three UI fixes that were sitting uncommitted in the working tree across recent CI debugging — finally shipping them.

**MAUI nav drawer** ([MainLayout.razor](DropShot.Maui/Components/Layout/MainLayout.razor) + [NavMenu.razor](DropShot.Maui/Components/Layout/NavMenu.razor)):
- Menu button now \`Edge.End\` and drawer \`Anchor.End\` — right-side drawer
- User avatar/username/role moved from AppBar into drawer header
- Username no longer appears in the banner

**Match setup player picker** ([MatchSetupWizard.razor](DropShot.UI/Components/Shared/MatchSetupWizard.razor)):
- First-time users (empty roster) used to get an empty autocomplete. Now falls back to the fuzzy seed (all verified players) when no roster exists, both pre-type and during search.
- Removes a redundant "my players only" filter — \`StartMatch\` already auto-bookmarks any verified pick.

## Test plan
- [ ] Trigger iOS TestFlight workflow manually
- [ ] On install: drawer opens from right when menu icon tapped
- [ ] User avatar + username show inside drawer header (not in app bar)
- [ ] Start Match → player picker shows suggestions before typing for first-time users
- [ ] Player picker search returns verified players outside user's roster