### PR TITLE
Tie rules sets to selected club; share Add dialog; gate host clubs by role

### DIFF
--- a/DropShot.Maui/Services/HttpRulesSetService.cs
+++ b/DropShot.Maui/Services/HttpRulesSetService.cs
@@ -10,8 +10,11 @@ namespace DropShot.Maui.Services;
 /// </summary>
 public sealed class HttpRulesSetService(HttpClient http) : IRulesSetService
 {
-    public async Task<List<RulesSetDto>> GetRulesSetsAsync(CancellationToken ct = default) =>
-        await http.GetFromJsonAsync<List<RulesSetDto>>("api/rulessets", ct) ?? [];
+    public async Task<List<RulesSetDto>> GetRulesSetsAsync(int? clubId = null, CancellationToken ct = default)
+    {
+        var url = clubId.HasValue ? $"api/rulessets?clubId={clubId.Value}" : "api/rulessets";
+        return await http.GetFromJsonAsync<List<RulesSetDto>>(url, ct) ?? [];
+    }
 
     public Task<RulesSetDetailDto?> GetRulesSetAsync(int id, CancellationToken ct = default) =>
         http.GetFromJsonAsync<RulesSetDetailDto>($"api/rulessets/{id}", ct);

--- a/DropShot.Shared/Dtos/RulesSetDtos.cs
+++ b/DropShot.Shared/Dtos/RulesSetDtos.cs
@@ -4,12 +4,14 @@ public record RulesSetDto(
     int RulesSetId,
     string Name,
     string? Description,
-    int ItemCount);
+    int ItemCount,
+    int ClubId);
 
 public record RulesSetDetailDto(
     int RulesSetId,
     string Name,
     string? Description,
+    int ClubId,
     List<RulesSetItemDto> Items);
 
 public record RulesSetItemDto(

--- a/DropShot.UI/Components/Pages/CompetitionPage.razor
+++ b/DropShot.UI/Components/Pages/CompetitionPage.razor
@@ -4,11 +4,13 @@
 @using DropShot.Shared.Extensions
 @using DropShot.UI.Components.Competitions.Setup
 @using DropShot.UI.Services
+@using DropShot.UI.Services.Auth
 @using TennisMatch = DropShot.Shared.Match
 
 @inject ICompetitionAdminService Admin
 @inject ICompetitionService Competitions
 @inject IRulesSetService RulesSetService
+@inject ICurrentUser CurrentUser
 @inject NavigationManager Nav
 @inject ISnackbar Snackbar
 @inject AuthenticationStateProvider AuthStateProvider
@@ -153,7 +155,10 @@ else
                                        ReadOnly="@_lockHostClub"
                                        Disabled="@_lockHostClub"
                                        Style="flex:1">
-                                @foreach (var c in _clubs)
+                                @* SuperAdmin / Admin see every club. Plain ClubAdmins only see
+                                   the clubs they administer; Users with no admin clubs see
+                                   nothing here (the host-club picker is moot for them). *@
+                                @foreach (var c in VisibleHostClubs())
                                 {
                                     <MudSelectItem T="int?" Value="@((int?)c.ClubId)">@c.Name</MudSelectItem>
                                 }
@@ -170,8 +175,11 @@ else
 
                     <MudStack Row="true" AlignItems="AlignItems.End" Spacing="0">
                         <MudSelect @bind-Value="Model.RulesSetId" Label="Rules Set (optional)" Variant="Variant.Text"
-                                   Clearable="true" Style="flex:1">
-                            @foreach (var r in _rulesSets)
+                                   Clearable="true" Style="flex:1"
+                                   Disabled="@(Model.HostClubId == null)">
+                            @* Tied to the host club: rules sets are club-scoped,
+                               so the list reflects the currently-selected club. *@
+                            @foreach (var r in VisibleRulesSets())
                             {
                                 <MudSelectItem T="int?" Value="@((int?)r.RulesSetId)">@r.Name</MudSelectItem>
                             }
@@ -186,7 +194,7 @@ else
                             <MudIconButton Icon="@Icons.Material.Filled.AddCircleOutline" Size="Size.Small"
                                            Color="Color.Primary"
                                            Disabled="@(Model.HostClubId == null)"
-                                           OnClick="@(() => _showAddRulesSetDialog = true)" />
+                                           OnClick="OpenAddRulesSetAsync" />
                         </MudTooltip>
                     </MudStack>
 
@@ -1382,67 +1390,10 @@ else
     </DialogActions>
 </MudDialog>
 
-@* ── Add Rules Set Dialog ───────────────────────────────────
-   Wider than the default MudDialogProvider Small so the rules list has
-   room to breathe on desktop; FullWidth keeps the dialog comfortable on
-   mobile too. Rules are staged client-side and committed in sequence on
-   Save so the user gets a single Save / Cancel decision. *@
-<MudDialog @bind-Visible="_showAddRulesSetDialog"
-           Options="@(new DialogOptions { MaxWidth = MaxWidth.Medium, FullWidth = true })">
-    <TitleContent>Add Rules Set</TitleContent>
-    <DialogContent>
-        <MudTextField @bind-Value="_newRulesSetName" Label="Rules Set Name"
-                      Variant="Variant.Outlined" Required="true" Class="mb-3"
-                      Disabled="@_newRulesSetSaving" />
-        <MudTextField @bind-Value="_newRulesSetDescription" Label="Description (optional)"
-                      Variant="Variant.Outlined" Class="mb-3"
-                      Disabled="@_newRulesSetSaving" />
-
-        <MudText Typo="Typo.subtitle2" Class="mt-2 mb-1">Rules</MudText>
-        @if (_newRulesSetItems.Count == 0)
-        {
-            <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mb-2">
-                No rules yet. Add as many as you like — they save with the rules set.
-            </MudText>
-        }
-        else
-        {
-            <MudList T="string" Dense="true" Class="mb-2">
-                @for (int i = 0; i < _newRulesSetItems.Count; i++)
-                {
-                    var idx = i;
-                    <MudListItem T="string">
-                        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
-                            <MudText Class="flex-grow-1">@(idx + 1). @_newRulesSetItems[idx]</MudText>
-                            <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small"
-                                           Color="Color.Error"
-                                           Disabled="@_newRulesSetSaving"
-                                           OnClick="@(() => _newRulesSetItems.RemoveAt(idx))" />
-                        </MudStack>
-                    </MudListItem>
-                }
-            </MudList>
-        }
-
-        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
-            <MudTextField @bind-Value="_newRuleText" @bind-Value:after="StageNewRuleIfReady"
-                          Label="New rule…" Variant="Variant.Outlined" Class="flex-grow-1"
-                          Immediate="true" OnKeyDown="OnNewRuleKeyDown"
-                          Disabled="@_newRulesSetSaving" />
-            <MudIconButton Icon="@Icons.Material.Filled.Add" Color="Color.Primary"
-                           Disabled="@(_newRulesSetSaving || string.IsNullOrWhiteSpace(_newRuleText))"
-                           OnClick="StageNewRule" />
-        </MudStack>
-    </DialogContent>
-    <DialogActions>
-        <MudButton OnClick="CancelNewRulesSet" Disabled="@_newRulesSetSaving">Cancel</MudButton>
-        <MudButton Variant="Variant.Filled" Color="Color.Primary"
-                   Disabled="@(_newRulesSetSaving || string.IsNullOrWhiteSpace(_newRulesSetName))"
-                   OnClick="SaveNewRulesSet">
-            @(_newRulesSetSaving ? "Saving…" : "Save")
-        </MudButton>
-    </DialogActions>
-</MudDialog>
+@* Add Rules Set is now a launched dialog (RulesSetCreateDialog) shared
+   with the dedicated /rulessets page so the two flows can't drift. The
+   inline markup that lived here previously was extracted into the
+   shared component. *@
 
 @* ── Add Event Dialog ─────────────────────────────────────── *@
 <MudDialog @bind-Visible="_showAddEventDialog">
@@ -1717,14 +1668,6 @@ else
     private string _newClubTown = "";
     private string _newClubPostcode = "";
 
-    // Add Rules Set dialog
-    private bool _showAddRulesSetDialog;
-    private string _newRulesSetName = "";
-    private string? _newRulesSetDescription;
-    private string _newRuleText = "";
-    private List<string> _newRulesSetItems = [];
-    private bool _newRulesSetSaving;
-
     // Add Event dialog
     private bool _showAddEventDialog;
     private string _newEventName = "";
@@ -1911,7 +1854,9 @@ else
         }
 
         _clubs = view.Clubs.ToList();
