### PR TITLE
Equalise mobile control-bar gaps and fix scroll landing below sticky band

### DIFF
--- a/DropShot.UI/Components/Pages/CompetitionPage.razor
+++ b/DropShot.UI/Components/Pages/CompetitionPage.razor
@@ -1579,11 +1579,17 @@ else
     // at once and clicking a chip smooth-scrolls its anchor div into view.
     // _activeTabIndex still drives the chip's filled/outlined highlight so
     // users see which section they last navigated to.
+    //
+    // Why JS measures the sticky band live instead of using CSS
+    // `scroll-margin-top`: the sticky header height varies (mobile splits the
+    // band into two stacked cards; long competition titles wrap; the role
+    // banner pushes everything down). A live measurement keeps the landed
+    // section flush below the band on every layout.
     private async Task ScrollToSectionAsync(int idx, string anchorId)
     {
         _activeTabIndex = idx;
         await JS.InvokeVoidAsync("eval",
-            $"document.getElementById('{anchorId}')?.scrollIntoView({{behavior:'smooth',block:'start'}})");
+            $"(()=>{{const a=document.getElementById('{anchorId}');if(!a)return;const s=document.querySelector('.competition-sticky-header');const o=s?s.getBoundingClientRect().bottom:0;window.scrollTo({{top:a.getBoundingClientRect().top+window.scrollY-o-12,behavior:'smooth'}});}})()");
     }
 
     private CompetitionFormModel Model { get; set; } = new();

--- a/DropShot.UI/Components/Pages/CompetitionPage.razor
+++ b/DropShot.UI/Components/Pages/CompetitionPage.razor
@@ -58,94 +58,104 @@ else
         </MudStack>
     </MudPaper>
 
