### PR TITLE
Add Login link to MAUI hamburger menu when logged out

### DIFF
--- a/DropShot.Maui/Components/Layout/NavMenu.razor
+++ b/DropShot.Maui/Components/Layout/NavMenu.razor
@@ -112,6 +112,12 @@
                 Logout
             </MudNavLink>
         </Authorized>
+        <NotAuthorized>
+            <MudDivider Class="my-2" />
+            <MudNavLink Href="/login" Icon="@Icons.Material.Filled.Login">
+                Login
+            </MudNavLink>
+        </NotAuthorized>
     </AuthorizeView>
 </MudNavMenu>
 


### PR DESCRIPTION
## Summary
- The MAUI `NavMenu` only rendered Logout inside an `Authorized` branch, so signed-out users had no entry point to the login page from the drawer.
- Added a `NotAuthorized` branch with a `Login` MudNavLink that navigates to `/login`.

## Test plan
- [ ] Launch MAUI app while logged out and confirm the hamburger menu shows a "Login" entry that opens the login page.
- [ ] Log in and confirm the menu now shows the Logout entry (and role-switch options when applicable) instead of Login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)