-        _rulesSets = view.RulesSets.ToList();
+        // Keep the full set in memory; VisibleRulesSets() filters by the
+        // currently-selected host club at render time.
+        _rulesSets = view.RulesSets.OrderBy(r => r.Name).ToList();
         _events = view.Events.ToList();
         _canEdit = view.CanEdit;
         _isSuperAdmin = view.IsSuperAdmin;
@@ -2101,113 +2046,75 @@ else
         Snackbar.Add("Adding clubs from this page is no longer supported — use Admin → Clubs.", Severity.Warning);
     }
 
-    private void OnHostClubChanged(int? clubId)
+    private async Task OnHostClubChanged(int? clubId)
     {
         Model.HostClubId = clubId;
+        // Rules sets are club-scoped; the previously-selected one almost
+        // certainly doesn't belong to the new host club, so clear it and
+        // refresh the dropdown source filtered to the new club.
+        Model.RulesSetId = null;
+        await ReloadRulesSetsAsync();
     }
 
-    private void StageNewRule()
+    private async Task ReloadRulesSetsAsync()
     {
-        var text = _newRuleText.Trim();
-        if (string.IsNullOrWhiteSpace(text)) return;
-        _newRulesSetItems.Add(text);
-        _newRuleText = "";
+        try
+        {
+            // Refetch all sets across all clubs — VisibleRulesSets() does the
+            // per-club filter at render time. The full list keeps cached
+            // sets for other clubs available if the host club changes again.
+            _rulesSets = (await RulesSetService.GetRulesSetsAsync())
+                .OrderBy(r => r.Name).ToList();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to reload rules sets.");
+            _rulesSets = [];
+        }
     }
 
