### PR TITLE
In-flow site alert banner replaces floating Snackbar toasts

### DIFF
--- a/DropShot.Maui/Components/Layout/NavMenu.razor
+++ b/DropShot.Maui/Components/Layout/NavMenu.razor
@@ -3,7 +3,7 @@
 @using DropShot.UI.Services.Auth
 @inject AuthService Auth
 @inject ICurrentUser CurrentUser
-@inject ISnackbar Snackbar
+@inject ISiteAlertService SiteAlerts
 @inject NavigationManager Nav
 @inject ThemeState Theme
 
@@ -135,7 +135,7 @@
     private async Task SwitchRoleAsync(string role)
     {
         var ok = await Auth.SwitchRoleAsync(role);
-        Snackbar.Add(
+        SiteAlerts.Add(
             ok ? $"Switched to {role}." : $"Failed to switch to {role}.",
             ok ? Severity.Success : Severity.Error);
         // Pages that need to react to a role change subscribe to

--- a/DropShot.Maui/Components/_Imports.razor
+++ b/DropShot.Maui/Components/_Imports.razor
@@ -15,4 +15,5 @@
 @using DropShot.Shared
 @using DropShot.Shared.Dtos
 @using DropShot.UI.Components.Shared
+@using DropShot.UI.Services
 @using DropShot.UI.Services.Auth

--- a/DropShot.Maui/MauiProgram.cs
+++ b/DropShot.Maui/MauiProgram.cs
@@ -75,6 +75,7 @@ public static class MauiProgram
 
         // ── MudBlazor ────────────────────────────────────────────────────────
         builder.Services.AddMudServices();
+        builder.Services.AddScoped<ISiteAlertService, SiteAlertService>();
 
         return builder.Build();
     }

--- a/DropShot.UI/Components/Pages/Admin/SiteSettings.razor
+++ b/DropShot.UI/Components/Pages/Admin/SiteSettings.razor
@@ -1,5 +1,5 @@
 @inject ISiteSettingsService Settings
-@inject ISnackbar Snackbar
+@inject ISiteAlertService SiteAlerts
 
 @* Routing + auth + MudProviders supplied by host shims. *@
 
@@ -54,11 +54,11 @@
         try
         {
             await Settings.SetContentMaxWidthPxAsync(_contentMaxWidthPx);
-            Snackbar.Add($"Content max width set to {_contentMaxWidthPx}px.", Severity.Success);
+            SiteAlerts.Add($"Content max width set to {_contentMaxWidthPx}px.", Severity.Success);
         }
         catch (Exception ex)
         {
-            Snackbar.Add(ex.Message, Severity.Error);
+            SiteAlerts.Add(ex.Message, Severity.Error);
         }
         finally
         {

--- a/DropShot.UI/Components/Pages/Admin/UserManagement.razor
+++ b/DropShot.UI/Components/Pages/Admin/UserManagement.razor
@@ -1,7 +1,7 @@
 @inject IUserService UserService
 @inject IClubService ClubService
 @inject ICurrentUser CurrentUser
-@inject ISnackbar Snackbar
+@inject ISiteAlertService SiteAlerts
 @inject IDialogService Dialog
 
 @* Routing + auth + MudProviders supplied by host shims. *@
@@ -202,11 +202,11 @@
         {
             await UserService.SetRoleAsync(row.Id, "SuperAdmin", make);
             await LoadAsync();
-            Snackbar.Add(
+            SiteAlerts.Add(
                 $"{row.UserName} {(make ? "granted" : "removed from")} Super Admin role.",
                 make ? Severity.Success : Severity.Warning);
         }
-        catch (Exception ex) { Snackbar.Add(ex.Message, Severity.Error); }
+        catch (Exception ex) { SiteAlerts.Add(ex.Message, Severity.Error); }
     }
 
     private async Task ToggleAdmin(UserManagementRowDto row, bool make)
@@ -215,11 +215,11 @@
         {
             await UserService.SetRoleAsync(row.Id, "Admin", make);
             await LoadAsync();
-            Snackbar.Add(
+            SiteAlerts.Add(
                 $"{row.UserName} {(make ? "granted" : "removed from")} Admin role.",
                 make ? Severity.Success : Severity.Warning);
         }
-        catch (Exception ex) { Snackbar.Add(ex.Message, Severity.Error); }
+        catch (Exception ex) { SiteAlerts.Add(ex.Message, Severity.Error); }
     }
 
     private async Task TogglePremium(UserManagementRowDto row, bool make)
@@ -228,11 +228,11 @@
         {
             await UserService.SetPremiumAsync(row.Id, make);
             await LoadAsync();
-            Snackbar.Add(
+            SiteAlerts.Add(
                 $"{row.UserName} premium {(make ? "enabled" : "disabled")}.",
                 make ? Severity.Success : Severity.Warning);
         }
-        catch (Exception ex) { Snackbar.Add(ex.Message, Severity.Error); }
+        catch (Exception ex) { SiteAlerts.Add(ex.Message, Severity.Error); }
     }
 
     private void OpenAddClubDialog(UserManagementRowDto row)
@@ -249,11 +249,11 @@
         {
             await UserService.AddClubAdminAsync(_targetRow.Id, _selectedClubId.Value);
             var clubName = _allClubs.First(c => c.ClubId == _selectedClubId.Value).Name;
-            Snackbar.Add($"{_targetRow.UserName} is now a Club Admin for {clubName}.", Severity.Success);
+            SiteAlerts.Add($"{_targetRow.UserName} is now a Club Admin for {clubName}.", Severity.Success);
             _showAddClubDialog = false;
             await LoadAsync();
         }
-        catch (Exception ex) { Snackbar.Add(ex.Message, Severity.Error); }
+        catch (Exception ex) { SiteAlerts.Add(ex.Message, Severity.Error); }
     }
 
     private void OpenEditDialog(UserManagementRowDto row)
@@ -270,11 +270,11 @@
         try
         {
             await UserService.UpdateAsync(_editRow.Id, new UpdateUserRequest(_editUsername, _editEmail));
-            Snackbar.Add("User updated successfully.", Severity.Success);
+            SiteAlerts.Add("User updated successfully.", Severity.Success);
             _showEditDialog = false;
             await LoadAsync();
         }
-        catch (Exception ex) { Snackbar.Add(ex.Message, Severity.Error); }
+        catch (Exception ex) { SiteAlerts.Add(ex.Message, Severity.Error); }
     }
 
     private async Task DeleteUserAsync(UserManagementRowDto row)
@@ -290,9 +290,9 @@
         {
             await UserService.DeleteAsync(row.Id);
             _rows.Remove(row);
-            Snackbar.Add($"User '{row.UserName}' deleted.", Severity.Warning);
+            SiteAlerts.Add($"User '{row.UserName}' deleted.", Severity.Warning);
         }
-        catch (Exception ex) { Snackbar.Add(ex.Message, Severity.Error); }
+        catch (Exception ex) { SiteAlerts.Add(ex.Message, Severity.Error); }
     }
 
     private async Task RemoveClubAdmin(UserManagementRowDto row, int clubId)
@@ -301,9 +301,9 @@
         {
             await UserService.RemoveClubAdminAsync(row.Id, clubId);
             var clubName = _allClubs.FirstOrDefault(c => c.ClubId == clubId)?.Name ?? clubId.ToString();
-            Snackbar.Add($"Removed {row.UserName} as Club Admin for {clubName}.", Severity.Warning);
+            SiteAlerts.Add($"Removed {row.UserName} as Club Admin for {clubName}.", Severity.Warning);
             await LoadAsync();
         }
-        catch (Exception ex) { Snackbar.Add(ex.Message, Severity.Error); }
+        catch (Exception ex) { SiteAlerts.Add(ex.Message, Severity.Error); }
     }
 }

--- a/DropShot.UI/Components/Pages/ClubAdmin/ClubLinkRequests.razor
+++ b/DropShot.UI/Components/Pages/ClubAdmin/ClubLinkRequests.razor
@@ -1,6 +1,6 @@
 @inject IClubService ClubService
 @inject ICurrentUser CurrentUser
-@inject ISnackbar Snackbar
+@inject ISiteAlertService SiteAlerts
 
 @* Routing + auth + MudProviders supplied by host shims. *@
 
@@ -67,11 +67,11 @@ else
             await ClubService.ApproveLinkRequestAsync(request.ClubLinkRequestId);
             _requests.Remove(request);
             var who = string.IsNullOrEmpty(request.UserDisplayName) ? request.UserName : request.UserDisplayName;
-            Snackbar.Add($"Approved {who} → {request.ClubName}.", Severity.Success);
+            SiteAlerts.Add($"Approved {who} → {request.ClubName}.", Severity.Success);
         }
         catch (Exception ex)
         {
-            Snackbar.Add(ex.Message, Severity.Error);
+            SiteAlerts.Add(ex.Message, Severity.Error);
         }
     }
 
@@ -82,11 +82,11 @@ else
             await ClubService.RejectLinkRequestAsync(request.ClubLinkRequestId);
             _requests.Remove(request);
             var who = string.IsNullOrEmpty(request.UserDisplayName) ? request.UserName : request.UserDisplayName;
-            Snackbar.Add($"Rejected {who}.", Severity.Warning);
+            SiteAlerts.Add($"Rejected {who}.", Severity.Warning);
         }
         catch (Exception ex)
         {
-            Snackbar.Add(ex.Message, Severity.Error);
+            SiteAlerts.Add(ex.Message, Severity.Error);
         }
     }
 }

--- a/DropShot.UI/Components/Pages/ClubPlayers.razor
+++ b/DropShot.UI/Components/Pages/ClubPlayers.razor
@@ -1,7 +1,7 @@
 @inject IPlayerService PlayerService
 @inject IClubService ClubService
 @inject ICurrentUser CurrentUser
-@inject ISnackbar Snackbar
+@inject ISiteAlertService SiteAlerts
 
 @* Routing + auth + MudProviders supplied by host shims. The page used
    to wrap content in its own background-image + dark overlay layer
@@ -324,7 +324,7 @@ else
                 new UpdateLightPlayerRequest(
                     _form.DisplayName.Trim(), _form.FirstName, _form.LastName,
                     _form.Email, _form.MobileNumber, dob, _form.CompetitionCategory));
