### PR TITLE
Frosted-card on Competitions, Users, Club Players, and nested tables

### DIFF
--- a/DropShot.UI/Components/Pages/Admin/UserManagement.razor
+++ b/DropShot.UI/Components/Pages/Admin/UserManagement.razor
@@ -18,7 +18,8 @@
               Immediate="true" Class="mb-4" />
 
 <MudTable Items="@_rows" Hover="true" Breakpoint="Breakpoint.Sm" Loading="@_loading" Dense="true"
-          Filter="@(row => FilterUsers(row))">
+          Filter="@(row => FilterUsers(row))"
+          Class="frosted-card" Elevation="0">
     <HeaderContent>
         <MudTh>Username</MudTh>
         <MudTh>Email</MudTh>

--- a/DropShot.UI/Components/Pages/ClubPlayers.razor
+++ b/DropShot.UI/Components/Pages/ClubPlayers.razor
@@ -3,19 +3,19 @@
 @inject ICurrentUser CurrentUser
 @inject ISnackbar Snackbar
 
-@* Routing + auth + MudProviders supplied by host shims. *@
+@* Routing + auth + MudProviders supplied by host shims. The page used
+   to wrap content in its own background-image + dark overlay layer
+   (legacy from before the host-level branded bg + .frosted-card
+   pattern). That double-darkened the list and conflicted with the
+   shared frosted look — drop it and rely on the host bg + frosted
+   list cards like the other list pages do. *@
 
-<div style="position: relative; min-height: 100vh; background-image: url('images/background.png'); background-repeat: no-repeat; background-size: cover; background-position: center; margin: -24px; padding: 0;">
-    <div style="position: absolute; inset: 0; background-color: rgba(18, 18, 18, 0.85); pointer-events: none;"></div>
-    <div style="position: relative; z-index: 1; padding: 1rem 0.5rem 2rem;">
-
-<MudText Typo="Typo.h4" Class="mb-4" Style="color: white;">Club Players</MudText>
+<MudText Typo="Typo.h4" Class="mb-4">Club Players</MudText>
 
 @if (_availableClubs.Count > 1)
 {
     <MudSelect T="int?" Value="_activeClubId" ValueChanged="OnClubChangedAsync"
-               Label="Club" Variant="Variant.Outlined" Class="mb-4"
-               Style="background-color: rgba(255,255,255,0.04);">
+               Label="Club" Variant="Variant.Outlined" Class="mb-4">
         @foreach (var club in _availableClubs)
         {
             <MudSelectItem T="int?" Value="@((int?)club.ClubId)">@club.Name</MudSelectItem>
@@ -33,7 +33,7 @@ else
 {
     @if (_availableClubs.Count == 1)
     {
-        <MudText Typo="Typo.subtitle1" Class="mb-3" Style="color: rgba(255,255,255,0.85);">Managing: <strong>@_clubName</strong></MudText>
+        <MudText Typo="Typo.subtitle1" Class="mb-3" Color="Color.Secondary">Managing: <strong>@_clubName</strong></MudText>
     }
 
     <MudStack Row="true" Spacing="2" Class="mb-4">
@@ -208,8 +208,6 @@ else
         <MudButton OnClick="@(() => _showAddExistingDialog = false)">Close</MudButton>
     </DialogActions>
 </MudDialog>
-
-</div></div>
 
 @code {
     private bool _loading = true;

--- a/DropShot.UI/Components/Pages/Competitions.razor
+++ b/DropShot.UI/Components/Pages/Competitions.razor
@@ -37,7 +37,7 @@
         }
         else
         {
-            <MudTable Items="@_myEnteredComps" Hover="true" Dense="true" Class="mb-6">
+            <MudTable Items="@_myEnteredComps" Hover="true" Dense="true" Class="mb-6 frosted-card" Elevation="0">
                 <HeaderContent>
                     <MudTh>Name</MudTh>
                     <MudTh>Format</MudTh>
@@ -74,7 +74,7 @@
         }
         else
         {
-            <MudTable Items="@_availableComps" Hover="true" Dense="true">
+            <MudTable Items="@_availableComps" Hover="true" Dense="true" Class="frosted-card" Elevation="0">
                 <HeaderContent>
                     <MudTh>Name</MudTh>
                     <MudTh>Format</MudTh>

--- a/DropShot.UI/wwwroot/css/shared.css
+++ b/DropShot.UI/wwwroot/css/shared.css
@@ -24,3 +24,22 @@
     background: rgba(255, 255, 255, 0.6) !important;
     border: 1px solid rgba(0, 0, 0, 0.08) !important;
 }
+
+/* MudBlazor child surfaces (table containers, card content, nested
+   paper) paint their own --mud-palette-surface which covers the
+   frosted parent. Force them transparent inside .frosted-card so the
+   parent's blurred bg shows through — covers:
+     - MudTable rendered inside a frosted MudCard (Home upcoming /
+       recent results, /match active matches list)
+     - MudTable used directly with frosted-card (Clubs, Players,
+       Competitions, Users) — its inner -container / -root children
+       still paint surface
+     - MudCardContent inside a frosted MudCard. */
+.frosted-card .mud-table,
+.frosted-card .mud-table-root,
+.frosted-card .mud-table-container,
+.frosted-card .mud-card-content,
+.frosted-card .mud-paper {
+    background: transparent !important;
+    background-color: transparent !important;
+}


### PR DESCRIPTION
## Summary
Follow-up to [PR #581](https://github.com/kingbeazer/DropShot/pull/581) — three lists were missed and nested MudBlazor surfaces inside `.frosted-card` still painted opaque grey.

- **Competitions**: both **My Competitions** and **Available to Enter** `MudTable`s get `Class="frosted-card" Elevation="0"`.
- **Admin → Users**: same on the user-management `MudTable`.
- **Club Players**: drop the legacy per-page background-image + dark overlay wrapper that was double-darkening the page. The host now paints the branded bg centrally; the list uses `.frosted-card` like every other list page.
- **`shared.css`**: nested `.mud-table` / `.mud-table-container` / `.mud-table-root` / `.mud-card-content` / `.mud-paper` inside `.frosted-card` are forced transparent. Covers:
  - `MudTable` inside a frosted `MudCard` — Home **Your Upcoming Matches** / **My Recent Results**, `/match` active matches list.
  - `MudTable` used directly with `frosted-card` (Clubs / Players / Competitions / Users) whose own inner scroll containers were painting the surface palette over the frosted root.

## Test plan
- [ ] Competitions, Users, Club Players: lists now show the frosted glass instead of solid grey.
- [ ] Home Upcoming Matches / Recent Results panel content is frosted (table doesn't paint a grey rectangle inside).
- [ ] `/match` active matches list shows frosted cards properly (no surface artefact).
- [ ] Light theme: glass darkens against `#f5f5f5` as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)