### PR TITLE
Add inline rule edit so SortOrder is preserved on rewording

### DIFF
--- a/DropShot.Maui/Services/HttpRulesSetService.cs
+++ b/DropShot.Maui/Services/HttpRulesSetService.cs
@@ -44,6 +44,15 @@ public sealed class HttpRulesSetService(HttpClient http) : IRulesSetService
         return (await resp.Content.ReadFromJsonAsync<RulesSetItemDto>(cancellationToken: ct))!;
     }
 
+    public async Task<RulesSetItemDto> UpdateRulesSetItemAsync(
+        int rulesSetId, int itemId, AddRulesSetItemRequest request, CancellationToken ct = default)
+    {
+        var resp = await http.PutAsJsonAsync(
+            $"api/rulessets/{rulesSetId}/items/{itemId}", request, ct);
+        resp.EnsureSuccessStatusCode();
+        return (await resp.Content.ReadFromJsonAsync<RulesSetItemDto>(cancellationToken: ct))!;
+    }
+
     public async Task DeleteRulesSetItemAsync(int rulesSetId, int itemId, CancellationToken ct = default)
     {
         var resp = await http.DeleteAsync($"api/rulessets/{rulesSetId}/items/{itemId}", ct);

--- a/DropShot.UI/Components/Pages/RulesSetItemsDialog.razor
+++ b/DropShot.UI/Components/Pages/RulesSetItemsDialog.razor
@@ -1,5 +1,6 @@
 @using DropShot.Shared.Dtos
 @using DropShot.UI.Services
+@using Microsoft.AspNetCore.Components.Web
 @inject IRulesSetService RulesSets
 @inject ISnackbar Snackbar
 
@@ -21,12 +22,39 @@
                     @foreach (var item in _items.OrderBy(i => i.SortOrder))
                     {
                         <MudListItem>
-                            <MudStack Row="true" AlignItems="AlignItems.Center">
-                                <MudText Class="flex-grow-1">@item.SortOrder. @item.RuleText</MudText>
-                                <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small"
-                                               Color="Color.Error"
-                                               OnClick="@(() => DeleteItemAsync(item))" />
-                            </MudStack>
+                            @if (_editingItemId == item.RulesSetItemId)
+                            {
+                                @* Inline edit mode — keep SortOrder visible so the
+                                   admin sees the position they're editing. Enter
+                                   commits, Escape cancels. *@
+                                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                                    <MudText Style="min-width: 1.5rem;">@item.SortOrder.</MudText>
+                                    <MudTextField @bind-Value="_editingText"
+                                                  Variant="Variant.Outlined" Margin="Margin.Dense"
+                                                  Class="flex-grow-1" Immediate="true"
+                                                  AutoFocus="true"
+                                                  OnKeyDown="OnEditKeyDown" />
+                                    <MudIconButton Icon="@Icons.Material.Filled.Check" Size="Size.Small"
+                                                   Color="Color.Success"
+                                                   Disabled="@string.IsNullOrWhiteSpace(_editingText)"
+                                                   OnClick="@(() => SaveEditAsync(item))" />
+                                    <MudIconButton Icon="@Icons.Material.Filled.Close" Size="Size.Small"
+                                                   OnClick="CancelEdit" />
+                                </MudStack>
+                            }
+                            else
+                            {
+                                <MudStack Row="true" AlignItems="AlignItems.Center">
+                                    <MudText Class="flex-grow-1">@item.SortOrder. @item.RuleText</MudText>
+                                    <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="Size.Small"
+                                                   Disabled="@(_editingItemId.HasValue)"
+                                                   OnClick="@(() => StartEdit(item))" />
+                                    <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small"
+                                                   Color="Color.Error"
+                                                   Disabled="@(_editingItemId.HasValue)"
+                                                   OnClick="@(() => DeleteItemAsync(item))" />
+                                </MudStack>
+                            }
                         </MudListItem>
                     }
                 </MudList>
@@ -35,15 +63,16 @@
             <MudDivider Class="my-2" />
             <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
                 <MudTextField @bind-Value="_newRule" Label="New rule…"
-                              Variant="Variant.Outlined" Class="flex-grow-1" />
+                              Variant="Variant.Outlined" Class="flex-grow-1"
+                              Disabled="@(_editingItemId.HasValue)" />
                 <MudIconButton Icon="@Icons.Material.Filled.Add" Color="Color.Primary"
-                               Disabled="string.IsNullOrWhiteSpace(_newRule)"
+                               Disabled="@(_editingItemId.HasValue || string.IsNullOrWhiteSpace(_newRule))"
                                OnClick="AddItemAsync" />
             </MudStack>
         }
     </DialogContent>
     <DialogActions>