-    // Convenience for Enter-to-add inside the new-rule input.
-    private void OnNewRuleKeyDown(KeyboardEventArgs e)
+    private IEnumerable<RulesSetDto> VisibleRulesSets()
     {
-        if (e.Key is "Enter" or "NumpadEnter") StageNewRule();
+        if (Model.HostClubId is null) return [];
+        return _rulesSets.Where(r => r.ClubId == Model.HostClubId.Value);
     }
 
-    // Companion to @bind-Value:after — keeps a no-op so the binding fires
-    // updates without needing a separate ValueChanged handler.
-    private void StageNewRuleIfReady() { }
-
-    private void CancelNewRulesSet()
+    /// <summary>
+    /// SuperAdmin / Admin see every club; plain ClubAdmins only see their
+    /// own admin clubs. Always include the currently-selected host club
+    /// even if outside the admin's allowed list — admins editing a comp
+    /// they didn't create shouldn't see "(unset)" because filtering hides
+    /// the row.
+    /// </summary>
+    private IEnumerable<ClubDto> VisibleHostClubs()
     {
-        _showAddRulesSetDialog = false;
-        ResetNewRulesSetForm();
+        if (CurrentUser.IsAdmin) return _clubs;
+        var allowed = CurrentUser.AdminClubIds.ToHashSet();
+        return _clubs.Where(c =>
+            allowed.Contains(c.ClubId) ||
+            c.ClubId == Model.HostClubId);
     }
 