-            Snackbar.Add("Player updated.", Severity.Success);
+            SiteAlerts.Add("Player updated.", Severity.Success);
         }
         else
         {
@@ -332,7 +332,7 @@ else
                 new CreateLightPlayerRequest(
                     _form.DisplayName.Trim(), _form.FirstName, _form.LastName,
                     _form.Email, _form.MobileNumber, dob, _form.CompetitionCategory));
-            Snackbar.Add("Player added to club.", Severity.Success);
+            SiteAlerts.Add("Player added to club.", Severity.Success);
         }
 
         _showPlayerDialog = false;
@@ -361,7 +361,7 @@ else
     {
         if (_activeClubId is null) return;
         await PlayerService.LinkExistingPlayerToClubAsync(_activeClubId.Value, p.PlayerId);
-        Snackbar.Add($"{p.DisplayName} added to club.", Severity.Success);
+        SiteAlerts.Add($"{p.DisplayName} added to club.", Severity.Success);
         _showAddExistingDialog = false;
         await LoadPlayers();
     }
@@ -370,7 +370,7 @@ else
     {
         if (_activeClubId is null) return;
         await PlayerService.RemovePlayerFromClubAsync(_activeClubId.Value, row.PlayerId);
-        Snackbar.Add("Player removed from club.", Severity.Info);
+        SiteAlerts.Add("Player removed from club.", Severity.Info);
         await LoadPlayers();
     }
 }

--- a/DropShot.UI/Components/Pages/Clubs.razor
+++ b/DropShot.UI/Components/Pages/Clubs.razor
@@ -1,6 +1,6 @@
 @inject IClubService ClubService
 @inject ICurrentUser CurrentUser
-@inject ISnackbar Snackbar
+@inject ISiteAlertService SiteAlerts
 @inject IDialogService DialogService
 
 @* Routing + auth + MudProviders supplied by host shims. The 14 admin-template /
@@ -318,7 +318,7 @@
     {
         if (!CurrentUser.IsAuthenticated)
         {
-            Snackbar.Add("You must be signed in to request a link.", Severity.Warning);
+            SiteAlerts.Add("You must be signed in to request a link.", Severity.Warning);
             return;
         }
 
@@ -333,7 +333,7 @@
 
         await ClubService.RequestClubLinkAsync(club.ClubId);
         _pendingLinkClubIds.Add(club.ClubId);
-        Snackbar.Add($"Request sent to {club.Name}.", Severity.Success);
+        SiteAlerts.Add($"Request sent to {club.Name}.", Severity.Success);
     }
 
     private async Task CancelRequest(ClubDto club)
@@ -347,7 +347,7 @@
 
         await ClubService.CancelMyClubLinkRequestAsync(club.ClubId);
         _pendingLinkClubIds.Remove(club.ClubId);
-        Snackbar.Add($"Request to {club.Name} cancelled.", Severity.Success);
+        SiteAlerts.Add($"Request to {club.Name} cancelled.", Severity.Success);
     }
 
     private void OpenAddDialog()
@@ -390,12 +390,12 @@
         if (_editingClubId is null)
         {
             await ClubService.CreateClubAsync(req);
-            Snackbar.Add("Club added.", Severity.Success);
+            SiteAlerts.Add("Club added.", Severity.Success);
         }
         else
         {
             await ClubService.UpdateClubAsync(_editingClubId.Value, req);
-            Snackbar.Add("Club updated.", Severity.Success);
+            SiteAlerts.Add("Club updated.", Severity.Success);
         }
 
         _showClubDialog = false;
@@ -405,7 +405,7 @@
     private async Task DeleteClub(ClubDto club)
     {
         await ClubService.DeleteClubAsync(club.ClubId);
-        Snackbar.Add("Club deleted.", Severity.Warning);
+        SiteAlerts.Add("Club deleted.", Severity.Warning);
         await LoadClubs();
     }
 
@@ -426,7 +426,7 @@
             new AddCourtRequest(_courtForm.Name.Trim(), _courtForm.Surface, _courtForm.IsIndoor));
         _courtForm = new CourtForm();
         await ReloadCourts();
-        Snackbar.Add("Court added.", Severity.Success);
+        SiteAlerts.Add("Court added.", Severity.Success);
     }
 
     private void StartEditCourt(CourtDto court)
@@ -447,7 +447,7 @@
             new UpdateCourtRequest(_courtEditForm.Name.Trim(), _courtEditForm.Surface, _courtEditForm.IsIndoor));
         _editingCourtId = null;
         await ReloadCourts();
-        Snackbar.Add("Court updated.", Severity.Success);
+        SiteAlerts.Add("Court updated.", Severity.Success);
     }
 
     private async Task DeleteCourt(CourtDto court)
@@ -455,7 +455,7 @@
         if (_courtsClub is null) return;
         await ClubService.DeleteCourtAsync(_courtsClub.ClubId, court.CourtId);
         await ReloadCourts();
-        Snackbar.Add("Court deleted.", Severity.Info);
+        SiteAlerts.Add("Court deleted.", Severity.Info);
     }
 
     private async Task ReloadCourts()

--- a/DropShot.UI/Components/Pages/CompetitionPage.razor
+++ b/DropShot.UI/Components/Pages/CompetitionPage.razor
@@ -12,7 +12,7 @@
 @inject IRulesSetService RulesSetService
 @inject ICurrentUser CurrentUser
 @inject NavigationManager Nav
-@inject ISnackbar Snackbar
+@inject ISiteAlertService SiteAlerts
 @inject AuthenticationStateProvider AuthStateProvider
 @inject IDialogService DialogService
 @inject IJSRuntime JS
@@ -2060,7 +2060,7 @@ else
                 _templateWindowsApplied = false;
             }
 
-            Snackbar.Add("Competition saved.", Severity.Success);
+            SiteAlerts.Add("Competition saved.", Severity.Success);
         }
         catch (InvalidOperationException ex) { _serverError = ex.Message; }
         catch (Exception ex) { _serverError = ex.Message; }
@@ -2077,7 +2077,7 @@ else
     private async Task ToggleStartedAsync()
     {
         _isStarted = await Admin.ToggleStartedAsync(Id);
-        Snackbar.Add(_isStarted ? "Competition started." : "Competition stopped.", Severity.Success);
+        SiteAlerts.Add(_isStarted ? "Competition started." : "Competition stopped.", Severity.Success);
     }
 
     // ── Add New Entity Helpers ─────────────────────────────────────────────
@@ -2091,7 +2091,7 @@ else
     private void SaveNewClub()
     {
         _showAddClubDialog = false;
-        Snackbar.Add("Adding clubs from this page is no longer supported — use Admin → Clubs.", Severity.Warning);
+        SiteAlerts.Add("Adding clubs from this page is no longer supported — use Admin → Clubs.", Severity.Warning);
     }
 
     private async Task OnHostClubChanged(int? clubId)
@@ -2148,7 +2148,7 @@ else
         // Defensive: + button is gated on HostClubId so this should always pass.
         if (Model.HostClubId is null)
         {
-            Snackbar.Add("Select a host club first — rules sets are club-scoped.", Severity.Warning);
+            SiteAlerts.Add("Select a host club first — rules sets are club-scoped.", Severity.Warning);
             return;
         }
 
@@ -2192,7 +2192,7 @@ else
     private void SaveNewEvent()
     {
         _showAddEventDialog = false;
-        Snackbar.Add("Adding events from this page is no longer supported — use Admin → Events.", Severity.Warning);
+        SiteAlerts.Add("Adding events from this page is no longer supported — use Admin → Events.", Severity.Warning);
     }
 
     private void AutoGenerateName()
@@ -2254,7 +2254,7 @@ else
         var available = GetAvailableStageTypes();
         if (available.Count == 0)
         {
-            Snackbar.Add("All stage types have been added.", Severity.Info);
+            SiteAlerts.Add("All stage types have been added.", Severity.Info);
             return;
         }
         _stageForm = new StageForm { StageType = available[0] };
@@ -2267,7 +2267,7 @@ else
         await ReloadAfterServerMutationAsync();
         _showStageDialog = false;
         var addedOrder = _stages.FirstOrDefault(s => s.StageType == _stageForm.StageType)?.StageOrder ?? 0;
-        Snackbar.Add("Stage added.", Severity.Success);
+        SiteAlerts.Add("Stage added.", Severity.Success);
         OfferFollowOnStages(_stageForm.StageType, addedOrder);
     }
 
@@ -2353,7 +2353,7 @@ else
         await Admin.ApplyStageFollowUpAsync(Id, new ApplyStageFollowUpRequest(stages.Select(s => s.Type).ToList()));
         await ReloadAfterServerMutationAsync();
         _showStageFollowUpDialog = false;
-        Snackbar.Add($"{stages.Count} stage(s) added.", Severity.Success);
+        SiteAlerts.Add($"{stages.Count} stage(s) added.", Severity.Success);
     }
 
     private async Task DeleteStage(CompetitionStageDto stage)
@@ -2362,7 +2362,7 @@ else
         // mutation surface is ApplyStageFollowUp (additive). Until that
         // changes, surface a snackbar — admin needs to delete via DB.
         await Task.CompletedTask;
-        Snackbar.Add($"Stage delete is not yet wired into the admin service.", Severity.Warning);
+        SiteAlerts.Add($"Stage delete is not yet wired into the admin service.", Severity.Warning);
     }
 
     // ── Participants ─────────────────────────────────────────────────────────
@@ -2431,7 +2431,7 @@ else
 
         await ReloadAfterServerMutationAsync();
         _showNewPlayerDialog = false;
-        Snackbar.Add("Player updated.", Severity.Success);
+        SiteAlerts.Add("Player updated.", Severity.Success);
     }
 
     private async Task CreateAndAddClubPlayer()
@@ -2450,7 +2450,7 @@ else
 
         await ReloadAfterServerMutationAsync();
         _showNewPlayerDialog = false;
-        Snackbar.Add($"{_newPlayerForm.DisplayName} added to club and competition.", Severity.Success);
+        SiteAlerts.Add($"{_newPlayerForm.DisplayName} added to club and competition.", Severity.Success);
     }
 
     private async Task AddParticipant(PlayerSearchResultDto? player)
@@ -2459,7 +2459,7 @@ else
 
         if (Model.MaxParticipants.HasValue && _participants.Count >= Model.MaxParticipants.Value)
         {
-            Snackbar.Add($"Maximum of {Model.MaxParticipants.Value} participants reached.", Severity.Warning);
+            SiteAlerts.Add($"Maximum of {Model.MaxParticipants.Value} participants reached.", Severity.Warning);
             if (_participantAutocomplete != null)
                 await _participantAutocomplete.ClearAsync();
             return;
@@ -2495,7 +2495,7 @@ else
             new UpdateParticipantStatusRequest(_addParticipantStatus));
 
         await ReloadAfterServerMutationAsync();
