### PR TITLE
Clear remaining compile warnings across UI and server

### DIFF
--- a/DropShot.UI/Components/Pages/CompetitionPage.razor
+++ b/DropShot.UI/Components/Pages/CompetitionPage.razor
@@ -1955,7 +1955,7 @@ else
     private async Task SubmitAsync()
     {
         _serverError = null;
-        if (_form is not null) await _form.Validate();
+        if (_form is not null) await _form.ValidateAsync();
         _categoryError = Model.Category == null ? "Please select a category." : null;
         if (!_isValid || _categoryError != null) return;
 

--- a/DropShot.UI/_Imports.razor
+++ b/DropShot.UI/_Imports.razor
@@ -12,6 +12,7 @@
 @using MudBlazor
 @using DropShot.Shared
 @using DropShot.Shared.Dtos
+@using DropShot.UI.Components.Scoreboards
 @using DropShot.UI.Components.Shared
 @using DropShot.UI.Services
 @using DropShot.UI.Services.Auth

--- a/DropShot/Controllers/CompetitionsAdminController.cs
+++ b/DropShot/Controllers/CompetitionsAdminController.cs
@@ -16,8 +16,7 @@ namespace DropShot.Controllers;
 [Route("api/competitions/admin")]
 [Authorize(AuthenticationSchemes = "Bearer")]
 public class CompetitionsAdminController(
-    ICompetitionAdminService admin,
-    ILogger<CompetitionsAdminController> logger) : ControllerBase
+    ICompetitionAdminService admin) : ControllerBase
 {
     // ── Read ─────────────────────────────────────────────────────────────────
 

--- a/DropShot/Controllers/InvitationsController.cs
+++ b/DropShot/Controllers/InvitationsController.cs
@@ -23,7 +23,7 @@ public class InvitationsController(IInvitationService invitations) : ControllerB
         {
             return await invitations.CreateOrReuseLightPlayerInvitationAsync(lightPlayerId, ct);
         }
-        catch (InvalidOperationException ex)
+        catch (InvalidOperationException)
         {
             return Forbid();
         }


### PR DESCRIPTION
## Summary
Five compile warnings cleared, four files touched, no behaviour change.

- [DropShot.UI/_Imports.razor](DropShot.UI/_Imports.razor) — pull `DropShot.UI.Components.Scoreboards` into the project-level usings so `<WimbledonScoreboard>` and `<DefaultScoreboard>` resolve in `Pages/Scoreboard.razor` (the namespace was only imported in the Scoreboards folder's own `_Imports`). Clears two `RZ10012` warnings.
- [CompetitionPage.razor:1958](DropShot.UI/Components/Pages/CompetitionPage.razor:1958) — `_form.Validate()` → `_form.ValidateAsync()` (sync wrapper deprecated in modern MudBlazor; was already awaited). Clears `CS0618`.
- [CompetitionsAdminController.cs:20](DropShot/Controllers/CompetitionsAdminController.cs:20) — drop the unused `ILogger` primary-ctor parameter (no `logger.LogX` calls in the file). Clears `CS9113`.
- [InvitationsController.cs:26](DropShot/Controllers/InvitationsController.cs:26) — `catch (InvalidOperationException ex)` → `catch (InvalidOperationException)` (variable was never read). Clears `CS0168`.

DropShot.UI, DropShot.Shared, DropShot, and DropShot.Tests now all build with 0 warnings.

## Test plan
- [x] `dotnet build DropShot.UI/DropShot.UI.csproj` — 0 warnings.
- [x] `dotnet build DropShot/DropShot.csproj` — 0 code warnings (only file-copy retries from a running dev server).
- [x] `dotnet build DropShot.Tests/DropShot.Tests.csproj` — 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)