### PR TITLE
Halt auto-schedule before knockouts when round-robin can't be scheduled

### DIFF
--- a/DropShot.UI/Components/Pages/CompetitionPage.razor
+++ b/DropShot.UI/Components/Pages/CompetitionPage.razor
@@ -3358,6 +3358,16 @@ else
         else
             Snackbar.Add($"{result.FixturesScheduled} fixtures scheduled.", Severity.Success);
 
+        // Headline summary first when nothing got scheduled — gives the user
+        // immediate context for the per-participant warnings that follow.
+        if (result.FixturesScheduled == 0 && result.Warnings.Count > 0)
+        {
+            Snackbar.Add(
+                $"No fixtures scheduled — {result.Warnings.Count} participant(s) skipped because they are not Full Players. See per-player warnings below.",
+                Severity.Warning,
+                c => c.VisibleStateDuration = 20000);
+        }
+
         foreach (var w in result.Warnings)
             Snackbar.Add(w, Severity.Warning, c => c.VisibleStateDuration = 12000);
     }

--- a/DropShot/Services/CompetitionSchedulerService.cs
+++ b/DropShot/Services/CompetitionSchedulerService.cs
@@ -62,12 +62,27 @@ public class CompetitionSchedulerService(IDbContextFactory<MyDbContext> dbFactor
         // (added but not confirmed) or Substitute — those rows are intentionally
         // skipped by the scheduler, but it's easy to miss them on a big roster
         // and end up wondering why a fixture was generated without so-and-so.
+        // Format each entry with the status and the action the admin needs to
+        // take so the warning is actionable on its own (the UI used to render
+        // bare names with no context).
         var unconfirmed = comp.Participants
             .Where(p => p.Status != ParticipantStatus.FullPlayer
                      && p.Status != ParticipantStatus.Withdrawn
                      && p.Status != ParticipantStatus.Disqualified)
-            .Select(p => p.Player?.DisplayName ?? $"Player {p.PlayerId}")
-            .OrderBy(n => n)
+            .Select(p =>
+            {
+                var name = p.Player?.DisplayName ?? $"Player {p.PlayerId}";
+                var reason = p.Status switch
+                {
+                    ParticipantStatus.Registered =>
+                        "status 'Registered' — not yet confirmed; change to 'Full Player' on the Setup tab to include in scheduling.",
+                    ParticipantStatus.Substitute =>
+                        "status 'Substitute' — substitutes are not auto-scheduled.",
+                    _ => $"status '{p.Status}' — only Full Players are scheduled."
+                };
+                return $"{name} — {reason}";
+            })
+            .OrderBy(s => s, StringComparer.OrdinalIgnoreCase)
             .ToList();
 
         // ── Delete according to mode ─────────────────────────────────────────
@@ -380,6 +395,26 @@ public class CompetitionSchedulerService(IDbContextFactory<MyDbContext> dbFactor
             f.FixtureLabel = label;
             f.RoundNumber = roundNumber;
             newFixtures.Add(f);
+        }
+
+        // ── Round-robin viability gate ───────────────────────────────────────
+        // If the competition declares a round-robin stage but has no eligible
+        // players / teams to fill it, halt before any stage runs. Knockout
+        // placeholders that follow the round-robin would be meaningless without
+        // standings to feed them, so we'd rather create nothing than create
+        // orphaned TBD bracket fixtures the admin then has to delete.
+        bool hasRoundRobin = comp.Stages.Any(s => s.StageType == StageType.RoundRobin);
+        bool roundRobinViable = isTeamComp
+            ? comp.Teams.Count(t => comp.Participants
+                .Any(p => p.TeamId == t.CompetitionTeamId && p.Status == ParticipantStatus.FullPlayer)) >= 2
+            : activePlayers.Count >= 2;
+        if (hasRoundRobin && !roundRobinViable)
+        {
+            var headline = isTeamComp
+                ? $"Round-robin cannot be scheduled — only {comp.Teams.Count} team(s) with Full Players (need at least 2). No fixtures created; later stages were skipped because they depend on round-robin standings."
+                : $"Round-robin cannot be scheduled — only {activePlayers.Count} Full Player(s) (need at least 2). No fixtures created; later stages were skipped because they depend on round-robin standings.";
+            unconfirmed.Insert(0, headline);
+            return new ScheduleFixturesResult(0, 0, unconfirmed);
         }
 
         // ── Generate fixtures per stage ──────────────────────────────────────


### PR DESCRIPTION
## Summary
- Auto Schedule used to silently skip every Registered participant, produce 0 round-robin fixtures, and then lay down a full TBD knockout bracket — meaningless without standings to feed it. Each skipped participant generated a yellow snackbar that displayed only their name, with no hint of the problem.
- `CompetitionSchedulerService` now refuses to create any fixtures when a `RoundRobin` stage exists but fewer than 2 Full Players (or, for team competitions, fewer than 2 teams with Full Players) are available, and prepends a headline warning to the per-player list. Pure single-elimination competitions are unaffected.
- Per-participant warning text now includes the actual status and the action to take (`"Alice — status 'Registered' — not yet confirmed; change to 'Full Player' on the Setup tab to include in scheduling."`). Substitutes get their own message.
- `CompetitionPage` shows a headline-summary snackbar first when zero fixtures get scheduled, so the cause is clear before the user scrolls through per-player notices.

## Test plan
- [x] DropShot.UI and DropShot.Shared build clean.
- [ ] Setup → add several participants, leave them at status `Registered`, configure round-robin + knockout stages, click Auto Schedule. Expect 0 fixtures created (no RR, no knockout TBDs) and a clear headline warning followed by per-player detail.
- [ ] Change participants to `Full Player`, re-run Auto Schedule — expect round-robin fixtures and the knockout TBDs to populate as before.
- [ ] Pure-knockout competition with no RoundRobin stage and ≥2 participants: Auto Schedule still creates the bracket (regression check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)