-        Snackbar.Add($"{player.DisplayName} added as {ParticipantStatusLabel(_addParticipantStatus)}.", Severity.Success);
+        SiteAlerts.Add($"{player.DisplayName} added as {ParticipantStatusLabel(_addParticipantStatus)}.", Severity.Success);
         if (_participantAutocomplete != null)
             await _participantAutocomplete.ClearAsync();
     }
@@ -2511,7 +2511,7 @@ else
     {
         await Admin.RemoveParticipantAsync(Id, cp.PlayerId);
         _participants.Remove(cp);
-        Snackbar.Add("Participant removed.", Severity.Warning);
+        SiteAlerts.Add("Participant removed.", Severity.Warning);
     }
 
     private async Task AssignTeam(CompetitionParticipantDto cp, int? teamId)
@@ -2552,7 +2552,7 @@ else
     {
         var assigned = await Admin.AutoAssignCaptainsAsync(Id);
         await ReloadAfterServerMutationAsync();
-        Snackbar.Add($"Assigned {assigned} captain(s).", Severity.Success);
+        SiteAlerts.Add($"Assigned {assigned} captain(s).", Severity.Success);
     }
 
     private async Task AssignParticipantDivision(CompetitionParticipantDto cp, int? divisionId)
@@ -2617,7 +2617,7 @@ else
         }
         catch (InvalidOperationException ex)
         {
-            Snackbar.Add(ex.Message, Severity.Error);
+            SiteAlerts.Add(ex.Message, Severity.Error);
             return;
         }
 
@@ -2657,7 +2657,7 @@ else
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"Failed to clone competition: {ex.Message}", Severity.Error);
+            SiteAlerts.Add($"Failed to clone competition: {ex.Message}", Severity.Error);
         }
         finally
         {
@@ -2697,12 +2697,12 @@ else
             await ReloadAfterServerMutationAsync();
             Model.HasDivisions = true;
             Model.SeededFromCompetitionId = _seedSourceCompetitionId.Value;
-            Snackbar.Add($"Divisions seeded.", Severity.Success);
+            SiteAlerts.Add($"Divisions seeded.", Severity.Success);
             _showSeedDivisionsDialog = false;
         }
         catch (InvalidOperationException ex)
         {
-            Snackbar.Add(ex.Message, Severity.Error);
+            SiteAlerts.Add(ex.Message, Severity.Error);
         }
         finally
         {
@@ -2714,9 +2714,9 @@ else
     {
         var result = await Admin.ValidateTeamAsync(Id, team.CompetitionTeamId);
         if (result.Errors.Count == 0 && result.Warnings.Count == 0)
-            Snackbar.Add($"{team.Name}: Valid", Severity.Success);
+            SiteAlerts.Add($"{team.Name}: Valid", Severity.Success);
         else
-            Snackbar.Add($"{team.Name}: {string.Join("; ", result.Errors.Concat(result.Warnings))}", Severity.Warning);
+            SiteAlerts.Add($"{team.Name}: {string.Join("; ", result.Errors.Concat(result.Warnings))}", Severity.Warning);
     }
 
     // ── Teams ────────────────────────────────────────────────────────────────
@@ -2740,7 +2740,7 @@ else
         if (string.IsNullOrWhiteSpace(_teamName)) return;
         await Admin.SaveTeamAsync(Id, _editingTeam?.CompetitionTeamId, new SaveTeamRequest(_teamName.Trim()));
         await ReloadAfterServerMutationAsync();
-        Snackbar.Add(_editingTeam == null ? "Team added." : "Team updated.", Severity.Success);
+        SiteAlerts.Add(_editingTeam == null ? "Team added." : "Team updated.", Severity.Success);
         _showTeamDialog = false;
     }
 
@@ -2748,7 +2748,7 @@ else
     {
         await Admin.DeleteTeamAsync(Id, team.CompetitionTeamId);
         await ReloadAfterServerMutationAsync();
-        Snackbar.Add("Team removed.", Severity.Warning);
+        SiteAlerts.Add("Team removed.", Severity.Warning);
     }
 
     private async Task DeleteAllTeams()
@@ -2758,7 +2758,7 @@ else
         var removed = _teams.Count;
         await Admin.DeleteAllTeamsAsync(Id);
         await ReloadAfterServerMutationAsync();
-        Snackbar.Add($"Deleted {removed} team(s).", Severity.Warning);
+        SiteAlerts.Add($"Deleted {removed} team(s).", Severity.Warning);
     }
 
     private bool IsDoublesFormat() =>
@@ -2833,7 +2833,7 @@ else
             await ReloadAfterServerMutationAsync();
             _showGenerateDialog = false;
             var label = EffectivePersistedFormat() is CompetitionFormat.Doubles or CompetitionFormat.MixedDoubles ? "pairings" : "teams";
-            Snackbar.Add($"{_generatedPreview.Count} {label} created.", Severity.Success);
+            SiteAlerts.Add($"{_generatedPreview.Count} {label} created.", Severity.Success);
         }
         finally
         {
@@ -2880,7 +2880,7 @@ else
             .Where(id => id.HasValue).Select(id => id!.Value).ToHashSet();
         if (side1.Overlaps(side2))
         {
-            Snackbar.Add("A player cannot appear on both sides of a fixture.", Severity.Error);
+            SiteAlerts.Add("A player cannot appear on both sides of a fixture.", Severity.Error);
             return;
         }
 
@@ -2904,7 +2904,7 @@ else
 
         await Admin.SaveFixtureAsync(Id, _editingFixture?.CompetitionFixtureId, saveRequest);
         await ReloadAfterServerMutationAsync();
-        Snackbar.Add(_editingFixture == null ? "Fixture added." : "Fixture updated.", Severity.Success);
+        SiteAlerts.Add(_editingFixture == null ? "Fixture added." : "Fixture updated.", Severity.Success);
         _showFixtureDialog = false;
     }
 
@@ -2992,7 +2992,7 @@ else
     private async Task CopyQrUrl()
     {
         await JS.InvokeVoidAsync("copyToClipboard", _qrUrl);
-        Snackbar.Add("Link copied to clipboard.", Severity.Success);
+        SiteAlerts.Add("Link copied to clipboard.", Severity.Success);
     }
 
     // ── Fixture helpers used by the per-division Fixtures table ──────────
@@ -3056,11 +3056,11 @@ else
             }
             catch (InvalidOperationException ex)
             {
-                Snackbar.Add(ex.Message, Severity.Error);
+                SiteAlerts.Add(ex.Message, Severity.Error);
                 return;
             }
             await ReloadAfterServerMutationAsync();
-            Snackbar.Add("Result deleted. Match returned to upcoming.", Severity.Success);
+            SiteAlerts.Add("Result deleted. Match returned to upcoming.", Severity.Success);
         }
         else
         {
@@ -3072,7 +3072,7 @@ else
 
             await Admin.DeleteFixtureAsync(Id, fixture.CompetitionFixtureId);
             _fixtures.Remove(fixture);
-            Snackbar.Add("Fixture removed.", Severity.Warning);
+            SiteAlerts.Add("Fixture removed.", Severity.Warning);
         }
     }
 
@@ -3082,7 +3082,7 @@ else
         var count = _fixtures.Count;
         await Admin.DeleteAllFixturesAsync(Id);
         _fixtures.Clear();
-        Snackbar.Add($"{count} fixture(s) deleted.", Severity.Warning);
+        SiteAlerts.Add($"{count} fixture(s) deleted.", Severity.Warning);
     }
 
     private async Task SimulateRoundRobinAsync()
@@ -3094,15 +3094,15 @@ else
         {
             var result = await Admin.SimulateRoundRobinAsync(Id);
             if (result.FixturesUpdated > 0)
-                Snackbar.Add($"Simulated {result.FixturesUpdated} round-robin fixture(s).", Severity.Success);
+                SiteAlerts.Add($"Simulated {result.FixturesUpdated} round-robin fixture(s).", Severity.Success);
             else
-                Snackbar.Add("No eligible round-robin fixtures to simulate.", Severity.Info);
+                SiteAlerts.Add("No eligible round-robin fixtures to simulate.", Severity.Info);
 
             await OnParametersSetAsync();
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"Simulation failed: {ex.Message}", Severity.Error);
+            SiteAlerts.Add($"Simulation failed: {ex.Message}", Severity.Error);
         }
         finally
         {
@@ -3125,7 +3125,7 @@ else
             catch (KeyNotFoundException)
             {
                 _editingMatchWindowId = null;
-                Snackbar.Add("That window no longer exists.", Severity.Warning);
+                SiteAlerts.Add("That window no longer exists.", Severity.Warning);
                 return;
             }
             await Admin.AddMatchWindowAsync(Id, new SaveMatchWindowRequest(
@@ -3136,7 +3136,7 @@ else
                 CompetitionDivisionId: null));
             await ReloadAfterServerMutationAsync();
             _editingMatchWindowId = null;
-            Snackbar.Add("Window updated.", Severity.Success);
+            SiteAlerts.Add("Window updated.", Severity.Success);
             return;
         }
 
@@ -3149,7 +3149,7 @@ else
         await ReloadAfterServerMutationAsync();
         // Intentionally do NOT clear the form — admins often add multiple similar
         // windows differing in only one field (different day, different court).
-        Snackbar.Add("Window added.", Severity.Success);
+        SiteAlerts.Add("Window added.", Severity.Success);
     }
 
     private void CopyMatchWindowToForm(CompetitionMatchWindowDto w)
@@ -3186,7 +3186,7 @@ else
         {
             form.EditingId = null;
         }
-        Snackbar.Add("Window removed.", Severity.Warning);
+        SiteAlerts.Add("Window removed.", Severity.Warning);
     }
 
     // ── Per-division match windows ──────────────────────────────────────────
@@ -3216,7 +3216,7 @@ else
             catch (KeyNotFoundException)
             {
                 form.EditingId = null;
-                Snackbar.Add("That window no longer exists.", Severity.Warning);
+                SiteAlerts.Add("That window no longer exists.", Severity.Warning);
                 return;
             }
         }
@@ -3229,7 +3229,7 @@ else
             CompetitionDivisionId: divisionId));
         await ReloadAfterServerMutationAsync();
         form.EditingId = null;
