### PR TITLE
Fix MAUI Upgrade 401: SubscriptionController to Bearer + ICurrentUser

### DIFF
--- a/DropShot/Controllers/SubscriptionController.cs
+++ b/DropShot/Controllers/SubscriptionController.cs
@@ -1,27 +1,33 @@
 using DropShot.Data;
+using DropShot.UI.Services.Auth;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using System.Net.Http.Headers;
-using System.Security.Claims;
 using System.Text;
 using System.Text.Json;
 
 namespace DropShot.Controllers;
 
+// Bearer-only because the web uses WebPaymentService directly (see Program.cs)
+// — only the MAUI HttpPaymentService hits this controller. Plain [Authorize]
+// (default cookie scheme) silently 401'd every MAUI request.
 [ApiController]
 [Route("api/subscription")]
+[Authorize(AuthenticationSchemes = "Bearer")]
 public class SubscriptionController(
     UserManager<ApplicationUser> userManager,
+    ICurrentUser currentUser,
     IConfiguration configuration,
     ILogger<SubscriptionController> logger) : ControllerBase
 {
     // ── Activate ────────────────────────────────────────────────────────────────
     [HttpPost("activate")]
-    [Authorize]
     public async Task<IActionResult> Activate([FromBody] ActivateRequest request)
     {
-        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        // ICurrentUser already falls back from NameIdentifier to JWT 'sub' for
+        // bearer requests (PR #558), so this works for both cookie and JWT auth.
+        var userId = currentUser.UserId;
         if (userId is null) return Unauthorized();
 
         var user = await userManager.FindByIdAsync(userId);
@@ -108,10 +114,9 @@ public class SubscriptionController(
 
     // ── Status ──────────────────────────────────────────────────────────────────
     [HttpGet("status")]
-    [Authorize]
     public async Task<ActionResult<DropShot.Shared.Dtos.SubscriptionStatusDto>> Status()
     {
-        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var userId = currentUser.UserId;
         if (userId is null) return Unauthorized();
 
         var user = await userManager.FindByIdAsync(userId);


### PR DESCRIPTION
## Summary
- Tapping Upgrade in MAUI threw `HttpRequestException ... 401 (Unauthorized)` from `GET /api/subscription/status`. Two issues stacked:
  1. The controller had bare `[Authorize]`, defaulting to the Identity cookie scheme. MAUI sends a JWT bearer token, so the request was treated as anonymous and the authorize filter short-circuited before the method ran.
  2. The methods read `User.FindFirstValue(ClaimTypes.NameIdentifier)` directly. JWT bearer carries the user id under `sub`, not `NameIdentifier` (the modern `JsonWebTokenHandler` doesn't auto-map). [PR #558](https://github.com/kingbeazer/DropShot/pull/558) fixed `WebCurrentUser` with a sub fallback but this controller was the leftover flagged in the project memory.
- Switch class-level attribute to `[Authorize(AuthenticationSchemes = "Bearer")]` — the web uses `WebPaymentService` directly via DI per [Program.cs:141](DropShot/Program.cs:141), so this controller is MAUI-only.
- Inject `ICurrentUser` so the existing fallback chain (`NameIdentifier → JwtRegisteredClaimNames.Sub → "sub"`) applies in both `Activate` and `Status`.
- Webhook keeps `[AllowAnonymous]` (PayPal authenticates via signature).

## Test plan
- [ ] MAUI Upgrade page loads without 401 (calls `GET /api/subscription/status`).
- [ ] Subscription activation via the website still works for MAUI users (the activate endpoint is hit from the in-browser PayPal flow on the web; MAUI itself doesn't call activate).
- [ ] Web's `/upgrade` page unchanged — still uses `WebPaymentService` directly, doesn't touch this controller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)