### PR TITLE
Wire rules-set item management into CompetitionPage

### DIFF
--- a/DropShot.UI/Components/Pages/CompetitionPage.razor
+++ b/DropShot.UI/Components/Pages/CompetitionPage.razor
@@ -176,6 +176,12 @@ else
                                 <MudSelectItem T="int?" Value="@((int?)r.RulesSetId)">@r.Name</MudSelectItem>
                             }
                         </MudSelect>
+                        <MudTooltip Text="@(Model.RulesSetId.HasValue ? "Manage rules in this set" : "Select a rules set to manage its rules")">
+                            <MudIconButton Icon="@Icons.Material.Filled.FormatListBulleted" Size="Size.Small"
+                                           Color="Color.Primary"
+                                           Disabled="@(!Model.RulesSetId.HasValue)"
+                                           OnClick="ManageSelectedRulesSetItemsAsync" />
+                        </MudTooltip>
                         <MudTooltip Text="Add new rules set">
                             <MudIconButton Icon="@Icons.Material.Filled.AddCircleOutline" Size="Size.Small"
                                            Color="Color.Primary"
@@ -2051,9 +2057,10 @@ else
         var name = _newRulesSetName.Trim();
         if (string.IsNullOrWhiteSpace(name)) return;
 
+        RulesSetDto? saved = null;
         try
         {
-            var saved = await RulesSetService.SaveRulesSetAsync(0, new SaveRulesSetRequest(name, null));
+            saved = await RulesSetService.SaveRulesSetAsync(0, new SaveRulesSetRequest(name, null));
             if (saved is null)
             {
                 Snackbar.Add("Could not create rules set.", Severity.Error);
@@ -2074,6 +2081,35 @@ else
             _showAddRulesSetDialog = false;
             _newRulesSetName = "";
         }
+
+        // Empty rules set on its own isn't useful — drop the user straight
+        // into the items dialog so they can add the rules without hopping
+        // over to the dedicated Rules Sets page.
+        if (saved is not null)
+            await ShowRulesSetItemsDialogAsync(saved.RulesSetId, saved.Name);
+    }
+
+    private async Task ManageSelectedRulesSetItemsAsync()
+    {
+        if (!Model.RulesSetId.HasValue) return;
+        var rs = _rulesSets.FirstOrDefault(r => r.RulesSetId == Model.RulesSetId.Value);
+        if (rs is null) return;
+        await ShowRulesSetItemsDialogAsync(rs.RulesSetId, rs.Name);
+    }
+
+    private async Task ShowRulesSetItemsDialogAsync(int rulesSetId, string rulesSetName)
+    {
+        var parameters = new DialogParameters<RulesSetItemsDialog>
+        {
+            { x => x.RulesSetId, rulesSetId },
+            { x => x.RulesSetName, rulesSetName }
+        };
+        var dialog = await DialogService.ShowAsync<RulesSetItemsDialog>(
+            $"Rules — {rulesSetName}", parameters);
+        await dialog.Result;
+        // Refresh ItemCount on the dropdown's source list.
+        _rulesSets = (await RulesSetService.GetRulesSetsAsync())
+            .OrderBy(r => r.Name).ToList();
     }
 
     private void SaveNewEvent()


### PR DESCRIPTION
## Summary
- [PR #569](https://github.com/kingbeazer/DropShot/pull/569) enabled inline rules-set creation but left the new set empty with no way to add rules without navigating to `/rulessets`.
- Surface the existing [`RulesSetItemsDialog`](DropShot.UI/Components/Pages/RulesSetItemsDialog.razor) in two places on the Setup tab:
  - **Manage rules** icon button (`FormatListBulleted`) next to the `+`, enabled when a rules set is selected. Opens the items dialog for the current selection.
  - After `SaveNewRulesSet` successfully creates a rules set, immediately open the items dialog for the new id — empty rules sets aren't useful on their own.
- Both paths refresh `_rulesSets` after the dialog closes so dropdown labels show the latest item count.

For full edit (rename / change description / delete) the dedicated **Rules Sets** page (drawer → Rules Sets, route `/rulessets`) already exists; this PR doesn't duplicate it on the Setup tab.

## Test plan
- [ ] Setup tab: select an existing rules set → click the bullet-list icon → items dialog opens, can add/remove rules.
- [ ] Setup tab: click `+`, type a name, Add → success snackbar, then items dialog opens for the new set with no rules. Add a couple of rules → close → dropdown shows the new set selected with the right count.
- [ ] No rules-set selected: bullet-list icon is disabled with the "Select a rules set..." tooltip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)