### PR TITLE
Gate CanCreateUserCompetition on active role, not granted-role count

### DIFF
--- a/DropShot.UI/Components/Pages/Competitions.razor
+++ b/DropShot.UI/Components/Pages/Competitions.razor
@@ -22,7 +22,7 @@
     }
     else
     {
-        @if (CurrentUser.CanCreateUserCompetition)
+        @if (_canCreateUserCompetition)
         {
             <MudStack Row="true" Class="mb-4">
                 <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary"
@@ -431,7 +431,7 @@ else
     @allCompetitionsGrid
 }
 
-@if (CurrentUser.IsAdmin || _hasEditableClubs || CurrentUser.CanCreateUserCompetition)
+@if (CurrentUser.IsAdmin || _hasEditableClubs || _canCreateUserCompetition)
 {
     <MudStack Row="true" Spacing="2" Class="mt-3">
         <MudButton Size="@Size.Small" Variant="@Variant.Filled" Color="@Color.Primary"
@@ -463,6 +463,12 @@ else
     private List<CompetitionDto> _myEnteredComps = [];
     private List<CompetitionDto> _availableComps = [];
 
+    // Captured from CurrentUser after the snapshot is loaded so the
+    // Create Competition button doesn't flicker during interactive boot,
+    // when the freshly-constructed WebCurrentUser hasn't yet finished
+    // its fire-and-forget RefreshAsync.
+    private bool _canCreateUserCompetition;
+
     private sealed class EventGroup
     {
         public EventDto Event { get; init; } = default!;
@@ -476,6 +482,7 @@ else
         bool IsUserView,
         bool HasEditableClubs,
         bool HasPlayer,
+        bool CanCreateUserCompetition,
         List<CompetitionDto> Competitions,
         List<CompetitionDto> UngroupedCompetitions,
         List<EventDto> EventGroups,
@@ -525,6 +532,7 @@ else
         _isUserView = snap.IsUserView;
         _hasEditableClubs = snap.HasEditableClubs;
         _hasPlayer = snap.HasPlayer;
+        _canCreateUserCompetition = snap.CanCreateUserCompetition;
         _competitions = snap.Competitions;
         _ungroupedCompetitions = snap.UngroupedCompetitions;
         _myEnteredComps = snap.MyEnteredComps;
@@ -545,6 +553,7 @@ else
             _isUserView,
             _hasEditableClubs,
             _hasPlayer,
+            _canCreateUserCompetition,
             _competitions,
             _ungroupedCompetitions,
             _events.Select(g => g.Event).ToList(),
@@ -574,6 +583,7 @@ else
     private async Task LoadAsync()
     {
         _hasEditableClubs = CurrentUser.AdminClubIds.Count > 0;
+        _canCreateUserCompetition = CurrentUser.CanCreateUserCompetition;
         _pendingFixtures = await CompetitionService.GetPendingVerificationFixturesAsync();
 
         // _isUserView is driven by the ACTIVE role, not the underlying

--- a/DropShot.UI/Services/Auth/ICurrentUser.cs
+++ b/DropShot.UI/Services/Auth/ICurrentUser.cs
@@ -32,8 +32,8 @@ public interface ICurrentUser
     /// <summary>
     /// Whether the user can create a competition without a host club. Mirrors
     /// <c>ClubAuthorizationService.CanCreateUserCompetition</c> for the UI:
-    /// admin/superadmin always; otherwise only when "User" is the sole granted
-    /// role and the user has an active subscription.
+    /// admin/superadmin always; otherwise only when the active role is "User"
+    /// and the user has an active subscription.
     /// </summary>
     bool CanCreateUserCompetition { get; }
 

--- a/DropShot/Services/WebCurrentUser.cs
+++ b/DropShot/Services/WebCurrentUser.cs
@@ -213,10 +213,11 @@ public sealed class WebCurrentUser : ICurrentUser, IDisposable
         get
         {
             if (HasRole("SuperAdmin") || HasRole("Admin")) return true;
-            // Plain User mode AND subscribed
-            return _grantedRoles.Count == 1
-                && _grantedRoles[0].Equals("User", StringComparison.OrdinalIgnoreCase)
-                && _isSubscribed;
+            // Acting as plain User (active role) AND subscribed. Mirrors
+            // ClubAuthorizationService.CanCreateUserCompetition, which gates
+            // on the *active* role — a ClubAdmin who's toggled into User
+            // mode and subscribed is allowed too.
+            return ActiveRole is "User" && _isSubscribed;
         }
     }
 


### PR DESCRIPTION
## Summary
- Subscribed users with multi-role grants (e.g. ``[User, ClubAdmin]``) couldn't see the Create Competition button on /competitions, even when they had toggled into User mode and the server happily allowed the action.
- The UI's ``WebCurrentUser.CanCreateUserCompetition`` was checking that ``"User"`` was the **sole granted role**, while [ClubAuthorizationService.cs:165-169](DropShot/Services/ClubAuthorizationService.cs:165) gates on the **active role**. The UI was wrongly stricter than the API.
- Fix: read ``ActiveRole`` instead of ``_grantedRoles.Count``, mirroring the server. Updated the [ICurrentUser.cs](DropShot.UI/Services/Auth/ICurrentUser.cs) doc comment to match.

## Test plan
- [ ] Subscribed user with only the ``User`` role grant: button visible
- [ ] Subscribed user with ``[User, ClubAdmin]`` grants in User mode: button visible (was hidden — the bug)
- [ ] Same user toggled into ClubAdmin mode: button hidden
- [ ] Unsubscribed standard user: button hidden
- [ ] Admin/SuperAdmin (regardless of subscription): button visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)