-    private void ResetNewRulesSetForm()
+    private async Task OpenAddRulesSetAsync()
     {
-        _newRulesSetName = "";
-        _newRulesSetDescription = null;
-        _newRuleText = "";
-        _newRulesSetItems = [];
-        _newRulesSetSaving = false;
-    }
-
-    private async Task SaveNewRulesSet()
-    {
-        var name = _newRulesSetName.Trim();
-        if (string.IsNullOrWhiteSpace(name)) return;
-
-        // RulesSet.ClubId is a required FK in the schema — abort cleanly
-        // if the host club somehow became null between opening the dialog
-        // and clicking Save (the + button is gated on HostClubId so this
-        // is a defensive check, not the main path).
+        // Defensive: + button is gated on HostClubId so this should always pass.
         if (Model.HostClubId is null)
         {
             Snackbar.Add("Select a host club first — rules sets are club-scoped.", Severity.Warning);
             return;
         }
 
-        // Roll up any unstaged text in the New rule input so the user
-        // doesn't lose what they were typing on Save.
-        StageNewRule();
-
-        _newRulesSetSaving = true;
-        try
+        var parameters = new DialogParameters<RulesSetCreateDialog>
         {
-            var saved = await RulesSetService.SaveRulesSetAsync(
-                0, new SaveRulesSetRequest(
-                    name,
-                    string.IsNullOrWhiteSpace(_newRulesSetDescription) ? null : _newRulesSetDescription!.Trim(),
-                    Model.HostClubId));
-            if (saved is null)
-            {
-                Snackbar.Add("Could not create rules set.", Severity.Error);
-                return;
-            }
-
-            // Rules are committed sequentially because the API's SortOrder
-            // is auto-assigned per-item; preserving the order the user
-            // entered them matters for how rules render in the UI.
-            foreach (var ruleText in _newRulesSetItems)
-            {
-                try
-                {
-                    await RulesSetService.AddRulesSetItemAsync(
-                        saved.RulesSetId, new AddRulesSetItemRequest(ruleText));
-                }
-                catch (Exception itemEx)
-                {
-                    Logger.LogError(itemEx, "Failed to add rule '{RuleText}' to set {RulesSetId}.",
-                        ruleText, saved.RulesSetId);
-                    Snackbar.Add($"Saved set but rule \"{ruleText}\" could not be added.", Severity.Warning);
-                }
-            }
-
-            _rulesSets = (await RulesSetService.GetRulesSetsAsync())
-                .OrderBy(r => r.Name).ToList();
+            { x => x.ClubId, Model.HostClubId.Value }
+        };
+        var dialog = await DialogService.ShowAsync<RulesSetCreateDialog>(
+            "Add Rules Set", parameters);
+        var result = await dialog.Result;
+        if (result is { Canceled: false, Data: RulesSetDto saved })
+        {
+            await ReloadRulesSetsAsync();
             Model.RulesSetId = saved.RulesSetId;
-            Snackbar.Add(
-                $"Rules set \"{saved.Name}\" saved with {_newRulesSetItems.Count} rule(s).",
-                Severity.Success);
-
-            _showAddRulesSetDialog = false;
-            ResetNewRulesSetForm();
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "Failed to create rules set from CompetitionPage.");
-            Snackbar.Add("Could not create rules set.", Severity.Error);
-        }
-        finally
-        {
-            _newRulesSetSaving = false;
         }
     }
 

