### PR TITLE
Force MAUI body background with !important so the image actually paints

### DIFF
--- a/DropShot.Maui/wwwroot/css/app.css
+++ b/DropShot.Maui/wwwroot/css/app.css
@@ -2,11 +2,17 @@ html, body {
     font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
     height: 100%;
     overflow: hidden;
-    background-color: #121212;
+    /* !important here outweighs MudBlazor.min.css rule
+       `body { background-color: var(--mud-palette-background) }` which the
+       MudThemeProvider parameterises at runtime — without it the runtime
+       cascade can replace the bg-color and clobber the shorthand path on
+       some browsers, so the branded image is invisible on every page that
+       isn't the match scoreboard (which paints its own .bg-tennis). */
+    background-color: #121212 !important;
     background-image:
         linear-gradient(rgba(18, 18, 18, 0.85), rgba(18, 18, 18, 0.85)),
-        url('_content/DropShot.UI/images/background.png');
-    background-repeat: repeat;
+        url('_content/DropShot.UI/images/background.png') !important;
+    background-repeat: repeat !important;
 }
 
 /* Defensive guard against pages whose content (wide MudTables, fixed-width


### PR DESCRIPTION
## Summary
- PR #561 painted the branded background on `html, body` but MudBlazor.min.css ships `body { background-color: var(--mud-palette-background) }` parameterised at runtime by `MudThemeProvider`.
- Even though MAUI's `app.css` loads after `MudBlazor.min.css` in [index.html](DropShot.Maui/wwwroot/index.html), the runtime cascade kept MudBlazor's body bg-color on every page that wasn't the match scoreboard (which paints its own `.bg-tennis`). Result: the user saw the bg only on the match page.
- Adding `!important` to the body `background-color`, `background-image`, and `background-repeat` outranks the runtime palette rule unambiguously. `.mud-main-content` and `.mud-layout` were already forced transparent in PR #561 so body shows through.

## Test plan
- [ ] **Important:** rebuild the MAUI app (not hot-reload). Static `wwwroot/css/app.css` is bundled at build time; hot-reload won't pick it up.
- [ ] Dark mode: branded background visible on home, Competitions list, every Setup tab — including the side margins outside MudContainer's centered column.
- [ ] Match scoreboard: still shows only its own `.bg-tennis`, no doubling.
- [ ] iOS: layout still respects the safe-area inset (the iOS block in app.css is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)