### PR TITLE
Show My Players in MAUI nav for standard users

### DIFF
--- a/DropShot.Maui/Components/Layout/NavMenu.razor
+++ b/DropShot.Maui/Components/Layout/NavMenu.razor
@@ -51,13 +51,23 @@
         }
     }
 
-    @* Club Players stays MAUI-specific because the web swaps it with
-       My Players based on the active-role cookie — different per-host
-       behaviour, easier to keep out of the shared catalog. *@
+    @* Club Players / My Players stays MAUI-specific because the entry shown
+       flips based on the active role — mirroring the web's active-role cookie
+       swap but using CurrentUser.ActiveRole directly. *@
     <AuthorizeView Roles="ClubAdmin,Admin,SuperAdmin">
         <MudNavLink Href="/players/club" Icon="@Icons.Material.Filled.Groups">
             Club Players
         </MudNavLink>
+    </AuthorizeView>
+    <AuthorizeView>
+        <Authorized>
+            @if (CurrentUser.ActiveRole is not ("ClubAdmin" or "Admin" or "SuperAdmin"))
+            {
+                <MudNavLink Href="/players/mine" Icon="@Icons.Material.Filled.RecentActors">
+                    My Players
+                </MudNavLink>
+            }
+        </Authorized>
     </AuthorizeView>
 
     <AuthorizeView Roles="Admin,SuperAdmin,ClubAdmin">


### PR DESCRIPTION
## Summary
- Standard users (non-ClubAdmin/Admin/SuperAdmin) were missing the **My Players** nav link in the MAUI drawer
- The web host correctly toggles between Club Players and My Players based on active role, but the MAUI `NavMenu.razor` only rendered Club Players for elevated roles with no equivalent for regular users
- Added a `My Players` link that appears when `CurrentUser.ActiveRole` is not an elevated role, mirroring the web behaviour

## Test plan
- [ ] Log in as a standard user — **My Players** should appear in the MAUI drawer
- [ ] Log in as a ClubAdmin — **Club Players** should appear, **My Players** should not
- [ ] Log in as Admin/SuperAdmin — **Club Players** should appear, **My Players** should not
- [ ] User with multiple roles: switching to User role shows My Players; switching to ClubAdmin shows Club Players

🤖 Generated with [Claude Code](https://claude.com/claude-code)