-        <MudButton OnClick="() => MudDialog.Close()">Close</MudButton>
+        <MudButton OnClick="() => MudDialog.Close()" Disabled="@(_editingItemId.HasValue)">Close</MudButton>
     </DialogActions>
 </MudDialog>
 
@@ -55,6 +84,8 @@
     private List<RulesSetItemDto> _items = [];
     private bool _loading = true;
     private string _newRule = "";
+    private int? _editingItemId;
+    private string _editingText = "";
 
     protected override async Task OnInitializedAsync()
     {
@@ -87,6 +118,61 @@
         catch (Exception ex)
         {
             Snackbar.Add(ex.Message, Severity.Error);
+        }
+    }
+
+    private void StartEdit(RulesSetItemDto item)
+    {
+        _editingItemId = item.RulesSetItemId;
+        _editingText = item.RuleText;
+    }
+
+    private void CancelEdit()
+    {
+        _editingItemId = null;
+        _editingText = "";
+    }
+
+    // Enter commits, Escape cancels — typical inline-edit shortcuts.
+    private async Task OnEditKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key is "Escape")
+        {
+            CancelEdit();
+            return;
+        }
+        if (e.Key is "Enter" or "NumpadEnter")
+        {
+            var item = _items.FirstOrDefault(i => i.RulesSetItemId == _editingItemId);
+            if (item is not null) await SaveEditAsync(item);
+        }
+    }
+
+    private async Task SaveEditAsync(RulesSetItemDto item)
+    {
+        var text = _editingText.Trim();
+        if (string.IsNullOrWhiteSpace(text)) return;
+        // No-op when nothing changed — saves a round-trip.
+        if (text == item.RuleText)
+        {
+            CancelEdit();
+            return;
+        }
+        try
+        {
+            var updated = await RulesSets.UpdateRulesSetItemAsync(
+                RulesSetId, item.RulesSetItemId, new AddRulesSetItemRequest(text));
+            var idx = _items.FindIndex(i => i.RulesSetItemId == item.RulesSetItemId);
+            if (idx >= 0) _items[idx] = updated;
+            Snackbar.Add("Rule updated.", Severity.Success);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+        finally
+        {
+            CancelEdit();
         }
     }
 

--- a/DropShot.UI/Services/IRulesSetService.cs
+++ b/DropShot.UI/Services/IRulesSetService.cs
@@ -33,6 +33,15 @@ public interface IRulesSetService
     Task<RulesSetItemDto> AddRulesSetItemAsync(
         int rulesSetId, AddRulesSetItemRequest request, CancellationToken ct = default);
 
+    /// <summary>
+    /// Update the text of an existing rule in place. <c>SortOrder</c> is
+    /// preserved so admins can fix typos / wording without losing the
+    /// rule's position. Reuses <see cref="AddRulesSetItemRequest"/> since
+    /// the payload (just the new <c>RuleText</c>) is identical.
+    /// </summary>
+    Task<RulesSetItemDto> UpdateRulesSetItemAsync(
+        int rulesSetId, int itemId, AddRulesSetItemRequest request, CancellationToken ct = default);
+
     Task DeleteRulesSetItemAsync(
         int rulesSetId, int itemId, CancellationToken ct = default);
 }

