### PR TITLE
Maui polish: linkable logo, rectangular hamburger, comp title fixes

### DIFF
--- a/DropShot.Maui/Components/Layout/MainLayout.razor
+++ b/DropShot.Maui/Components/Layout/MainLayout.razor
@@ -12,8 +12,10 @@
 
 <MudLayout>
     <MudAppBar Elevation="1">
-        <img src="_content/DropShot.UI/images/Logo.png" alt="DropShot" class="appbar-logo" />
-        <MudText Typo="Typo.h6">DropShot</MudText>
+        <MudLink Href="/" Underline="Underline.None" Color="Color.Inherit" Class="d-flex align-center">
+            <img src="_content/DropShot.UI/images/Logo.png" alt="DropShot" class="appbar-logo" />
+            <MudText Typo="Typo.h6">DropShot</MudText>
+        </MudLink>
         <MudSpacer />
         <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit"
                        Edge="Edge.End" Class="appbar-hamburger" OnClick="@ToggleDrawer" />

--- a/DropShot.Maui/wwwroot/css/app.css
+++ b/DropShot.Maui/wwwroot/css/app.css
@@ -21,10 +21,14 @@ html:not([data-theme="light"]) .mud-appbar {
     color: #fff !important;
 }
 
-/* Pill the hamburger icon to match the web's contrast look. */
+/* Rectangular hamburger to match the web's .navbar-toggler shape. */
 .mud-appbar .appbar-hamburger {
-    background-color: rgba(255, 255, 255, 0.12);
-    border-radius: 50%;
+    background-color: rgba(255, 255, 255, 0.1);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 0.375rem;
+    width: 3.5rem;
+    height: 2.5rem;
+    padding: 0;
 }
 
 .mud-appbar .appbar-logo {

--- a/DropShot.UI/Components/Pages/CompetitionPage.razor
+++ b/DropShot.UI/Components/Pages/CompetitionPage.razor
@@ -35,17 +35,17 @@ else
         @if (_nameOverride)
         {
             <MudTextField T="string" @bind-Value="Model.CompetitionName" Variant="Variant.Text"
-                          Typo="Typo.h4" Style="flex:1" Immediate="true" Placeholder="Competition Name"
+                          Typo="Typo.h4" Class="competition-title" Style="flex:1" Immediate="true" Placeholder="Competition Name"
                           Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.Check"
                           OnAdornmentClick="@(() => _nameOverride = false)" />
         }
         else
         {
-            <MudText Typo="Typo.h4" Style="flex:1" Color="@(string.IsNullOrWhiteSpace(Model.CompetitionName) ? Color.Secondary : Color.Default)">
+            <MudText Typo="Typo.h4" Class="competition-title" Style="flex:1" Color="@(string.IsNullOrWhiteSpace(Model.CompetitionName) ? Color.Secondary : Color.Default)">
                 @(string.IsNullOrWhiteSpace(Model.CompetitionName) ? "New Competition" : Model.CompetitionName)
             </MudText>
             <MudTooltip Text="Edit name manually">
-                <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="Size.Small" OnClick="@(() => _nameOverride = true)" />
+                <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="Size.Small" OnClick="@(() => { _nameOverride = true; _nameManuallySet = true; })" />
             </MudTooltip>
         }
     </MudStack>
@@ -1543,6 +1543,7 @@ else
     private string? _serverError;
     private bool IsEdit => Id != 0;
     private bool _nameOverride;
+    private bool _nameManuallySet;
     private bool _isStarted;
     private int _activeTabIndex;
 
@@ -1918,7 +1919,7 @@ else
         if (IsEdit)
         {
             _isStarted = view.IsStarted;
-            _nameOverride = true; // Existing competition — preserve its name
+            _nameManuallySet = true; // Existing competition — don't auto-overwrite its name
 
             var (loadedCategory, loadedFormat) = SplitPersistedFormat(
                 view.CompetitionFormat ?? CompetitionFormat.Singles, view.EligibleSex);
@@ -2197,7 +2198,7 @@ else
 
     private void AutoGenerateName()
     {
-        if (_nameOverride) return;
+        if (_nameManuallySet) return;
         if (Model.Category == null || Model.Format == null) { Model.CompetitionName = ""; return; }
 
         var parts = new List<string>();

--- a/DropShot.UI/Components/Pages/CompetitionPage.razor.css
+++ b/DropShot.UI/Components/Pages/CompetitionPage.razor.css
@@ -1,5 +1,21 @@
 /* Competition edit page – mobile-specific polish */
 
+/* Allow long competition names to wrap rather than overflow the row. */
+::deep .competition-title {
+    word-break: break-word;
+    overflow-wrap: anywhere;
+}
+
+@media (max-width: 640.98px) {
+    /* Scale the h4 title down so long names like
+       "Surrey Mixed Doubles Winter League 2024-25" fit on a phone. */
+    ::deep .competition-title,
+    ::deep .competition-title input {
+        font-size: 1.5rem !important;
+        line-height: 1.3 !important;
+    }
+}
+
 @media (max-width: 640.98px) {
     /* Breathing room between the tab strip (Setup / Roster / Fixtures / Email)
        and the active panel's content. MudBlazor renders the tab headers in


### PR DESCRIPTION
## Summary
- **Brand link**: wrap the Maui app's logo and "DropShot" title in a `MudLink` to `/`, matching the web's `navbar-brand` anchor pattern
- **Rectangular hamburger**: replace the circular `.appbar-hamburger` with a 3.5rem × 2.5rem rectangle with a thin border, matching the web's `.navbar-toggler` look
- **Competition title — defaults to display mode**: split the conflated `_nameOverride` flag into `_nameOverride` (UI: textfield expanded) and `_nameManuallySet` (logic: skip auto-generation). Loading an existing competition now shows the title with the edit pencil instead of popping straight into edit mode
- **Competition title — responsive**: add a `.competition-title` class that wraps long names (`overflow-wrap: anywhere`) and scales the h4 down to 1.5rem under 641px so long names like "Surrey Mixed Doubles Winter League 2024-25" fit on a phone

## Test plan
- [ ] Maui app: clicking the logo / "DropShot" header navigates to `/`
- [ ] Maui app: hamburger button is rectangular with rounded corners and a translucent border
- [ ] Maui app: editing an existing competition shows the title text + pencil icon (not the textfield); clicking the pencil opens the textfield
- [ ] Maui app: creating a new competition still auto-generates the name as Category / Format / age fields are filled, and the auto-generation stops once the user clicks the pencil
- [ ] Maui app on phone: a long competition name fits on one or two lines without overflowing; on desktop it still uses the larger h4 size

🤖 Generated with [Claude Code](https://claude.com/claude-code)