### PR TITLE
Include light-player participation history in My Competitions view

### DIFF
--- a/DropShot/Services/WebCompetitionService.cs
+++ b/DropShot/Services/WebCompetitionService.cs
@@ -563,13 +563,28 @@ public sealed class WebCompetitionService(
             return new MyCompetitionsViewDto(false, [], []);
 
         await using var db = await dbFactory.CreateDbContextAsync(ct);
-        var player = await db.Players
-            .FirstOrDefaultAsync(p => p.UserId == currentUser.UserId && !p.IsLight, ct);
-        if (player is null) return new MyCompetitionsViewDto(false, [], []);
+
+        // A user can have multiple Player rows in flight: a verified row
+        // (IsLight=false) plus light rows that were created by an admin
+        // adding them to a competition before they registered, then later
+        // linked to their account. CompetitionParticipants entries can
+        // reference either. Filtering to !IsLight here was making My
+        // Competitions come back empty for users with light-only
+        // participation history while Available still worked (because
+        // Available just needs *a* player for eligibility checks).
+        // Match on UserId for the entered query; pick the verified
+        // player (or first if none) for eligibility.
+        var myPlayers = await db.Players
+            .Where(p => p.UserId == currentUser.UserId)
+            .ToListAsync(ct);
+        if (myPlayers.Count == 0) return new MyCompetitionsViewDto(false, [], []);
+        var myPlayerIds = myPlayers.Select(p => p.PlayerId).ToList();
+        var eligibilityPlayer = myPlayers.FirstOrDefault(p => !p.IsLight) ?? myPlayers[0];
 
         var enteredIds = await db.CompetitionParticipants
-            .Where(cp => cp.PlayerId == player.PlayerId)
+            .Where(cp => myPlayerIds.Contains(cp.PlayerId))
             .Select(cp => cp.CompetitionId)
+            .Distinct()
             .ToListAsync(ct);
 
         var enteredEntities = await db.Competition
@@ -591,7 +606,7 @@ public sealed class WebCompetitionService(
             .ToListAsync(ct);
 
         var available = candidates
-            .Where(c => EligibilityEvaluator.Evaluate(c, player).Count == 0)
+            .Where(c => EligibilityEvaluator.Evaluate(c, eligibilityPlayer).Count == 0)
             .Select(ToDto).ToList();
         return new MyCompetitionsViewDto(true, enteredEntities.Select(ToDto).ToList(), available);
     }


### PR DESCRIPTION
## Summary
[`WebCompetitionService.GetMyCompetitionsViewAsync`](DropShot/Services/WebCompetitionService.cs:560) was looking up the user's player with a hard `!IsLight` filter, then matching `CompetitionParticipants` on that single `PlayerId`. A user can have multiple `Player` rows in flight: a verified one (`IsLight=false`) plus light rows created by an admin adding them to a competition before they registered, then later linked to their account. Participants can reference either — but the entered query only saw the verified `PlayerId`, so users with light-only participation history showed an empty **My Competitions** while **Available** still populated (it only needs *a* player for eligibility).

This was the symptom the user hit:
- MAUI: My Competitions empty, Available fine.
- Web: intermittent — sometimes seemed to "fix itself" after a role-toggle / page reload (likely a different player record being picked up).

Now: match the entered query against all `PlayerId`s for the `UserId` (Distinct competition ids), and pick the verified player (or first if none) for the Available eligibility check.

Both hosts share the code path — MAUI's `HttpCompetitionService` calls `GET /api/competitions/my-view`, which the controller delegates straight to this method.

## Test plan
- [ ] Standard user with at least one light-player participation history: My Competitions now lists those entries.
- [ ] Standard user with verified-player history only: still works as before.
- [ ] Available list eligibility unchanged.
- [ ] User with no players at all: returns `HasPlayer=false` (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)