### PR TITLE
Stack match window form fields on mobile

### DIFF
--- a/DropShot.UI/Components/Competitions/Setup/DivisionsSection.razor
+++ b/DropShot.UI/Components/Competitions/Setup/DivisionsSection.razor
@@ -174,7 +174,7 @@
                     <MudDivider Class="my-3" />
                     <MudText Typo="Typo.subtitle1" Class="mb-2">Match Windows</MudText>
                     <MudGrid Spacing="1" Class="mb-2">
-                        <MudItem xs="3">
+                        <MudItem xs="12" sm="3">
                             <MudSelect @bind-Value="windowForm.Day" Label="Day" Variant="Variant.Outlined" Margin="Margin.Dense">
                                 @foreach (DayOfWeek dow in Enum.GetValues<DayOfWeek>())
                                 {
@@ -182,7 +182,7 @@
                                 }
                             </MudSelect>
                         </MudItem>
-                        <MudItem xs="3">
+                        <MudItem xs="12" sm="3">
                             <MudSelect @bind-Value="windowForm.CourtId" Label="Court" Variant="Variant.Outlined"
                                        Margin="Margin.Dense" Clearable="true">
                                 @foreach (var c in Courts)
@@ -191,15 +191,15 @@
                                 }
                             </MudSelect>
                         </MudItem>
-                        <MudItem xs="2">
+                        <MudItem xs="12" sm="2">
                             <MudTimePicker @bind-Time="windowForm.Start" Label="From" Variant="Variant.Outlined"
                                            Margin="Margin.Dense" AmPm="false" />
                         </MudItem>
-                        <MudItem xs="2">
+                        <MudItem xs="12" sm="2">
                             <MudTimePicker @bind-Time="windowForm.End" Label="To" Variant="Variant.Outlined"
                                            Margin="Margin.Dense" AmPm="false" />
                         </MudItem>
-                        <MudItem xs="2" Class="d-flex align-center">
+                        <MudItem xs="12" sm="2" Class="d-flex align-center">
                             <MudStack Row="true" Spacing="1">
                                 <MudButton Variant="Variant.Filled" Color="Color.Primary" Size="Size.Small"
                                            OnClick="@(() => OnAddDivisionMatchWindow.InvokeAsync(divId))">

--- a/DropShot.UI/Components/Competitions/Setup/MatchWindowsSection.razor
+++ b/DropShot.UI/Components/Competitions/Setup/MatchWindowsSection.razor
@@ -5,7 +5,7 @@
     <MudText Typo="Typo.h6" Class="mb-1">Match Windows</MudText>
 
     <MudGrid Spacing="1" Class="mb-2">
-        <MudItem xs="3">
+        <MudItem xs="12" sm="3">
             <MudSelect T="DayOfWeek" Value="NewWindowDay"
                        ValueChanged="@(v => NewWindowDayChanged.InvokeAsync(v))"
                        Label="Day" Variant="Variant.Outlined" Margin="Margin.Dense">
@@ -15,7 +15,7 @@
                 }
             </MudSelect>
         </MudItem>
-        <MudItem xs="3">
+        <MudItem xs="12" sm="3">
             <MudSelect T="int?" Value="NewWindowCourtId"
                        ValueChanged="@(v => NewWindowCourtIdChanged.InvokeAsync(v))"
                        Label="Court" Variant="Variant.Outlined"
@@ -26,19 +26,19 @@
                 }
             </MudSelect>
         </MudItem>
-        <MudItem xs="2">
+        <MudItem xs="12" sm="2">
             <MudTimePicker Time="NewWindowStart"
                            TimeChanged="@(v => NewWindowStartChanged.InvokeAsync(v))"
                            Label="From" Variant="Variant.Outlined"
                            Margin="Margin.Dense" AmPm="false" />
         </MudItem>
-        <MudItem xs="2">
+        <MudItem xs="12" sm="2">
             <MudTimePicker Time="NewWindowEnd"
                            TimeChanged="@(v => NewWindowEndChanged.InvokeAsync(v))"
                            Label="To" Variant="Variant.Outlined"
                            Margin="Margin.Dense" AmPm="false" />
         </MudItem>
-        <MudItem xs="2" Class="d-flex align-center">
+        <MudItem xs="12" sm="2" Class="d-flex align-center">
             <MudStack Row="true" Spacing="1">
                 <MudButton Variant="Variant.Filled" Color="Color.Primary" Size="Size.Small"
                            OnClick="@(() => OnAdd.InvokeAsync())">


### PR DESCRIPTION
## Summary
- The match-window input forms on the competition setup page (both the shared form in `MatchWindowsSection` and the per-division form in `DivisionsSection`) were laid out with fixed `xs` widths (Day/Court at 25%, From/To/Add at ~17%) which kept them in a single squashed row even on narrow phone screens.
- Added `xs="12"` to each `MudItem` so every field takes a full row on mobile, while the existing `sm` widths preserve the compact one-row layout from tablet sizes upward.

## Test plan
- [ ] On mobile width (<600px), open Competition Setup → Match Windows: confirm Day, Court, From, To, and Add stack vertically and inputs are no longer cramped.
- [ ] On a per-division Match Windows form, confirm the same stacking behaviour.
- [ ] On tablet/desktop (≥600px), confirm the row layout is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)