### PR TITLE
Move MAUI background to body so edges show, scoreboard stops doubling

### DIFF
--- a/DropShot.Maui/wwwroot/css/app.css
+++ b/DropShot.Maui/wwwroot/css/app.css
@@ -2,6 +2,11 @@ html, body {
     font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
     height: 100%;
     overflow: hidden;
+    background-color: #121212;
+    background-image:
+        linear-gradient(rgba(18, 18, 18, 0.85), rgba(18, 18, 18, 0.85)),
+        url('_content/DropShot.UI/images/background.png');
+    background-repeat: repeat;
 }
 
 /* Defensive guard against pages whose content (wide MudTables, fixed-width
@@ -36,22 +41,21 @@ html:not([data-theme="light"]) .mud-appbar {
 /* MudMainContent owns the scroll viewport so the AppBar and Drawer stay
    pinned while lists (Competitions, Clubs, etc.) scroll inside. Without
    this the body's overflow:hidden clips overflowing content and it
-   becomes unreachable. The branded background image lives here (not on
-   body) because MudLayout paints its own opaque background over body. */
+   becomes unreachable.
+
+   Force transparent so the body's branded background image shows through
+   on the side margins of MudContainer (matching the web layout, where
+   the body bg is visible outside the centered content column). MudBlazor
+   normally paints --mud-palette-background here, which would cover body. */
 .mud-main-content {
     height: 100vh;
     overflow-y: auto;
     -webkit-overflow-scrolling: touch;
-    background-color: #121212;
-    background-image:
-        linear-gradient(rgba(18, 18, 18, 0.85), rgba(18, 18, 18, 0.85)),
-        url('_content/DropShot.UI/images/background.png');
-    background-repeat: repeat;
+    background: transparent !important;
 }
 
-[data-theme="light"] .mud-main-content {
-    background-color: #f5f5f5;
-    background-image: none;
+.mud-layout {
+    background: transparent !important;
 }
 
 /* Force dark text + visible link colour on the lightyellow background.


### PR DESCRIPTION
## Summary
- PR #560 painted the branded background on `.mud-main-content`. Two regressions surfaced:
  1. Match scoreboard ([TennisScore.razor.css:58-79](DropShot.UI/Components/Pages/TennisScore.razor.css:58)) already paints its own `.bg-tennis` full-bleed background. With `.mud-main-content` also painting the same image, the user saw it both inside the scoreboard's zone and on the surrounding scroll-container area.
  2. Image didn't show in the side margins of MudContainer-wrapped pages the way it does on the web. Web paints `body` directly, and the side margins outside the centered content column show body through. In MAUI, MudBlazor paints `--mud-palette-background` on `.mud-layout` / `.mud-main-content`, covering body.
- Now match the web exactly: paint on `html, body` (using the same rule as `DropShot/wwwroot/app.css`, now feasible since PR #560 moved `background.png` to shared `DropShot.UI` assets), force `.mud-main-content` + `.mud-layout` transparent so MudBlazor's theme palette doesn't paint over body.
- Light-theme override dropped — the web doesn't have one, and adding one diverged the two hosts.

## Test plan
- [ ] MAUI Windows debug, dark mode: branded background visible on the side margins of every page; match scoreboard shows only its own `.bg-tennis` (no surrounding double-image).
- [ ] MAUI Windows debug, light mode: matches the web's light-mode behaviour (the rgba(18,18,18,0.85) overlay still applies, same as web).
- [ ] iOS TestFlight: layout still respects status-bar safe-area inset.
- [ ] Web: unchanged (no files touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)