### PR TITLE
Show EF inner exception in team-generate dialog

### DIFF
--- a/DropShot.UI/Components/Pages/CompetitionPage.razor
+++ b/DropShot.UI/Components/Pages/CompetitionPage.razor
@@ -3212,7 +3212,7 @@ else
         catch (Exception ex)
         {
             Logger.LogError(ex, "Failed to preview generated teams for competition {CompetitionId}.", Id);
-            _generateError = $"Failed to preview teams: {ex.Message}";
+            _generateError = $"Failed to preview teams: {FormatExceptionChain(ex)}";
         }
     }
 
@@ -3241,12 +3241,31 @@ else
             // the previous fix look like "nothing happens" when it actually
             // failed.
             Logger.LogError(ex, "Failed to confirm team generation for competition {CompetitionId}.", Id);
-            _generateError = $"Failed to create teams: {ex.Message}";
+            _generateError = $"Failed to create teams: {FormatExceptionChain(ex)}";
         }
         finally
         {
             _generating = false;
         }
+    }
+
+    // EF Core's DbUpdateException wraps the actual SQL failure (FK violation,
+    // unique constraint, etc.) in its InnerException — the outer message is
+    // just "An error occurred while saving the entity changes." which tells
+    // the admin nothing actionable. Walk the chain so the inline alert
+    // includes the real reason.
+    private static string FormatExceptionChain(Exception ex)
+    {
+        var parts = new List<string>();
+        Exception? current = ex;
+        var seen = new HashSet<Exception>();
+        while (current != null && seen.Add(current))
+        {
+            if (!string.IsNullOrWhiteSpace(current.Message))
+                parts.Add(current.Message);
+            current = current.InnerException;
+        }
+        return parts.Count > 0 ? string.Join(" → ", parts) : ex.GetType().Name;
     }
 
     // ── Fixtures ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
Follow-up to [#624](https://github.com/kingbeazer/DropShot/pull/624).

The inline alert was showing the generic EF `DbUpdateException` message ("An error occurred while saving the entity changes. See the inner exception for details.") — the actual SQL reason (FK violation, unique-constraint, etc.) was hidden in `ex.InnerException`.

`PreviewGeneratedTeams` and `ConfirmGenerateTeams` now use a small `FormatExceptionChain` helper that walks the `InnerException` chain and joins each non-empty `Message` with `" → "`. So the inline alert ends with the real cause:

> Failed to create teams: An error occurred while saving the entity changes. See the inner exception for details. → SqliteException: SQLite Error 19: 'FOREIGN KEY constraint failed'.

(or the SQL Server equivalent).

The helper guards against circular `InnerException` chains via a `HashSet` and falls back to the exception type name if every message is whitespace.

## Test plan
- [ ] Trigger the team-generate failure again — the dialog's inline alert should now end with the inner exception's actual message instead of stopping at the EF wrapper.
- [ ] Server log via `Logger.LogError` still has the full stack trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)