-        Snackbar.Add(form.EditingId.HasValue ? "Window updated." : "Division window added.", Severity.Success);
+        SiteAlerts.Add(form.EditingId.HasValue ? "Window updated." : "Division window added.", Severity.Success);
     }
 
     private void CopyDivisionMatchWindowToForm(CompetitionMatchWindowDto w)
@@ -3269,9 +3269,9 @@ else
         _selectedTemplateId = null;
         await ReloadAfterServerMutationAsync();
         if (imported == 0)
-            Snackbar.Add("All windows from that template are already present.", Severity.Info);
+            SiteAlerts.Add("All windows from that template are already present.", Severity.Info);
         else
-            Snackbar.Add($"Imported {imported} window(s) from template.", Severity.Success);
+            SiteAlerts.Add($"Imported {imported} window(s) from template.", Severity.Success);
     }
 
     // ── Competition Templates ────────────────────────────────────────────────
@@ -3310,11 +3310,11 @@ else
                 StartTime: w.StartTime,
                 EndTime: w.EndTime)).ToList();
             _templateWindowsApplied = true;
-            Snackbar.Add($"Template '{t.Name}' applied. Save to persist.", Severity.Info);
+            SiteAlerts.Add($"Template '{t.Name}' applied. Save to persist.", Severity.Info);
         }
         else
         {
-            Snackbar.Add($"Template '{t.Name}' applied.", Severity.Success);
+            SiteAlerts.Add($"Template '{t.Name}' applied.", Severity.Success);
         }
     }
 
@@ -3334,7 +3334,7 @@ else
     {
         await Admin.ApplyRubberPresetAsync(Id, new ApplyRubberPresetRequest(string.IsNullOrWhiteSpace(key) ? null : key));
         await ReloadRubberTemplateAsync();
-        Snackbar.Add("Rubber preset applied.", Severity.Success);
+        SiteAlerts.Add("Rubber preset applied.", Severity.Success);
     }
 
     private async Task ConvertToCustomTemplate()
@@ -3342,7 +3342,7 @@ else
         if (_rubberTemplateDefs.Count == 0) return;
         await Admin.ConvertToCustomTemplateAsync(Id);
         await ReloadRubberTemplateAsync();
-        Snackbar.Add("Template snapshot saved. You can now edit it.", Severity.Success);
+        SiteAlerts.Add("Template snapshot saved. You can now edit it.", Severity.Success);
     }
 
     private async Task AddCustomRubberRow()
@@ -3390,7 +3390,7 @@ else
     {
         await Admin.RevertToDefaultTemplateAsync(Id);
         await ReloadRubberTemplateAsync();
-        Snackbar.Add("Reverted to default rubber template.", Severity.Info);
+        SiteAlerts.Add("Reverted to default rubber template.", Severity.Info);
     }
 
     private static List<string> ParseRoles(string csv) =>
@@ -3417,19 +3417,19 @@ else
         {
             await Admin.AddCompetitionAdminAsync(Id, new AddCompetitionAdminRequest(_newAdminEmail.Trim()));
         }
-        catch (KeyNotFoundException) { Snackbar.Add("No user found with that email.", Severity.Warning); return; }
-        catch (InvalidOperationException) { Snackbar.Add("Already an admin.", Severity.Info); return; }
+        catch (KeyNotFoundException) { SiteAlerts.Add("No user found with that email.", Severity.Warning); return; }
+        catch (InvalidOperationException) { SiteAlerts.Add("Already an admin.", Severity.Info); return; }
 
         _newAdminEmail = "";
         _competitionAdmins = (await Admin.GetCompetitionAdminsAsync(Id)).ToList();
-        Snackbar.Add("Admin added.", Severity.Success);
+        SiteAlerts.Add("Admin added.", Severity.Success);
     }
 
     private async Task RemoveCompetitionAdmin(CompetitionAdminRowDto row)
     {
         await Admin.RemoveCompetitionAdminAsync(Id, row.UserId);
         _competitionAdmins.RemoveAll(a => a.UserId == row.UserId);
-        Snackbar.Add("Admin removed.", Severity.Warning);
+        SiteAlerts.Add("Admin removed.", Severity.Warning);
     }
 
     // ── Send Email ───────────────────────────────────────────────────────────
@@ -3459,7 +3459,7 @@ else
             FixtureId: _emailFixtureId.Value,
             Subject: _emailSubject,
             Body: _emailBody));
-        Snackbar.Add("Emails sent to fixture players.", Severity.Success);
+        SiteAlerts.Add("Emails sent to fixture players.", Severity.Success);
     }
 
     private async Task SendCompetitionEmail()
@@ -3468,7 +3468,7 @@ else
         await Admin.SendCompetitionEmailAsync(Id, new SendCompetitionEmailRequest(
             Subject: _compEmailSubject,
             Body: _compEmailBody));
-        Snackbar.Add($"Emails sent to participants.", Severity.Success);
+        SiteAlerts.Add($"Emails sent to participants.", Severity.Success);
     }
 
     private void OpenScheduleConfirm()
@@ -3486,22 +3486,22 @@ else
         await ReloadAfterServerMutationAsync();
 
         if (result.FixturesSkipped > 0)
-            Snackbar.Add($"{result.FixturesScheduled} fixtures scheduled. {result.FixturesSkipped} could not be scheduled — not enough available slots in the match windows.", Severity.Warning);
+            SiteAlerts.Add($"{result.FixturesScheduled} fixtures scheduled. {result.FixturesSkipped} could not be scheduled — not enough available slots in the match windows.", Severity.Warning);
         else
-            Snackbar.Add($"{result.FixturesScheduled} fixtures scheduled.", Severity.Success);
+            SiteAlerts.Add($"{result.FixturesScheduled} fixtures scheduled.", Severity.Success);
 
         // Headline summary first when nothing got scheduled — gives the user
         // immediate context for the per-participant warnings that follow.
         if (result.FixturesScheduled == 0 && result.Warnings.Count > 0)
         {
-            Snackbar.Add(
+            SiteAlerts.Add(
                 $"No fixtures scheduled — {result.Warnings.Count} participant(s) skipped because they are not Full Players. See per-player warnings below.",
                 Severity.Warning,
-                c => c.VisibleStateDuration = 20000);
+                autoDismissAfter: TimeSpan.FromSeconds(20));
         }
 
         foreach (var w in result.Warnings)
-            Snackbar.Add(w, Severity.Warning, c => c.VisibleStateDuration = 12000);
+            SiteAlerts.Add(w, Severity.Warning, autoDismissAfter: TimeSpan.FromSeconds(12));
     }
 
     private async Task SeedKnockoutFromStandingsAsync()
@@ -3511,11 +3511,11 @@ else
         await ReloadAfterServerMutationAsync();
         if (result.FixturesSeeded == 0 && result.Warnings.Count > 0)
         {
-            foreach (var w in result.Warnings) Snackbar.Add(w, Severity.Warning);
+            foreach (var w in result.Warnings) SiteAlerts.Add(w, Severity.Warning);
         }
         else
         {
-            Snackbar.Add($"Quarter-final fixtures seeded from standings.", Severity.Success);
+            SiteAlerts.Add($"Quarter-final fixtures seeded from standings.", Severity.Success);
         }
     }
 

--- a/DropShot.UI/Components/Pages/Competitions.razor
+++ b/DropShot.UI/Components/Pages/Competitions.razor
@@ -8,7 +8,7 @@
 @inject IClubService ClubService
 @inject ICurrentUser CurrentUser
 @inject IDialogService DialogService
-@inject ISnackbar Snackbar
+@inject ISiteAlertService SiteAlerts
 @inject PersistentComponentState AppState
 
 @if (_isUserView)
@@ -643,11 +643,11 @@ else
         }
         catch (InvalidOperationException ex)
         {
-            Snackbar.Add(ex.Message, Severity.Warning);
+            SiteAlerts.Add(ex.Message, Severity.Warning);
             return;
         }
 
-        Snackbar.Add($"Entered '{comp.CompetitionName}'.", Severity.Success);
+        SiteAlerts.Add($"Entered '{comp.CompetitionName}'.", Severity.Success);
 
         _availableComps.RemoveAll(c => c.CompetitionId == comp.CompetitionId);
         _myEnteredComps.Add(comp);
@@ -686,12 +686,12 @@ else
         }
         catch (Exception)
         {
-            Snackbar.Add("Failed to approve. Please try again.", Severity.Error);
+            SiteAlerts.Add("Failed to approve. Please try again.", Severity.Error);
             return;
         }
 
         _pendingFixtures.Remove(fixture);
-        Snackbar.Add("Result approved.", Severity.Success);
+        SiteAlerts.Add("Result approved.", Severity.Success);
     }
 
     private async Task OpenReviewDialogAsync(CompetitionFixtureDto fixture)
@@ -714,7 +714,7 @@ else
         if (result is not null && !result.Canceled)
         {
             _pendingFixtures.Remove(fixture);
-            Snackbar.Add("Result verified.", Severity.Success);
+            SiteAlerts.Add("Result verified.", Severity.Success);
         }
     }
 
@@ -738,7 +738,7 @@ else
         }
         catch (Exception)
         {
-            Snackbar.Add("Failed to create the event. Please try again.", Severity.Error);
+            SiteAlerts.Add("Failed to create the event. Please try again.", Severity.Error);
             return;
         }
 
@@ -754,7 +754,7 @@ else
         }
         catch (Exception)
         {
-            Snackbar.Add("Event created, but adding the competitions failed.", Severity.Warning);
+            SiteAlerts.Add("Event created, but adding the competitions failed.", Severity.Warning);
             return;
         }
 
@@ -764,7 +764,7 @@ else
         }
         _events.Add(new EventGroup { Event = ev, Competitions = created });
 
-        Snackbar.Add($"Event '{ev.Name}' created with {created.Count} competition(s).", Severity.Success);
+        SiteAlerts.Add($"Event '{ev.Name}' created with {created.Count} competition(s).", Severity.Success);
         _activeTab = 1;
     }
 
@@ -776,7 +776,7 @@ else
         }
         catch (Exception)
         {
-            Snackbar.Add("Failed to update. Please try again.", Severity.Error);
+            SiteAlerts.Add("Failed to update. Please try again.", Severity.Error);
             return;
         }
 
@@ -784,7 +784,7 @@ else
         var updated = comp with { IsArchived = !comp.IsArchived };
         ReplaceCompetition(comp, updated);
 
