### PR TITLE
Zero .bg-tennis overlay on MAUI to stop double-darkening the centre

### DIFF
--- a/DropShot.Maui/wwwroot/css/app.css
+++ b/DropShot.Maui/wwwroot/css/app.css
@@ -59,12 +59,14 @@ html:not([data-theme="light"]) .mud-appbar {
    same image from its own top-left, which doesn't line up with the
    .mud-main-content tile pattern and produces a visible seam at the
    .bg-tennis edge. Disable .bg-tennis's own image so the underlying
-   .mud-main-content image shows through uniformly; the ::before overlay
-   (--overlay-color / --overlay-alpha) is unaffected so the scoreboard
-   keeps its darkened atmosphere. */
+   .mud-main-content image shows through uniformly. Also zero the
+   ::before overlay alpha — the .mud-main-content rule already applies
+   an 85% dark gradient over the image, so .bg-tennis's darkening on
+   top would double-up and turn the centre section black. */
 .mud-main-content .bg-tennis {
     --bg-image: none !important;
     --bg-fallback: transparent !important;
+    --overlay-alpha: 0 !important;
 }
 
 [data-theme="light"] .mud-main-content {


### PR DESCRIPTION
## Summary
- [PR #565](https://github.com/kingbeazer/DropShot/pull/565) disabled `.bg-tennis`'s own image so the `.mud-main-content` tile shows uniformly under the scoreboard. But `.bg-tennis::before` still painted its `rgba(18, 18, 18, 0.85)` overlay over that area.
- `.mud-main-content` already applies an 85% dark gradient overlay on top of the image, so the `::before` overlay stacked on top double-darkened the centre and turned it almost black.
- Set `--overlay-alpha: 0` inside `.mud-main-content .bg-tennis` so the per-page `::before` becomes transparent. The single shared overlay from `.mud-main-content` carries the darkening across the whole page.

## Test plan
- [ ] Clean rebuild MAUI app.
- [ ] Match scoreboard: centre section now matches the rest of the page (single shared darkening), bg image uniformly visible, no black square in the middle.
- [ ] Regular pages unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)