### PR TITLE
ICurrentUser.EnsureLoadedAsync to defeat snapshot race in Competitions

### DIFF
--- a/DropShot.Maui/Services/MauiCurrentUser.cs
+++ b/DropShot.Maui/Services/MauiCurrentUser.cs
@@ -75,6 +75,8 @@ public sealed class MauiCurrentUser : ICurrentUser, IDisposable
 
     public bool CanCreateUserCompetition => IsAdmin;
 
+    public Task EnsureLoadedAsync(CancellationToken ct = default) => RefreshAsync();
+
     public void Dispose()
     {
         _auth.AuthenticationStateChanged -= OnAuthStateChanged;

--- a/DropShot.UI/Components/Pages/Competitions.razor
+++ b/DropShot.UI/Components/Pages/Competitions.razor
@@ -476,13 +476,17 @@ else
 
     protected override async Task OnInitializedAsync()
     {
-        // Subscribe to CurrentUser changes so a late-arriving auth-state
-        // snapshot (Blazor circuits load it asynchronously after circuit
-        // start) or a role switch (drawer "Switch role") triggers a reload
-        // of the list. Without this, OnInitializedAsync may run with a
-        // half-populated WebCurrentUser snapshot and the user sees an
-        // empty list that never recovers without a hard refresh.
+        // Subscribe to CurrentUser changes so a role switch via the drawer
+        // triggers a reload of the list automatically.
         CurrentUser.Changed += OnCurrentUserChanged;
+
+        // Force the snapshot to be populated BEFORE branching on IsAdmin /
+        // AdminClubIds / UserId. WebCurrentUser kicks off its snapshot
+        // load as fire-and-forget in its constructor — without this await
+        // the page can race ahead and read null UserId, which makes the
+        // server's GetMyCompetitionsViewAsync return an empty list
+        // (My Competitions empty even though the user has entries).
+        await CurrentUser.EnsureLoadedAsync();
         await LoadAsync();
     }
 

--- a/DropShot.UI/Services/Auth/ICurrentUser.cs
+++ b/DropShot.UI/Services/Auth/ICurrentUser.cs
@@ -39,4 +39,14 @@ public interface ICurrentUser
 
     /// <summary>Raised after the underlying auth state changes (login, logout, role switch, session restore).</summary>
     event Action? Changed;
+
+    /// <summary>
+    /// Forces the user-state snapshot (UserId, ActiveRole, GrantedRoles,
+    /// AdminClubIds) to be populated before property reads return stable
+    /// values. Pages call this in OnInitializedAsync before branching on
+    /// IsAdmin / AdminClubIds / CanEditCompetition so they don't race the
+    /// constructor's fire-and-forget snapshot load. Idempotent — safe to
+    /// call repeatedly.
+    /// </summary>
+    Task EnsureLoadedAsync(CancellationToken ct = default);
 }

--- a/DropShot/Services/WebCurrentUser.cs
+++ b/DropShot/Services/WebCurrentUser.cs
@@ -64,6 +64,8 @@ public sealed class WebCurrentUser : ICurrentUser, IDisposable
 
     private async Task RefreshAsync() => await ApplyStateAsync(await _authState.GetAuthenticationStateAsync());
 
+    public Task EnsureLoadedAsync(CancellationToken ct = default) => RefreshAsync();
+
     private async Task ApplyStateAsync(AuthenticationState state)
     {
         var user = state.User;


### PR DESCRIPTION
## Summary
[PR #588](https://github.com/kingbeazer/DropShot/pull/588) subscribed Competitions.razor to `CurrentUser.Changed` so a role switch reloads the list — but the original empty load on the first render still happened silently. `WebCurrentUser`'s constructor kicks off `RefreshAsync` as fire-and-forget, and the page's `OnInitializedAsync` can read property values (`UserId` / `IsAdmin` / `AdminClubIds`) **before** the snapshot lands. `Changed` only fires later if the auth state actually changes (revalidation, login, role switch), so without explicit prodding the user stays stuck on an empty list.

- New `ICurrentUser.EnsureLoadedAsync()` — a one-liner around `RefreshAsync` on each implementation. Pages await it before branching on `IsAdmin` / `AdminClubIds` / `UserId`.
- [`Competitions.razor.OnInitializedAsync`](DropShot.UI/Components/Pages/Competitions.razor:477) now awaits `CurrentUser.EnsureLoadedAsync()` before `LoadAsync()`.
- Same fix lights up Edit buttons in the admin grid for ClubAdmins on the first render after a role switch (the `Edit` gate in [Competitions.razor:223](DropShot.UI/Components/Pages/Competitions.razor:223) calls `CanEditCompetition` which reads `_adminClubIds` — also populated by `RefreshAsync`).

Tests reference `WebCurrentUser` concretely so no test stub needs updating.

## Test plan
- [ ] Web standard user → /competitions on first SSR pass: My Competitions populates with the user's entries.
- [ ] Web standard user → navigate to /match → back to /competitions: My Competitions still populates.
- [ ] Web ClubAdmin → /competitions: Edit buttons visible on competitions hosted by their club, on first render.
- [ ] MAUI standard user: My Competitions populates after login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)