-        Snackbar.Add(updated.IsArchived
+        SiteAlerts.Add(updated.IsArchived
             ? $"'{updated.CompetitionName}' archived."
             : $"'{updated.CompetitionName}' restored.", Severity.Success);
     }
@@ -818,7 +818,7 @@ else
         }
         catch (Exception)
         {
-            Snackbar.Add("Failed to delete. Please try again.", Severity.Error);
+            SiteAlerts.Add("Failed to delete. Please try again.", Severity.Error);
             return;
         }
 
@@ -827,6 +827,6 @@ else
             ev.Competitions.RemoveAll(c => c.CompetitionId == comp.CompetitionId);
         _ungroupedCompetitions.Remove(comp);
 
-        Snackbar.Add($"'{comp.CompetitionName}' deleted.", Severity.Success);
+        SiteAlerts.Add($"'{comp.CompetitionName}' deleted.", Severity.Success);
     }
 }

--- a/DropShot.UI/Components/Pages/Home.razor
+++ b/DropShot.UI/Components/Pages/Home.razor
@@ -3,7 +3,7 @@
 @inject ICompetitionService CompetitionService
 @inject ICourtClaimService CourtClaim
 @inject IDialogService DialogService
-@inject ISnackbar Snackbar
+@inject ISiteAlertService SiteAlerts
 @inject NavigationManager Navigation
 @inject IJSRuntime JS
 
@@ -518,12 +518,12 @@
         }
         catch
         {
-            Snackbar.Add("Failed to approve. Please try again.", Severity.Error);
+            SiteAlerts.Add("Failed to approve. Please try again.", Severity.Error);
             return;
         }
 
         _pendingReviews.Remove(fixture);
-        Snackbar.Add("Result approved.", Severity.Success);
+        SiteAlerts.Add("Result approved.", Severity.Success);
     }
 
     private async Task OpenReviewDialogAsync(CompetitionFixtureDto fixture)
@@ -543,7 +543,7 @@
         if (result is not null && !result.Canceled)
         {
             _pendingReviews.Remove(fixture);
-            Snackbar.Add("Result verified.", Severity.Success);
+            SiteAlerts.Add("Result verified.", Severity.Success);
         }
     }
 }

--- a/DropShot.UI/Components/Pages/MyPlayers.razor
+++ b/DropShot.UI/Components/Pages/MyPlayers.razor
@@ -1,7 +1,7 @@
 @inject IPlayerService PlayerService
 @inject IInvitationService InvitationService
 @inject ICurrentUser CurrentUser
-@inject ISnackbar Snackbar
+@inject ISiteAlertService SiteAlerts
 @inject IDialogService DialogService
 @inject IJSRuntime JS
 
@@ -369,7 +369,7 @@
                     new UpdateMyLightPlayerRequest(
                         _form.DisplayName.Trim(), _form.FirstName, _form.LastName,
                         _form.Email, _form.MobileNumber, _form.CompetitionCategory));
-                Snackbar.Add("Player updated.", Severity.Success);
+                SiteAlerts.Add("Player updated.", Severity.Success);
             }
             else
             {
@@ -377,12 +377,12 @@
                     new CreateMyLightPlayerRequest(
                         _form.DisplayName.Trim(), _form.FirstName, _form.LastName,
                         _form.Email, _form.MobileNumber, _form.CompetitionCategory));
-                Snackbar.Add("Player added.", Severity.Success);
+                SiteAlerts.Add("Player added.", Severity.Success);
             }
         }
         catch (Exception ex)
         {
-            Snackbar.Add(ex.Message, Severity.Error);
+            SiteAlerts.Add(ex.Message, Severity.Error);
             return;
         }
 
@@ -402,12 +402,12 @@
         try
         {
             await PlayerService.DeleteMyLightPlayerAsync(player.PlayerId);
-            Snackbar.Add("Player deleted.", Severity.Warning);
+            SiteAlerts.Add("Player deleted.", Severity.Warning);
             await LoadPlayers();
         }
         catch (Exception ex)
         {
-            Snackbar.Add(ex.Message, Severity.Warning);
+            SiteAlerts.Add(ex.Message, Severity.Warning);
         }
     }
 
@@ -453,11 +453,11 @@
         try
         {
             await PlayerService.LinkLightToVerifiedAsync(_linkingPlayer.PlayerId, _selectedLinkPlayer.PlayerId);
-            Snackbar.Add($"Linked to \"{_selectedLinkPlayer.DisplayName}\". Match history transferred.", Severity.Success);
+            SiteAlerts.Add($"Linked to \"{_selectedLinkPlayer.DisplayName}\". Match history transferred.", Severity.Success);
         }
         catch (Exception ex)
         {
-            Snackbar.Add(ex.Message, Severity.Error);
+            SiteAlerts.Add(ex.Message, Severity.Error);
             return;
         }
 
@@ -479,11 +479,11 @@
         try
         {
             await PlayerService.LinkLightToVerifiedAsync(_editingPlayerId.Value, verified.PlayerId);
-            Snackbar.Add($"Linked to \"{verified.DisplayName}\". Match history transferred.", Severity.Success);
+            SiteAlerts.Add($"Linked to \"{verified.DisplayName}\". Match history transferred.", Severity.Success);
         }
         catch (Exception ex)
         {
-            Snackbar.Add(ex.Message, Severity.Error);
+            SiteAlerts.Add(ex.Message, Severity.Error);
             return;
         }
 
@@ -506,7 +506,7 @@
         }
         catch (Exception ex)
         {
-            Snackbar.Add(ex.Message, Severity.Error);
+            SiteAlerts.Add(ex.Message, Severity.Error);
         }
     }
 
@@ -516,11 +516,11 @@
         try
         {
             await JS.InvokeVoidAsync("navigator.clipboard.writeText", _inviteLink);
-            Snackbar.Add("Invite link copied to clipboard.", Severity.Success);
+            SiteAlerts.Add("Invite link copied to clipboard.", Severity.Success);
         }
         catch
         {
-            Snackbar.Add("Couldn't copy automatically — please copy the link manually.", Severity.Warning);
+            SiteAlerts.Add("Couldn't copy automatically — please copy the link manually.", Severity.Warning);
         }
     }
 
@@ -532,12 +532,12 @@
         try
         {
             await InvitationService.SendInvitationEmailAsync(_inviteToken, _inviteEmail.Trim());
-            Snackbar.Add($"Invite sent to {_inviteEmail.Trim()}.", Severity.Success);
+            SiteAlerts.Add($"Invite sent to {_inviteEmail.Trim()}.", Severity.Success);
             _showInviteDialog = false;
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"Failed to send email: {ex.Message}", Severity.Error);
+            SiteAlerts.Add($"Failed to send email: {ex.Message}", Severity.Error);
         }
         finally
         {

--- a/DropShot.UI/Components/Pages/Players.razor
+++ b/DropShot.UI/Components/Pages/Players.razor
@@ -1,5 +1,5 @@
 @inject IPlayerService PlayerService
-@inject ISnackbar Snackbar
+@inject ISiteAlertService SiteAlerts
 
 @* Routing + auth + MudProviders supplied by host shims (web:
    DropShot/Components/Pages/Players.razor; MAUI:
@@ -259,7 +259,7 @@
             IsLight: true));
 
         _showAddDialog = false;
-        Snackbar.Add("Player added.", Severity.Success);
+        SiteAlerts.Add("Player added.", Severity.Success);
         await LoadPlayers();
     }
 
@@ -291,14 +291,14 @@
             _form.ContactPreferences, _form.MobileNumber));
 
         _showEditDialog = false;
-        Snackbar.Add("Player updated.", Severity.Success);
+        SiteAlerts.Add("Player updated.", Severity.Success);
         await LoadPlayers();
     }
 
     private async Task DeletePlayer(PlayerWithClubsDto player)
     {
         await PlayerService.DeletePlayerAsync(player.PlayerId);
-        Snackbar.Add("Player deleted.", Severity.Warning);
+        SiteAlerts.Add("Player deleted.", Severity.Warning);
         await LoadPlayers();
     }
 
@@ -315,7 +315,7 @@
         if (_linkingPlayer is null) return;
         await PlayerService.LinkPlayerAccountAsync(_linkingPlayer.PlayerId, _selectedUserId);
         _showLinkDialog = false;
-        Snackbar.Add("Account link updated.", Severity.Success);
+        SiteAlerts.Add("Account link updated.", Severity.Success);
         await LoadPlayers();
     }
 }

--- a/DropShot.UI/Components/Pages/RulesSetCreateDialog.razor
+++ b/DropShot.UI/Components/Pages/RulesSetCreateDialog.razor
@@ -2,7 +2,7 @@
 @using DropShot.UI.Services
 @using Microsoft.AspNetCore.Components.Web
 @inject IRulesSetService RulesSets
-@inject ISnackbar Snackbar
+@inject ISiteAlertService SiteAlerts
 @inject Microsoft.Extensions.Logging.ILogger<RulesSetCreateDialog> Logger
 
 @*
@@ -120,7 +120,7 @@
                     ClubId));
             if (saved is null)
             {
-                Snackbar.Add("Could not create rules set.", Severity.Error);
+                SiteAlerts.Add("Could not create rules set.", Severity.Error);
                 return;
             }
 
@@ -138,11 +138,11 @@
                 {
                     Logger.LogError(itemEx, "Failed to add rule '{RuleText}' to set {RulesSetId}.",
                         ruleText, saved.RulesSetId);
-                    Snackbar.Add($"Saved set but rule \"{ruleText}\" could not be added.", Severity.Warning);
+                    SiteAlerts.Add($"Saved set but rule \"{ruleText}\" could not be added.", Severity.Warning);
                 }
             }
 
