### PR TITLE
Make MAUI background URL root-relative so /css/app.css can find it

### DIFF
--- a/DropShot.Maui/wwwroot/css/app.css
+++ b/DropShot.Maui/wwwroot/css/app.css
@@ -51,7 +51,7 @@ html:not([data-theme="light"]) .mud-appbar {
     background-color: #121212;
     background-image:
         linear-gradient(rgba(18, 18, 18, 0.85), rgba(18, 18, 18, 0.85)),
-        url('_content/DropShot.UI/images/background.png');
+        url('/_content/DropShot.UI/images/background.png');
     background-repeat: repeat;
 }
 


### PR DESCRIPTION
## Summary
- PRs [#560](https://github.com/kingbeazer/DropShot/pull/560), [#561](https://github.com/kingbeazer/DropShot/pull/561), [#562](https://github.com/kingbeazer/DropShot/pull/562), [#563](https://github.com/kingbeazer/DropShot/pull/563) all chased a CSS cascade ghost. The actual bug: `css/app.css` is served at `/css/app.css`, so the relative URL `_content/DropShot.UI/images/background.png` resolved to `/css/_content/DropShot.UI/images/background.png` — a 404.
- The match page worked only because its scoped CSS bundle lives at `/_content/DropShot.UI/.../DropShot.UI.<hash>.bundle.scp.css`, where the same relative URL resolves correctly to `/_content/DropShot.UI/images/background.png`.
- Add a leading `/` to make the URL root-relative regardless of the stylesheet's location.

## Test plan
- [x] Confirmed working on MAUI Windows after clean rebuild — branded background visible on regular pages, match page still shows only `.bg-tennis`.
- [ ] iOS TestFlight: same path resolves under the BlazorWebView's content host.
- [ ] Light mode override (`#f5f5f5`, no image) still kicks in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)