### PR TITLE
Apply frosted-glass background to list cards across the app

### DIFF
--- a/DropShot.Maui/wwwroot/index.html
+++ b/DropShot.Maui/wwwroot/index.html
@@ -7,6 +7,7 @@
     <base href="/" />
     <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
     <link rel="stylesheet" href="css/app.css" />
+    <link rel="stylesheet" href="_content/DropShot.UI/css/shared.css" />
     <link rel="stylesheet" href="css/theme-light.css" />
     <link rel="stylesheet" href="DropShot.Maui.styles.css" />
     <link rel="icon" href="data:,">

--- a/DropShot.UI/Components/Pages/ClubPlayers.razor
+++ b/DropShot.UI/Components/Pages/ClubPlayers.razor
@@ -52,7 +52,8 @@ else
                   Immediate="true" Class="mb-4" />
 
     <MudTable Items="@_players" Hover="true" Breakpoint="Breakpoint.Sm" Loading="@_loading"
-              Filter="@(row => FilterPlayers(row))">
+              Filter="@(row => FilterPlayers(row))"
+              Class="frosted-card" Elevation="0">
         <HeaderContent>
             <MudTh>Player</MudTh>
             <MudTh>First Name</MudTh>

--- a/DropShot.UI/Components/Pages/Clubs.razor
+++ b/DropShot.UI/Components/Pages/Clubs.razor
@@ -24,7 +24,8 @@
               Immediate="true" Class="mb-4" />
 
 <MudTable Items="@_clubs" Hover="true" Breakpoint="Breakpoint.Sm" Loading="@_loading"
-          Filter="@(club => FilterClubs(club))">
+          Filter="@(club => FilterClubs(club))"
+          Class="frosted-card" Elevation="0">
     <HeaderContent>
         <MudTh>Name</MudTh>
         <MudTh>Town</MudTh>