-    @* ── Action button row ───────────────────────────────────── *@
-    @* AlignItems=Stretch + height:100% on each button ensures the Clone
-       button (and its tooltip wrapper) grows to match the tallest sibling
-       when text wraps onto two lines on narrow viewports. *@
-    @if (IsEdit)
-    {
-        <MudPaper Elevation="0" Class="frosted-card mb-3 competition-action-row"
-                  Style="border-radius: 12px; padding: 0.75rem;">
-            <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Stretch" Style="flex-wrap: wrap;">
-                @if (_canEdit)
-                {
-                    <MudButton Variant="@(_isStarted ? Variant.Outlined : Variant.Filled)"
-                               Color="@(_isStarted ? Color.Warning : Color.Success)"
-                               StartIcon="@(_isStarted ? Icons.Material.Filled.Stop : Icons.Material.Filled.PlayArrow)"
-                               Class="px-4"
-                               Style="height: 100%;"
-                               OnClick="ToggleStartedAsync">
-                        @(_isStarted ? "Stop Competition" : "Start Competition")
-                    </MudButton>
-                }
-                else if (!_isStarted)
-                {
-                    <MudChip T="string" Color="Color.Warning" Variant="Variant.Outlined">Not Started</MudChip>
-                }
-                @if (_canEdit && IsEdit)
-                {
-                    <MudTooltip Text="Create a new competition based on this one" Style="display: flex; align-self: stretch;">
-                        <MudButton Variant="Variant.Outlined" Color="Color.Secondary"
-                                   StartIcon="@Icons.Material.Filled.ContentCopy"
-                                   Class="px-4"
-                                   Style="height: 100%;"
-                                   OnClick="OpenCloneDialog">
-                            Clone
-                        </MudButton>
-                    </MudTooltip>
-                }
-                <MudButton Variant="Variant.Outlined" Color="Color.Info" StartIcon="@Icons.Material.Filled.Visibility"
-                           Class="px-4"
-                           Style="height: 100%;"
-                           OnClick="@(() => Nav.NavigateTo($"/competition/{Id}/view"))">
-                    View Competition
-                </MudButton>
-            </MudStack>
-        </MudPaper>
-    }
-
-    @* ── Section nav (replaces MudTabs) ──────────────────────────
-       Chip / pill row with the same frosted look as the list cards.
-       Tab indices preserved: 0=Setup, 1=Roster, 2=Fixtures, 3=Email.
-       Wraps onto multiple lines on narrow screens instead of forcing
-       a horizontal scroll. *@
-    <MudPaper Elevation="0" Class="frosted-card competition-section-nav"
-              Style="border-radius: 12px; padding: 0.75rem;">
-    <MudStack Row="true" Spacing="2" Style="flex-wrap: wrap;">
-        <MudChip T="int" Value="0"
-                 Icon="@Icons.Material.Filled.Settings"
-                 Color="@(_activeTabIndex == 0 ? Color.Primary : Color.Default)"
-                 Variant="@(_activeTabIndex == 0 ? Variant.Filled : Variant.Outlined)"
-                 OnClick="@(() => _activeTabIndex = 0)">Setup</MudChip>
+    @* ── Combined control bar ─────────────────────────────────
+       Wraps the action buttons + section nav. On desktop they sit in
+       a single combined band (nav chips on the left, action buttons on
+       the right). On mobile the wrapper drops back to normal flow so
+       each MudPaper renders as its own frosted card — preserving the
+       two-section look but keeping the chip-styled buttons. *@
+    <div class="competition-control-bar mb-3">
+        @* ── Action button row ───────────────────────────────────
+           Buttons share the pill / chip styling via .competition-action-button
+           so they read as a coordinated set with the section nav chips.
+           AlignItems=Center keeps the pills vertically centred next to the
+           chip row when both sit in the desktop combined band. *@
         @if (IsEdit)
         {
-            <MudChip T="int" Value="1"
-                     Icon="@Icons.Material.Filled.Group"
-                     Color="@(_activeTabIndex == 1 ? Color.Primary : Color.Default)"
-                     Variant="@(_activeTabIndex == 1 ? Variant.Filled : Variant.Outlined)"
-                     OnClick="@(() => _activeTabIndex = 1)">Roster</MudChip>
-            <MudChip T="int" Value="2"
-                     Icon="@Icons.Material.Filled.EventNote"
-                     Color="@(_activeTabIndex == 2 ? Color.Primary : Color.Default)"
-                     Variant="@(_activeTabIndex == 2 ? Variant.Filled : Variant.Outlined)"
-                     OnClick="@(() => _activeTabIndex = 2)">Fixtures/Results</MudChip>
+            <MudPaper Elevation="0" Class="frosted-card competition-action-row"
+                      Style="border-radius: 12px; padding: 0.75rem;">
+                <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Style="flex-wrap: wrap;">
+                    @if (_canEdit)
+                    {
+                        <MudButton Variant="@(_isStarted ? Variant.Outlined : Variant.Filled)"
+                                   Color="@(_isStarted ? Color.Warning : Color.Success)"
+                                   StartIcon="@(_isStarted ? Icons.Material.Filled.Stop : Icons.Material.Filled.PlayArrow)"
+                                   Class="competition-action-button"
+                                   OnClick="ToggleStartedAsync">
+                            @(_isStarted ? "Stop Competition" : "Start Competition")
+                        </MudButton>
+                    }
+                    else if (!_isStarted)
+                    {
+                        <MudChip T="string" Color="Color.Warning" Variant="Variant.Outlined">Not Started</MudChip>
+                    }
+                    @if (_canEdit && IsEdit)
+                    {
+                        <MudTooltip Text="Create a new competition based on this one">
+                            <MudButton Variant="Variant.Outlined" Color="Color.Secondary"
+                                       StartIcon="@Icons.Material.Filled.ContentCopy"
+                                       Class="competition-action-button"
+                                       OnClick="OpenCloneDialog">
+                                Clone
+                            </MudButton>
+                        </MudTooltip>
+                    }
+                    <MudButton Variant="Variant.Outlined" Color="Color.Info" StartIcon="@Icons.Material.Filled.Visibility"
+                               Class="competition-action-button"
+                               OnClick="@(() => Nav.NavigateTo($"/competition/{Id}/view"))">
+                        View Competition
+                    </MudButton>
+                </MudStack>
+            </MudPaper>
         }
