### PR TITLE
Frosted-card on admin grid + Home welcome card; cover MudDataGrid surfaces

### DIFF
--- a/DropShot.UI/Components/Pages/Competitions.razor
+++ b/DropShot.UI/Components/Pages/Competitions.razor
@@ -189,7 +189,8 @@
 <MudTabs @bind-ActivePanelIndex="_activeTab" Elevation="0" ApplyEffectsToContainer="true" Class="mb-4">
     <MudTabPanel Text="All Competitions" Icon="@Icons.Material.Filled.List">
         <MudDataGrid Items="@_competitions" Filterable="false" SortMode="@SortMode.None" Groupable="false"
-                     QuickFilter="@FilterCompetitions">
+                     QuickFilter="@FilterCompetitions"
+                     Class="frosted-card" Elevation="0">
             <Columns>
                 <PropertyColumn Property="x => x.CompetitionName" />
                 <PropertyColumn Property="x => x.CompetitionFormat.ToDisplayName()" Title="Format" />

--- a/DropShot.UI/Components/Pages/Home.razor
+++ b/DropShot.UI/Components/Pages/Home.razor
@@ -110,7 +110,7 @@
     </MudCarouselItem>
 </MudCarousel>
 
-<MudCard Class="mt-4 mb-8">
+<MudCard Class="mt-4 mb-8 frosted-card" Elevation="0">
     <MudCardContent>
         @if (!_isAuthenticated)
         {

--- a/DropShot.UI/wwwroot/css/shared.css
+++ b/DropShot.UI/wwwroot/css/shared.css
@@ -25,19 +25,25 @@
     border: 1px solid rgba(0, 0, 0, 0.08) !important;
 }
 
-/* MudBlazor child surfaces (table containers, card content, nested
-   paper) paint their own --mud-palette-surface which covers the
+/* MudBlazor child surfaces (table containers, card content, data
+   grid, tabs) paint their own --mud-palette-surface which covers the
    frosted parent. Force them transparent inside .frosted-card so the
-   parent's blurred bg shows through — covers:
-     - MudTable rendered inside a frosted MudCard (Home upcoming /
-       recent results, /match active matches list)
-     - MudTable used directly with frosted-card (Clubs, Players,
-       Competitions, Users) — its inner -container / -root children
-       still paint surface
+   parent's blurred bg shows through. Covers:
+     - MudTable inside a frosted MudCard (Home upcoming / recent
+       results, /match active matches list)
+     - MudTable used directly with frosted-card (Clubs, Players, etc.)
+       — inner -container / -root children still paint surface
+     - MudDataGrid (admin Competitions list) and its inner header /
+       row / cell containers
      - MudCardContent inside a frosted MudCard. */
 .frosted-card .mud-table,
 .frosted-card .mud-table-root,
 .frosted-card .mud-table-container,
+.frosted-card .mud-data-grid,
+.frosted-card .mud-data-grid-paper,
+.frosted-card .mud-data-grid-header,
+.frosted-card .mud-data-grid-row,
+.frosted-card .mud-data-grid-cell,
 .frosted-card .mud-card-content,
 .frosted-card .mud-paper {
     background: transparent !important;


### PR DESCRIPTION
## Summary
- **Admin Competitions list**: it's a `MudDataGrid`, not a `MudTable`. Apply `Class="frosted-card" Elevation="0"` so the grid root joins the frosted look. Add `.mud-data-grid`, `.mud-data-grid-paper`, `.mud-data-grid-header`, `.mud-data-grid-row`, `.mud-data-grid-cell` to the inner-transparent rule in `shared.css` so the grid's own header / row / cell surfaces don't paint over the frosted root in either populated or empty states.
- **Home welcome card**: the `<MudCard>` under the carousel (the "Welcome to DropShot" / "Welcome back" block) gets `frosted-card` + `Elevation="0"` so it stops showing solid grey.

If the user-view "no competitions" empty state still reads as grey after this lands, there's no MudTable / MudDataGrid in that branch — only headings + caption text — so the grey would have to be coming from a wrapper I haven't identified. Will iterate if it persists.

## Test plan
- [ ] Admin **Competitions** → All Competitions tab: list (populated *and* empty) shows frosted glass instead of grey.
- [ ] Home: the welcome / dashboard card under the carousel shows frosted glass.
- [ ] Light theme: glass darkens to white-on-light, no full-grey.

🤖 Generated with [Claude Code](https://claude.com/claude-code)