### PR TITLE
Fall back to principal role claims when _grantedRoles is empty

### DIFF
--- a/DropShot/Services/WebCurrentUser.cs
+++ b/DropShot/Services/WebCurrentUser.cs
@@ -212,11 +212,22 @@ public sealed class WebCurrentUser : ICurrentUser, IDisposable
     {
         get
         {
+            // Admin escape hatch — check the snapshot first, then fall back
+            // to the live principal. _grantedRoles can be empty when
+            // ApplyStateAsync's await on FindByIdAsync threw "A second
+            // operation was started on this context" — UserManager and the
+            // constructor's fire-and-forget RefreshAsync both share the
+            // scoped DbContext. The HTTP principal carries every granted
+            // Role claim regardless of which task won the race, so it's a
+            // reliable fallback during prerender.
             if (HasRole("SuperAdmin") || HasRole("Admin")) return true;
-            // Acting as plain User (active role) AND subscribed. Mirrors
-            // ClubAuthorizationService.CanCreateUserCompetition, which gates
-            // on the *active* role — a ClubAdmin who's toggled into User
-            // mode and subscribed is allowed too.
+            if (ApiPrincipal is { } u && (u.IsInRole("SuperAdmin") || u.IsInRole("Admin")))
+                return true;
+
+            // Otherwise: acting as plain User (active role) AND subscribed.
+            // Mirrors ClubAuthorizationService.CanCreateUserCompetition,
+            // which gates on the *active* role — a ClubAdmin who's toggled
+            // into User mode and subscribed is allowed too.
             //
             // Use the _activeRole *field* (set from the filtered Blazor
             // AuthenticationState) rather than the ActiveRole *property*:


### PR DESCRIPTION
## Summary
A user with admin grants (User+ClubAdmin+Admin+SuperAdmin) wasn't seeing the Create Competition button on /competitions even though their account is long-subscribed and they're acting in User mode.

Root cause: ``WebCurrentUser`` fires ``_ = RefreshAsync()`` from its constructor (fire-and-forget) and the page additionally calls ``EnsureLoadedAsync()`` from ``OnInitializedAsync``. Both call ``UserManager.FindByIdAsync`` against the same scoped EF Core ``DbContext``. ``DbContext`` is not thread-safe, so the two concurrent ``await``s race and one throws *A second operation was started on this context*. The synchronous fields (``_userId``, ``_activeRole``) get set first, but the ``await FindByIdAsync`` throws before reaching ``_grantedRoles = (await GetRolesAsync(…)).ToList()`` — leaving granted roles empty. ``EnsureLoadedAsync``'s ``try/catch {}`` swallows the exception, so the failure is silent. The page renders against a populated principal (``HttpContext.User``) but an empty ``_grantedRoles``, so ``HasRole(\"SuperAdmin\")`` falsely returns false on the first branch of [WebCurrentUser.cs:211](DropShot/Services/WebCurrentUser.cs:211), and the prerender persists ``CanCreateUserCompetition = false`` into the snapshot.

The fix: add an ``ApiPrincipal`` fallback to the admin-escape-hatch branch. The HTTP principal carries every granted Role claim regardless of which task won the EF race, so the prerender persists the correct ``true`` and the interactive boot reads it cleanly. Why My Competitions still loaded for this user: ``WebCompetitionService.GetMyCompetitionsViewAsync`` reads ``currentUser.UserId``, which already has an ``ApiPrincipal`` fallback path of its own.

## Test plan
- [ ] Multi-role admin (User+SuperAdmin+Admin+ClubAdmin) in User mode, subscribed: button visible
- [ ] Single-role User, subscribed: button visible
- [ ] Single-role User, unsubscribed: button hidden
- [ ] Multi-role with no admin grant (User+ClubAdmin) in User mode, subscribed: button visible
- [ ] Same user toggled into ClubAdmin mode: button hidden

## Follow-up worth considering
The underlying ``DbContext`` race is still present and could cause other silent failures elsewhere in ``WebCurrentUser``. Worth a separate PR to either drop the constructor's fire-and-forget ``RefreshAsync`` (the page awaits ``EnsureLoadedAsync`` explicitly) or serialize the two refresh paths with a ``SemaphoreSlim``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)