### PR TITLE
Gate Rules Sets nav on admin roles; reload current page on MAUI role switch

### DIFF
--- a/DropShot.Maui/Components/Layout/NavMenu.razor
+++ b/DropShot.Maui/Components/Layout/NavMenu.razor
@@ -122,6 +122,16 @@
         Snackbar.Add(
             ok ? $"Switched to {role}." : $"Failed to switch to {role}.",
             ok ? Severity.Success : Severity.Error);
+        if (!ok) return;
+
+        // Force a hard reload of the current page so any role-gated UI
+        // (admin sections, nav links, page-level @attribute [Authorize]
+        // route guards) re-evaluates against the new ActiveRole instead
+        // of showing stale state from before the switch. forceLoad: true
+        // is needed because Blazor's normal router-based navigation
+        // doesn't tear down the existing component tree.
+        var currentUri = Nav.Uri;
+        Nav.NavigateTo(currentUri, forceLoad: true);
     }
 
     private async Task LogoutAsync()

--- a/DropShot.UI/Services/Navigation/NavCatalog.cs
+++ b/DropShot.UI/Services/Navigation/NavCatalog.cs
@@ -51,7 +51,12 @@ public static class NavCatalog
 
         new("rulessets", "Rules Sets",
             Icons.Material.Filled.Gavel,
-            "Match rules templates"),
+            "Match rules templates",
+            // Plain users don't manage or browse rules-set templates —
+            // those are an admin / club-admin concern, mirrored on the
+            // /rulessets page itself where Edit / Rules / Delete are
+            // already CurrentUser.IsAdmin gated.
+            RequiredRoles: "ClubAdmin,Admin,SuperAdmin"),
 
         new("players", "Players",
             Icons.Material.Filled.People,


### PR DESCRIPTION
## Summary
Two small tweaks:

- **Rules Sets nav** is now gated on `ClubAdmin / Admin / SuperAdmin` in [`NavCatalog`](DropShot.UI/Services/Navigation/NavCatalog.cs). Plain users have no business browsing or editing rules-set templates — the dedicated `/rulessets` page already gates the Edit / Rules / Delete buttons on `CurrentUser.IsAdmin`, so hiding the menu link mirrors that. Both web and MAUI menus iterate the catalog, so the gate applies to both hosts.
- **MAUI role switcher** does a `Nav.NavigateTo(currentUri, forceLoad: true)` after a successful `Auth.SwitchRoleAsync` so the current page tears down and re-evaluates with the new `ActiveRole`. Without it, role-gated UI (admin shortcuts, hidden nav items, `AuthorizeRouteView` route guards) stayed stale from before the switch. Web is unaffected — its role switch is a full POST to `/Account/SwitchRole` which already triggers a full reload.

**Re Create Competition button gating:** already correctly gated via `CurrentUser.CanCreateUserCompetition` (true for SuperAdmin/Admin or subscribed plain User; false for unsubscribed plain User) on both buttons in [Competitions.razor](DropShot.UI/Components/Pages/Competitions.razor). No change needed for the web. MAUI hardcodes `IsSubscribed = false` (login DTO doesn't carry subscription bit) — separate and bigger gap, not addressed here.

## Test plan
- [ ] Web/MAUI as plain User: no **Rules Sets** entry in the nav.
- [ ] Web/MAUI as ClubAdmin/Admin/SuperAdmin: **Rules Sets** entry visible.
- [ ] MAUI: switch role from Admin → User on a setup page → page reloads and the admin-only buttons disappear immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)