-            Snackbar.Add(
+            SiteAlerts.Add(
                 $"Rules set \"{saved.Name}\" saved with {_items.Count} rule(s).",
                 Severity.Success);
 
@@ -152,7 +152,7 @@
         catch (Exception ex)
         {
             Logger.LogError(ex, "Failed to create rules set.");
-            Snackbar.Add("Could not create rules set.", Severity.Error);
+            SiteAlerts.Add("Could not create rules set.", Severity.Error);
         }
         finally
         {

--- a/DropShot.UI/Components/Pages/RulesSetItemsDialog.razor
+++ b/DropShot.UI/Components/Pages/RulesSetItemsDialog.razor
@@ -2,7 +2,7 @@
 @using DropShot.UI.Services
 @using Microsoft.AspNetCore.Components.Web
 @inject IRulesSetService RulesSets
-@inject ISnackbar Snackbar
+@inject ISiteAlertService SiteAlerts
 
 <MudDialog>
     <DialogContent>
@@ -97,7 +97,7 @@
         }
         catch (Exception ex)
         {
-            Snackbar.Add(ex.Message, Severity.Error);
+            SiteAlerts.Add(ex.Message, Severity.Error);
         }
         finally
         {
@@ -113,11 +113,11 @@
                 RulesSetId, new AddRulesSetItemRequest(_newRule.Trim()));
             _items.Add(added);
             _newRule = "";
-            Snackbar.Add("Rule added.", Severity.Success);
+            SiteAlerts.Add("Rule added.", Severity.Success);
         }
         catch (Exception ex)
         {
-            Snackbar.Add(ex.Message, Severity.Error);
+            SiteAlerts.Add(ex.Message, Severity.Error);
         }
     }
 
@@ -164,11 +164,11 @@
                 RulesSetId, item.RulesSetItemId, new AddRulesSetItemRequest(text));
             var idx = _items.FindIndex(i => i.RulesSetItemId == item.RulesSetItemId);
             if (idx >= 0) _items[idx] = updated;
-            Snackbar.Add("Rule updated.", Severity.Success);
+            SiteAlerts.Add("Rule updated.", Severity.Success);
         }
         catch (Exception ex)
         {
-            Snackbar.Add(ex.Message, Severity.Error);
+            SiteAlerts.Add(ex.Message, Severity.Error);
         }
         finally
         {
@@ -182,11 +182,11 @@
         {
             await RulesSets.DeleteRulesSetItemAsync(RulesSetId, item.RulesSetItemId);
             _items.Remove(item);
-            Snackbar.Add("Rule deleted.", Severity.Success);
+            SiteAlerts.Add("Rule deleted.", Severity.Success);
         }
         catch (Exception ex)
         {
-            Snackbar.Add(ex.Message, Severity.Error);
+            SiteAlerts.Add(ex.Message, Severity.Error);
         }
     }
 }

--- a/DropShot.UI/Components/Pages/RulesSets.razor
+++ b/DropShot.UI/Components/Pages/RulesSets.razor
@@ -4,7 +4,7 @@
 @inject IRulesSetService RulesSetService
 @inject IClubService ClubService
 @inject ICurrentUser CurrentUser
-@inject ISnackbar Snackbar
+@inject ISiteAlertService SiteAlerts
 @inject IDialogService Dialog
 
 @* Routing + auth + MudProviders supplied by host shims. *@
@@ -135,7 +135,7 @@ else
     {
         if (_selectedClubId is null)
         {
-            Snackbar.Add("Pick a club first — rules sets are club-scoped.", Severity.Warning);
+            SiteAlerts.Add("Pick a club first — rules sets are club-scoped.", Severity.Warning);
             return;
         }
         // Use the shared RulesSetCreateDialog (also driven by CompetitionPage's
@@ -186,11 +186,11 @@ else
                     if (idx >= 0) _rulesSets![idx] = dto;
                 }
             }
-            Snackbar.Add(id == 0 ? "Rules set created." : "Rules set updated.", Severity.Success);
+            SiteAlerts.Add(id == 0 ? "Rules set created." : "Rules set updated.", Severity.Success);
         }
         catch (Exception ex)
         {
-            Snackbar.Add(ex.Message, Severity.Error);
+            SiteAlerts.Add(ex.Message, Severity.Error);
         }
     }
 
@@ -218,11 +218,11 @@ else
         {
             await RulesSetService.DeleteRulesSetAsync(rs.RulesSetId);
             _rulesSets?.Remove(rs);
-            Snackbar.Add("Rules set deleted.", Severity.Success);
+            SiteAlerts.Add("Rules set deleted.", Severity.Success);
         }
         catch (Exception ex)
         {
-            Snackbar.Add(ex.Message, Severity.Error);
+            SiteAlerts.Add(ex.Message, Severity.Error);
         }
     }
 }

--- a/DropShot.UI/Components/Pages/TennisScore.razor
+++ b/DropShot.UI/Components/Pages/TennisScore.razor
@@ -24,7 +24,7 @@
 @inject ICompetitionService Competitions
 @inject IScoreboardHubFactory ScoreboardHubFactory
 @inject ICurrentUser CurrentUser
-@inject ISnackbar Snackbar
+@inject ISiteAlertService SiteAlerts
 @inject IJSRuntime JS
 
 @* FixtureId is passed as a query param when starting a match from a competition fixture *@
@@ -427,7 +427,7 @@
         if (_currentUserId != null)
         {
             await Scoring.SavePreferredGameScoringAsync(_state.GameScoring);
-            Snackbar.Add("Scoring preference saved.", Severity.Success);
+            SiteAlerts.Add("Scoring preference saved.", Severity.Success);
         }
     }
 
@@ -442,23 +442,18 @@
         // Server-side SendFriendRequestAsync is idempotent (skips if a request
         // already exists in either direction), so it's safe to offer the
         // snackbar based on the in-memory accepted-friend set alone.
-        Snackbar.Add(
+        SiteAlerts.Add(
             $"Add {displayName} as a friend?",
             Severity.Info,
-            options =>
-            {
-                options.Action = "Add";
-                options.ActionColor = Color.Primary;
-                options.ActionVariant = Variant.Filled;
-                options.OnClick = async _ => await SendFriendRequest(selectedId, displayName);
-            });
+            actionLabel: "Add",
+            actionCallback: () => SendFriendRequest(selectedId, displayName));
     }
 
     private async Task SendFriendRequest(int targetPlayerId, string displayName)
     {
         if (_myPlayerId == null) return;
         await Scoring.SendFriendRequestAsync(targetPlayerId);
-        Snackbar.Add($"Friend request sent to {displayName}.", Severity.Success);
+        SiteAlerts.Add($"Friend request sent to {displayName}.", Severity.Success);
     }
 
     private readonly DialogOptions _maxWidth = new() { MaxWidth = MaxWidth.Medium, FullWidth = true };
@@ -583,19 +578,19 @@
     {
         if (string.IsNullOrWhiteSpace(_value) || string.IsNullOrWhiteSpace(_value2))
         {
-            Snackbar.Add("Please select both players before starting.", Severity.Warning);
+            SiteAlerts.Add("Please select both players before starting.", Severity.Warning);
             return;
         }
 
         if (Label_Switch1 && (string.IsNullOrWhiteSpace(_value3) || string.IsNullOrWhiteSpace(_value4)))
         {
-            Snackbar.Add("Please select all four players for a doubles match.", Severity.Warning);
+            SiteAlerts.Add("Please select all four players for a doubles match.", Severity.Warning);
             return;
         }
 
         if (!Label_Switch1 && _value.Equals(_value2, StringComparison.OrdinalIgnoreCase))
         {
-            Snackbar.Add("Player 1 and Player 2 must be different.", Severity.Warning);
+            SiteAlerts.Add("Player 1 and Player 2 must be different.", Severity.Warning);
             return;
         }
 
@@ -604,7 +599,7 @@
             var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { _value, _value2, _value3, _value4 };
             if (names.Count < 4)
             {
-                Snackbar.Add("All four players must be different.", Severity.Warning);
+                SiteAlerts.Add("All four players must be different.", Severity.Warning);
                 return;
             }
         }
@@ -766,12 +761,12 @@
             if (answer)
             {
                 await CourtClaim.ExtendGraceAsync(savedMatchId);
-                Snackbar.Add("Court held for a few more minutes.", Severity.Info);
+                SiteAlerts.Add("Court held for a few more minutes.", Severity.Info);
             }
             else
             {
                 await CourtClaim.EndMatchAsync(savedMatchId);
-                Snackbar.Add("Match ended — court released.", Severity.Info);
+                SiteAlerts.Add("Match ended — court released.", Severity.Info);
                 await SetScoringFullscreen(false);
                 Navigation.NavigateTo("/", forceLoad: false);
             }
@@ -1131,7 +1126,7 @@
             // Don't let a serialize/network failure tear down the renderer
             // — keep the in-memory score, surface the cause so the next tap
             // can be diagnosed instead of triggering Blazor's reload bar.
-            Snackbar.Add($"Couldn't save score: {ex.GetType().Name} — {ex.Message}", Severity.Error);
+            SiteAlerts.Add($"Couldn't save score: {ex.GetType().Name} — {ex.Message}", Severity.Error);
             return;
         }
 

--- a/DropShot.UI/Components/Shared/BulkRubberScoreDialog.razor
+++ b/DropShot.UI/Components/Shared/BulkRubberScoreDialog.razor
@@ -1,5 +1,5 @@
 @inject ICompetitionService CompetitionService
-@inject ISnackbar Snackbar
+@inject ISiteAlertService SiteAlerts
 
 <MudDialog>
     <TitleContent>Enter all rubber scores</TitleContent>

--- a/DropShot.UI/Components/Shared/MatchSetupWizard.razor
+++ b/DropShot.UI/Components/Shared/MatchSetupWizard.razor
@@ -6,7 +6,7 @@
 @inject IPlayerService PlayerService
 @inject ICourtClaimService CourtClaim
 @inject FuzzySearchService FuzzySearch
-@inject ISnackbar Snackbar
+@inject ISiteAlertService SiteAlerts
 @inject IDialogService DialogService
 
 <MudStack Spacing="3">
@@ -672,7 +672,7 @@
 
             case CourtClaimOutcome.InGrace:
                 var mins = RemainingMinutes(result.GraceUntilUtc);
