### PR TITLE
Reload Competitions on CurrentUser.Changed; revert MAUI forceLoad reload

### DIFF
--- a/DropShot.Maui/Components/Layout/NavMenu.razor
+++ b/DropShot.Maui/Components/Layout/NavMenu.razor
@@ -122,16 +122,13 @@
         Snackbar.Add(
             ok ? $"Switched to {role}." : $"Failed to switch to {role}.",
             ok ? Severity.Success : Severity.Error);
-        if (!ok) return;
-
-        // Force a hard reload of the current page so any role-gated UI
-        // (admin sections, nav links, page-level @attribute [Authorize]
-        // route guards) re-evaluates against the new ActiveRole instead
-        // of showing stale state from before the switch. forceLoad: true
-        // is needed because Blazor's normal router-based navigation
-        // doesn't tear down the existing component tree.
-        var currentUri = Nav.Uri;
-        Nav.NavigateTo(currentUri, forceLoad: true);
+        // Pages that need to react to a role change subscribe to
+        // CurrentUser.Changed and reload their data from the handler
+        // (Competitions.razor does this). Forcing a full page reload
+        // here was redirecting MAUI users to the host page —
+        // BlazorWebView treats forceLoad on the current URI as a
+        // navigation back to wwwroot/index.html, so the user lost
+        // their place in the app on every role switch.
     }
 
     private async Task LogoutAsync()

--- a/DropShot.UI/Components/Pages/Competitions.razor
+++ b/DropShot.UI/Components/Pages/Competitions.razor
@@ -1,4 +1,5 @@
 @using DropShot.Shared.Extensions
+@implements IDisposable
 
 @inject NavigationManager Nav
 @inject ICompetitionService CompetitionService
@@ -474,6 +475,32 @@ else
         c.CompetitionFormat.ToDisplayName().Contains(_searchText, StringComparison.OrdinalIgnoreCase));
 
     protected override async Task OnInitializedAsync()
+    {
+        // Subscribe to CurrentUser changes so a late-arriving auth-state
+        // snapshot (Blazor circuits load it asynchronously after circuit
+        // start) or a role switch (drawer "Switch role") triggers a reload
+        // of the list. Without this, OnInitializedAsync may run with a
+        // half-populated WebCurrentUser snapshot and the user sees an
+        // empty list that never recovers without a hard refresh.
+        CurrentUser.Changed += OnCurrentUserChanged;
+        await LoadAsync();
+    }
+
+    private void OnCurrentUserChanged()
+    {
+        _ = InvokeAsync(async () =>
+        {
+            await LoadAsync();
+            StateHasChanged();
+        });
+    }
+
+    public void Dispose()
+    {
+        CurrentUser.Changed -= OnCurrentUserChanged;
+    }
+
+    private async Task LoadAsync()
     {
         var isAdmin = CurrentUser.IsAdmin;
         _hasEditableClubs = CurrentUser.AdminClubIds.Count > 0;


### PR DESCRIPTION
## Summary
Two related bugs in one PR:

- **Web/MAUI Competitions list often empty for a standard user.** [`Competitions.razor.OnInitializedAsync`](DropShot.UI/Components/Pages/Competitions.razor:476) read `CurrentUser.IsAdmin` and `CurrentUser.UserId` to decide `_isUserView` and to call `GetMyCompetitionsViewAsync`. On interactive Blazor renders (no `HttpContext`, e.g. nav-back to `/competitions` inside an existing circuit) `WebCurrentUser` falls back to its async-populated `_userId` snapshot — the page raced that snapshot, occasionally ran first, and `GetMyCompetitionsViewAsync` returned an empty result for the rest of the page's life. Now subscribing to `CurrentUser.Changed` and re-running the data load on every state update so a late-arriving snapshot or a role switch automatically refreshes the list.
- **MAUI role switch redirected users to home.** [PR #586](https://github.com/kingbeazer/DropShot/pull/586)'s `Nav.NavigateTo(currentUri, forceLoad: true)` was wrong on `BlazorWebView` — `forceLoad` of the current URI navigates back to `wwwroot/index.html`, wiping the route. Drop the forceLoad call; pages that need to react subscribe to `CurrentUser.Changed` instead (Competitions does this now).

## Test plan
- [ ] Web standard user → /competitions on first SSR pass: My Competitions populates.
- [ ] Web standard user → navigate to /match → back to /competitions: My Competitions still populates (was empty before).
- [ ] Web standard user → switch to ClubAdmin and back: list still works.
- [ ] MAUI standard user → My Competitions populates.
- [ ] MAUI any user → role switch: stays on the current page (no redirect to home).

🤖 Generated with [Claude Code](https://claude.com/claude-code)