-        @* Email chip hidden for now — feature not yet in use. Restore by
-           re-enabling this block (and the _emailDisabled flag above). *@
-        @*
-        <MudChip T="int" Value="3"
-                 Icon="@Icons.Material.Filled.Email"
-                 Disabled="@_emailDisabled"
-                 Color="@(_activeTabIndex == 3 ? Color.Primary : Color.Default)"
-                 Variant="@(_activeTabIndex == 3 ? Variant.Filled : Variant.Outlined)"
-                 OnClick="@(() => { if (!_emailDisabled) _activeTabIndex = 3; })">Email</MudChip>
-        *@
-    </MudStack>
-    </MudPaper>
+
+        @* ── Section nav (replaces MudTabs) ──────────────────────────
+           Chip / pill row with the same frosted look as the list cards.
+           Tab indices preserved: 0=Setup, 1=Roster, 2=Fixtures, 3=Email.
+           Clicking a chip smooth-scrolls the matching anchor into view;
+           all sections render simultaneously so users can also scroll
+           manually between them. *@
+        <MudPaper Elevation="0" Class="frosted-card competition-section-nav"
+                  Style="border-radius: 12px; padding: 0.75rem;">
+            <MudStack Row="true" Spacing="2" Style="flex-wrap: wrap;">
+                <MudChip T="int" Value="0"
+                         Icon="@Icons.Material.Filled.Settings"
+                         Color="@(_activeTabIndex == 0 ? Color.Primary : Color.Default)"
+                         Variant="@(_activeTabIndex == 0 ? Variant.Filled : Variant.Outlined)"
+                         OnClick="@(() => ScrollToSectionAsync(0, "nav-anchor-setup"))">Setup</MudChip>
+                @if (IsEdit)
+                {
+                    <MudChip T="int" Value="1"
+                             Icon="@Icons.Material.Filled.Group"
+                             Color="@(_activeTabIndex == 1 ? Color.Primary : Color.Default)"
+                             Variant="@(_activeTabIndex == 1 ? Variant.Filled : Variant.Outlined)"
+                             OnClick="@(() => ScrollToSectionAsync(1, "nav-anchor-roster"))">Roster</MudChip>
+                    <MudChip T="int" Value="2"
+                             Icon="@Icons.Material.Filled.EventNote"
+                             Color="@(_activeTabIndex == 2 ? Color.Primary : Color.Default)"
+                             Variant="@(_activeTabIndex == 2 ? Variant.Filled : Variant.Outlined)"
+                             OnClick="@(() => ScrollToSectionAsync(2, "nav-anchor-fixtures"))">Fixtures/Results</MudChip>
+                }
+                @* Email chip hidden for now — feature not yet in use. Restore by
+                   re-enabling this block (and the _emailDisabled flag above). *@
+                @*
+                <MudChip T="int" Value="3"
+                         Icon="@Icons.Material.Filled.Email"
+                         Disabled="@_emailDisabled"
+                         Color="@(_activeTabIndex == 3 ? Color.Primary : Color.Default)"
+                         Variant="@(_activeTabIndex == 3 ? Variant.Filled : Variant.Outlined)"
+                         OnClick="@(() => { if (!_emailDisabled) ScrollToSectionAsync(3, "nav-anchor-email"); })">Email</MudChip>
+                *@
+            </MudStack>
+        </MudPaper>
+    </div>
 </div>
 
-@if (_activeTabIndex == 0)
-{
+@* All sections render simultaneously; the section nav chips smooth-scroll
+   the matching `nav-anchor-*` div into view (sticky-header offset is handled
+   by .section-anchor's scroll-margin-top). Edit-only sections retain their
+   IsEdit / _canEdit guards below. *@
+<div id="nav-anchor-setup" class="section-anchor"></div>
     @* ── Details form ───────────────────────────────────────── *@
     <MudPaper id="section-details" Class="pa-4 mb-4 setup-section" Elevation="0"
                  Style="background: rgba(255,255,255,0.08); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border: 1px solid rgba(255,255,255,0.12); border-radius: 12px; color: white;">
@@ -520,9 +530,9 @@ else
                     OnApplyTemplate="ApplyCompetitionTemplate" />
             }
         }