--- a/DropShot.UI/Components/Pages/RulesSetCreateDialog.razor
+++ b/DropShot.UI/Components/Pages/RulesSetCreateDialog.razor
@@ -1,0 +1,162 @@
+@using DropShot.Shared.Dtos
+@using DropShot.UI.Services
+@using Microsoft.AspNetCore.Components.Web
+@inject IRulesSetService RulesSets
+@inject ISnackbar Snackbar
+@inject Microsoft.Extensions.Logging.ILogger<RulesSetCreateDialog> Logger
+
+@*
+    Shared "Add Rules Set" dialog used by both the dedicated /rulessets page
+    and CompetitionPage's inline Setup flow. Captures Name, optional
+    Description, and a staged-in-memory list of rules — committed in one
+    sequence on Save so Cancel actually cancels (no orphaned set-with-no-rules
+    state). Returns the saved RulesSetDto via DialogResult, or Cancel.
+
+    Wider than the default MudDialogProvider Small so the rules list has
+    room on desktop.
+*@
+
+<MudDialog Options="@(new DialogOptions { MaxWidth = MaxWidth.Medium, FullWidth = true })">
+    <DialogContent>
+        <MudTextField @bind-Value="_name" Label="Rules Set Name"
+                      Variant="Variant.Outlined" Required="true" Class="mb-3"
+                      Disabled="@_saving" />
+        <MudTextField @bind-Value="_description" Label="Description (optional)"
+                      Variant="Variant.Outlined" Class="mb-3"
+                      Disabled="@_saving" />
+
+        <MudText Typo="Typo.subtitle2" Class="mt-2 mb-1">Rules</MudText>
+        @if (_items.Count == 0)
+        {
+            <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mb-2">
+                No rules yet. Add as many as you like — they save with the rules set.
+            </MudText>
+        }
+        else
+        {
+            <MudList T="string" Dense="true" Class="mb-2">
+                @for (int i = 0; i < _items.Count; i++)
+                {
+                    var idx = i;
+                    <MudListItem T="string">
+                        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                            <MudText Class="flex-grow-1">@(idx + 1). @_items[idx]</MudText>
+                            <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small"
+                                           Color="Color.Error"
+                                           Disabled="@_saving"
+                                           OnClick="@(() => _items.RemoveAt(idx))" />
+                        </MudStack>
+                    </MudListItem>
+                }
+            </MudList>
+        }
+
+        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+            <MudTextField @bind-Value="_newRule" Label="New rule…"
+                          Variant="Variant.Outlined" Class="flex-grow-1"
+                          Immediate="true" OnKeyDown="OnNewRuleKeyDown"
+                          Disabled="@_saving" />
+            <MudIconButton Icon="@Icons.Material.Filled.Add" Color="Color.Primary"
+                           Disabled="@(_saving || string.IsNullOrWhiteSpace(_newRule))"
+                           OnClick="StageRule" />
+        </MudStack>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel" Disabled="@_saving">Cancel</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                   Disabled="@(_saving || string.IsNullOrWhiteSpace(_name))"
+                   OnClick="SaveAsync">
+            @(_saving ? "Saving…" : "Save")
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = null!;
+
+    /// <summary>Club the new rules set is owned by. Required — the schema
+    /// FK_RulesSets_Clubs_ClubId is non-null.</summary>
+    [Parameter, EditorRequired] public int ClubId { get; set; }
+
+    private string _name = "";
+    private string? _description;
+    private string _newRule = "";
+    private List<string> _items = [];
+    private bool _saving;
+
+    private void StageRule()
+    {
+        var text = _newRule.Trim();
+        if (string.IsNullOrWhiteSpace(text)) return;
+        _items.Add(text);
+        _newRule = "";
+    }
+
+    // Enter-to-add inside the New rule input.
+    private void OnNewRuleKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key is "Enter" or "NumpadEnter") StageRule();
+    }
+
+    private void Cancel() => MudDialog.Cancel();
+
+    private async Task SaveAsync()
+    {
+        var name = _name.Trim();
+        if (string.IsNullOrWhiteSpace(name) || ClubId <= 0) return;
+
+        // Roll up unstaged text in the New rule input so the user doesn't
+        // lose what they were typing on Save.
+        StageRule();
+
+        _saving = true;
+        try
+        {
+            var saved = await RulesSets.SaveRulesSetAsync(
+                0,
+                new SaveRulesSetRequest(
+                    name,
+                    string.IsNullOrWhiteSpace(_description) ? null : _description!.Trim(),
+                    ClubId));
+            if (saved is null)
+            {
+                Snackbar.Add("Could not create rules set.", Severity.Error);
+                return;
+            }
+
+            // Rules committed sequentially because the API auto-assigns
+            // SortOrder per item; preserving entry order matters for how
+            // rules render later.
+            foreach (var ruleText in _items)
+            {
+                try
+                {
+                    await RulesSets.AddRulesSetItemAsync(
+                        saved.RulesSetId, new AddRulesSetItemRequest(ruleText));
+                }
+                catch (Exception itemEx)
+                {
+                    Logger.LogError(itemEx, "Failed to add rule '{RuleText}' to set {RulesSetId}.",
+                        ruleText, saved.RulesSetId);
+                    Snackbar.Add($"Saved set but rule \"{ruleText}\" could not be added.", Severity.Warning);
+                }
+            }
+
+            Snackbar.Add(
+                $"Rules set \"{saved.Name}\" saved with {_items.Count} rule(s).",
+                Severity.Success);
+
+            // Caller refreshes its rules-set list from the returned DTO.
+            MudDialog.Close(DialogResult.Ok(saved));
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to create rules set.");
+            Snackbar.Add("Could not create rules set.", Severity.Error);
+        }
+        finally
+        {
+            _saving = false;
+        }
+    }
+}

