### PR TITLE
Fix MAUI/iOS empty home page: read JWT principal off HttpContext.User

### DIFF
--- a/DropShot/Services/WebCurrentUser.cs
+++ b/DropShot/Services/WebCurrentUser.cs
@@ -112,10 +112,43 @@ public sealed class WebCurrentUser : ICurrentUser, IDisposable
             .ToListAsync();
     }
 
-    public string? UserId => _userId;
-    public string? UserName => _userName;
+    /// <summary>
+    /// API requests authenticated via JWT bearer (MAUI / iOS) populate
+    /// HttpContext.User but never feed the Blazor AuthenticationStateProvider
+    /// (which only tracks SignalR circuits) — and ServerAuthenticationStateProvider
+    /// throws on circuits that were never initialised, faulting the constructor's
+    /// fire-and-forget RefreshAsync so the snapshot fields stay null. Read the
+    /// principal-derived fields straight off HttpContext.User when one is present,
+    /// and fall back to the Blazor snapshot for interactive Blazor pages
+    /// (where HttpContext is null during SignalR mode).
+    /// </summary>
+    private ClaimsPrincipal? ApiPrincipal
+    {
+        get
+        {
+            var u = _httpContextAccessor.HttpContext?.User;
+            return u?.Identity?.IsAuthenticated == true ? u : null;
+        }
+    }
+
+    public string? UserId =>
+        ApiPrincipal is { } u
+            ? u.FindFirstValue(ClaimTypes.NameIdentifier)
+              ?? u.FindFirstValue(JwtRegisteredClaimNames.Sub)
+              ?? u.FindFirstValue("sub")
+            : _userId;
+
+    public string? UserName =>
+        ApiPrincipal is { } u
+            ? u.Identity?.Name ?? u.FindFirstValue(JwtRegisteredClaimNames.UniqueName)
+            : _userName;
+
     public string? Email => _email;
-    public string? ActiveRole => _activeRole;
+
+    public string? ActiveRole =>
+        ApiPrincipal is { } u
+            ? u.FindFirstValue(ClaimTypes.Role) ?? u.FindFirstValue("active_role")
+            : _activeRole;
     public IReadOnlyCollection<string> GrantedRoles => _grantedRoles;
     public IReadOnlyCollection<int> AdminClubIds => _adminClubIds;
 
@@ -133,7 +166,7 @@ public sealed class WebCurrentUser : ICurrentUser, IDisposable
         }
     }
 
-    public bool IsAuthenticated => _isAuthenticated;
+    public bool IsAuthenticated => ApiPrincipal is not null || _isAuthenticated;
     public bool IsAdmin => _activeRole is "Admin" or "SuperAdmin";
     public bool IsClubAdmin => _activeRole == "ClubAdmin";
     public bool IsSubscribed => _isSubscribed;


### PR DESCRIPTION
## Summary
- PR #557's `WebCurrentUser` fallback (`NameIdentifier` → `sub`) was correct in isolation but never ran for API requests, so MAUI/iOS users still saw an empty home page (no upcoming matches, no recent results).
- `WebCurrentUser` snapshots its state via `AuthenticationStateProvider`, which is the Blazor circuit's `RevalidatingServerAuthenticationStateProvider` — only sees SignalR-circuit principals, throws for API requests. The constructor's fire-and-forget `RefreshAsync` silently faulted and `_userId` stayed null for every JWT-bearer request. `ResolveCurrentPlayerAsync` then short-circuited to `[]`.
- Read `UserId` / `UserName` / `ActiveRole` / `IsAuthenticated` straight off `IHttpContextAccessor.HttpContext.User` when it's authenticated; fall back to the Blazor snapshot only when `HttpContext` is null (interactive Blazor SignalR mode). Cookie-auth web is unchanged because cookies populate `HttpContext.User` with `NameIdentifier` directly during initial render.

## Test plan
- [x] Local: rebuild API on `localhost:7243`, sign in on MAUI Debug build, confirm "Your Upcoming Matches" and "My Recent Results" cards render with data.
- [ ] Production iOS: after deploy, sign in on TestFlight build and confirm the home page populates.
- [ ] Web: sign in via cookie auth, confirm the home page still populates (regression check on the cookie path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)