### PR TITLE
Fix Release build: missing ClubId arg + drop AutoGrow

### DIFF
--- a/DropShot/Components/Pages/Clubs.razor
+++ b/DropShot/Components/Pages/Clubs.razor
@@ -348,7 +348,7 @@
                 <MudTextField @bind-Value="_editRulesSetForm.Name" Label="Name" Variant="Variant.Outlined"
                               Required="true" Class="mb-3" />
                 <MudTextField @bind-Value="_editRulesSetForm.Description" Label="Description (optional)"
-                              Variant="Variant.Outlined" Lines="3" AutoGrow="true" />
+                              Variant="Variant.Outlined" Lines="3" />
             </DialogContent>
             <DialogActions>
                 <MudButton OnClick="@(() => _showEditRulesSetDialog = false)">Cancel</MudButton>

--- a/DropShot/Services/WebCompetitionAdminService.cs
+++ b/DropShot/Services/WebCompetitionAdminService.cs
@@ -34,7 +34,7 @@ public sealed class WebCompetitionAdminService(
                 c.Phone, c.Email, c.Website, c.Courts.Count))
             .ToListAsync(ct);
         var rulesSets = await db.RulesSets.AsNoTracking().OrderBy(r => r.Name)
-            .Select(r => new RulesSetDto(r.RulesSetId, r.Name, r.Description, r.Items.Count))
+            .Select(r => new RulesSetDto(r.RulesSetId, r.Name, r.Description, r.Items.Count, r.ClubId))
             .ToListAsync(ct);
         var events = await db.Events.AsNoTracking().OrderBy(e => e.Name)
             .Select(e => new EventDto(e.EventId, e.Name, e.Description, e.StartDate, e.EndDate,


### PR DESCRIPTION
## Summary
- [PR #574](https://github.com/kingbeazer/DropShot/pull/574) added `ClubId` to `RulesSetDto` but missed the projection in [`WebCompetitionAdminService.GetCompetitionForEditAsync`](DropShot/Services/WebCompetitionAdminService.cs:37). CI caught it under `--configuration Release`; my local Debug build masked it because the running dev server held the previous assembly and the file-copy retry path swallowed the actual recompile attempt.
- Also clears the `MUD0002` warning on [Clubs.razor:351](DropShot/Components/Pages/Clubs.razor:351) — the MudBlazor analyzer flags `AutoGrow` as not recognised on `MudTextField` (it's pattern-matched as a lowercased HTML attribute pass-through). `Lines="3"` already yields a multi-line textarea; growth-on-overflow isn't worth a CI warning.

## Test plan
- [x] `dotnet build DropShot.UI/DropShot.UI.csproj --configuration Release` — clean.
- [ ] CI re-runs `dotnet build DropShot/DropShot.csproj --configuration Release` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)