### PR TITLE
Persist CanCreateUserCompetition in snapshot to stop button flicker

### DIFF
--- a/DropShot.UI/Components/Pages/Competitions.razor
+++ b/DropShot.UI/Components/Pages/Competitions.razor
@@ -22,7 +22,7 @@
     }
     else
     {
-        @if (CurrentUser.CanCreateUserCompetition)
+        @if (_canCreateUserCompetition)
         {
             <MudStack Row="true" Class="mb-4">
                 <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary"
@@ -431,7 +431,7 @@ else
     @allCompetitionsGrid
 }
 
-@if (CurrentUser.IsAdmin || _hasEditableClubs || CurrentUser.CanCreateUserCompetition)
+@if (CurrentUser.IsAdmin || _hasEditableClubs || _canCreateUserCompetition)
 {
     <MudStack Row="true" Spacing="2" Class="mt-3">
         <MudButton Size="@Size.Small" Variant="@Variant.Filled" Color="@Color.Primary"
@@ -463,6 +463,12 @@ else
     private List<CompetitionDto> _myEnteredComps = [];
     private List<CompetitionDto> _availableComps = [];
 
+    // Captured from CurrentUser after the snapshot is loaded so the
+    // Create Competition button doesn't flicker during interactive boot,
+    // when the freshly-constructed WebCurrentUser hasn't yet finished
+    // its fire-and-forget RefreshAsync.
+    private bool _canCreateUserCompetition;
+
     private sealed class EventGroup
     {
         public EventDto Event { get; init; } = default!;
@@ -476,6 +482,7 @@ else
         bool IsUserView,
         bool HasEditableClubs,
         bool HasPlayer,
+        bool CanCreateUserCompetition,
         List<CompetitionDto> Competitions,
         List<CompetitionDto> UngroupedCompetitions,
         List<EventDto> EventGroups,
@@ -525,6 +532,7 @@ else
         _isUserView = snap.IsUserView;
         _hasEditableClubs = snap.HasEditableClubs;
         _hasPlayer = snap.HasPlayer;
+        _canCreateUserCompetition = snap.CanCreateUserCompetition;
         _competitions = snap.Competitions;
         _ungroupedCompetitions = snap.UngroupedCompetitions;
         _myEnteredComps = snap.MyEnteredComps;
@@ -545,6 +553,7 @@ else
             _isUserView,
             _hasEditableClubs,
             _hasPlayer,
+            _canCreateUserCompetition,
             _competitions,
             _ungroupedCompetitions,
             _events.Select(g => g.Event).ToList(),
@@ -574,6 +583,7 @@ else
     private async Task LoadAsync()
     {
         _hasEditableClubs = CurrentUser.AdminClubIds.Count > 0;
+        _canCreateUserCompetition = CurrentUser.CanCreateUserCompetition;
         _pendingFixtures = await CompetitionService.GetPendingVerificationFixturesAsync();
 
         // _isUserView is driven by the ACTIVE role, not the underlying


### PR DESCRIPTION
## Summary
- Persist ``CanCreateUserCompetition`` in the prerender → interactive snapshot in [Competitions.razor](DropShot.UI/Components/Pages/Competitions.razor) so the first interactive render matches the prerendered HTML.
- The Create Competition button (and admin-grid Add Competition button) now read a local ``_canCreateUserCompetition`` field instead of ``CurrentUser.CanCreateUserCompetition`` directly, eliminating the brief pop-then-disappear blink standard users were seeing on each load.

The freshly-constructed ``WebCurrentUser`` on the interactive circuit starts with empty ``_grantedRoles`` / ``_isSubscribed=false`` and only populates asynchronously via fire-and-forget ``RefreshAsync()``. Re-renders during that window were re-evaluating the property against partially-loaded state.

## Test plan
- [ ] As an unsubscribed standard user, navigate to /competitions and confirm the Create Competition button does not flash on initial load
- [ ] As a subscribed standard user, confirm the Create Competition button is shown stably (no disappear/reappear)
- [ ] As an admin in user-view mode, confirm the button is shown stably
- [ ] As an admin in admin view, confirm the Add Competition row at the bottom of the grid does not flicker

🤖 Generated with [Claude Code](https://claude.com/claude-code)