--- a/DropShot.UI/Components/Pages/RulesSets.razor
+++ b/DropShot.UI/Components/Pages/RulesSets.razor
@@ -101,11 +101,14 @@ else
         try
         {
             _clubs = await ClubService.GetClubsAsync();
-            // Default to the first admin-club for ClubAdmins (they only have
-            // one) so Add is enabled out of the box; SuperAdmins still pick.
-            if (CurrentUser.AdminClubIds.Count == 1)
+            // SuperAdmin / Admin can pick any club; ClubAdmins are scoped to
+            // their own admin clubs and default to the first one (usually
+            // their only one) so Add is enabled out of the box.
+            if (!CurrentUser.IsAdmin)
+                _clubs = _clubs.Where(c => CurrentUser.AdminClubIds.Contains(c.ClubId)).ToList();
+            if (CurrentUser.AdminClubIds.Count >= 1)
                 _selectedClubId = CurrentUser.AdminClubIds.First();
-            _rulesSets = await RulesSetService.GetRulesSetsAsync();
+            _rulesSets = await RulesSetService.GetRulesSetsAsync(_selectedClubId);
         }
         catch (Exception ex)
         {
@@ -117,9 +120,15 @@ else
         }
     }
 
-    private void OnClubChanged(int? clubId)
+    private async Task OnClubChanged(int? clubId)
     {
         _selectedClubId = clubId;
+        // The list below is scoped to the selected club; refetch on change
+        // (or clear when the picker is cleared) so the user sees only that
+        // club's sets.
+        _rulesSets = clubId is null
+            ? null
+            : await RulesSetService.GetRulesSetsAsync(clubId);
     }
 
     private async Task OpenAddDialog()
@@ -129,10 +138,21 @@ else
             Snackbar.Add("Pick a club first — rules sets are club-scoped.", Severity.Warning);
             return;
         }
-        var dialog = await Dialog.ShowAsync<RulesSetDialog>("Add Rules Set");
+        // Use the shared RulesSetCreateDialog (also driven by CompetitionPage's
+        // inline +) so the two flows can't drift in fields, validation, or
+        // rules-list staging behaviour.
+        var parameters = new DialogParameters<RulesSetCreateDialog>
+        {
+            { x => x.ClubId, _selectedClubId.Value }
+        };
+        var dialog = await Dialog.ShowAsync<RulesSetCreateDialog>("Add Rules Set", parameters);
         var result = await dialog.Result;
-        if (result is { Canceled: false, Data: RulesSetFormModel model })
-            await SaveAsync(0, model);
+        if (result is { Canceled: false, Data: RulesSetDto saved })
+        {
+            // Refresh from the server so ItemCount reflects any rules the
+            // user added inside the dialog.
+            _rulesSets = await RulesSetService.GetRulesSetsAsync(_selectedClubId);
+        }
     }
 
     private async Task OpenEditDialog(RulesSetDto rs)
@@ -182,8 +202,8 @@ else
             { x => x.RulesSetName, rs.Name }
         };
         await Dialog.ShowAsync<RulesSetItemsDialog>($"Rules — {rs.Name}", parameters);
-        // Reload to get updated item count
-        _rulesSets = await RulesSetService.GetRulesSetsAsync();
+        // Reload to get updated item count, scoped to the selected club.
+        _rulesSets = await RulesSetService.GetRulesSetsAsync(_selectedClubId);
     }
 
     private async Task DeleteAsync(RulesSetDto rs)

