### PR TITLE
Fix horizontal overflow in admin competitions list on mobile

### DIFF
--- a/DropShot.UI/Components/Pages/Competitions.razor
+++ b/DropShot.UI/Components/Pages/Competitions.razor
@@ -210,7 +210,7 @@ RenderFragment allCompetitionsGrid =
                         }
                     </CellTemplate>
                 </TemplateColumn>
-                <TemplateColumn CellClass="d-flex justify-end gap-2">
+                <TemplateColumn CellClass="d-flex flex-wrap justify-end align-center gap-1">
                     <CellTemplate>
                         @if (!context.Item.IsStarted)
                         {
@@ -220,39 +220,37 @@ RenderFragment allCompetitionsGrid =
                         {
                             <MudChip T="string" Size="Size.Small" Color="Color.Warning" Variant="Variant.Outlined">Archived</MudChip>
                         }
-                        <MudButton Size="@Size.Small"
-                                   Variant="@Variant.Outlined"
-                                   Color="@Color.Info"
-                                   OnClick="@(() => Nav.NavigateTo($"/competition/{context.Item.CompetitionId}/view"))">
-                            View
-                        </MudButton>
+                        <MudTooltip Text="View">
+                            <MudIconButton Size="@Size.Small"
+                                           Icon="@Icons.Material.Filled.Visibility"
+                                           Color="@Color.Info"
+                                           OnClick="@(() => Nav.NavigateTo($"/competition/{context.Item.CompetitionId}/view"))" />
+                        </MudTooltip>
                         @if (CanEdit(context.Item))
                         {
                             @if (!context.Item.IsArchived)
                             {
-                                <MudButton Size="@Size.Small"
-                                           Variant="@Variant.Filled"
-                                           Color="@Color.Primary"
-                                           OnClick="@(() => Nav.NavigateTo($"/competition/{context.Item.CompetitionId}"))">
-                                    Edit
-                                </MudButton>
+                                <MudTooltip Text="Edit">
+                                    <MudIconButton Size="@Size.Small"
+                                                   Icon="@Icons.Material.Filled.Edit"
+                                                   Color="@Color.Primary"
+                                                   OnClick="@(() => Nav.NavigateTo($"/competition/{context.Item.CompetitionId}"))" />
+                                </MudTooltip>
                             }
-                            <MudButton Size="@Size.Small"
-                                       Variant="@Variant.Outlined"
-                                       Color="@(context.Item.IsArchived ? Color.Success : Color.Warning)"
-                                       StartIcon="@(context.Item.IsArchived ? Icons.Material.Filled.Unarchive : Icons.Material.Filled.Archive)"
-                                       OnClick="@(() => ToggleArchiveAsync(context.Item))">
-                                @(context.Item.IsArchived ? "Unarchive" : "Archive")
-                            </MudButton>
+                            <MudTooltip Text="@(context.Item.IsArchived ? "Unarchive" : "Archive")">
+                                <MudIconButton Size="@Size.Small"
+                                               Icon="@(context.Item.IsArchived ? Icons.Material.Filled.Unarchive : Icons.Material.Filled.Archive)"
+                                               Color="@(context.Item.IsArchived ? Color.Success : Color.Warning)"
+                                               OnClick="@(() => ToggleArchiveAsync(context.Item))" />
+                            </MudTooltip>
                             @if (context.Item.IsArchived)
                             {
-                                <MudButton Size="@Size.Small"
-                                           Variant="@Variant.Filled"
-                                           Color="@Color.Error"
-                                           StartIcon="@Icons.Material.Filled.Delete"
-                                           OnClick="@(() => DeleteCompetitionAsync(context.Item))">
-                                    Delete
-                                </MudButton>
+                                <MudTooltip Text="Delete">
+                                    <MudIconButton Size="@Size.Small"
+                                                   Icon="@Icons.Material.Filled.Delete"
+                                                   Color="@Color.Error"
+                                                   OnClick="@(() => DeleteCompetitionAsync(context.Item))" />
+                                </MudTooltip>
                             }
                         }
                     </CellTemplate>
@@ -318,31 +316,32 @@ RenderFragment allCompetitionsGrid =
                                             }
                                         </td>
                                         <td>@comp.CompetitionFormat.ToDisplayName()</td>
