### PR TITLE
Clean up team-referencing fixtures when regenerating teams

### DIFF
--- a/DropShot.UI/Components/Pages/CompetitionPage.razor
+++ b/DropShot.UI/Components/Pages/CompetitionPage.razor
@@ -1524,6 +1524,38 @@ else
                 </MudAlert>
             }
 
+            @* Regenerating teams replaces the current team pool, which invalidates
+               any fixtures that reference the old teams via HomeTeamId / AwayTeamId.
+               Surface the impact before the admin clicks Create so completed
+               results aren't deleted by surprise. *@
+            @{
+                var teamFixtureCount = _fixtures.Count(f => f.HomeTeamId.HasValue || f.AwayTeamId.HasValue);
+                var completedTeamFixtureCount = _fixtures.Count(f =>
+                    (f.HomeTeamId.HasValue || f.AwayTeamId.HasValue)
+                    && f.Status is FixtureStatus.Completed or FixtureStatus.AwaitingVerification);
+            }
+            @if (teamFixtureCount > 0)
+            {
+                <MudAlert Severity="@(completedTeamFixtureCount > 0 ? Severity.Warning : Severity.Info)" Dense="true">
+                    @if (completedTeamFixtureCount > 0)
+                    {
+                        <text>
+                            <b>@completedTeamFixtureCount completed</b> of @teamFixtureCount existing
+                            team fixture@(teamFixtureCount == 1 ? "" : "s") will be deleted —
+                            <b>this wipes the recorded results</b>. Continue only if you intend to
+                            start scoring from scratch.
+                        </text>
+                    }
+                    else
+                    {
+                        <text>
+                            @teamFixtureCount existing team fixture@(teamFixtureCount == 1 ? "" : "s")
+                            will be deleted when the new teams are created.
+                        </text>
+                    }
+                </MudAlert>
+            }
+
             @if (_generatedPreview.Count > 0)
             {
                 var showDivColumn = Model.HasDivisions && _generatedPreview.Any(t => t.DivisionId.HasValue);

--- a/DropShot/Services/WebCompetitionAdminService.cs
+++ b/DropShot/Services/WebCompetitionAdminService.cs
@@ -1568,6 +1568,46 @@ public sealed class WebCompetitionAdminService(
         var existingTeams = await db.CompetitionTeams.Where(t => t.CompetitionId == competitionId).ToListAsync(ct);
         if (existingTeams.Count > 0)
         {
+            // Fixtures hold FK references (HomeTeamId / AwayTeamId / WinnerTeamId)
+            // to the teams we're about to delete, so a straight RemoveRange on
+            // CompetitionTeams trips a "DELETE conflicted with REFERENCE constraint
+            // FK_CompetitionFixtures_CompetitionTeams_HomeTeamId". Regenerating the
+            // team pool invalidates any fixtures based on the previous teams, so
+            // delete the team-referencing fixtures (and their rubbers + saved
+            // matches) here using the same cleanup pattern as DeleteAllFixturesAsync.
+            // Fixtures unrelated to teams (e.g. singles/doubles with only PlayerN
+            // refs) are left in place.
+            var teamFixtures = await db.CompetitionFixtures
+                .Where(f => f.CompetitionId == competitionId
+                            && (f.HomeTeamId != null || f.AwayTeamId != null))
+                .ToListAsync(ct);
+            if (teamFixtures.Count > 0)
+            {
+                var fixtureIds = teamFixtures.Select(f => f.CompetitionFixtureId).ToList();
+                var rubbers = await db.Rubbers
+                    .Where(r => fixtureIds.Contains(r.CompetitionFixtureId))
+                    .ToListAsync(ct);
+                var rubberSavedMatchIds = rubbers
+                    .Where(r => r.SavedMatchId.HasValue)
+                    .Select(r => r.SavedMatchId!.Value);
+                if (rubbers.Count > 0) db.Rubbers.RemoveRange(rubbers);
+
+                var directSavedMatchIds = teamFixtures
+                    .Where(f => f.SavedMatchId.HasValue)
+                    .Select(f => f.SavedMatchId!.Value);
+                var savedMatchIds = directSavedMatchIds.Concat(rubberSavedMatchIds).Distinct().ToList();
+                if (savedMatchIds.Count > 0)
+                {
+                    var savedMatches = await db.SavedMatch
+                        .Where(m => savedMatchIds.Contains(m.SavedMatchId))
+                        .ToListAsync(ct);
+                    if (savedMatches.Count > 0) db.SavedMatch.RemoveRange(savedMatches);
+                }
+
+                db.CompetitionFixtures.RemoveRange(teamFixtures);
+                await db.SaveChangesAsync(ct);
+            }
+
             var existingMembers = await db.CompetitionParticipants
                 .Where(cp => cp.CompetitionId == competitionId && cp.TeamId != null)
                 .ToListAsync(ct);


### PR DESCRIPTION
## Root cause
`ConfirmGenerateTeamsAsync` removed the existing teams without first clearing the `CompetitionFixtures` rows that referenced them, so SQL Server rejected the delete with `FK_CompetitionFixtures_CompetitionTeams_HomeTeamId` whenever the admin tried to regenerate teams in a competition that had already generated fixtures.

## Fix
- **Server** ([WebCompetitionAdminService.cs](DropShot/Services/WebCompetitionAdminService.cs)): before removing the existing teams, find the fixtures that reference any of those teams (`HomeTeamId != null || AwayTeamId != null`) and delete them along with their rubbers + SavedMatches. Reuses the same cleanup pattern as `DeleteAllFixturesAsync` (lines 1857-1877). Singles/doubles fixtures that only reference `PlayerN` columns are left alone.
- **UI** ([CompetitionPage.razor](DropShot.UI/Components/Pages/CompetitionPage.razor)): the generate-teams preview now shows an alert when team-referencing fixtures exist:
  - **Info** (blue) — *"N existing team fixtures will be deleted when the new teams are created."*
  - **Warning** (amber, escalated) — *"M completed of N existing team fixtures will be deleted — this wipes the recorded results."* when any of those fixtures are `Completed` or `AwaitingVerification`.

The admin sees the impact in the preview before clicking Create, so scored matches aren't wiped by surprise.

## Test plan
- [ ] Competition with existing teams + scheduled (no-results) fixtures: preview shows blue info alert with the fixture count; clicking Create deletes fixtures and teams cleanly, then creates the new teams.
- [ ] Competition with existing teams + at least one Completed fixture: preview shows amber warning highlighting the completed count. Clicking Create proceeds and deletes everything (admin explicitly chose to proceed).
- [ ] Singles competition: no team alert, no fixture cleanup, no regression to the existing flow.
- [ ] Server log still receives the `Logger.LogError` stack trace if any unexpected exception fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)