-}
 
-@if (_activeTabIndex == 1 && IsEdit)
+<div id="nav-anchor-roster" class="section-anchor"></div>
+@if (IsEdit)
 {
             @* ── Participants ────────────────────────────────── *@
             <MudPaper id="section-participants" Class="pa-4 mb-4 setup-section frosted-card" Elevation="0"
@@ -832,7 +842,8 @@ else
             }
 }
 
-@if (_activeTabIndex == 2 && IsEdit)
+<div id="nav-anchor-fixtures" class="section-anchor"></div>
+@if (IsEdit)
 {
             @if (!Model.HasDivisions)
             {
@@ -1563,6 +1574,17 @@ else
     private bool _nameManuallySet;
     private bool _isStarted;
     private int _activeTabIndex;
+
+    // Section-nav chips no longer hide/show sections — every section renders
+    // at once and clicking a chip smooth-scrolls its anchor div into view.
+    // _activeTabIndex still drives the chip's filled/outlined highlight so
+    // users see which section they last navigated to.
+    private async Task ScrollToSectionAsync(int idx, string anchorId)
+    {
+        _activeTabIndex = idx;
+        await JS.InvokeVoidAsync("eval",
+            $"document.getElementById('{anchorId}')?.scrollIntoView({{behavior:'smooth',block:'start'}})");
+    }
 
     private CompetitionFormModel Model { get; set; } = new();
 

--- a/DropShot.UI/wwwroot/css/shared.css
+++ b/DropShot.UI/wwwroot/css/shared.css
@@ -84,3 +84,86 @@
 body:has(.role-banner) .competition-sticky-header {
     top: 5.5rem;
 }
+
+/* ── Competition control bar (action row + section nav) ────────────────
+   Mobile: no styling — children render as two stacked frosted cards
+   exactly as before (action row on top, section nav below). Desktop:
+   collapse the two MudPapers into a single combined band with the nav
+   chips left and the action buttons right. We hide the children's own
+   frosted-card chrome and apply the frosted look to the wrapper instead
+   so the band looks like one card rather than two pressed together. */
+@media (min-width: 768px) {
+    .competition-control-bar {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        gap: 0.75rem;
+        background: rgba(255, 255, 255, 0.08);
+        backdrop-filter: blur(12px);
+        -webkit-backdrop-filter: blur(12px);
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        border-radius: 12px;
+        padding: 0.5rem 0.75rem;
+    }
+
+    [data-theme="light"] .competition-control-bar {
+        background: rgba(255, 255, 255, 0.6);
+        border: 1px solid rgba(0, 0, 0, 0.08);
+    }
+
+    /* Children drop their own card chrome inside the wrapper. */
+    .competition-control-bar > .competition-action-row,
+    .competition-control-bar > .competition-section-nav {
+        background: transparent !important;
+        backdrop-filter: none !important;
+        -webkit-backdrop-filter: none !important;
+        border: none !important;
+        box-shadow: none !important;
+        border-radius: 0 !important;
+        padding: 0 !important;
+        margin: 0 !important;
+    }
+
+    /* Order: nav left, actions right. Markup order is action-then-nav so
+       mobile (block flow) keeps the existing top-to-bottom arrangement;
+       on desktop we flip the visual order with `order` and push the
+       action group to the trailing edge with `margin-left: auto`. */
+    .competition-control-bar > .competition-section-nav { order: 0; }
+    .competition-control-bar > .competition-action-row {
+        order: 1;
+        margin-left: auto !important;
+    }
+}
+
+/* ── Pill-style action buttons ──────────────────────────────────────────
+   Round the Start / Stop / Clone / View buttons to match the section-nav
+   chips so the combined desktop band reads as a single coordinated
+   control surface — and so the buttons keep the same pill look when they
+   wrap onto their own row on mobile. */
+.competition-action-button {
+    border-radius: 9999px !important;
+    text-transform: none !important;
+    min-height: 32px;
+    padding-left: 14px !important;
+    padding-right: 14px !important;
+    font-size: 0.8125rem !important;
+    font-weight: 500;
+    line-height: 1.2;
+}
+
+/* ── Section-nav scroll anchors ─────────────────────────────────────────
+   The section-nav chips smooth-scroll one of these zero-height anchors
+   into view. scroll-margin-top reserves space for the sticky header so
+   the section title isn't hidden behind it after the scroll lands. The
+   sticky band is taller on mobile (action row + nav row stacked), so we
+   reserve a bit more room there. */
+.section-anchor {
+    height: 0;
+    scroll-margin-top: 230px;
+}
+
+@media (max-width: 767.98px) {
+    .section-anchor {
+        scroll-margin-top: 280px;
+    }
+}

--- a/DropShot.UI/wwwroot/css/shared.css
+++ b/DropShot.UI/wwwroot/css/shared.css
@@ -86,18 +86,24 @@ body:has(.role-banner) .competition-sticky-header {
 }
 
 /* ── Competition control bar (action row + section nav) ────────────────
-   Mobile: no styling — children render as two stacked frosted cards
-   exactly as before (action row on top, section nav below). Desktop:
-   collapse the two MudPapers into a single combined band with the nav
-   chips left and the action buttons right. We hide the children's own
-   frosted-card chrome and apply the frosted look to the wrapper instead
-   so the band looks like one card rather than two pressed together. */
+   Mobile: column flex with a 0.75rem gap so the two stacked frosted
+   cards (action row on top, section nav below) have the same breathing
+   room as the .mb-3 used between the title row and the first content
+   section — keeping every gap in the sticky band visually equal.
+   Desktop (>= 768px): collapse the two MudPapers into a single
+   combined band with nav chips left and action buttons right. The
+   children's own frosted-card chrome is hidden so the band reads as
+   one card. */
+.competition-control-bar {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
 @media (min-width: 768px) {
     .competition-control-bar {
-        display: flex;
         flex-direction: row;
         align-items: center;
-        gap: 0.75rem;
         background: rgba(255, 255, 255, 0.08);
         backdrop-filter: blur(12px);
         -webkit-backdrop-filter: blur(12px);
@@ -152,18 +158,11 @@ body:has(.role-banner) .competition-sticky-header {
 }
 
 /* ── Section-nav scroll anchors ─────────────────────────────────────────
-   The section-nav chips smooth-scroll one of these zero-height anchors
-   into view. scroll-margin-top reserves space for the sticky header so
-   the section title isn't hidden behind it after the scroll lands. The
-   sticky band is taller on mobile (action row + nav row stacked), so we
-   reserve a bit more room there. */
+   Zero-height marker divs that ScrollToSectionAsync targets. The Y
+   offset is computed in JS from the live .competition-sticky-header
+   bottom rather than via scroll-margin-top, because the band height
+   varies with viewport (mobile stacks action + nav into two cards) and
+   with the role banner. */
 .section-anchor {
     height: 0;
-    scroll-margin-top: 230px;
-}
-
-@media (max-width: 767.98px) {
-    .section-anchor {
-        scroll-margin-top: 280px;
-    }
 }


### PR DESCRIPTION
Follow-up to [#615](https://github.com/kingbeazer/DropShot/pull/615).

## Summary
- Mobile control bar (action card + section nav card) now uses column flex with a 0.75rem gap so spacing between title → action → nav → first content section is uniform at 12px. Previously the action card sat directly on top of the nav card with no gap.
- Replaced the static `scroll-margin-top` (which was a guess at the sticky band height and undershooting on mobile) with a JS measurement of the live `.competition-sticky-header` bottom. ScrollToSectionAsync now scrolls so the anchor lands exactly 12px below the band on every viewport / theme / role-banner state.

## Test plan
- [ ] Mobile (< 768px): equal 12px gaps between title row, action card, nav card, and first content section.
- [ ] Click each section-nav chip — top of the target section sits a small breathing-room gap below the sticky band, not hidden underneath it.
- [ ] Desktop combined band still renders as one frosted card with chips left, buttons right.
- [ ] Role-banner enabled (multi-role user): scroll landing still respects the taller sticky offset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)