-                Snackbar.Add(
+                SiteAlerts.Add(
                     $"Court is held by {result.OccupantLabel} for another {mins} minute{(mins == 1 ? "" : "s")}.",
                     Severity.Warning);
                 return;
@@ -681,7 +681,7 @@
                 // The match is still being actively scored (within the
                 // abandon threshold). Rather than interrupt the current
                 // scorer, tell the new user to pick another court.
-                Snackbar.Add(
+                SiteAlerts.Add(
                     $"{result.OccupantLabel ?? "Another match"} is currently on this court. Please pick another.",
                     Severity.Warning);
                 return;
@@ -781,7 +781,7 @@
         // Prevent duplicates
         if (val.PlayerId.HasValue && _players.Any(p => p.PlayerId == val.PlayerId))
         {
-            Snackbar.Add("This player is already in the match.", Severity.Warning);
+            SiteAlerts.Add("This player is already in the match.", Severity.Warning);
             return;
         }
 
@@ -951,7 +951,7 @@
         // Prevent duplicates
         if (_players.Any(p => p.PlayerId == suggestion.PlayerId))
         {
-            Snackbar.Add("This player is already in the match.", Severity.Warning);
+            SiteAlerts.Add("This player is already in the match.", Severity.Warning);
             _showInlineCreate = false;
             return;
         }
@@ -995,7 +995,7 @@
         await FuzzySearch.UpdateCollectionAsync(items);
 
         _showInlineCreate = false;
-        Snackbar.Add("Player created.", Severity.Success);
+        SiteAlerts.Add("Player created.", Severity.Success);
     }
 
     // ── Court ───────────────────────────────────────────────

--- a/DropShot.UI/Components/Shared/MudProviders.razor
+++ b/DropShot.UI/Components/Shared/MudProviders.razor
@@ -1,7 +1,11 @@
 @* Place this component at the top of every @rendermode InteractiveServer page.
    It brings MudBlazor's providers into the same circuit scope as the page so
    that Snackbar, Dialog and Popover services share the circuit's DI scope and
-   can update the UI in response to events raised by the page. *@
+   can update the UI in response to events raised by the page.
+
+   <SiteAlertHost /> renders the in-flow site-wide alert banner (pushes content
+   down) — keep it adjacent to the providers so every interactive page gets it. *@
 <MudPopoverProvider />
 <MudDialogProvider />
 <MudSnackbarProvider />
+<SiteAlertHost />

--- a/DropShot.UI/Components/Shared/SiteAlertHost.razor
+++ b/DropShot.UI/Components/Shared/SiteAlertHost.razor
@@ -1,0 +1,104 @@
+@implements IDisposable
+@inject ISiteAlertService SiteAlerts
+@using DropShot.UI.Services
+
+@* Site-wide alert banner. Renders inline at the top of the page so alerts
+   push content down rather than overlaying it. The grid wrapper stays mounted
+   at all times so the open/close height transition runs. Multiple alerts
+   stack vertically and dismiss independently. *@
+
+<div class="site-alert-host @(_visible ? "is-visible" : "")">
+    <div class="site-alert-inner">
+        @foreach (var entry in _rendered)
+        {
+            <MudAlert @key="entry.Id"
+                      Severity="@entry.Severity"
+                      ShowCloseIcon="true"
+                      CloseIconClicked="@(() => SiteAlerts.Dismiss(entry.Id))"
+                      Class="site-alert-banner"
+                      Square="true"
+                      Variant="Variant.Filled">
+                <div class="site-alert-row">
+                    <span class="site-alert-message">@entry.Message</span>
+                    @if (!string.IsNullOrEmpty(entry.ActionLabel) && entry.ActionCallback is not null)
+                    {
+                        <MudButton Variant="Variant.Filled"
+                                   Color="Color.Primary"
+                                   Size="Size.Small"
+                                   OnClick="@(() => OnAction(entry))"
+                                   Class="site-alert-action">
+                            @entry.ActionLabel
+                        </MudButton>
+                    }
+                </div>
+            </MudAlert>
+        }
+    </div>
+</div>
+
+@code {
+    private IReadOnlyList<SiteAlertEntry> _rendered = Array.Empty<SiteAlertEntry>();
+    private bool _visible;
+    private CancellationTokenSource? _exitCts;
+
+    protected override void OnInitialized()
+    {
+        SiteAlerts.OnChange += HandleChange;
+        _rendered = SiteAlerts.Entries;
+        _visible = _rendered.Count > 0;
+    }
+
+    private void HandleChange()
+    {
+        _ = InvokeAsync(ApplyAsync);
+    }
+
+    private async Task ApplyAsync()
+    {
+        var next = SiteAlerts.Entries;
+
+        if (next.Count > 0)
+        {
+            _exitCts?.Cancel();
+            _rendered = next;
+            _visible = true;
+            StateHasChanged();
+            return;
+        }
+
+        if (_rendered.Count == 0) return;
+
+        _visible = false;
+        StateHasChanged();
+
+        _exitCts?.Cancel();
+        _exitCts = new CancellationTokenSource();
+        var token = _exitCts.Token;
+
+        try
+        {
+            await Task.Delay(260, token);
+        }
+        catch (TaskCanceledException) { return; }
+
+        if (token.IsCancellationRequested) return;
+        if (SiteAlerts.Entries.Count > 0) return;
+
+        _rendered = Array.Empty<SiteAlertEntry>();
+        StateHasChanged();
+    }
+
+    private async Task OnAction(SiteAlertEntry entry)
+    {
+        if (entry.ActionCallback is null) return;
+        SiteAlerts.Dismiss(entry.Id);
+        await entry.ActionCallback();
+    }
+
+    public void Dispose()
+    {
+        SiteAlerts.OnChange -= HandleChange;
+        _exitCts?.Cancel();
+        _exitCts?.Dispose();
+    }
+}

--- a/DropShot.UI/Components/Shared/SiteAlertHost.razor.css
+++ b/DropShot.UI/Components/Shared/SiteAlertHost.razor.css
@@ -1,0 +1,36 @@
+.site-alert-host {
+    display: grid;
+    grid-template-rows: 0fr;
+    transition: grid-template-rows 240ms ease;
+}
+
+.site-alert-host.is-visible {
+    grid-template-rows: 1fr;
+}
+
+.site-alert-inner {
+    min-height: 0;
+    overflow: hidden;
+}
+
+.site-alert-inner ::deep .site-alert-banner {
+    border-radius: 0;
+    margin: 0;
+}
+
+.site-alert-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+    width: 100%;
+}
+
+.site-alert-message {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.site-alert-action {
+    flex: 0 0 auto;
+}

--- a/DropShot.UI/Components/Shared/SubmitScoreDialog.razor
+++ b/DropShot.UI/Components/Shared/SubmitScoreDialog.razor
@@ -1,5 +1,5 @@
 @inject ICompetitionService CompetitionService
-@inject ISnackbar Snackbar
+@inject ISiteAlertService SiteAlerts
 
 <MudDialog>
     <TitleContent>

--- a/DropShot.UI/Services/ISiteAlertService.cs
+++ b/DropShot.UI/Services/ISiteAlertService.cs
@@ -1,0 +1,35 @@
+using MudBlazor;
+
+namespace DropShot.UI.Services;
+
+public sealed record SiteAlertEntry(
+    Guid Id,
+    string Message,
+    Severity Severity,
+    TimeSpan AutoDismissAfter,
+    string? ActionLabel = null,
+    Func<Task>? ActionCallback = null);
+
+/// <summary>
+/// Site-wide alert service. Replaces ad-hoc <c>ISnackbar.Add</c> calls so that
+/// action / error notifications surface in an in-flow banner that pushes page
+/// content down rather than floating over controls. Scoped per circuit; the
+/// matching <c>SiteAlertHost</c> component subscribes to <see cref="OnChange"/>
+/// to render and animate the active alert.
+/// </summary>
+public interface ISiteAlertService
+{
+    event Action? OnChange;
+    SiteAlertEntry? Current { get; }
+    IReadOnlyList<SiteAlertEntry> Entries { get; }
+
+    void Add(
+        string message,
+        Severity severity = Severity.Normal,
+        TimeSpan? autoDismissAfter = null,
+        string? actionLabel = null,
+        Func<Task>? actionCallback = null);
+
+    void Dismiss(Guid id);
+    void DismissCurrent();
+}

--- a/DropShot.UI/Services/SiteAlertService.cs
+++ b/DropShot.UI/Services/SiteAlertService.cs
@@ -1,0 +1,102 @@
+using MudBlazor;
+
+namespace DropShot.UI.Services;
+
+public sealed class SiteAlertService : ISiteAlertService, IDisposable
+{
+    private static readonly TimeSpan DefaultLifetime = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan ErrorLifetime = TimeSpan.FromSeconds(8);
+
+    private readonly Lock _gate = new();
+    private readonly List<SiteAlertEntry> _entries = new();
+    private readonly Dictionary<Guid, CancellationTokenSource> _timers = new();
+
+    public event Action? OnChange;
+
+    public SiteAlertEntry? Current
+    {
+        get { lock (_gate) return _entries.Count > 0 ? _entries[^1] : null; }
+    }
+
+    public IReadOnlyList<SiteAlertEntry> Entries
+    {
+        get { lock (_gate) return _entries.ToArray(); }
+    }
+
+    public void Add(
+        string message,
+        Severity severity = Severity.Normal,
+        TimeSpan? autoDismissAfter = null,
+        string? actionLabel = null,
+        Func<Task>? actionCallback = null)
+    {
+        if (string.IsNullOrWhiteSpace(message)) return;
+
+        var lifetime = autoDismissAfter ?? (severity == Severity.Error ? ErrorLifetime : DefaultLifetime);
+        var entry = new SiteAlertEntry(Guid.NewGuid(), message, severity, lifetime, actionLabel, actionCallback);
+
+        CancellationToken token;
+        lock (_gate)
+        {
+            _entries.Add(entry);
+            var cts = new CancellationTokenSource();
+            _timers[entry.Id] = cts;
+            token = cts.Token;
+        }
+
+        OnChange?.Invoke();
+
+        if (lifetime > TimeSpan.Zero)
+        {
+            _ = AutoDismissAsync(entry.Id, lifetime, token);
+        }
+    }
+
+    public void Dismiss(Guid id)
+    {
+        lock (_gate)
+        {
+            var idx = _entries.FindIndex(e => e.Id == id);
+            if (idx < 0) return;
+            _entries.RemoveAt(idx);
+            if (_timers.Remove(id, out var cts))
+            {
+                cts.Cancel();
+                cts.Dispose();
+            }
+        }
+        OnChange?.Invoke();
+    }
+
+    public void DismissCurrent()
+    {
+        Guid? id;
+        lock (_gate) id = _entries.Count > 0 ? _entries[^1].Id : null;
+        if (id is { } value) Dismiss(value);
+    }
+
+    private async Task AutoDismissAsync(Guid id, TimeSpan delay, CancellationToken token)
+    {
+        try
+        {
+            await Task.Delay(delay, token);
+            if (token.IsCancellationRequested) return;
+            Dismiss(id);
+        }
+        catch (TaskCanceledException) { }
+    }
+
+    public void Dispose()
+    {
+        lock (_gate)
+        {
+            foreach (var cts in _timers.Values)
+            {
+                cts.Cancel();
+                cts.Dispose();
+            }
+            _timers.Clear();
+            _entries.Clear();
+        }
+    }
+}

--- a/DropShot/Components/Pages/Clubs.razor
+++ b/DropShot/Components/Pages/Clubs.razor
@@ -9,7 +9,7 @@
 @using DropShot.Shared.Dtos
 @using DropShot.Shared.Extensions
 @inject IDbContextFactory<MyDbContext> DbFactory
-@inject ISnackbar Snackbar
+@inject ISiteAlertService SiteAlerts
 @inject IDialogService DialogService
 
 @* The 14 admin-template / rules-management write paths stay web-only on this
@@ -439,7 +439,7 @@
         _newWindowStart[template.ClubSchedulingTemplateId] = null;
         _newWindowEnd[template.ClubSchedulingTemplateId] = null;
         _newTemplateName = "";
-        Snackbar.Add("Template added.", Severity.Success);
+        SiteAlerts.Add("Template added.", Severity.Success);
     }
 
     private async Task DeleteTemplate(ClubSchedulingTemplate template)
