### PR TITLE
Confirm division delete and cascade team removal

### DIFF
--- a/DropShot.UI/Components/Competitions/Setup/DivisionsSection.razor
+++ b/DropShot.UI/Components/Competitions/Setup/DivisionsSection.razor
@@ -27,6 +27,35 @@
         Rank 1 is the top division. Teams and match windows for each division are configured within the panels below. Fixtures for each division are managed on the <b>Fixtures</b> tab.
     </MudText>
 
+    @if (PendingDeleteDivisionId.HasValue)
+    {
+        var pending = Divisions.FirstOrDefault(x => x.CompetitionDivisionId == PendingDeleteDivisionId.Value);
+        if (pending is not null)
+        {
+            var pendingTeamCount = Teams.Count(t => t.CompetitionDivisionId == pending.CompetitionDivisionId);
+            var pendingTeamLabel = (Format is CompetitionFormat.Doubles or CompetitionFormat.MixedDoubles) ? "pairing" : "team";
+            <MudAlert Severity="Severity.Warning" Class="mb-3" ShowCloseIcon="true"
+                      CloseIconClicked="@(() => OnCancelDeleteDivision.InvokeAsync())">
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                    <MudText Typo="Typo.body2">
+                        Delete division <b>@pending.Name</b>?
+                        @if (pendingTeamCount > 0)
+                        {
+                            <text> All @pendingTeamCount @(pendingTeamCount == 1 ? pendingTeamLabel : pendingTeamLabel + "s") in this division will also be deleted, and any participants assigned to those @(pendingTeamLabel)s will be unassigned.</text>
+                        }
+                        else
+                        {
+                            <text> Participants in this division will be unassigned from it.</text>
+                        }
+                        This cannot be undone.
+                    </MudText>
+                    <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Error"
+                               OnClick="@(() => OnConfirmDeleteDivision.InvokeAsync())">Confirm Delete</MudButton>
+                </MudStack>
+            </MudAlert>
+        }
+    }
+
     @if (AddingDivision)
     {
         <MudPaper Class="pa-3 mb-3" Elevation="0" Style="background: rgba(255,255,255,0.04); border: 1px dashed rgba(255,255,255,0.2); border-radius: 8px;">
@@ -360,6 +389,9 @@
     [Parameter] public EventCallback<CompetitionDivisionDto> OnStartInlineEditDivision { get; set; }
     [Parameter] public EventCallback OnCancelInlineEditDivision { get; set; }
     [Parameter] public EventCallback<CompetitionDivisionDto> OnDeleteDivision { get; set; }
+    [Parameter] public int? PendingDeleteDivisionId { get; set; }
+    [Parameter] public EventCallback OnConfirmDeleteDivision { get; set; }
+    [Parameter] public EventCallback OnCancelDeleteDivision { get; set; }
     [Parameter] public EventCallback OnOpenSeedDivisionsDialog { get; set; }
     [Parameter] public EventCallback OnRunSeedDivisions { get; set; }
     [Parameter] public EventCallback OnOpenGenerateDialog { get; set; }

--- a/DropShot.UI/Components/Pages/CompetitionPage.razor
+++ b/DropShot.UI/Components/Pages/CompetitionPage.razor
@@ -29,34 +29,35 @@ else
     <div style="position: absolute; inset: 0; background-color: rgba(18, 18, 18, 0.85); pointer-events: none;"></div>
     <div style="position: relative; z-index: 1; padding: 1rem 0.5rem 2rem;">
 
-<MudStack Class="mb-4" Spacing="2">
-    @* ── Title row ───────────────────────────────────────────── *@
-    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
-        @if (_nameOverride)
-        {
-            <MudTextField T="string" @bind-Value="Model.CompetitionName" Variant="Variant.Text"
-                          Typo="Typo.h4" Class="competition-title" Style="flex:1" Immediate="true" Placeholder="Competition Name"
-                          Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.Check"
-                          OnAdornmentClick="@(() => _nameOverride = false)" />
-        }
-        else
-        {
-            <MudText Typo="Typo.h4" Class="competition-title" Style="flex:1" Color="@(string.IsNullOrWhiteSpace(Model.CompetitionName) ? Color.Secondary : Color.Default)">
-                @(string.IsNullOrWhiteSpace(Model.CompetitionName) ? "New Competition" : Model.CompetitionName)
-            </MudText>
-            <MudTooltip Text="Edit name manually">
-                <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="Size.Small" OnClick="@(() => { _nameOverride = true; _nameManuallySet = true; })" />
-            </MudTooltip>
-        }
-    </MudStack>
-</MudStack>
-
 <CascadingValue Value="this" IsFixed="true">
 @* ── Sticky header ─────────────────────────────────────────────
-   Pins the action buttons + section nav to the top of the page so
-   the user can scroll the detail sections below and still navigate
-   between tabs. *@
+   Pins the title, action buttons + section nav to the top of the
+   page so the user can scroll the detail sections below and still
+   navigate between tabs. *@
 <div class="competition-sticky-header mb-6">
+    @* ── Title row ───────────────────────────────────────────── *@
+    <MudPaper Elevation="0" Class="frosted-card mb-3 competition-title-card"
+              Style="border-radius: 12px; padding: 0.75rem;">
+        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+            @if (_nameOverride)
+            {
+                <MudTextField T="string" @bind-Value="Model.CompetitionName" Variant="Variant.Text"
+                              Typo="Typo.h4" Class="competition-title" Style="flex:1" Immediate="true" Placeholder="Competition Name"
+                              Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.Check"
+                              OnAdornmentClick="@(() => _nameOverride = false)" />
+            }
+            else
+            {
+                <MudText Typo="Typo.h4" Class="competition-title" Style="flex:1" Color="@(string.IsNullOrWhiteSpace(Model.CompetitionName) ? Color.Secondary : Color.Default)">
+                    @(string.IsNullOrWhiteSpace(Model.CompetitionName) ? "New Competition" : Model.CompetitionName)
+                </MudText>
+                <MudTooltip Text="Edit name manually">
+                    <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="Size.Small" OnClick="@(() => { _nameOverride = true; _nameManuallySet = true; })" />
+                </MudTooltip>
+            }
+        </MudStack>
+    </MudPaper>
+
     @* ── Action button row ───────────────────────────────────── *@
     @* AlignItems=Stretch + height:100% on each button ensures the Clone
        button (and its tooltip wrapper) grows to match the tallest sibling
@@ -786,7 +787,10 @@ else
                     OnSaveDivision="SaveDivisionDialog"
                     OnStartInlineEditDivision="StartInlineEditDivision"
                     OnCancelInlineEditDivision="CancelInlineEditDivision"
-                    OnDeleteDivision="DeleteDivision"
+                    OnDeleteDivision="RequestDeleteDivision"
+                    PendingDeleteDivisionId="_pendingDeleteDivisionId"
+                    OnConfirmDeleteDivision="ConfirmDeleteDivision"
+                    OnCancelDeleteDivision="CancelDeleteDivision"
                     OnOpenSeedDivisionsDialog="OpenSeedDivisionsDialog"
                     OnRunSeedDivisions="RunSeedDivisions"
                     OnOpenGenerateDialog="OpenGenerateDialog"
@@ -1687,6 +1691,7 @@ else
     private CompetitionTeamDto? _editingTeam;
     private string _teamName = "";
     private bool _showDeleteAllTeamsConfirm;
+    private int? _pendingDeleteDivisionId;
 
     // Auto-generate teams/pairings dialog
     private bool _showGenerateDialog;
@@ -2643,11 +2648,45 @@ else
         _editingDivision = null;
     }
 