-                                        <td class="d-flex justify-end gap-2">
-                                            <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Info"
-                                                       OnClick="@(() => Nav.NavigateTo($"/competition/{comp.CompetitionId}/view"))">
-                                                View
-                                            </MudButton>
+                                        <td class="d-flex flex-wrap justify-end align-center gap-1">
+                                            <MudTooltip Text="View">
+                                                <MudIconButton Size="Size.Small" Icon="@Icons.Material.Filled.Visibility" Color="Color.Info"
+                                                               OnClick="@(() => Nav.NavigateTo($"/competition/{comp.CompetitionId}/view"))" />
+                                            </MudTooltip>
                                             @if (CanEdit(comp))
                                             {
                                                 @if (!comp.IsArchived)
                                                 {
-                                                    <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary"
-                                                               OnClick="@(() => Nav.NavigateTo($"/competition/{comp.CompetitionId}"))">
-                                                        Edit
-                                                    </MudButton>
+                                                    <MudTooltip Text="Edit">
+                                                        <MudIconButton Size="Size.Small" Icon="@Icons.Material.Filled.Edit" Color="Color.Primary"
+                                                                       OnClick="@(() => Nav.NavigateTo($"/competition/{comp.CompetitionId}"))" />
+                                                    </MudTooltip>
                                                 }
-                                                <MudButton Size="Size.Small" Variant="Variant.Outlined"
-                                                           Color="@(comp.IsArchived ? Color.Success : Color.Warning)"
-                                                           OnClick="@(() => ToggleArchiveAsync(comp))">
-                                                    @(comp.IsArchived ? "Unarchive" : "Archive")
-                                                </MudButton>
+                                                <MudTooltip Text="@(comp.IsArchived ? "Unarchive" : "Archive")">
+                                                    <MudIconButton Size="Size.Small"
+                                                                   Icon="@(comp.IsArchived ? Icons.Material.Filled.Unarchive : Icons.Material.Filled.Archive)"
+                                                                   Color="@(comp.IsArchived ? Color.Success : Color.Warning)"
+                                                                   OnClick="@(() => ToggleArchiveAsync(comp))" />
+                                                </MudTooltip>
                                                 @if (comp.IsArchived)
                                                 {
-                                                    <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Error"
-                                                               OnClick="@(() => DeleteCompetitionAsync(comp))">
-                                                        Delete
-                                                    </MudButton>
+                                                    <MudTooltip Text="Delete">
+                                                        <MudIconButton Size="Size.Small" Icon="@Icons.Material.Filled.Delete" Color="Color.Error"
+                                                                       OnClick="@(() => DeleteCompetitionAsync(comp))" />
+                                                    </MudTooltip>
                                                 }
                                             }
                                         </td>
@@ -387,31 +386,32 @@ RenderFragment allCompetitionsGrid =
                                             }
                                         </td>
                                         <td>@comp.CompetitionFormat.ToDisplayName()</td>
-                                        <td class="d-flex justify-end gap-2">
-                                            <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Info"
-                                                       OnClick="@(() => Nav.NavigateTo($"/competition/{comp.CompetitionId}/view"))">
-                                                View
-                                            </MudButton>
+                                        <td class="d-flex flex-wrap justify-end align-center gap-1">
+                                            <MudTooltip Text="View">
+                                                <MudIconButton Size="Size.Small" Icon="@Icons.Material.Filled.Visibility" Color="Color.Info"
+                                                               OnClick="@(() => Nav.NavigateTo($"/competition/{comp.CompetitionId}/view"))" />
+                                            </MudTooltip>
                                             @if (CanEdit(comp))
                                             {
                                                 @if (!comp.IsArchived)
                                                 {
-                                                    <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary"
-                                                               OnClick="@(() => Nav.NavigateTo($"/competition/{comp.CompetitionId}"))">
-                                                        Edit
-                                                    </MudButton>
+                                                    <MudTooltip Text="Edit">
+                                                        <MudIconButton Size="Size.Small" Icon="@Icons.Material.Filled.Edit" Color="Color.Primary"
+                                                                       OnClick="@(() => Nav.NavigateTo($"/competition/{comp.CompetitionId}"))" />
+                                                    </MudTooltip>
                                                 }
-                                                <MudButton Size="Size.Small" Variant="Variant.Outlined"
-                                                           Color="@(comp.IsArchived ? Color.Success : Color.Warning)"
-                                                           OnClick="@(() => ToggleArchiveAsync(comp))">
-                                                    @(comp.IsArchived ? "Unarchive" : "Archive")
-                                                </MudButton>
+                                                <MudTooltip Text="@(comp.IsArchived ? "Unarchive" : "Archive")">
+                                                    <MudIconButton Size="Size.Small"
+                                                                   Icon="@(comp.IsArchived ? Icons.Material.Filled.Unarchive : Icons.Material.Filled.Archive)"
+                                                                   Color="@(comp.IsArchived ? Color.Success : Color.Warning)"
+                                                                   OnClick="@(() => ToggleArchiveAsync(comp))" />
+                                                </MudTooltip>
                                                 @if (comp.IsArchived)
                                                 {
-                                                    <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Error"
-                                                               OnClick="@(() => DeleteCompetitionAsync(comp))">
-                                                        Delete
-                                                    </MudButton>
+                                                    <MudTooltip Text="Delete">
+                                                        <MudIconButton Size="Size.Small" Icon="@Icons.Material.Filled.Delete" Color="Color.Error"
+                                                                       OnClick="@(() => DeleteCompetitionAsync(comp))" />
+                                                    </MudTooltip>
                                                 }
                                             }
                                         </td>


### PR DESCRIPTION
## Summary
- Replaced labelled action `MudButton`s (View / Edit / Archive / Unarchive / Delete) with `MudIconButton`s wrapped in `MudTooltip`s in the admin "All Competitions" `MudDataGrid` and the two "By Event" tab tables
- Action cell now uses `d-flex flex-wrap justify-end align-center gap-1` so any remaining width pressure wraps to a second line inside the cell instead of stretching the table
- Status chips ("Not Started", "Archived") kept as-is since they're already compact

The admin competitions list previously scrolled horizontally inside its container on phones — the row of full-text action buttons was wider than the viewport. Icon buttons collapse each action to ~36px and tooltips preserve discoverability on desktop.

## Test plan
- [ ] Open the MAUI app on a phone, sign in as admin, navigate to Competitions — confirm no horizontal drag/scroll inside the list container
- [ ] Tap each icon (View, Edit, Archive/Unarchive, Delete) and confirm it triggers the same action as before
- [ ] Switch to the "By Event" tab (when at least one event exists) and confirm the same row layout fits without horizontal scroll
- [ ] On desktop, hover each icon and confirm tooltip text appears