--- a/DropShot.UI/Services/IRulesSetService.cs
+++ b/DropShot.UI/Services/IRulesSetService.cs
@@ -9,7 +9,12 @@ namespace DropShot.UI.Services;
 /// </summary>
 public interface IRulesSetService
 {
-    Task<List<RulesSetDto>> GetRulesSetsAsync(CancellationToken ct = default);
+    /// <summary>
+    /// Returns rules sets, optionally filtered to a single club. Pass
+    /// <paramref name="clubId"/> to scope the result; pass <c>null</c> to
+    /// return all sets across all clubs (admin-only contexts).
+    /// </summary>
+    Task<List<RulesSetDto>> GetRulesSetsAsync(int? clubId = null, CancellationToken ct = default);
     Task<RulesSetDetailDto?> GetRulesSetAsync(int id, CancellationToken ct = default);
 
     /// <summary>

--- a/DropShot/Controllers/RulesSetsController.cs
+++ b/DropShot/Controllers/RulesSetsController.cs
@@ -13,11 +13,14 @@ namespace DropShot.Controllers;
 public class RulesSetsController(IDbContextFactory<MyDbContext> dbFactory) : ControllerBase
 {
     [HttpGet]
-    public async Task<ActionResult<List<RulesSetDto>>> GetAll()
+    public async Task<ActionResult<List<RulesSetDto>>> GetAll([FromQuery] int? clubId = null)
     {
         await using var db = dbFactory.CreateDbContext();
-        var sets = await db.RulesSets.Include(r => r.Items).OrderBy(r => r.Name).ToListAsync();
-        return sets.Select(r => new RulesSetDto(r.RulesSetId, r.Name, r.Description, r.Items.Count)).ToList();
+        var query = db.RulesSets.Include(r => r.Items).AsQueryable();
+        if (clubId is not null)
+            query = query.Where(r => r.ClubId == clubId.Value);
+        var sets = await query.OrderBy(r => r.Name).ToListAsync();
+        return sets.Select(r => new RulesSetDto(r.RulesSetId, r.Name, r.Description, r.Items.Count, r.ClubId)).ToList();
     }
 
     [HttpGet("{id:int}")]
@@ -28,7 +31,7 @@ public class RulesSetsController(IDbContextFactory<MyDbContext> dbFactory) : Con
             .FirstOrDefaultAsync(x => x.RulesSetId == id);
         if (r is null) return NotFound();
 
-        return new RulesSetDetailDto(r.RulesSetId, r.Name, r.Description,
+        return new RulesSetDetailDto(r.RulesSetId, r.Name, r.Description, r.ClubId,
             r.Items.Select(i => new RulesSetItemDto(i.RulesSetItemId, i.RulesSetId, i.SortOrder, i.RuleText)).ToList());
     }
 
@@ -51,7 +54,7 @@ public class RulesSetsController(IDbContextFactory<MyDbContext> dbFactory) : Con
         db.RulesSets.Add(r);
         await db.SaveChangesAsync();
         return CreatedAtAction(nameof(Get), new { id = r.RulesSetId },
-            new RulesSetDto(r.RulesSetId, r.Name, r.Description, 0));
+            new RulesSetDto(r.RulesSetId, r.Name, r.Description, 0, r.ClubId));
     }
 
     [HttpPut("{id:int}")]
@@ -64,7 +67,7 @@ public class RulesSetsController(IDbContextFactory<MyDbContext> dbFactory) : Con
         r.Name = req.Name.Trim();
         r.Description = req.Description;
         await db.SaveChangesAsync();
-        return new RulesSetDto(r.RulesSetId, r.Name, r.Description, r.Items.Count);
+        return new RulesSetDto(r.RulesSetId, r.Name, r.Description, r.Items.Count, r.ClubId);
     }
 
     [HttpDelete("{id:int}")]