-    private async Task DeleteDivision(CompetitionDivisionDto d)
+    private void RequestDeleteDivision(CompetitionDivisionDto d)
     {
-        await Admin.DeleteDivisionAsync(Id, d.CompetitionDivisionId);
-        _divisionWindowForms.Remove(d.CompetitionDivisionId);
+        _pendingDeleteDivisionId = d.CompetitionDivisionId;
+    }
+
+    private void CancelDeleteDivision()
+    {
+        _pendingDeleteDivisionId = null;
+    }
+
+    private async Task ConfirmDeleteDivision()
+    {
+        if (!_pendingDeleteDivisionId.HasValue) return;
+        var divisionId = _pendingDeleteDivisionId.Value;
+        _pendingDeleteDivisionId = null;
+
+        var teamsInDivision = _teams
+            .Where(t => t.CompetitionDivisionId == divisionId)
+            .ToList();
+        foreach (var team in teamsInDivision)
+        {
+            await Admin.DeleteTeamAsync(Id, team.CompetitionTeamId);
+        }
+
+        await Admin.DeleteDivisionAsync(Id, divisionId);
+        _divisionWindowForms.Remove(divisionId);
         await ReloadAfterServerMutationAsync();
+
+        if (teamsInDivision.Count > 0)
+        {
+            var label = IsDoublesFormat()
+                ? (teamsInDivision.Count == 1 ? "pairing" : "pairings")
+                : (teamsInDivision.Count == 1 ? "team" : "teams");
+            SiteAlerts.Add($"Division deleted along with {teamsInDivision.Count} {label}.", Severity.Warning);
+        }
+        else
+        {
+            SiteAlerts.Add("Division deleted.", Severity.Warning);
+        }
     }
 
     // ── Clone competition ───────────────────────────────────────────────────

