### PR TITLE
Frosted active toolbar button + inset; frost TennisScore upcoming card

### DIFF
--- a/DropShot.UI/Components/Pages/TennisScore.razor
+++ b/DropShot.UI/Components/Pages/TennisScore.razor
@@ -75,7 +75,7 @@
 
         @if (_upcomingFixtures.Any())
         {
-            <MudCard Class="mt-4">
+            <MudCard Class="mt-4 frosted-card" Elevation="0">
                 <MudCardHeader>
                     <CardHeaderContent>
                         <MudText Typo="Typo.h6">Your Upcoming Matches</MudText>

--- a/DropShot/Components/Layout/NavMenu.razor.css
+++ b/DropShot/Components/Layout/NavMenu.razor.css
@@ -66,9 +66,12 @@
 .nav-item > .nav-link {
     color: #d7d7d7;
     background: none;
-    border: none;
-    border-radius: 4px;
-    height: 3.5rem;
+    border: 1px solid transparent;
+    border-radius: 8px;
+    /* 2.5rem link in a 3.5rem toolbar gives a 0.5rem gap top + bottom so
+       the buttons sit in the middle instead of stretching edge-to-edge. */
+    height: 2.5rem;
+    margin: 0.5rem 0;
     display: flex;
     align-items: center;
     gap: 0.5rem;
@@ -79,8 +82,14 @@
     font-size: 0.9rem;
 }
 
+/* Active route uses the same frosted-glass look as list cards
+   (shared.css .frosted-card) so the toolbar selection doesn't feel
+   like a different visual language. */
 .nav-item ::deep a.active {
-    background-color: rgba(255,255,255,0.37);
+    background: rgba(255, 255, 255, 0.12);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border: 1px solid rgba(255, 255, 255, 0.2);
     color: white;
 }
 
@@ -101,8 +110,11 @@
     gap: 0.5rem;
     color: #d7d7d7;
     background: none;
-    border: none;
-    height: 3.5rem;
+    border: 1px solid transparent;
+    border-radius: 8px;
+    /* Match .nav-link inset so toolbar buttons line up. */
+    height: 2.5rem;
+    margin: 0.5rem 0;
     padding: 0 0.75rem;
     cursor: pointer;
     font-size: 0.9rem;


### PR DESCRIPTION
## Summary
- **Web NavMenu top-row buttons:**
  - Active route now uses the same frosted-glass treatment as list cards (`rgba(255,255,255,0.12)` + `blur(12px)` + `0.2`-alpha border + `8px` radius), replacing the flat `0.37`-alpha white wash that didn't match the rest of the visual language.
  - Reduce `.nav-link` / `.nav-dropdown-trigger` height from `3.5rem` to `2.5rem` and add `0.5rem` vertical margin so the buttons sit centred in the `3.5rem` toolbar with `0.5rem` gap top + bottom instead of stretching edge-to-edge.
  - Mobile drawer rules unaffected — they already explicitly override with `min-height` + `height: auto`.
- **TennisScore "Your Upcoming Matches" card** on `/match/{id}` (visible under the start-a-match setup) gets `Class="frosted-card" Elevation="0"` so it stops showing solid grey under the scoreboard.

## Test plan
- [ ] Web nav: hover and active states show frosted buttons inset from the toolbar edges.
- [ ] Active route highlights with the frosted look, not the flat wash.
- [ ] Mobile drawer (≤640px): unchanged.
- [ ] /match/{id} page with upcoming fixtures: card renders frosted instead of grey.

🤖 Generated with [Claude Code](https://claude.com/claude-code)