### PR TITLE
Suppress AdSense block on MAUI hosts

### DIFF
--- a/DropShot.UI/Components/Pages/Home.razor
+++ b/DropShot.UI/Components/Pages/Home.razor
@@ -289,18 +289,24 @@
     </MudGrid>
 }
 
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6819827391362636"
-     crossorigin="anonymous"></script>
-<!-- Home page Ad -->
-<ins class="adsbygoogle"
-     style="display:block"
-     data-ad-client="ca-pub-6819827391362636"
-     data-ad-slot="5137127862"
-     data-ad-format="auto"
-     data-full-width-responsive="true"></ins>
-<script>
-     (adsbygoogle = window.adsbygoogle || []).push({});
-</script>
+@* AdSense rejects WebView contexts and redirects to googlesyndication on
+   mobile MAUI hosts. Suppress in iOS/Android/MacCatalyst where the C# runs
+   on-device; web users (Blazor Server runs on Linux) still see ads. *@
+@if (!OperatingSystem.IsIOS() && !OperatingSystem.IsAndroid() && !OperatingSystem.IsMacCatalyst())
+{
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6819827391362636"
+         crossorigin="anonymous"></script>
+    <!-- Home page Ad -->
+    <ins class="adsbygoogle"
+         style="display:block"
+         data-ad-client="ca-pub-6819827391362636"
+         data-ad-slot="5137127862"
+         data-ad-format="auto"
+         data-full-width-responsive="true"></ins>
+    <script>
+         (adsbygoogle = window.adsbygoogle || []).push({});
+    </script>
+}
 
 @code {
     private bool arrows = true;


### PR DESCRIPTION
## Summary
First-launch redirect to \`pagead2.googlesyndication.com\` on iOS is AdSense detecting a WebView context (against AdSense ToS) and serving its policy-violation redirect. AdSense is not supported in mobile WebViews — for native ads we'd need AdMob with a proper SDK.

Wrap the AdSense script + \`<ins>\` block in [Home.razor](DropShot.UI/Components/Pages/Home.razor) in an OS check so MAUI iOS/Android/MacCatalyst hosts skip it. Web users (Blazor Server runtime on Azure Linux) still see ads — \`OperatingSystem.IsIOS()\` checks the runtime, not the user-agent.

## Test plan
- [ ] Trigger iOS TestFlight workflow
- [ ] Install new build on iOS — first launch goes straight to home, no redirect
- [ ] Verify ad still renders on web app (visit deployed Azure site in a desktop browser)
- [ ] Verify ad still renders for iOS Safari users on the web app (mobile browser, not the MAUI app)