--- a/DropShot.UI/wwwroot/css/shared.css
+++ b/DropShot.UI/wwwroot/css/shared.css
@@ -51,13 +51,36 @@
 }
 
 /* ── Competition setup sticky header ───────────────────────────────────
-   Pins the action buttons + section nav to the top of the viewport so the
-   user can scroll through detail sections below and still navigate
+   Pins the title, action buttons + section nav to the top of the viewport
+   so the user can scroll through detail sections below and still navigate
    between Setup / Roster / Fixtures tabs. The top offset clears the web
    host's top navbar (3.5rem) and the MAUI MudAppBar (~4rem); a small gap
-   on web is preferable to overlap on MAUI. */
+   on web is preferable to overlap on MAUI.
+
+   The tennis-theme bg + dark overlay mirrors the page's own backdrop so
+   detail content scrolling behind the sticky band stays hidden. Negative
+   horizontal margins break out of the page-content wrapper's 0.5rem
+   padding so the band spans the full content width. */
 .competition-sticky-header {
     position: sticky;
     top: 4rem;
     z-index: 5;
+    background-image:
+        linear-gradient(rgba(18, 18, 18, 0.85), rgba(18, 18, 18, 0.85)),
+        url('../images/background.png');
+    background-size: cover, cover;
+    background-position: center, center;
+    background-repeat: no-repeat, no-repeat;
+    margin-left: -0.5rem;
+    margin-right: -0.5rem;
+    padding: 0.5rem;
+}
+
+/* On web, multi-role users get a sticky `.role-banner` (~1.6rem tall)
+   below the navbar. Push the competition sticky header down so it
+   parks below the banner instead of underneath it. Hardcoded for the
+   single-line banner case; multi-line wrapping on very narrow viewports
+   will produce a small overlap. */
+body:has(.role-banner) .competition-sticky-header {
+    top: 5.5rem;
 }


### PR DESCRIPTION
## Summary

- When a division is deleted from Competition Setup → Rosters/Roster, surface a warning banner naming the division and the count of teams/pairings that will be removed with it. Confirm/cancel actions live on the banner.
- On confirm, the parent now cascades the delete: every team in the division is removed first (which clears each participant's `TeamId` server-side), then the division itself is deleted. A site alert reports how many teams were removed alongside the division.
- The Participants list reflects the cleared team selections automatically: `WebCompetitionAdminService.DeleteTeamAsync` already nulls the participant `TeamId`, and the page reloads `_participants` from the server after every mutation, so the team `MudSelect` clears for both the cascade path and the existing manual single-team delete path.

This branch also includes the earlier `c4e095d` sticky-header refactor (pin title in the sticky competition header + tennis-theme backdrop). Mentioning here for transparency since both commits land together.

## Test plan

- [ ] Open a competition with `HasDivisions = true`, at least one division containing teams, and participants assigned to those teams.
- [ ] Click the trash icon on a division. Confirm the warning banner appears at the top of the Divisions panel and names the division + the team/pairing count.
- [ ] Click the close icon on the banner — the banner dismisses and no delete occurs.
- [ ] Click the trash icon again, then Confirm Delete. The division is removed, every team in it is removed, and the Participants table shows the affected players with no team selected.
- [ ] Repeat for a Doubles/MixedDoubles competition — banner copy uses "pairing"/"pairings".
- [ ] Delete a single team via the trash icon (existing flow). The Participants table still clears that team's members' team selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)