### PR TITLE
Paint MAUI background on .mud-main-content (suppress on match page)

### DIFF
--- a/DropShot.Maui/wwwroot/css/app.css
+++ b/DropShot.Maui/wwwroot/css/app.css
@@ -2,17 +2,6 @@ html, body {
     font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
     height: 100%;
     overflow: hidden;
-    /* !important here outweighs MudBlazor.min.css rule
-       `body { background-color: var(--mud-palette-background) }` which the
-       MudThemeProvider parameterises at runtime — without it the runtime
-       cascade can replace the bg-color and clobber the shorthand path on
-       some browsers, so the branded image is invisible on every page that
-       isn't the match scoreboard (which paints its own .bg-tennis). */
-    background-color: #121212 !important;
-    background-image:
-        linear-gradient(rgba(18, 18, 18, 0.85), rgba(18, 18, 18, 0.85)),
-        url('_content/DropShot.UI/images/background.png') !important;
-    background-repeat: repeat !important;
 }
 
 /* Defensive guard against pages whose content (wide MudTables, fixed-width
@@ -49,19 +38,30 @@ html:not([data-theme="light"]) .mud-appbar {
    this the body's overflow:hidden clips overflowing content and it
    becomes unreachable.
 
-   Force transparent so the body's branded background image shows through
-   on the side margins of MudContainer (matching the web layout, where
-   the body bg is visible outside the centered content column). MudBlazor
-   normally paints --mud-palette-background here, which would cover body. */
+   Paint the branded background here (rather than on body) because
+   MudBlazor's MudThemeProvider runtime palette covers body's bg on
+   every regular page — only the match page worked when the bg was on
+   body, because TennisScore.razor.css paints its own .bg-tennis on top.
+   :has(.bg-tennis) suppresses this on the scoreboard so the user
+   doesn't see the same image at two different scroll positions. */
 .mud-main-content {
     height: 100vh;
     overflow-y: auto;
     -webkit-overflow-scrolling: touch;
-    background: transparent !important;
+    background-color: #121212;
+    background-image:
+        linear-gradient(rgba(18, 18, 18, 0.85), rgba(18, 18, 18, 0.85)),
+        url('_content/DropShot.UI/images/background.png');
+    background-repeat: repeat;
 }
 
-.mud-layout {
-    background: transparent !important;
+.mud-main-content:has(.bg-tennis) {
+    background: transparent;
+}
+
+[data-theme="light"] .mud-main-content {
+    background-color: #f5f5f5;
+    background-image: none;
 }
 
 /* Force dark text + visible link colour on the lightyellow background.


### PR DESCRIPTION
## Summary
- After three iterations on `body` + transparent overrides ([PR #560](https://github.com/kingbeazer/DropShot/pull/560), [PR #561](https://github.com/kingbeazer/DropShot/pull/561), [PR #562](https://github.com/kingbeazer/DropShot/pull/562)) the branded background still never painted on regular MAUI pages — only the match page showed it because `TennisScore.razor.css` applies its own `.bg-tennis`. Some opaque element inside MudLayout that the `.mud-layout` / `.mud-main-content` transparent overrides don't reach is still covering body.
- Skip body entirely and paint `.mud-main-content` directly — that's the visible scroll container, and the user previously saw the bg there. Use `:has(.bg-tennis)` to drop the bg on the scoreboard page so the user doesn't see the image at two different scroll positions.
- Light-theme override (`#f5f5f5` + `background-image: none`) restored, mirroring `theme-light.css`'s body override on the web.

## Test plan
- [ ] Clean rebuild MAUI app (Build → Clean Solution → F5; static `wwwroot/css/app.css` is bundled at build time).
- [ ] Dark mode: bg image visible on home, Competitions, every Setup tab; visible on side margins outside the centered MudContainer column.
- [ ] Light mode: solid `#f5f5f5` background, no image.
- [ ] Match scoreboard: only `.bg-tennis` is painted, no doubled image.
- [ ] iOS: layout still respects safe-area inset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)