### PR TITLE
Share primary nav entries between web and MAUI; add web /rulessets

### DIFF
--- a/DropShot.Maui/Components/Layout/NavMenu.razor
+++ b/DropShot.Maui/Components/Layout/NavMenu.razor
@@ -29,28 +29,34 @@
     <MudNavLink Href="/" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Home">
         Home
     </MudNavLink>
-    <AuthorizeView Roles="User">
-        <MudNavLink Href="/match" Icon="@Icons.Material.Filled.SportsTennis">
-            Match
-        </MudNavLink>
-    </AuthorizeView>
-    <MudNavLink Href="/competitions" Icon="@Icons.Material.Filled.EmojiEvents">
-        Competitions
-    </MudNavLink>
-    <MudNavLink Href="/clubs" Icon="@Icons.Material.Filled.SportsTennis">
-        Clubs
-    </MudNavLink>
-    <MudNavLink Href="/rulessets" Icon="@Icons.Material.Filled.Gavel">
-        Rules Sets
-    </MudNavLink>
+
+    @* Primary nav links live in DropShot.UI.Services.Navigation.NavCatalog
+       so the web and MAUI menus stay in sync — adding a link in the catalog
+       lights it up in both hosts automatically. *@
+    @foreach (var link in DropShot.UI.Services.Navigation.NavCatalog.Primary)
+    {
+        if (!string.IsNullOrEmpty(link.RequiredRoles))
+        {
+            <AuthorizeView Roles="@link.RequiredRoles">
+                <MudNavLink Href="@($"/{link.Href}")" Icon="@link.Icon">
+                    @link.Label
+                </MudNavLink>
+            </AuthorizeView>
+        }
+        else
+        {
+            <MudNavLink Href="@($"/{link.Href}")" Icon="@link.Icon">
+                @link.Label
+            </MudNavLink>
+        }
+    }
+
+    @* Club Players stays MAUI-specific because the web swaps it with
+       My Players based on the active-role cookie — different per-host
+       behaviour, easier to keep out of the shared catalog. *@
     <AuthorizeView Roles="ClubAdmin,Admin,SuperAdmin">
         <MudNavLink Href="/players/club" Icon="@Icons.Material.Filled.Groups">
             Club Players
-        </MudNavLink>
-    </AuthorizeView>
-    <AuthorizeView Roles="SuperAdmin">
-        <MudNavLink Href="/players" Icon="@Icons.Material.Filled.People">
-            Players
         </MudNavLink>
     </AuthorizeView>
 

--- a/DropShot.UI/Services/Navigation/NavCatalog.cs
+++ b/DropShot.UI/Services/Navigation/NavCatalog.cs
@@ -1,0 +1,61 @@
+using MudBlazor;
+
+namespace DropShot.UI.Services.Navigation;
+
+/// <summary>
+/// Shared definition of a primary navigation link. The two hosts render
+/// these in their own style (web: top-row anchor with sub-label; MAUI:
+/// drawer's MudNavLink) but agree on the set of entries — adding or
+/// removing a link in one place automatically updates both.
+/// </summary>
+/// <param name="Href">App-relative path, no leading slash. The hosts add
+/// the slash where their renderer expects it.</param>
+/// <param name="Label">Primary label shown to the user.</param>
+/// <param name="Icon">MudBlazor icon SVG path string
+/// (e.g. <c>Icons.Material.Filled.Gavel</c>).</param>
+/// <param name="Sublabel">Optional secondary label shown by the web's
+/// nav-sublabel slot. MAUI ignores it.</param>
+/// <param name="RequiredRoles">Optional comma-separated roles. When
+/// <c>null</c> the link is rendered for any authenticated user. When
+/// empty the link is rendered for everyone (including anonymous).</param>
+public sealed record NavLinkEntry(
+    string Href,
+    string Label,
+    string Icon,
+    string? Sublabel = null,
+    string? RequiredRoles = null);
+
+/// <summary>
+/// Single source of truth for the primary navigation links shown in the
+/// web's top-row navbar and the MAUI drawer. Host-specific entries (web's
+/// My-Players-vs-Club-Players toggle, MAUI's Home shortcut, account /
+/// admin / theme sections) stay in their respective <c>NavMenu.razor</c>
+/// because they need bespoke rendering.
+/// </summary>
+public static class NavCatalog
+{
+    public static readonly IReadOnlyList<NavLinkEntry> Primary =
+    [
+        new("match", "Match",
+            Icons.Material.Filled.SportsTennis,
+            "Score or join a match",
+            RequiredRoles: "User"),
+
+        new("competitions", "Competitions",
+            Icons.Material.Filled.EmojiEvents,
+            "Browse and manage events"),
+
+        new("clubs", "Clubs",
+            Icons.Material.Filled.Business,
+            "Browse tennis clubs"),
+
+        new("rulessets", "Rules Sets",
+            Icons.Material.Filled.Gavel,
+            "Match rules templates"),
+
+        new("players", "Players",
+            Icons.Material.Filled.People,
+            "All players in the system",
+            RequiredRoles: "SuperAdmin"),
+    ];
+}

