### PR TITLE
Equalise mobile control-bar gaps and fix scroll landing below sticky band

### DIFF
--- a/DropShot.UI/Components/Pages/CompetitionPage.razor
+++ b/DropShot.UI/Components/Pages/CompetitionPage.razor
@@ -1579,11 +1579,17 @@ else
     // at once and clicking a chip smooth-scrolls its anchor div into view.
     // _activeTabIndex still drives the chip's filled/outlined highlight so
     // users see which section they last navigated to.
+    //
+    // Why JS measures the sticky band live instead of using CSS
+    // `scroll-margin-top`: the sticky header height varies (mobile splits the
+    // band into two stacked cards; long competition titles wrap; the role
+    // banner pushes everything down). A live measurement keeps the landed
+    // section flush below the band on every layout.
     private async Task ScrollToSectionAsync(int idx, string anchorId)
     {
         _activeTabIndex = idx;
         await JS.InvokeVoidAsync("eval",
-            $"document.getElementById('{anchorId}')?.scrollIntoView({{behavior:'smooth',block:'start'}})");
+            $"(()=>{{const a=document.getElementById('{anchorId}');if(!a)return;const s=document.querySelector('.competition-sticky-header');const o=s?s.getBoundingClientRect().bottom:0;window.scrollTo({{top:a.getBoundingClientRect().top+window.scrollY-o-12,behavior:'smooth'}});}})()");
     }
 
     private CompetitionFormModel Model { get; set; } = new();

--- a/DropShot.UI/wwwroot/css/shared.css
+++ b/DropShot.UI/wwwroot/css/shared.css
@@ -86,18 +86,24 @@ body:has(.role-banner) .competition-sticky-header {
 }
 
 /* ── Competition control bar (action row + section nav) ────────────────
-   Mobile: no styling — children render as two stacked frosted cards
-   exactly as before (action row on top, section nav below). Desktop:
-   collapse the two MudPapers into a single combined band with the nav
-   chips left and the action buttons right. We hide the children's own
-   frosted-card chrome and apply the frosted look to the wrapper instead
-   so the band looks like one card rather than two pressed together. */
+   Mobile: column flex with a 0.75rem gap so the two stacked frosted
+   cards (action row on top, section nav below) have the same breathing
+   room as the .mb-3 used between the title row and the first content
+   section — keeping every gap in the sticky band visually equal.
+   Desktop (>= 768px): collapse the two MudPapers into a single
+   combined band with nav chips left and action buttons right. The
+   children's own frosted-card chrome is hidden so the band reads as
+   one card. */
+.competition-control-bar {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
 @media (min-width: 768px) {
     .competition-control-bar {
-        display: flex;
         flex-direction: row;
         align-items: center;
-        gap: 0.75rem;
         background: rgba(255, 255, 255, 0.08);
         backdrop-filter: blur(12px);
         -webkit-backdrop-filter: blur(12px);
@@ -152,18 +158,11 @@ body:has(.role-banner) .competition-sticky-header {
 }
 
 /* ── Section-nav scroll anchors ─────────────────────────────────────────
-   The section-nav chips smooth-scroll one of these zero-height anchors
-   into view. scroll-margin-top reserves space for the sticky header so
-   the section title isn't hidden behind it after the scroll lands. The
-   sticky band is taller on mobile (action row + nav row stacked), so we
-   reserve a bit more room there. */
+   Zero-height marker divs that ScrollToSectionAsync targets. The Y
+   offset is computed in JS from the live .competition-sticky-header
+   bottom rather than via scroll-margin-top, because the band height
+   varies with viewport (mobile stacks action + nav into two cards) and
+   with the role banner. */
 .section-anchor {
     height: 0;
-    scroll-margin-top: 230px;
-}
-
-@media (max-width: 767.98px) {
-    .section-anchor {
-        scroll-margin-top: 280px;
-    }
 }


### PR DESCRIPTION
Follow-up to [#615](https://github.com/kingbeazer/DropShot/pull/615). Supersedes [#616](https://github.com/kingbeazer/DropShot/pull/616) (which had a noisy diff because the branch still carried the pre-squash version of #615's commit).

## Summary
- Mobile control bar (action card + section nav card) now uses column flex with a 0.75rem gap so spacing between title → action → nav → first content section is uniform at 12px. Previously the action card sat directly on top of the nav card with no gap.
- Replaced the static `scroll-margin-top` (which was a guess at the sticky band height and undershooting on mobile) with a JS measurement of the live `.competition-sticky-header` bottom. ScrollToSectionAsync now scrolls so the anchor lands 12px below the band on every viewport / theme / role-banner state.

## Test plan
- [ ] Mobile (< 768px): equal 12px gaps between title row, action card, nav card, and first content section.
- [ ] Click each section-nav chip — top of the target section sits a small breathing-room gap below the sticky band, not hidden underneath it.
- [ ] Desktop combined band still renders as one frosted card with chips left, buttons right.
- [ ] Role-banner enabled (multi-role user): scroll landing still respects the taller sticky offset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)