--- a/DropShot/Services/WebRulesSetService.cs
+++ b/DropShot/Services/WebRulesSetService.cs
@@ -12,11 +12,14 @@ namespace DropShot.Services;
 /// </summary>
 public sealed class WebRulesSetService(IDbContextFactory<MyDbContext> dbFactory) : IRulesSetService
 {
-    public async Task<List<RulesSetDto>> GetRulesSetsAsync(CancellationToken ct = default)
+    public async Task<List<RulesSetDto>> GetRulesSetsAsync(int? clubId = null, CancellationToken ct = default)
     {
         await using var db = await dbFactory.CreateDbContextAsync(ct);
-        var sets = await db.RulesSets.Include(r => r.Items).OrderBy(r => r.Name).ToListAsync(ct);
-        return sets.Select(r => new RulesSetDto(r.RulesSetId, r.Name, r.Description, r.Items.Count)).ToList();
+        var query = db.RulesSets.Include(r => r.Items).AsQueryable();
+        if (clubId is not null)
+            query = query.Where(r => r.ClubId == clubId.Value);
+        var sets = await query.OrderBy(r => r.Name).ToListAsync(ct);
+        return sets.Select(r => new RulesSetDto(r.RulesSetId, r.Name, r.Description, r.Items.Count, r.ClubId)).ToList();
     }
 
     public async Task<RulesSetDetailDto?> GetRulesSetAsync(int id, CancellationToken ct = default)
@@ -26,7 +29,7 @@ public sealed class WebRulesSetService(IDbContextFactory<MyDbContext> dbFactory)
             .FirstOrDefaultAsync(x => x.RulesSetId == id, ct);
         if (r is null) return null;
 
-        return new RulesSetDetailDto(r.RulesSetId, r.Name, r.Description,
+        return new RulesSetDetailDto(r.RulesSetId, r.Name, r.Description, r.ClubId,
             r.Items.Select(i => new RulesSetItemDto(i.RulesSetItemId, i.RulesSetId, i.SortOrder, i.RuleText)).ToList());
     }
 
@@ -52,7 +55,7 @@ public sealed class WebRulesSetService(IDbContextFactory<MyDbContext> dbFactory)
             };
             db.RulesSets.Add(r);
             await db.SaveChangesAsync(ct);
-            return new RulesSetDto(r.RulesSetId, r.Name, r.Description, 0);
+            return new RulesSetDto(r.RulesSetId, r.Name, r.Description, 0, r.ClubId);
         }
         else
         {
@@ -64,7 +67,7 @@ public sealed class WebRulesSetService(IDbContextFactory<MyDbContext> dbFactory)
             // between clubs would orphan its references on competitions and
             // ladders that point to the original club.
             await db.SaveChangesAsync(ct);
-            return new RulesSetDto(r.RulesSetId, r.Name, r.Description, r.Items.Count);
+            return new RulesSetDto(r.RulesSetId, r.Name, r.Description, r.Items.Count, r.ClubId);
         }
     }
 


### PR DESCRIPTION
## Summary
Three asks rolled into one PR:

1. **Rules Sets filtered by selected host club.** `RulesSetDto` now carries `ClubId`. `IRulesSetService.GetRulesSetsAsync` takes an optional `clubId` filter (controller accepts `?clubId=N`). On `CompetitionPage`, changing the host club clears `Model.RulesSetId` and refreshes the dropdown via `VisibleRulesSets()`. The dedicated `/rulessets` page also filters its card grid by the selected club.
2. **Host-club dropdown gated by role.** SuperAdmin / Admin still see every club. Plain ClubAdmins see only their own `CurrentUser.AdminClubIds`, with the currently-selected host club always included so admins editing a comp they didn't create don't see "(unset)" because filtering hid the row.
3. **Shared Add Rules Set dialog.** Extracted `RulesSetCreateDialog` (`DropShot.UI/Components/Pages/`) — both `CompetitionPage`'s `+` and the dedicated `/rulessets` Add button now `Dialog.ShowAsync<RulesSetCreateDialog>` with a `ClubId` parameter and consume the saved `RulesSetDto` from the dialog result. The two flows can't drift in fields, validation, or rules-list staging behaviour.

## Test plan
- [ ] CompetitionPage Setup as ClubAdmin: host-club dropdown shows only your clubs; rules set dropdown is empty until you pick a host club, then shows that club's sets.
- [ ] CompetitionPage Setup as SuperAdmin: every club listed.
- [ ] Change host club mid-edit → rules set selection is cleared and the dropdown reflects the new club.
- [ ] `+` next to Rules Set opens the same dialog as `/rulessets` Add. Cancel discards. Save creates the set + items, dropdown refreshes, new set is auto-selected.
- [ ] `/rulessets`: pick a club → see only that club's sets. Add → opens shared dialog → on save, list refreshes for the same club.

🤖 Generated with [Claude Code](https://claude.com/claude-code)