### PR TITLE
Equalise competition sticky header band spacing

### DIFF
--- a/DropShot.UI/Components/Pages/CompetitionPage.razor
+++ b/DropShot.UI/Components/Pages/CompetitionPage.razor
@@ -34,7 +34,7 @@ else
    Pins the title, action buttons + section nav to the top of the
    page so the user can scroll the detail sections below and still
    navigate between tabs. *@
-<div class="competition-sticky-header mb-6">
+<div class="competition-sticky-header">
     @* ── Title row ───────────────────────────────────────────── *@
     <MudPaper Elevation="0" Class="frosted-card mb-3 competition-title-card"
               Style="border-radius: 12px; padding: 0.75rem;">
@@ -64,7 +64,7 @@ else
        the right). On mobile the wrapper drops back to normal flow so
        each MudPaper renders as its own frosted card — preserving the
        two-section look but keeping the chip-styled buttons. *@
-    <div class="competition-control-bar mb-3">
+    <div class="competition-control-bar">
         @* ── Action button row ───────────────────────────────────
            Buttons share the pill / chip styling via .competition-action-button
            so they read as a coordinated set with the section nav chips.

--- a/DropShot.UI/wwwroot/css/shared.css
+++ b/DropShot.UI/wwwroot/css/shared.css
@@ -73,7 +73,11 @@
     background-repeat: no-repeat, no-repeat;
     margin-left: -0.5rem;
     margin-right: -0.5rem;
-    padding: 0.5rem;
+    /* Vertical 0.75rem matches the .mb-3 already on the title paper and the
+       .competition-control-bar's internal gap, so all four bands (title ->
+       action -> nav -> first content section) sit at a uniform 12px apart.
+       Horizontal 0.5rem cancels the negative side margins above. */
+    padding: 0.75rem 0.5rem;
 }
 
 /* On web, multi-role users get a sticky `.role-banner` (~1.6rem tall)


### PR DESCRIPTION
Follow-up to [#618](https://github.com/kingbeazer/DropShot/pull/618).

## Summary
The four bands above the first content section were unevenly spaced because three margins were stacking under the sticky band:

| Gap | Before | Source |
|---|---|---|
| Title → Action | 12px | `title.mb-3` |
| Action → Nav | 12px | `wrapper.gap` |
| Nav → first content section | **~44px** | `wrapper.mb-3` (12) + `sticky-header.padding-bottom` (8) + `sticky-header.mb-6` (24) |

This commit:
- Drops `mb-6` from `competition-sticky-header`.
- Drops `mb-3` from the `competition-control-bar` wrapper.
- Bumps `competition-sticky-header`'s vertical padding from `0.5rem` to `0.75rem` so the title still has 12px above it and the band still has 12px below it before the next section.

All four bands now sit a uniform 12px apart.

## Test plan
- [ ] Mobile (< 768px): title, action card, nav card, first content section all visually equidistant (12px).
- [ ] Desktop combined band: title row, combined action+nav band, first content section all 12px apart.
- [ ] Sticky behaviour intact — band still parks below the navbar at the right offset.
- [ ] Scroll-to-section landing still leaves the chip-clicked section visible just below the band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)