--- a/DropShot/Controllers/RulesSetsController.cs
+++ b/DropShot/Controllers/RulesSetsController.cs
@@ -95,6 +95,19 @@ public class RulesSetsController(IDbContextFactory<MyDbContext> dbFactory) : Con
         return Ok(new RulesSetItemDto(item.RulesSetItemId, item.RulesSetId, item.SortOrder, item.RuleText));
     }
 
+    [HttpPut("{id:int}/items/{itemId:int}")]
+    [Authorize(Roles = "Admin")]
+    public async Task<ActionResult<RulesSetItemDto>> UpdateItem(int id, int itemId, [FromBody] AddRulesSetItemRequest req)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        var item = await db.RulesSetItems.FindAsync(itemId);
+        if (item is null || item.RulesSetId != id) return NotFound();
+        // SortOrder preserved so editing a rule doesn't move it.
+        item.RuleText = req.RuleText.Trim();
+        await db.SaveChangesAsync();
+        return Ok(new RulesSetItemDto(item.RulesSetItemId, item.RulesSetId, item.SortOrder, item.RuleText));
+    }
+
     [HttpDelete("{id:int}/items/{itemId:int}")]
     [Authorize(Roles = "Admin")]
     public async Task<IActionResult> DeleteItem(int id, int itemId)

--- a/DropShot/Services/WebRulesSetService.cs
+++ b/DropShot/Services/WebRulesSetService.cs
@@ -97,6 +97,22 @@ public sealed class WebRulesSetService(IDbContextFactory<MyDbContext> dbFactory)
         return new RulesSetItemDto(item.RulesSetItemId, item.RulesSetId, item.SortOrder, item.RuleText);
     }
 
+    public async Task<RulesSetItemDto> UpdateRulesSetItemAsync(
+        int rulesSetId, int itemId, AddRulesSetItemRequest request, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var item = await db.RulesSetItems.FindAsync([itemId], ct)
+            ?? throw new KeyNotFoundException("Rule not found.");
+        if (item.RulesSetId != rulesSetId)
+            throw new InvalidOperationException("Rule does not belong to the specified rules set.");
+        // SortOrder is intentionally preserved — admins fixing wording
+        // shouldn't lose the rule's position. Renumbering is a separate
+        // future concern (drag-to-reorder).
+        item.RuleText = request.RuleText.Trim();
+        await db.SaveChangesAsync(ct);
+        return new RulesSetItemDto(item.RulesSetItemId, item.RulesSetId, item.SortOrder, item.RuleText);
+    }
+
     public async Task DeleteRulesSetItemAsync(int rulesSetId, int itemId, CancellationToken ct = default)
     {
         await using var db = await dbFactory.CreateDbContextAsync(ct);


### PR DESCRIPTION
## Summary
- Previously the only way to fix a rule's wording was Delete + Add, which auto-assigned a new `SortOrder` at the end of the list and lost the rule's position.
- New `IRulesSetService.UpdateRulesSetItemAsync` (reuses `AddRulesSetItemRequest` since payload is identical) updates `RuleText` in place; `SortOrder` is intentionally preserved.
- `RulesSetsController` exposes `PUT /api/rulessets/{id}/items/{itemId}` with the same `Admin`-only auth as the other write paths.
- `RulesSetItemsDialog` gets an Edit pencil per row that swaps the row into inline edit mode (textfield + check / cancel icons). **Enter** commits, **Escape** cancels. Other rows' Edit/Delete buttons disable while one is being edited so the admin can't interleave operations. No-op when text is unchanged saves a round-trip.

## Test plan
- [ ] Open Rules dialog (CompetitionPage's bullet-list icon, or `/rulessets` Rules button on a card).
- [ ] Click the pencil on rule #2 → row becomes editable with current text. Edit and click ✓ → success snackbar; rule keeps SortOrder #2.
- [ ] Press Escape during edit → no save, original text remains.
- [ ] Press Enter in the edit field → commits.
- [ ] Edit but leave text unchanged → ✓ closes the editor without an API call.
- [ ] While editing, the Add input and other rows' buttons are disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)