### PR TITLE
Surface team-generation errors in the alert banner

### DIFF
--- a/DropShot.UI/Components/Pages/CompetitionPage.razor
+++ b/DropShot.UI/Components/Pages/CompetitionPage.razor
@@ -3170,26 +3170,34 @@ else
 
         // The admin service generates per-division. When divisions are off,
         // pass null and use the global pool.
-        if (Model.HasDivisions && _divisions.Count > 0)
+        try
         {
-            foreach (var div in _divisions.OrderBy(d => d.Rank))
+            if (Model.HasDivisions && _divisions.Count > 0)
+            {
+                foreach (var div in _divisions.OrderBy(d => d.Rank))
+                {
+                    var result = await Admin.GenerateTeamsPreviewAsync(Id, new GenerateTeamsRequest(
+                        TeamSize: _generateTeamSize,
+                        BalanceByGender: _generateGenderBalance,
+                        CompetitionDivisionId: div.CompetitionDivisionId));
+                    _generatedPreview.AddRange(result.Preview);
+                    foreach (var w in result.Warnings) _generateWarnings.Add($"[{div.Name}] {w}");
+                }
+            }
+            else
             {
                 var result = await Admin.GenerateTeamsPreviewAsync(Id, new GenerateTeamsRequest(
                     TeamSize: _generateTeamSize,
                     BalanceByGender: _generateGenderBalance,
-                    CompetitionDivisionId: div.CompetitionDivisionId));
+                    CompetitionDivisionId: null));
                 _generatedPreview.AddRange(result.Preview);
-                foreach (var w in result.Warnings) _generateWarnings.Add($"[{div.Name}] {w}");
+                _generateWarnings.AddRange(result.Warnings);
             }
         }
-        else
+        catch (Exception ex)
         {
-            var result = await Admin.GenerateTeamsPreviewAsync(Id, new GenerateTeamsRequest(
-                TeamSize: _generateTeamSize,
-                BalanceByGender: _generateGenderBalance,
-                CompetitionDivisionId: null));
-            _generatedPreview.AddRange(result.Preview);
-            _generateWarnings.AddRange(result.Warnings);
+            Logger.LogError(ex, "Failed to preview generated teams for competition {CompetitionId}.", Id);
+            SiteAlerts.Add($"Failed to preview teams: {ex.Message}", Severity.Error);
         }
     }
 
@@ -3206,6 +3214,16 @@ else
             _showGenerateDialog = false;
             var label = EffectivePersistedFormat() is CompetitionFormat.Doubles or CompetitionFormat.MixedDoubles ? "pairings" : "teams";
             SiteAlerts.Add($"{_generatedPreview.Count} {label} created.", Severity.Success);
+        }
+        catch (Exception ex)
+        {
+            // Without this, the service-layer exception escapes the handler entirely
+            // and the user just sees an empty MudBlazor error bar from the circuit
+            // boundary. Logging the full exception (with stack trace) plus surfacing
+            // ex.Message via SiteAlerts mirrors the pattern used by the other admin
+            // handlers in this page (e.g. clone competition).
+            Logger.LogError(ex, "Failed to confirm team generation for competition {CompetitionId}.", Id);
+            SiteAlerts.Add($"Failed to create teams: {ex.Message}", Severity.Error);
         }
         finally
         {


### PR DESCRIPTION
## Summary
`ConfirmGenerateTeams` on the competition setup page wrapped its service call in a `try/finally` with no `catch`, so any exception thrown by `Admin.ConfirmGenerateTeamsAsync` escaped the handler entirely. The user saw only the empty MudBlazor circuit-boundary error bar — with no way to tell what went wrong.

Both `ConfirmGenerateTeams` and `PreviewGeneratedTeams` now `catch (Exception ex)`, log it with the full stack trace via `Logger.LogError`, and surface `ex.Message` to the in-flow alert banner with `Severity.Error`. Same pattern the clone-competition handler in this file already uses (around line 3030).

This doesn't fix the underlying team-creation failure — that root cause needs to be diagnosed once the error message is visible. Most likely candidates given the service code at `WebCompetitionAdminService.ConfirmGenerateTeamsAsync`:
- FK violation when deleting existing teams that already have fixtures or matches attached (`DbUpdateException`).
- Unique-index violation on team name within the same competition.
- Authorization check returning false (`UnauthorizedAccessException` — but message *would* surface now).

## Test plan
- [ ] Trigger a team-creation failure (e.g. attempt to regenerate teams when fixtures exist against the old teams) and confirm the alert banner now shows the exception message instead of an empty bar.
- [ ] Check that successful generation still shows the green "N teams created." alert.
- [ ] Confirm the server log (`dotnet run` stdout) captures the full stack trace for the failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)