### PR TITLE
Fix iOS bottom-content clipping on MAUI app

### DIFF
--- a/DropShot.Maui/wwwroot/css/app.css
+++ b/DropShot.Maui/wwwroot/css/app.css
@@ -132,9 +132,22 @@ html:not([data-theme="light"]) .mud-appbar {
         top: env(safe-area-inset-top) !important;
     }
 
+    /* The .status-bar-safe-area div above is in flow and takes
+       env(safe-area-inset-top) of body height; with body overflow:hidden
+       and .mud-main-content { height: 100vh } the bottom safe-inset gets
+       clipped, hiding ~47px of scrollable content (and the home-indicator
+       padding inside it) on iPhone 13 / 15 Plus. Subtract the top inset
+       so the scroll container fits the actual visible area below the
+       status-bar div.
+
+       padding-top is just the 64px AppBar height — the AppBar is already
+       offset by env(safe-area-inset-top) above (top: env(...)), and
+       .mud-main-content's own top sits below the status-bar-safe-area
+       div, so adding the inset here would double-count it. */
     .mud-main-content {
-        padding-top: calc(64px + env(safe-area-inset-top)) !important;
-        padding-bottom: max(2rem, env(safe-area-inset-bottom)) !important;
+        height: calc(100dvh - env(safe-area-inset-top)) !important;
+        padding-top: 64px !important;
+        padding-bottom: calc(2rem + env(safe-area-inset-bottom)) !important;
     }
 
     .mud-drawer-fixed {


### PR DESCRIPTION
## Summary
- On iPhone 13 / 15 Plus the bottom of every page was clipped by ~47px and buttons near the bottom were unreachable (often under the home-indicator gesture zone).
- Root cause in [DropShot.Maui/wwwroot/css/app.css](DropShot.Maui/wwwroot/css/app.css): `.status-bar-safe-area` is in flow and consumes `env(safe-area-inset-top)` above `.mud-main-content`, but `.mud-main-content` was `height: 100vh`. With `body { overflow: hidden }`, the bottom safe-inset of the scroll container was being clipped — including the `padding-bottom: max(2rem, env(safe-area-inset-bottom))` that should have cleared the home indicator.
- Fix: switch `.mud-main-content` to `height: calc(100dvh - env(safe-area-inset-top))` so it fits the actual visible area, and bump `padding-bottom` to `calc(2rem + env(safe-area-inset-bottom))` for proper breathing room.
- Bonus fix in the same block: `padding-top` was `calc(64px + env(safe-area-inset-top))`, but the AppBar is already offset by `env(safe-area-inset-top)` (`top: env(...)`) and `.mud-main-content`'s own top sits below the status-bar-safe-area div — so the inset was being double-counted, over-padding the top by ~47px. Reduced to `64px`.

Both bugs approximately cancelled out (over-padded top, clipped bottom), which is probably why this went unnoticed during the iOS bring-up.

## Test plan
- [ ] iPhone 13 — confirm bottom-of-page buttons are tappable on a content-heavy page like Competitions / Players
- [ ] iPhone 15 Plus — confirm extra bottom padding above the home indicator
- [ ] iPhone with Dynamic Island (e.g. 15 Pro) — confirm AppBar still clears the island and content top isn't pushed too far down
- [ ] Windows / Android / MacCatalyst hosts — `@supports(-webkit-touch-callout: none)` block doesn't apply, so behaviour is unchanged
- [ ] TennisScore / Scoreboard pages — full-bleed pages still render correctly inside the corrected scroll viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)