--- a/DropShot.UI/Components/Pages/Competitions.razor
+++ b/DropShot.UI/Components/Pages/Competitions.razor
@@ -103,7 +103,7 @@
 
 @if (!_isUserView && _pendingFixtures.Count > 0)
 {
-    <MudCard Class="mb-4" Elevation="2">
+    <MudCard Class="mb-4 frosted-card" Elevation="0">
         <MudCardHeader>
             <CardHeaderContent>
                 <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">

--- a/DropShot.UI/Components/Pages/Home.razor
+++ b/DropShot.UI/Components/Pages/Home.razor
@@ -186,7 +186,7 @@
         @if (_upcomingFixtures.Any())
         {
             <MudItem xs="12" md="@(_recentItems.Any() ? 7 : 12)">
-                <MudCard>
+                <MudCard Class="frosted-card" Elevation="0">
                     <MudCardHeader>
                         <CardHeaderContent>
                             <MudText Typo="Typo.h6">Your Upcoming Matches</MudText>
@@ -238,7 +238,7 @@
         @if (_recentItems.Any())
         {
             <MudItem xs="12" md="@(_upcomingFixtures.Any() ? 5 : 12)">
-                <MudCard>
+                <MudCard Class="frosted-card" Elevation="0">
                     <MudCardHeader>
                         <CardHeaderContent>
                             <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">

--- a/DropShot.UI/Components/Pages/Match.razor
+++ b/DropShot.UI/Components/Pages/Match.razor
@@ -19,7 +19,7 @@
             @foreach (var m in _matches)
             {
                 <MudListItem T="ActiveMatchDto">
-                    <MudCard Outlined="true" Class="mb-2" Style="cursor:pointer" @onclick="@(() => Navigation.NavigateTo($"/match/{m.SavedMatchId}"))">
+                    <MudCard Class="mb-2 frosted-card" Style="cursor:pointer" @onclick="@(() => Navigation.NavigateTo($"/match/{m.SavedMatchId}"))">
                         <MudCardContent Class="py-2 px-3">
                             <MudText Typo="Typo.subtitle1">
                                 @PlayerLabel(m)

--- a/DropShot.UI/Components/Pages/MyPlayers.razor
+++ b/DropShot.UI/Components/Pages/MyPlayers.razor
@@ -23,7 +23,8 @@
               Immediate="true" Class="mb-4" />
 
 <MudTable Items="@_players" Hover="true" Breakpoint="Breakpoint.Sm" Loading="@_loading"
-          Filter="@(row => FilterPlayers(row))">
+          Filter="@(row => FilterPlayers(row))"
+          Class="frosted-card" Elevation="0">
     <HeaderContent>
         <MudTh>Player</MudTh>
         <MudTh>First Name</MudTh>

--- a/DropShot.UI/Components/Pages/Players.razor
+++ b/DropShot.UI/Components/Pages/Players.razor
@@ -17,7 +17,8 @@
               Immediate="true" Class="mb-4" />
 
 <MudTable Items="@_players" Hover="true" Breakpoint="Breakpoint.Sm" Loading="@_loading"
-          Filter="@(row => FilterPlayers(row))">
+          Filter="@(row => FilterPlayers(row))"
+          Class="frosted-card" Elevation="0">
     <HeaderContent>
         <MudTh>Display Name</MudTh>
         <MudTh>Name</MudTh>

--- a/DropShot.UI/Components/Pages/RulesSets.razor
+++ b/DropShot.UI/Components/Pages/RulesSets.razor
@@ -54,7 +54,7 @@ else
             @foreach (var rs in _rulesSets ?? [])
             {
                 <MudItem xs="12" sm="6" md="4">
-                    <MudCard Elevation="2">
+                    <MudCard Elevation="0" Class="frosted-card">
                         <MudCardHeader>
                             <CardHeaderContent>
                                 <MudText Typo="Typo.h6">@rs.Name</MudText>

--- a/DropShot.UI/wwwroot/css/shared.css
+++ b/DropShot.UI/wwwroot/css/shared.css
@@ -1,0 +1,26 @@
+/* ══════════════════════════════════════════════════════════════════════
+   DropShot — shared CSS loaded by both the web and MAUI hosts via
+   _content/DropShot.UI/css/shared.css. Add cross-host visual primitives
+   here so both hosts pick them up without re-declaration.
+   ══════════════════════════════════════════════════════════════════════ */
+
+/* ── Frosted-glass card ────────────────────────────────────────────────
+   Replaces the default MudCard / MudPaper grey surface with the same
+   frosted look used on the competition setup sections (AdminsSection,
+   DivisionsSection, etc.). Used on list / row cards across pages so the
+   branded background image shows through with a subtle blur instead of
+   a flat grey block.
+   ══════════════════════════════════════════════════════════════════════ */
+.frosted-card {
+    background: rgba(255, 255, 255, 0.08) !important;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border: 1px solid rgba(255, 255, 255, 0.12) !important;
+    border-radius: 12px !important;
+}
+
+/* Light-theme override: glass darkens against the lighter background. */
+[data-theme="light"] .frosted-card {
+    background: rgba(255, 255, 255, 0.6) !important;
+    border: 1px solid rgba(0, 0, 0, 0.08) !important;
+}

--- a/DropShot/Components/App.razor
+++ b/DropShot/Components/App.razor
@@ -9,6 +9,7 @@
     <link href="_content/MudBlazor/MudBlazor.min.css?v=@(MudBlazor.Metadata.Version)" rel="stylesheet" />
     <link rel="stylesheet" href="bootstrap/bootstrap.min.css" />
     <link rel="stylesheet" href="app.css" />
+    <link rel="stylesheet" href="_content/DropShot.UI/css/shared.css" />
     <link rel="stylesheet" href="DropShot.styles.css" />
     <link rel="stylesheet" href="css/theme-light.css" />
     <script>


### PR DESCRIPTION
## Summary
The competition setup sections already use a translucent glass look (`background: rgba(255,255,255,0.08) + backdrop-filter: blur(12px)`) — picks up the branded background image instead of the flat MudBlazor grey. Lists across the rest of the app kept the default grey, jarring against the rest of the treatment.

- New shared **[`DropShot.UI/wwwroot/css/shared.css`](DropShot.UI/wwwroot/css/shared.css)** with a single `.frosted-card` class. Linked from web's [`App.razor`](DropShot/Components/App.razor) and MAUI's [`index.html`](DropShot.Maui/wwwroot/index.html). Light-theme override darkens the glass against `#f5f5f5`.
- Apply `Class="frosted-card" Elevation="0"` to:
  - `MudCard` rows on **Match**, **Home** (upcoming + recent), **Competitions** (pending verification), **RulesSets**.
  - `MudTable` directly on **Clubs**, **Players**, **MyPlayers**, **ClubPlayers** (no outer card wrapper there).
- Setup-section inline styles aren't migrated here — they're a mechanical follow-up but their inline blocks work today.

## Test plan
- [ ] Dark theme: list pages above show frosted cards over the branded background instead of flat grey.
- [ ] Light theme: same cards show as a subtle white-on-light glass.
- [ ] Existing setup-page sections (AdminsSection etc.) unchanged.
- [ ] Web and MAUI both load `_content/DropShot.UI/css/shared.css` (check DevTools / WebView2 inspector that the file resolves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)