--- a/DropShot/Components/Layout/NavMenu.razor
+++ b/DropShot/Components/Layout/NavMenu.razor
@@ -4,6 +4,7 @@
 @using Microsoft.AspNetCore.Identity
 @using Microsoft.EntityFrameworkCore
 @using DropShot.Data
+@using DropShot.UI.Services.Navigation
 
 @inject NavigationManager NavigationManager
 @inject IDbContextFactory<MyDbContext> DbFactory
@@ -18,30 +19,55 @@
 
     <div class="nav-content" onclick="document.getElementById('nav-toggle').click()">
         <nav class="nav-primary">
-            <AuthorizeView Roles="User">
-                <div class="nav-item">
-                    <NavLink class="nav-link" href="match">
-                        <MudIcon Icon="@Icons.Material.Filled.SportsTennis" Class="nav-icon" />
-                        <span class="nav-label-group">
-                            <span class="nav-label">Match</span>
-                            <span class="nav-sublabel">Score or join a match</span>
-                        </span>
-                    </NavLink>
-                </div>
-            </AuthorizeView>
+            @* Primary nav entries come from DropShot.UI.Services.Navigation.NavCatalog
+               so the web and MAUI menus can't drift. Host-specific entries
+               (the My-Players-vs-Club-Players role-aware swap below, plus the
+               account/admin/utility dropdown) stay in this file. *@
+            @foreach (var link in NavCatalog.Primary)
+            {
+                if (!string.IsNullOrEmpty(link.RequiredRoles))
+                {
+                    <AuthorizeView Roles="@link.RequiredRoles">
+                        <div class="nav-item">
+                            <NavLink class="nav-link" href="@link.Href">
+                                <MudIcon Icon="@link.Icon" Class="nav-icon" />
+                                <span class="nav-label-group">
+                                    <span class="nav-label">@link.Label</span>
+                                    @if (!string.IsNullOrEmpty(link.Sublabel))
+                                    {
+                                        <span class="nav-sublabel">@link.Sublabel</span>
+                                    }
+                                </span>
+                            </NavLink>
+                        </div>
+                    </AuthorizeView>
+                }
+                else
+                {
+                    <AuthorizeView>
+                        <Authorized>
+                            <div class="nav-item">
+                                <NavLink class="nav-link" href="@link.Href">
+                                    <MudIcon Icon="@link.Icon" Class="nav-icon" />
+                                    <span class="nav-label-group">
+                                        <span class="nav-label">@link.Label</span>
+                                        @if (!string.IsNullOrEmpty(link.Sublabel))
+                                        {
+                                            <span class="nav-sublabel">@link.Sublabel</span>
+                                        }
+                                    </span>
+                                </NavLink>
+                            </div>
+                        </Authorized>
+                    </AuthorizeView>
+                }
+            }
 
