### PR TITLE
Gate Competitions tabs on events; reuse frosted-card on setup sections

### DIFF
--- a/DropShot.UI/Components/Competitions/Setup/FixturesSection.razor
+++ b/DropShot.UI/Components/Competitions/Setup/FixturesSection.razor
@@ -1,8 +1,8 @@
 @using DropShot.Shared
 @using DropShot.Shared.Dtos
 
-<MudPaper id="section-fixtures" Class="pa-4 setup-section" Elevation="0"
-     Style="background: rgba(255,255,255,0.08); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border: 1px solid rgba(255,255,255,0.12); border-radius: 12px; color: white;">
+<MudPaper id="section-fixtures" Class="pa-4 setup-section frosted-card" Elevation="0"
+     Style="color: white;">
     <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="mb-3">
         <MudText Typo="Typo.h6" Style="flex:1">Fixtures</MudText>
         @if (IsSuperAdmin && Stages.Any(s => s.StageType == StageType.RoundRobin))

--- a/DropShot.UI/Components/Competitions/Setup/StagesSection.razor
+++ b/DropShot.UI/Components/Competitions/Setup/StagesSection.razor
@@ -1,8 +1,8 @@
 @using DropShot.Shared
 @using DropShot.Shared.Dtos
 
-<MudPaper id="section-stages" Class="pa-4 mb-4 setup-section" Elevation="0"
-     Style="background: rgba(255,255,255,0.08); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border: 1px solid rgba(255,255,255,0.12); border-radius: 12px; color: white;">
+<MudPaper id="section-stages" Class="pa-4 mb-4 setup-section frosted-card" Elevation="0"
+     Style="color: white;">
     <MudStack Row="true" AlignItems="AlignItems.Center" Class="mb-3">
         <MudText Typo="Typo.h6" Style="flex:1">Stages</MudText>
         <MudButton Size="Size.Small" Variant="Variant.Outlined" StartIcon="@Icons.Material.Filled.Add"

--- a/DropShot.UI/Components/Pages/CompetitionPage.razor
+++ b/DropShot.UI/Components/Pages/CompetitionPage.razor
@@ -465,8 +465,8 @@ else
     {
         <MudTabPanel Text="Roster">
             @* ── Participants ────────────────────────────────── *@
-            <MudPaper id="section-participants" Class="pa-4 mb-4 setup-section" Elevation="0"
-                 Style="background: rgba(255,255,255,0.08); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border: 1px solid rgba(255,255,255,0.12); border-radius: 12px; color: white;">
+            <MudPaper id="section-participants" Class="pa-4 mb-4 setup-section frosted-card" Elevation="0"
+                 Style="color: white;">
                 <MudStack Row="true" AlignItems="AlignItems.Center" Class="mb-3">
                     <MudText Typo="Typo.h6" Style="flex:1">Participants</MudText>
                     <MudAutocomplete T="PlayerSearchResultDto" Label="Add player" SearchFunc="SearchPlayers"

--- a/DropShot.UI/Components/Pages/Competitions.razor
+++ b/DropShot.UI/Components/Pages/Competitions.razor
@@ -186,11 +186,14 @@
                  Dense="true" />
 </MudStack>
 
-<MudTabs @bind-ActivePanelIndex="_activeTab" Elevation="0" ApplyEffectsToContainer="true" Class="mb-4">
-    <MudTabPanel Text="All Competitions" Icon="@Icons.Material.Filled.List">
-        <MudDataGrid Items="@_competitions" Filterable="false" SortMode="@SortMode.None" Groupable="false"
-                     QuickFilter="@FilterCompetitions"
-                     Class="frosted-card" Elevation="0">
+@* Inline RenderFragment so the All Competitions grid can be reused in
+   both the tabbed (events present) and untabbed (no events) paths
+   below without duplicating ~60 lines of grid markup. We're already
+   inside an @if(!_isUserView) code block so no @{ } wrapper here. *@
+RenderFragment allCompetitionsGrid =
+    @<MudDataGrid Items="@_competitions" Filterable="false" SortMode="@SortMode.None" Groupable="false"
+                      QuickFilter="@FilterCompetitions"
+                      Class="frosted-card" Elevation="0">
             <Columns>
                 <PropertyColumn Property="x => x.CompetitionName" />
                 <PropertyColumn Property="x => x.CompetitionFormat.ToDisplayName()" Title="Format" />
@@ -252,7 +255,17 @@
                     </CellTemplate>
                 </TemplateColumn>
             </Columns>
-        </MudDataGrid>
+        </MudDataGrid>;
+
+@* The "All Competitions / By Event" tab strip only earns its keep when
+   at least one competition belongs to an event — otherwise the By Event
+   tab is empty and the tab strip is just visual noise. Hide the tabs
+   entirely in that case and render the grid directly. *@
+@if (_events.Any())
+{
+<MudTabs @bind-ActivePanelIndex="_activeTab" Elevation="0" ApplyEffectsToContainer="true" Class="mb-4">
+    <MudTabPanel Text="All Competitions" Icon="@Icons.Material.Filled.List">
+        @allCompetitionsGrid
     </MudTabPanel>
 
     <MudTabPanel Text="By Event" Icon="@Icons.Material.Filled.FolderOpen">
@@ -409,6 +422,11 @@
         }
     </MudTabPanel>
 </MudTabs>
+}
+else
+{
+    @allCompetitionsGrid
+}
 
 @if (CurrentUser.IsAdmin || _hasEditableClubs || CurrentUser.CanCreateUserCompetition)
 {


### PR DESCRIPTION
## Summary
- **Competitions admin view**: hide the "All Competitions / By Event" tab strip when no competition has an event (i.e. `_events` is empty). The grid is rendered bare in that case so the tabs aren't visual noise. Used an inline `RenderFragment` so the ~60-line grid markup isn't duplicated across the tabbed and untabbed paths.
- **Setup-page sections** (Stages, Participants, Fixtures) had near-identical inline frosted styling. Drop the inline declarations and switch to `Class="setup-section frosted-card"` so they share the rule from [shared.css](DropShot.UI/wwwroot/css/shared.css). The descendant rule forces nested `MudTable` surfaces transparent — fixes the inner-table grey rectangle inside the otherwise-frosted sections. `color: white` inline stays (these sections assume dark text regardless of theme).

## Test plan
- [ ] Competitions admin: with events present, tabs show. Without events, just the grid.
- [ ] Setup tab: Stages / Participants / Fixtures sections show frosted bg with frosted (not grey) inner tables.
- [ ] Light theme: sections still render (color: white may now jar against a light surface — pre-existing concern, separate cleanup if you want).

🤖 Generated with [Claude Code](https://claude.com/claude-code)