@@ -451,7 +451,7 @@
         _newWindowDay.Remove(template.ClubSchedulingTemplateId);
         _newWindowStart.Remove(template.ClubSchedulingTemplateId);
         _newWindowEnd.Remove(template.ClubSchedulingTemplateId);
-        Snackbar.Add("Template deleted.", Severity.Warning);
+        SiteAlerts.Add("Template deleted.", Severity.Warning);
     }
 
     private async Task AddTemplateWindow(ClubSchedulingTemplate template)
@@ -473,7 +473,7 @@
         template.Windows.Add(window);
         _newWindowStart[template.ClubSchedulingTemplateId] = null;
         _newWindowEnd[template.ClubSchedulingTemplateId] = null;
-        Snackbar.Add("Window added.", Severity.Success);
+        SiteAlerts.Add("Window added.", Severity.Success);
     }
 
     private async Task DeleteTemplateWindow(ClubSchedulingTemplate template, ClubSchedulingTemplateWindow window)
@@ -482,7 +482,7 @@
         var w = await dbc.ClubSchedulingTemplateWindows.FindAsync(window.ClubSchedulingTemplateWindowId);
         if (w != null) { dbc.ClubSchedulingTemplateWindows.Remove(w); await dbc.SaveChangesAsync(); }
         template.Windows.Remove(window);
-        Snackbar.Add("Window removed.", Severity.Warning);
+        SiteAlerts.Add("Window removed.", Severity.Warning);
     }
 
     private async Task OpenRules(ClubDto club)
@@ -540,7 +540,7 @@
         r.Description = NullIfEmpty(_editRulesSetForm.Description);
         await dbc.SaveChangesAsync();
         _showEditRulesSetDialog = false;
-        Snackbar.Add("Rules set updated.", Severity.Success);
+        SiteAlerts.Add("Rules set updated.", Severity.Success);
         await LoadRulesSets();
     }
 
@@ -549,7 +549,7 @@
         await using var dbc = DbFactory.CreateDbContext();
         var r = await dbc.RulesSets.FindAsync(set.RulesSetId);
         if (r != null) { dbc.RulesSets.Remove(r); await dbc.SaveChangesAsync(); }
-        Snackbar.Add("Rules set deleted.", Severity.Warning);
+        SiteAlerts.Add("Rules set deleted.", Severity.Warning);
         await LoadRulesSets();
     }
 
@@ -573,7 +573,7 @@
         });
         await dbc.SaveChangesAsync();
         _newRuleTextByRulesSet[set.RulesSetId] = "";
-        Snackbar.Add("Rule added.", Severity.Success);
+        SiteAlerts.Add("Rule added.", Severity.Success);
         await LoadRulesSets();
     }
 
@@ -582,7 +582,7 @@
         await using var dbc = DbFactory.CreateDbContext();
         var i = await dbc.RulesSetItems.FindAsync(item.RulesSetItemId);
         if (i != null) { dbc.RulesSetItems.Remove(i); await dbc.SaveChangesAsync(); }
-        Snackbar.Add("Rule removed.", Severity.Warning);
+        SiteAlerts.Add("Rule removed.", Severity.Warning);
         await LoadRulesSets();
     }
 
@@ -619,7 +619,7 @@
         _newCTWindowStart[t.CompetitionTemplateId] = null;
         _newCTWindowEnd[t.CompetitionTemplateId] = null;
         _newCompTemplateName = "";
-        Snackbar.Add("Template added.", Severity.Success);
+        SiteAlerts.Add("Template added.", Severity.Success);
     }
 
     private async Task SaveCompetitionTemplate(CompetitionTemplate t)
@@ -633,7 +633,7 @@
         dbT.EligibleSex = t.EligibleSex;
         dbT.RulesSetId = t.RulesSetId;
         await dbc.SaveChangesAsync();
-        Snackbar.Add("Template saved.", Severity.Success);
+        SiteAlerts.Add("Template saved.", Severity.Success);
     }
 
     private async Task DeleteCompetitionTemplate(CompetitionTemplate t)
@@ -645,15 +645,15 @@
         _newCTWindowDay.Remove(t.CompetitionTemplateId);
         _newCTWindowStart.Remove(t.CompetitionTemplateId);
         _newCTWindowEnd.Remove(t.CompetitionTemplateId);
-        Snackbar.Add("Template deleted.", Severity.Warning);
+        SiteAlerts.Add("Template deleted.", Severity.Warning);
     }
 
     private async Task AddCTWindow(CompetitionTemplate t)
     {
         var start = _newCTWindowStart.GetValueOrDefault(t.CompetitionTemplateId);
         var end = _newCTWindowEnd.GetValueOrDefault(t.CompetitionTemplateId);
-        if (start == null || end == null) { Snackbar.Add("Please set both start and end times.", Severity.Warning); return; }
-        if (end <= start) { Snackbar.Add("End time must be after start time.", Severity.Warning); return; }
+        if (start == null || end == null) { SiteAlerts.Add("Please set both start and end times.", Severity.Warning); return; }
+        if (end <= start) { SiteAlerts.Add("End time must be after start time.", Severity.Warning); return; }
         await using var dbc = DbFactory.CreateDbContext();
         var w = new CompetitionTemplateWindow
         {
@@ -667,7 +667,7 @@
         ((ICollection<CompetitionTemplateWindow>)t.Windows).Add(w);
         _newCTWindowStart[t.CompetitionTemplateId] = null;
         _newCTWindowEnd[t.CompetitionTemplateId] = null;
-        Snackbar.Add("Window added.", Severity.Success);
+        SiteAlerts.Add("Window added.", Severity.Success);
     }
 
     private async Task DeleteCTWindow(CompetitionTemplate t, CompetitionTemplateWindow w)
@@ -676,7 +676,7 @@
         var dbW = await dbc.CompetitionTemplateWindows.FindAsync(w.CompetitionTemplateWindowId);
         if (dbW != null) { dbc.CompetitionTemplateWindows.Remove(dbW); await dbc.SaveChangesAsync(); }
         ((ICollection<CompetitionTemplateWindow>)t.Windows).Remove(w);
-        Snackbar.Add("Window removed.", Severity.Warning);
+        SiteAlerts.Add("Window removed.", Severity.Warning);
     }
 
     private async Task OpenEmailTemplates(ClubDto club)
@@ -710,7 +710,7 @@
         _newEmailTemplateName = "";
         _newEmailTemplateSubject = "";
         _newEmailTemplateBody = "";
-        Snackbar.Add("Email template added.", Severity.Success);
+        SiteAlerts.Add("Email template added.", Severity.Success);
     }
 
     private async Task DeleteEmailTemplate(ClubEmailTemplate t)
@@ -719,7 +719,7 @@
         var dbT = await dbc.ClubEmailTemplates.FindAsync(t.ClubEmailTemplateId);
         if (dbT != null) { dbc.ClubEmailTemplates.Remove(dbT); await dbc.SaveChangesAsync(); }
         _emailTemplatesList.Remove(t);
-        Snackbar.Add("Email template deleted.", Severity.Warning);
+        SiteAlerts.Add("Email template deleted.", Severity.Warning);
     }
 
     private static string? NullIfEmpty(string? s) => string.IsNullOrWhiteSpace(s) ? null : s.Trim();

--- a/DropShot/Components/_Imports.razor
+++ b/DropShot/Components/_Imports.razor
@@ -13,5 +13,6 @@
 @using DropShot.Services
 @using DropShot.UI.Components.Scoreboards
 @using DropShot.UI.Components.Shared
+@using DropShot.UI.Services
 @using DropShot.UI.Services.Auth
 @using MudBlazor

--- a/DropShot/Program.cs
+++ b/DropShot/Program.cs
@@ -152,6 +152,7 @@ builder.Services.AddScoped<CompetitionSchedulerService>();
 builder.Services.AddSingleton<QrLoginService>();
 builder.Services.AddHostedService<QrSessionCleanupService>();
 builder.Services.AddMudServices();
+builder.Services.AddScoped<ISiteAlertService, SiteAlertService>();
 
 var app = builder.Build();
 


### PR DESCRIPTION
## Summary
- New `ISiteAlertService` + `SiteAlertHost` render an in-flow banner that expands under the top navbar and **pushes page content down** instead of overlaying controls.
- Banner stacks multiple alerts, dismissable individually with per-alert auto-dismiss; optional action button (used by the friend-request flow).
- Wired via `MudProviders` so every `@rendermode InteractiveServer` page gets the host automatically. Service registered scoped in both `DropShot/Program.cs` and `DropShot.Maui/MauiProgram.cs`.
- Swept all ~50 `Snackbar.Add(...)` call sites across `DropShot`, `DropShot.UI`, and `DropShot.Maui` to the new service. Inline `<MudAlert>` form-confirmation blocks left untouched (not notifications).

## Test plan
- [ ] Run the web app and trigger a success path (e.g. save Site Settings, add a club rules set) — banner expands under the navbar and pushes content down.
- [ ] Trigger an error path (invalid input on Site Settings) — error banner shows for ~8s.
- [ ] Fire multiple warnings at once on Competition scheduling — they stack, each dismissable.
- [ ] On TennisScore, search for a player and confirm the "Add as friend?" banner shows the action button.
- [ ] Confirm Maui app still builds and runs (NavMenu logout flow uses the service).

🤖 Generated with [Claude Code](https://claude.com/claude-code)