+            @* My-Players / Club-Players is web-specific — the entry shown
+               flips based on the active-role cookie. Lives outside the
+               shared catalog because MAUI doesn't have the toggle. *@
             <AuthorizeView>
-                <Authorized Context="mainCtx">
-                    <div class="nav-item">
-                        <NavLink class="nav-link" href="competitions">
-                            <MudIcon Icon="@Icons.Material.Filled.EmojiEvents" Class="nav-icon" />
-                            <span class="nav-label-group">
-                                <span class="nav-label">Competitions</span>
-                                <span class="nav-sublabel">Browse and manage events</span>
-                            </span>
-                        </NavLink>
-                    </div>
-
+                <Authorized Context="playersCtx">
                     <div class="nav-item">
                         @if (_isClubAdminActive)
                         {
@@ -65,30 +91,6 @@
                         }
                     </div>
                 </Authorized>
-            </AuthorizeView>
-
-            <AuthorizeView Roles="SuperAdmin">
-                <div class="nav-item">
-                    <NavLink class="nav-link" href="players">
-                        <MudIcon Icon="@Icons.Material.Filled.People" Class="nav-icon" />
-                        <span class="nav-label-group">
-                            <span class="nav-label">Players</span>
-                            <span class="nav-sublabel">All players in the system</span>
-                        </span>
-                    </NavLink>
-                </div>
-            </AuthorizeView>
-
-            <AuthorizeView>
-                <div class="nav-item">
-                    <NavLink class="nav-link" href="clubs">
-                        <MudIcon Icon="@Icons.Material.Filled.Business" Class="nav-icon" />
-                        <span class="nav-label-group">
-                            <span class="nav-label">Clubs</span>
-                            <span class="nav-sublabel">Browse tennis clubs</span>
-                        </span>
-                    </NavLink>
-                </div>
             </AuthorizeView>
         </nav>
 

--- a/DropShot/Components/Pages/RulesSets.razor
+++ b/DropShot/Components/Pages/RulesSets.razor
@@ -1,0 +1,8 @@
+@page "/rulessets"
+@rendermode InteractiveServer
+@attribute [Authorize]
+@using Microsoft.AspNetCore.Authorization
+
+<MudProviders />
+
+<DropShot.UI.Components.Pages.RulesSets />


### PR DESCRIPTION
## Summary
- The web NavMenu and MAUI drawer maintained separate hard-coded lists of primary links — adding **Rules Sets** to MAUI's drawer in [PR #555](https://github.com/kingbeazer/DropShot/pull/555) silently skipped the web. The web was also missing a `/rulessets` route shim, so even after surfacing the link it would 404.
- New `DropShot.UI.Services.Navigation.NavCatalog` holds the shared list of primary entries (`NavLinkEntry` records: Href / Label / Icon / Sublabel / RequiredRoles). Both `NavMenu`s iterate the catalog for the shared subset; host-specific entries stay in the per-host file:
  - **Web only:** the role-aware **My Players ↔ Club Players** swap (depends on the `ActiveRole` cookie).
  - **MAUI only:** Home shortcut, **Club Players** link (the web has the swap above instead), theme toggle, role switcher, logout.
- Adding a link in [NavCatalog.cs](DropShot.UI/Services/Navigation/NavCatalog.cs) now lights it up in both hosts automatically — no more drift.
- Also adds [DropShot/Components/Pages/RulesSets.razor](DropShot/Components/Pages/RulesSets.razor) as a `@page "/rulessets"` shim mounting the shared `DropShot.UI.Components.Pages.RulesSets` so the new menu link goes somewhere.

## Test plan
- [ ] Web (any auth role): top nav shows **Match** (User only), **Competitions**, **Clubs**, **Rules Sets**, **Players** (SuperAdmin only). Clicking Rules Sets opens the page.
- [ ] Web admin: Rules Sets card shows Edit / Rules / Delete buttons.
- [ ] MAUI drawer still shows Home + the same five primary links + Club Players + the bottom-section utilities.
- [ ] Adding a new entry to `NavCatalog.Primary` shows it in both hosts after rebuild — verifiable by inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)