### PR TITLE
Drop .bg-tennis's own image on MAUI so .mud-main-content tiles uniformly

### DIFF
--- a/DropShot.Maui/wwwroot/css/app.css
+++ b/DropShot.Maui/wwwroot/css/app.css
@@ -55,8 +55,16 @@ html:not([data-theme="light"]) .mud-appbar {
     background-repeat: repeat;
 }
 
-.mud-main-content:has(.bg-tennis) {
-    background: transparent;
+/* The match scoreboard's .bg-tennis (TennisScore.razor.css) paints the
+   same image from its own top-left, which doesn't line up with the
+   .mud-main-content tile pattern and produces a visible seam at the
+   .bg-tennis edge. Disable .bg-tennis's own image so the underlying
+   .mud-main-content image shows through uniformly; the ::before overlay
+   (--overlay-color / --overlay-alpha) is unaffected so the scoreboard
+   keeps its darkened atmosphere. */
+.mud-main-content .bg-tennis {
+    --bg-image: none !important;
+    --bg-fallback: transparent !important;
 }
 
 [data-theme="light"] .mud-main-content {


### PR DESCRIPTION
## Summary
- [PR #563](https://github.com/kingbeazer/DropShot/pull/563) hid `.mud-main-content`'s bg via `:has(.bg-tennis)` to stop the seam between the two image tile origins on the match page. But `.bg-tennis` (in [TennisScore.razor.css:58-79](DropShot.UI/Components/Pages/TennisScore.razor.css:58)) uses `flex: 1` assuming a flex parent — MudContainer is a plain block, so `.bg-tennis` only fills its content box, not the viewport. With the parent transparent, the rest of the match page showed nothing.
- Now let `.mud-main-content` paint everywhere (including under the scoreboard) and disable `.bg-tennis`'s own `--bg-image` / `--bg-fallback` on MAUI. The single shared image tiles uniformly from one origin, no seam, and the `::before` overlay still gives the scoreboard its darkened atmosphere.
- Web is unaffected — the override is scoped to `.mud-main-content .bg-tennis`, and the web doesn't use MudLayout.

## Test plan
- [ ] Clean rebuild MAUI app.
- [ ] Match scoreboard: branded image visible, scoreboard area slightly darker (overlay), no seam at `.bg-tennis` edges.
- [ ] Regular pages still show the bg as in PR #564.
- [ ] iOS: layout / safe-area unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)