### PR TITLE
Add per-player Elo rating with placement suggestions in roster

### DIFF
--- a/DropShot.Maui/Services/HttpCompetitionAdminService.cs
+++ b/DropShot.Maui/Services/HttpCompetitionAdminService.cs
@@ -243,6 +243,58 @@ public sealed class HttpCompetitionAdminService(HttpClient http) : ICompetitionA
         resp.EnsureSuccessStatusCode();
     }
 
+    public async Task SetParticipantInitialRatingAsync(
+        int competitionId, int playerId, SetParticipantInitialRatingRequest request, CancellationToken ct = default)
+    {
+        var resp = await http.PutAsJsonAsync(
+            $"api/competitions/admin/{competitionId}/participants/{playerId}/initial-rating", request, ct);
+        resp.EnsureSuccessStatusCode();
+    }
+
+    public async Task<PlayerRatingSuggestionDto?> AcceptParticipantRatingAsync(
+        int competitionId, int playerId, CancellationToken ct = default)
+    {
+        var resp = await http.PostAsync(
+            $"api/competitions/admin/{competitionId}/participants/{playerId}/accept-rating", content: null, ct);
+        resp.EnsureSuccessStatusCode();
+        if (resp.StatusCode == System.Net.HttpStatusCode.NoContent) return null;
+        return await resp.Content.ReadFromJsonAsync<PlayerRatingSuggestionDto>(cancellationToken: ct);
+    }
+
+    public async Task<List<PlayerRatingSuggestionDto>> AcceptAllParticipantRatingsAsync(
+        int competitionId, CancellationToken ct = default)
+    {
+        var resp = await http.PostAsync(
+            $"api/competitions/admin/{competitionId}/ratings/apply-all", content: null, ct);
+        resp.EnsureSuccessStatusCode();
+        return await resp.Content.ReadFromJsonAsync<List<PlayerRatingSuggestionDto>>(cancellationToken: ct)
+            ?? new List<PlayerRatingSuggestionDto>();
+    }
+
+    public async Task ApplyDivisionPlacementAsync(
+        int competitionId, int playerId, ApplyDivisionPlacementRequest request, CancellationToken ct = default)
+    {
+        var resp = await http.PutAsJsonAsync(
+            $"api/competitions/admin/{competitionId}/participants/{playerId}/division-placement", request, ct);
+        resp.EnsureSuccessStatusCode();
+    }
+
+    public async Task ApplyRolePlacementAsync(
+        int competitionId, int playerId, ApplyRolePlacementRequest request, CancellationToken ct = default)
+    {
+        var resp = await http.PutAsJsonAsync(
+            $"api/competitions/admin/{competitionId}/participants/{playerId}/role-placement", request, ct);
+        resp.EnsureSuccessStatusCode();
+    }
+
+    public async Task<int> ApplyAllPlacementsAsync(int competitionId, CancellationToken ct = default)
+    {
+        var resp = await http.PostAsync(
+            $"api/competitions/admin/{competitionId}/placements/apply-all", content: null, ct);
+        resp.EnsureSuccessStatusCode();
+        return await resp.Content.ReadFromJsonAsync<int>(cancellationToken: ct);
+    }
+
     public async Task<int> CreateLightPlayerAsync(
         int competitionId, CreateLightPlayerForCompetitionRequest request, CancellationToken ct = default)
     {

--- a/DropShot.Shared/Dtos/CompetitionDtos.cs
+++ b/DropShot.Shared/Dtos/CompetitionDtos.cs
@@ -70,7 +70,23 @@ public record CompetitionParticipantDto(
     string? Role = null,
     PlayerSex? Sex = null,
     int? CompetitionDivisionId = null,
-    string? DivisionName = null);
+    string? DivisionName = null,
+    PlayerRatingDto? Rating = null,
+    PlayerRatingSuggestionDto? RatingSuggestion = null,
+    PlacementSuggestionDto? PlacementSuggestion = null);
+
+public record PlayerRatingDto(double CurrentRating, bool IsProvisional);
+
+public record PlayerRatingSuggestionDto(
+    double PreviousRating,
+    double SuggestedRating,
+    double Delta,
+    int RubbersPlayed);
+
+public record PlacementSuggestionDto(
+    int? SuggestedDivisionId,
+    string? SuggestedDivisionName,
+    string? SuggestedRole);
 
 public record CompetitionFixtureDto(
     int CompetitionFixtureId,
@@ -317,6 +333,12 @@ public record TeamLeagueTableEntryDto(
 public record SaveCourtPairRequest(int Court1Id, int Court2Id, string Name);
 
 public record SetParticipantRoleRequest(string? Role);
+
+public record SetParticipantInitialRatingRequest(double Rating);
+
+public record ApplyDivisionPlacementRequest(int CompetitionDivisionId);
+
+public record ApplyRolePlacementRequest(string Role);
 
 // ── Divisions (multi-tier within a competition) ──────────────────────────────
 

--- a/DropShot.Shared/Enums.cs
+++ b/DropShot.Shared/Enums.cs
@@ -78,6 +78,12 @@ public enum SetWinMode : byte
     FirstTo = 1
 }
 
+public enum PlayerRatingSnapshotKind : byte
+{
+    SeasonStart = 1,
+    SeasonEnd   = 2
+}
+
 /// <summary>
 /// How to resolve a knockout team-match when the rubbers are tied.
 /// Applied by <c>RubberResolutionService.ResolveTieBreakAsync</c> after

--- a/DropShot.Shared/RubberTemplateRegistry.cs
+++ b/DropShot.Shared/RubberTemplateRegistry.cs
@@ -23,6 +23,7 @@ public static class RubberTemplateRegistry
     }
 
     public const string MttKey = "mtt";
+    public const string MttRatedKey = "mtt-rated";
     public const string CountyDoublesKey = "county-doubles";
 
     // One rubber per matchup, played as the competition's configured
@@ -59,9 +60,12 @@ public static class RubberTemplateRegistry
 
     /// <summary>
     /// Player attributes the assigner needs. Kept as a plain record so the registry
-    /// stays decoupled from EF models.
+    /// stays decoupled from EF models. <see cref="Rating"/> is optional — assigners
+    /// that don't use it ignore the field; the rating-aware MTT variant prefers
+    /// the higher-rated player within a sex bucket for the A slot.
     /// </summary>
-    public record AssignmentCandidate(int PlayerId, string DisplayName, PlayerSex? Sex);
+    public record AssignmentCandidate(
+        int PlayerId, string DisplayName, PlayerSex? Sex, double? Rating = null);
 
     /// <summary>
     /// Maps players to the roles of a team. Returns a dictionary keyed by PlayerId.
@@ -73,6 +77,7 @@ public static class RubberTemplateRegistry
     private static readonly Dictionary<string, RoleAssigner> Assigners = new()
     {
         [MttKey]           = AssignMtt,
+        [MttRatedKey]      = AssignMttByRating,
         [CountyDoublesKey] = AssignSequential,
     };
 
@@ -122,6 +127,26 @@ public static class RubberTemplateRegistry
         var result = new Dictionary<int, string>();
         var males = players.Where(p => p.Sex == PlayerSex.Male).OrderBy(p => p.DisplayName).ToList();
         var females = players.Where(p => p.Sex == PlayerSex.Female).OrderBy(p => p.DisplayName).ToList();
+        if (males.Count >= 1)   result[males[0].PlayerId]   = Roles.MA;
+        if (males.Count >= 2)   result[males[1].PlayerId]   = Roles.MB;
+        if (females.Count >= 1) result[females[0].PlayerId] = Roles.FA;
+        if (females.Count >= 2) result[females[1].PlayerId] = Roles.FB;
+        return result;
+    }
+
+    private static IReadOnlyDictionary<int, string> AssignMttByRating(
+        IReadOnlyList<AssignmentCandidate> players)
+    {
+        // Within each sex bucket the higher-rated player takes the A slot
+        // (MA / FA) and the lower-rated takes B (MB / FB). Ties break on
+        // DisplayName so the output stays deterministic when ratings match.
+        var result = new Dictionary<int, string>();
+        var males = players.Where(p => p.Sex == PlayerSex.Male)
+            .OrderByDescending(p => p.Rating ?? double.MinValue)
+            .ThenBy(p => p.DisplayName).ToList();
+        var females = players.Where(p => p.Sex == PlayerSex.Female)
+            .OrderByDescending(p => p.Rating ?? double.MinValue)
+            .ThenBy(p => p.DisplayName).ToList();
         if (males.Count >= 1)   result[males[0].PlayerId]   = Roles.MA;
         if (males.Count >= 2)   result[males[1].PlayerId]   = Roles.MB;
         if (females.Count >= 1) result[females[0].PlayerId] = Roles.FA;

--- a/DropShot.Tests/Helpers/DropShotTestContext.cs
+++ b/DropShot.Tests/Helpers/DropShotTestContext.cs
@@ -134,6 +134,7 @@ public class DropShotTestContext : BunitContext
         Services.AddSingleton<BackgroundTaskQueue>();
         Services.AddScoped<ICompetitionRubberTemplateProvider, CompetitionRubberTemplateProvider>();
         Services.AddScoped<RubberResolutionService>();
+        Services.AddScoped<PlayerRatingService>();
         Services.AddScoped<FixtureSimulationService>();
         Services.AddScoped<CompetitionSchedulerService>();
         Services.AddScoped<FuzzySearchService>();

--- a/DropShot.Tests/Helpers/PlayerRatingServiceTests.cs
+++ b/DropShot.Tests/Helpers/PlayerRatingServiceTests.cs
@@ -1,0 +1,716 @@
+using DropShot.Models;
+using DropShot.Services;
+using DropShot.Shared;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace DropShot.Tests.Helpers;
+
+public class PlayerRatingServiceTests
+{
+    private static PlayerRatingService BuildService(TestDbContextFactory factory) => new(factory);
+
+    [Fact]
+    public async Task NoPriorSnapshot_ReturnsDefault()
+    {
+        var factory = new TestDbContextFactory();
+        using (var db = factory.CreateDbContext())
+        {
+            db.Players.Add(new Player { PlayerId = 1, DisplayName = "A" });
+            db.Competition.Add(new Competition
+            {
+                CompetitionID = 100, CompetitionName = "Parent"
+            });
+            db.Competition.Add(new Competition
+            {
+                CompetitionID = 200, CompetitionName = "Child",
+                SeededFromCompetitionId = 100
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var svc = BuildService(factory);
+        var rating = await svc.GetCurrentRatingAsync(playerId: 1, competitionId: 200);
+
+        Assert.Equal(PlayerRatingService.DefaultRating, rating.Value);
+        Assert.True(rating.IsProvisional);
+    }
+
+    [Fact]
+    public async Task ParentHasSeasonEnd_ReturnsIt()
+    {
+        var factory = new TestDbContextFactory();
+        using (var db = factory.CreateDbContext())
+        {
+            db.Players.Add(new Player { PlayerId = 1, DisplayName = "A" });
+            db.Competition.Add(new Competition { CompetitionID = 100, CompetitionName = "Parent" });
+            db.Competition.Add(new Competition
+            {
+                CompetitionID = 200, CompetitionName = "Child",
+                SeededFromCompetitionId = 100
+            });
+            db.PlayerRatingSnapshots.Add(new PlayerRatingSnapshot
+            {
+                PlayerId = 1,
+                CompetitionId = 100,
+                Kind = PlayerRatingSnapshotKind.SeasonEnd,
+                Rating = 1620,
+                RubbersPlayed = 15,
+                IsProvisional = false
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var svc = BuildService(factory);
+        var rating = await svc.GetCurrentRatingAsync(playerId: 1, competitionId: 200);
+
+        Assert.Equal(1620, rating.Value);
+        Assert.False(rating.IsProvisional);
+    }
+
+    [Fact]
+    public async Task ChainSkipsParent_ReturnsParentSeasonStart_NotGrandparent()
+    {
+        // grandparent (Z) has SeasonEnd=1700; parent (Y) was a season the player
+        // didn't play in, but they carried in via Y.SeasonStart=1700; child (X)
+        // looks at Y only and must return Y.SeasonStart, never walking back to Z.
+        var factory = new TestDbContextFactory();
+        using (var db = factory.CreateDbContext())
+        {
+            db.Players.Add(new Player { PlayerId = 1, DisplayName = "A" });
+            db.Competition.Add(new Competition { CompetitionID = 100, CompetitionName = "Z" });
+            db.Competition.Add(new Competition
+            {
+                CompetitionID = 200, CompetitionName = "Y",
+                SeededFromCompetitionId = 100
+            });
+            db.Competition.Add(new Competition
+            {
+                CompetitionID = 300, CompetitionName = "X",
+                SeededFromCompetitionId = 200
+            });
+            db.PlayerRatingSnapshots.Add(new PlayerRatingSnapshot
+            {
+                PlayerId = 1, CompetitionId = 100,
+                Kind = PlayerRatingSnapshotKind.SeasonEnd,
+                Rating = 1700, RubbersPlayed = 20, IsProvisional = false
+            });
+            db.PlayerRatingSnapshots.Add(new PlayerRatingSnapshot
+            {
+                PlayerId = 1, CompetitionId = 200,
+                Kind = PlayerRatingSnapshotKind.SeasonStart,
+                Rating = 1700, RubbersPlayed = 0, IsProvisional = false
+            });
+            // No Y.SeasonEnd (player didn't play in Y).
+            await db.SaveChangesAsync();
+        }
+
+        var svc = BuildService(factory);
+        var rating = await svc.GetCurrentRatingAsync(playerId: 1, competitionId: 300);
+
+        Assert.Equal(1700, rating.Value);
+        Assert.False(rating.IsProvisional);
+
+        // Sanity check: the service should NOT walk past parent. Confirm by also
+        // removing Y.SeasonStart and asserting we fall back to default (not Z).
+    }
+
+    [Fact]
+    public async Task ChainSkipsParent_NoParentSnapshots_ReturnsDefault_NotGrandparent()
+    {
+        var factory = new TestDbContextFactory();
+        using (var db = factory.CreateDbContext())
+        {
+            db.Players.Add(new Player { PlayerId = 1, DisplayName = "A" });
+            db.Competition.Add(new Competition { CompetitionID = 100, CompetitionName = "Z" });
+            db.Competition.Add(new Competition
+            {
+                CompetitionID = 200, CompetitionName = "Y",
+                SeededFromCompetitionId = 100
+            });
+            db.Competition.Add(new Competition
+            {
+                CompetitionID = 300, CompetitionName = "X",
+                SeededFromCompetitionId = 200
+            });
+            // Z has a SeasonEnd but Y has no snapshots at all — service must
+            // return default, NOT walk back to Z.
+            db.PlayerRatingSnapshots.Add(new PlayerRatingSnapshot
+            {
+                PlayerId = 1, CompetitionId = 100,
+                Kind = PlayerRatingSnapshotKind.SeasonEnd,
+                Rating = 1700, RubbersPlayed = 20, IsProvisional = false
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var svc = BuildService(factory);
+        var rating = await svc.GetCurrentRatingAsync(playerId: 1, competitionId: 300);
+
+        Assert.Equal(PlayerRatingService.DefaultRating, rating.Value);
+        Assert.True(rating.IsProvisional);
+    }
+
+    [Fact]
+    public async Task NoParentCompetition_ReturnsDefault()
+    {
+        var factory = new TestDbContextFactory();
+        using (var db = factory.CreateDbContext())
+        {
+            db.Competition.Add(new Competition { CompetitionID = 100, CompetitionName = "Standalone" });
+            await db.SaveChangesAsync();
+        }
+
+        var svc = BuildService(factory);
+        var rating = await svc.GetCurrentRatingAsync(playerId: 1, competitionId: 100);
+
+        Assert.Equal(PlayerRatingService.DefaultRating, rating.Value);
+        Assert.True(rating.IsProvisional);
+    }
+
+    [Fact]
+    public async Task SetInitialRating_InsertsSeasonStart_OnCurrentCompetition()
+    {
+        var factory = new TestDbContextFactory();
+        using (var db = factory.CreateDbContext())
+        {
+            db.Players.Add(new Player { PlayerId = 1, DisplayName = "A" });
+            db.Competition.Add(new Competition { CompetitionID = 100, CompetitionName = "Standalone" });
+            db.CompetitionParticipants.Add(new CompetitionParticipant { CompetitionId = 100, PlayerId = 1 });
+            await db.SaveChangesAsync();
+        }
+
+        var svc = BuildService(factory);
+        await svc.SetInitialRatingAsync(competitionId: 100, playerId: 1, rating: 1450, acceptedByUserId: "admin");
+
+        using var dbCheck = factory.CreateDbContext();
+        var snap = await dbCheck.PlayerRatingSnapshots.SingleAsync();
+        Assert.Equal(100, snap.CompetitionId);
+        Assert.Equal(PlayerRatingSnapshotKind.SeasonStart, snap.Kind);
+        Assert.Equal(1450, snap.Rating);
+        Assert.False(snap.IsProvisional);
+        Assert.Equal("admin", snap.AcceptedByUserId);
+    }
+
+    [Fact]
+    public async Task SetInitialRating_IsIdempotent_UpdatesExistingRow()
+    {
+        var factory = new TestDbContextFactory();
+        using (var db = factory.CreateDbContext())
+        {
+            db.Players.Add(new Player { PlayerId = 1, DisplayName = "A" });
+            db.Competition.Add(new Competition { CompetitionID = 100, CompetitionName = "Standalone" });
+            db.CompetitionParticipants.Add(new CompetitionParticipant { CompetitionId = 100, PlayerId = 1 });
+            await db.SaveChangesAsync();
+        }
+
+        var svc = BuildService(factory);
+        await svc.SetInitialRatingAsync(100, 1, rating: 1400, acceptedByUserId: "admin");
+        await svc.SetInitialRatingAsync(100, 1, rating: 1550, acceptedByUserId: "admin");
+
+        using var dbCheck = factory.CreateDbContext();
+        var snaps = await dbCheck.PlayerRatingSnapshots.ToListAsync();
+        Assert.Single(snaps);
+        Assert.Equal(1550, snaps[0].Rating);
+    }
+
+    [Fact]
+    public async Task RosterLookup_PrefersCurrentSeasonStart_OverParent()
+    {
+        var factory = new TestDbContextFactory();
+        using (var db = factory.CreateDbContext())
+        {
+            db.Players.Add(new Player { PlayerId = 1, DisplayName = "A" });
+            db.Competition.Add(new Competition { CompetitionID = 100, CompetitionName = "Parent" });
+            db.Competition.Add(new Competition
+            {
+                CompetitionID = 200, CompetitionName = "Child",
+                SeededFromCompetitionId = 100
+            });
+            db.CompetitionParticipants.Add(new CompetitionParticipant { CompetitionId = 200, PlayerId = 1 });
+            // Parent has SeasonEnd=1700, but the admin set a manual override on
+            // the current competition — that override must win.
+            db.PlayerRatingSnapshots.AddRange(
+                new PlayerRatingSnapshot
+                {
+                    PlayerId = 1, CompetitionId = 100,
+                    Kind = PlayerRatingSnapshotKind.SeasonEnd,
+                    Rating = 1700, RubbersPlayed = 12, IsProvisional = false
+                },
+                new PlayerRatingSnapshot
+                {
+                    PlayerId = 1, CompetitionId = 200,
+                    Kind = PlayerRatingSnapshotKind.SeasonStart,
+                    Rating = 1500, RubbersPlayed = 0, IsProvisional = false
+                });
+            await db.SaveChangesAsync();
+        }
+
+        var svc = BuildService(factory);
+        var ratings = await svc.GetRosterRatingsAsync(competitionId: 200);
+
+        Assert.Equal(1500, ratings[1].Value);
+    }
+
+    [Fact]
+    public async Task ComputePending_NoParent_ReturnsEmpty()
+    {
+        var factory = new TestDbContextFactory();
+        using (var db = factory.CreateDbContext())
+        {
+            db.Competition.Add(new Competition { CompetitionID = 100, CompetitionName = "Standalone" });
+            await db.SaveChangesAsync();
+        }
+
+        var svc = BuildService(factory);
+        var suggestions = await svc.ComputePendingSuggestionsAsync(competitionId: 100);
+
+        Assert.Empty(suggestions);
+    }
+
+    [Fact]
+    public async Task ComputePending_OneRubber_WinnerGainsLoserLoses()
+    {
+        // P1+P2 (home, ratings 1500/1500) beat P3+P4 (away, 1500/1500). Equal
+        // pair averages → expected = 0.5; home wins → home each gain ~20
+        // (K=40, score=1.0, delta=40*(1.0-0.5)=20). Away each lose ~20.
+        var factory = new TestDbContextFactory();
+        using (var db = factory.CreateDbContext())
+        {
+            db.Players.AddRange(
+                new Player { PlayerId = 1, DisplayName = "P1" },
+                new Player { PlayerId = 2, DisplayName = "P2" },
+                new Player { PlayerId = 3, DisplayName = "P3" },
+                new Player { PlayerId = 4, DisplayName = "P4" });
+            db.Competition.Add(new Competition { CompetitionID = 100, CompetitionName = "Parent" });
+            db.Competition.Add(new Competition
+            {
+                CompetitionID = 200, CompetitionName = "Child",
+                SeededFromCompetitionId = 100
+            });
+            db.CompetitionParticipants.AddRange(
+                new CompetitionParticipant { CompetitionId = 200, PlayerId = 1 },
+                new CompetitionParticipant { CompetitionId = 200, PlayerId = 2 },
+                new CompetitionParticipant { CompetitionId = 200, PlayerId = 3 },
+                new CompetitionParticipant { CompetitionId = 200, PlayerId = 4 });
+            db.CompetitionTeams.AddRange(
+                new CompetitionTeam { CompetitionTeamId = 10, CompetitionId = 100, Name = "Home" },
+                new CompetitionTeam { CompetitionTeamId = 11, CompetitionId = 100, Name = "Away" });
+            db.CompetitionFixtures.Add(new CompetitionFixture
+            {
+                CompetitionFixtureId = 50, CompetitionId = 100,
+                HomeTeamId = 10, AwayTeamId = 11, WinnerTeamId = 10,
+                Status = DropShot.Shared.FixtureStatus.Completed,
+                CompletedAt = new DateTime(2026, 1, 1),
+            });
+            db.Rubbers.Add(new Rubber
+            {
+                RubberId = 1, CompetitionFixtureId = 50,
+                Name = "R1", Order = 1, CourtNumber = 1,
+                HomePlayer1Id = 1, HomePlayer2Id = 2,
+                AwayPlayer1Id = 3, AwayPlayer2Id = 4,
+                IsComplete = true,
+                WinnerTeamId = 10,
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var svc = BuildService(factory);
+        var suggestions = (await svc.ComputePendingSuggestionsAsync(competitionId: 200))
+            .ToDictionary(s => s.PlayerId);
+
+        Assert.Equal(4, suggestions.Count);
+        Assert.Equal(20.0, suggestions[1].Delta, precision: 3);
+        Assert.Equal(20.0, suggestions[2].Delta, precision: 3);
+        Assert.Equal(-20.0, suggestions[3].Delta, precision: 3);
+        Assert.Equal(-20.0, suggestions[4].Delta, precision: 3);
+        Assert.Equal(1, suggestions[1].RubbersPlayed);
+    }
+
+    [Fact]
+    public async Task ComputePending_PlayerDidntPlay_NotInSuggestions()
+    {
+        var factory = new TestDbContextFactory();
+        using (var db = factory.CreateDbContext())
+        {
+            db.Players.AddRange(
+                new Player { PlayerId = 1, DisplayName = "P1" },
+                new Player { PlayerId = 2, DisplayName = "P2" },
+                new Player { PlayerId = 99, DisplayName = "Spectator" });
+            db.Competition.Add(new Competition { CompetitionID = 100, CompetitionName = "Parent" });
+            db.Competition.Add(new Competition
+            {
+                CompetitionID = 200, CompetitionName = "Child",
+                SeededFromCompetitionId = 100
+            });
+            // Player 99 is on the new roster but didn't appear in any rubber.
+            db.CompetitionParticipants.AddRange(
+                new CompetitionParticipant { CompetitionId = 200, PlayerId = 1 },
+                new CompetitionParticipant { CompetitionId = 200, PlayerId = 2 },
+                new CompetitionParticipant { CompetitionId = 200, PlayerId = 99 });
+            db.CompetitionTeams.AddRange(
+                new CompetitionTeam { CompetitionTeamId = 10, CompetitionId = 100, Name = "H" },
+                new CompetitionTeam { CompetitionTeamId = 11, CompetitionId = 100, Name = "A" });
+            db.CompetitionFixtures.Add(new CompetitionFixture
+            {
+                CompetitionFixtureId = 50, CompetitionId = 100,
+                HomeTeamId = 10, AwayTeamId = 11, WinnerTeamId = 10,
+                Status = DropShot.Shared.FixtureStatus.Completed,
+            });
+            db.Rubbers.Add(new Rubber
+            {
+                RubberId = 1, CompetitionFixtureId = 50, Name = "R1",
+                HomePlayer1Id = 1, AwayPlayer1Id = 2,
+                IsComplete = true, WinnerTeamId = 10,
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var svc = BuildService(factory);
+        var suggestions = await svc.ComputePendingSuggestionsAsync(competitionId: 200);
+
+        Assert.DoesNotContain(suggestions, s => s.PlayerId == 99);
+        Assert.Contains(suggestions, s => s.PlayerId == 1);
+        Assert.Contains(suggestions, s => s.PlayerId == 2);
+    }
+
+    [Fact]
+    public async Task Accept_WritesBothSnapshots_AndIsIdempotent()
+    {
+        var factory = new TestDbContextFactory();
+        using (var db = factory.CreateDbContext())
+        {
+            db.Players.AddRange(
+                new Player { PlayerId = 1, DisplayName = "P1" },
+                new Player { PlayerId = 2, DisplayName = "P2" });
+            db.Competition.Add(new Competition { CompetitionID = 100, CompetitionName = "Parent" });
+            db.Competition.Add(new Competition
+            {
+                CompetitionID = 200, CompetitionName = "Child",
+                SeededFromCompetitionId = 100
+            });
+            db.CompetitionParticipants.AddRange(
+                new CompetitionParticipant { CompetitionId = 200, PlayerId = 1 },
+                new CompetitionParticipant { CompetitionId = 200, PlayerId = 2 });
+            db.CompetitionTeams.AddRange(
+                new CompetitionTeam { CompetitionTeamId = 10, CompetitionId = 100, Name = "H" },
+                new CompetitionTeam { CompetitionTeamId = 11, CompetitionId = 100, Name = "A" });
+            db.CompetitionFixtures.Add(new CompetitionFixture
+            {
+                CompetitionFixtureId = 50, CompetitionId = 100,
+                HomeTeamId = 10, AwayTeamId = 11, WinnerTeamId = 10,
+                Status = DropShot.Shared.FixtureStatus.Completed,
+            });
+            db.Rubbers.Add(new Rubber
+            {
+                RubberId = 1, CompetitionFixtureId = 50, Name = "R1",
+                HomePlayer1Id = 1, AwayPlayer1Id = 2,
+                IsComplete = true, WinnerTeamId = 10,
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var svc = BuildService(factory);
+        var applied1 = await svc.AcceptAllSuggestionsAsync(competitionId: 200, acceptedByUserId: "admin");
+        Assert.Equal(2, applied1.Count);
+
+        using (var dbCheck = factory.CreateDbContext())
+        {
+            // Two snapshots per player: SeasonEnd on parent (100), SeasonStart on child (200).
+            Assert.Equal(4, await dbCheck.PlayerRatingSnapshots.CountAsync());
+            var p1Start = await dbCheck.PlayerRatingSnapshots.SingleAsync(s =>
+                s.PlayerId == 1 && s.CompetitionId == 200 && s.Kind == PlayerRatingSnapshotKind.SeasonStart);
+            var p1End = await dbCheck.PlayerRatingSnapshots.SingleAsync(s =>
+                s.PlayerId == 1 && s.CompetitionId == 100 && s.Kind == PlayerRatingSnapshotKind.SeasonEnd);
+            Assert.Equal(p1Start.Rating, p1End.Rating);
+        }
+
+        // Idempotency: a second Accept-All over the same data must NOT create
+        // duplicate rows. After Accept the suggestions are filtered out by
+        // GetVisibleSuggestionsAsync, but ComputePendingSuggestionsAsync still
+        // returns the same numbers, and the upsert path keeps row count flat.
+        var applied2 = await svc.AcceptAllSuggestionsAsync(competitionId: 200, acceptedByUserId: "admin");
+        Assert.Equal(2, applied2.Count);
+        using (var dbCheck = factory.CreateDbContext())
+        {
+            Assert.Equal(4, await dbCheck.PlayerRatingSnapshots.CountAsync());
+        }
+    }
+
+    [Fact]
+    public async Task GetVisibleSuggestions_HidesAlreadyApplied()
+    {
+        var factory = new TestDbContextFactory();
+        using (var db = factory.CreateDbContext())
+        {
+            db.Players.AddRange(
+                new Player { PlayerId = 1, DisplayName = "P1" },
+                new Player { PlayerId = 2, DisplayName = "P2" });
+            db.Competition.Add(new Competition { CompetitionID = 100, CompetitionName = "Parent" });
+            db.Competition.Add(new Competition
+            {
+                CompetitionID = 200, CompetitionName = "Child",
+                SeededFromCompetitionId = 100
+            });
+            db.CompetitionParticipants.AddRange(
+                new CompetitionParticipant { CompetitionId = 200, PlayerId = 1 },
+                new CompetitionParticipant { CompetitionId = 200, PlayerId = 2 });
+            db.CompetitionTeams.AddRange(
+                new CompetitionTeam { CompetitionTeamId = 10, CompetitionId = 100, Name = "H" },
+                new CompetitionTeam { CompetitionTeamId = 11, CompetitionId = 100, Name = "A" });
+            db.CompetitionFixtures.Add(new CompetitionFixture
+            {
+                CompetitionFixtureId = 50, CompetitionId = 100,
+                HomeTeamId = 10, AwayTeamId = 11, WinnerTeamId = 10,
+                Status = DropShot.Shared.FixtureStatus.Completed,
+            });
+            db.Rubbers.Add(new Rubber
+            {
+                RubberId = 1, CompetitionFixtureId = 50, Name = "R1",
+                HomePlayer1Id = 1, AwayPlayer1Id = 2,
+                IsComplete = true, WinnerTeamId = 10,
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var svc = BuildService(factory);
+        // Before any Accept: both players see a suggestion.
+        var before = await svc.GetVisibleSuggestionsAsync(competitionId: 200);
+        Assert.Equal(2, before.Count);
+
+        // Accept for P1 only.
+        await svc.AcceptSuggestionAsync(competitionId: 200, playerId: 1, acceptedByUserId: "admin");
+
+        var after = await svc.GetVisibleSuggestionsAsync(competitionId: 200);
+        Assert.Single(after);
+        Assert.Equal(2, after[0].PlayerId);
+    }
+
+    [Fact]
+    public async Task SuggestDivisions_PartitionsByRating()
+    {
+        var factory = new TestDbContextFactory();
+        using (var db = factory.CreateDbContext())
+        {
+            db.Players.AddRange(
+                Enumerable.Range(1, 6).Select(i => new Player { PlayerId = i, DisplayName = $"P{i}" }));
+            db.Competition.Add(new Competition { CompetitionID = 100, CompetitionName = "C" });
+            db.CompetitionDivisions.AddRange(
+                new CompetitionDivision { CompetitionDivisionId = 1, CompetitionId = 100, Rank = 1, Name = "Top" },
+                new CompetitionDivision { CompetitionDivisionId = 2, CompetitionId = 100, Rank = 2, Name = "Mid" },
+                new CompetitionDivision { CompetitionDivisionId = 3, CompetitionId = 100, Rank = 3, Name = "Bot" });
+            db.CompetitionParticipants.AddRange(
+                new CompetitionParticipant { CompetitionId = 100, PlayerId = 1, CompetitionDivisionId = 3 },
+                new CompetitionParticipant { CompetitionId = 100, PlayerId = 2 },
+                new CompetitionParticipant { CompetitionId = 100, PlayerId = 3 },
+                new CompetitionParticipant { CompetitionId = 100, PlayerId = 4 },
+                new CompetitionParticipant { CompetitionId = 100, PlayerId = 5 },
+                new CompetitionParticipant { CompetitionId = 100, PlayerId = 6 });
+            // No parent → use manual SeasonStart ratings on this competition.
+            db.PlayerRatingSnapshots.AddRange(
+                new PlayerRatingSnapshot { PlayerId = 1, CompetitionId = 100, Kind = PlayerRatingSnapshotKind.SeasonStart, Rating = 1800 },
+                new PlayerRatingSnapshot { PlayerId = 2, CompetitionId = 100, Kind = PlayerRatingSnapshotKind.SeasonStart, Rating = 1700 },
+                new PlayerRatingSnapshot { PlayerId = 3, CompetitionId = 100, Kind = PlayerRatingSnapshotKind.SeasonStart, Rating = 1600 },
+                new PlayerRatingSnapshot { PlayerId = 4, CompetitionId = 100, Kind = PlayerRatingSnapshotKind.SeasonStart, Rating = 1500 },
+                new PlayerRatingSnapshot { PlayerId = 5, CompetitionId = 100, Kind = PlayerRatingSnapshotKind.SeasonStart, Rating = 1400 },
+                new PlayerRatingSnapshot { PlayerId = 6, CompetitionId = 100, Kind = PlayerRatingSnapshotKind.SeasonStart, Rating = 1300 });
+            await db.SaveChangesAsync();
+        }
+
+        var svc = BuildService(factory);
+        var placements = (await svc.SuggestDivisionPlacementsAsync(competitionId: 100))
+            .ToDictionary(p => p.PlayerId);
+
+        // 6 players / 3 divisions → 2 each. P1+P2 top, P3+P4 mid, P5+P6 bot.
+        Assert.Equal(1, placements[1].SuggestedDivisionId);
+        Assert.Equal(1, placements[2].SuggestedDivisionId);
+        Assert.Equal(2, placements[3].SuggestedDivisionId);
+        Assert.Equal(2, placements[4].SuggestedDivisionId);
+        Assert.Equal(3, placements[5].SuggestedDivisionId);
+        // P6 is suggested to stay in Bot (3); but P6 currently has no division
+        // assigned, so the suggestion IS returned.
+        // P1 was in Bot (3), suggested to move to Top (1).
+
+        // Sanity: anyone already in the right division shouldn't appear.
+        // P1 was placed in 3 but suggested 1 — appears.
+        Assert.True(placements.ContainsKey(1));
+    }
+
+    [Fact]
+    public async Task SuggestDivisions_NoRatings_ReturnsEmpty()
+    {
+        var factory = new TestDbContextFactory();
+        using (var db = factory.CreateDbContext())
+        {
+            db.Players.Add(new Player { PlayerId = 1, DisplayName = "P1" });
+            db.Competition.Add(new Competition { CompetitionID = 100, CompetitionName = "C" });
+            db.CompetitionDivisions.AddRange(
+                new CompetitionDivision { CompetitionDivisionId = 1, CompetitionId = 100, Rank = 1, Name = "A" },
+                new CompetitionDivision { CompetitionDivisionId = 2, CompetitionId = 100, Rank = 2, Name = "B" });
+            db.CompetitionParticipants.Add(
+                new CompetitionParticipant { CompetitionId = 100, PlayerId = 1 });
+            await db.SaveChangesAsync();
+        }
+
+        var svc = BuildService(factory);
+        var placements = await svc.SuggestDivisionPlacementsAsync(competitionId: 100);
+
+        Assert.Empty(placements);
+    }
+
+    [Fact]
+    public async Task SuggestRoles_AssignsHigherRatedToSlotA()
+    {
+        var factory = new TestDbContextFactory();
+        using (var db = factory.CreateDbContext())
+        {
+            db.Players.AddRange(
+                new Player { PlayerId = 1, DisplayName = "M-Strong", Sex = PlayerSex.Male },
+                new Player { PlayerId = 2, DisplayName = "M-Weak",   Sex = PlayerSex.Male },
+                new Player { PlayerId = 3, DisplayName = "F-Strong", Sex = PlayerSex.Female },
+                new Player { PlayerId = 4, DisplayName = "F-Weak",   Sex = PlayerSex.Female });
+            db.Competition.Add(new Competition
+            {
+                CompetitionID = 100, CompetitionName = "C",
+                CompetitionFormat = CompetitionFormat.TeamMatch
+            });
+            db.CompetitionTeams.Add(new CompetitionTeam
+            {
+                CompetitionTeamId = 10, CompetitionId = 100, Name = "T1"
+            });
+            // Members in the WRONG starting roles to verify the assigner moves them.
+            db.CompetitionParticipants.AddRange(
+                new CompetitionParticipant { CompetitionId = 100, PlayerId = 1, TeamId = 10, Role = "MB" },
+                new CompetitionParticipant { CompetitionId = 100, PlayerId = 2, TeamId = 10, Role = "MA" },
+                new CompetitionParticipant { CompetitionId = 100, PlayerId = 3, TeamId = 10, Role = "FB" },
+                new CompetitionParticipant { CompetitionId = 100, PlayerId = 4, TeamId = 10, Role = "FA" });
+            db.PlayerRatingSnapshots.AddRange(
+                new PlayerRatingSnapshot { PlayerId = 1, CompetitionId = 100, Kind = PlayerRatingSnapshotKind.SeasonStart, Rating = 1700 },
+                new PlayerRatingSnapshot { PlayerId = 2, CompetitionId = 100, Kind = PlayerRatingSnapshotKind.SeasonStart, Rating = 1400 },
+                new PlayerRatingSnapshot { PlayerId = 3, CompetitionId = 100, Kind = PlayerRatingSnapshotKind.SeasonStart, Rating = 1650 },
+                new PlayerRatingSnapshot { PlayerId = 4, CompetitionId = 100, Kind = PlayerRatingSnapshotKind.SeasonStart, Rating = 1450 });
+            await db.SaveChangesAsync();
+        }
+
+        var svc = BuildService(factory);
+        var placements = (await svc.SuggestRolePlacementsAsync(competitionId: 100))
+            .ToDictionary(p => p.PlayerId);
+
+        // Higher-rated male (P1) → MA; lower (P2) → MB. Same for females.
+        Assert.Equal("MA", placements[1].SuggestedRole);
+        Assert.Equal("MB", placements[2].SuggestedRole);
+        Assert.Equal("FA", placements[3].SuggestedRole);
+        Assert.Equal("FB", placements[4].SuggestedRole);
+    }
+
+    [Fact]
+    public void AssignMttByRating_DegradesToAlphabetical_WhenNoRatings()
+    {
+        // When no ratings are set, ordering must fall back to DisplayName so
+        // the registry-default behavior matches AssignMtt.
+        var assigner = DropShot.Shared.RubberTemplateRegistry.GetRoleAssigner(
+            DropShot.Shared.RubberTemplateRegistry.MttRatedKey);
+        Assert.NotNull(assigner);
+
+        var candidates = new List<DropShot.Shared.RubberTemplateRegistry.AssignmentCandidate>
+        {
+            new(1, "Bob",     PlayerSex.Male,   Rating: null),
+            new(2, "Alice",   PlayerSex.Male,   Rating: null),
+            new(3, "Dana",    PlayerSex.Female, Rating: null),
+            new(4, "Charlie", PlayerSex.Female, Rating: null),
+        };
+        var result = assigner!(candidates);
+        Assert.Equal("MA", result[2]); // Alice (alphabetically first male) → MA
+        Assert.Equal("MB", result[1]); // Bob → MB
+        Assert.Equal("FA", result[4]); // Charlie → FA
+        Assert.Equal("FB", result[3]); // Dana → FB
+    }
+
+    [Fact]
+    public async Task SuggestRoles_TeamWithMissingRating_Skipped()
+    {
+        var factory = new TestDbContextFactory();
+        using (var db = factory.CreateDbContext())
+        {
+            db.Players.AddRange(
+                new Player { PlayerId = 1, DisplayName = "M1", Sex = PlayerSex.Male },
+                new Player { PlayerId = 2, DisplayName = "M2", Sex = PlayerSex.Male });
+            db.Competition.Add(new Competition
+            {
+                CompetitionID = 100, CompetitionName = "C",
+                CompetitionFormat = CompetitionFormat.TeamMatch
+            });
+            db.CompetitionTeams.Add(new CompetitionTeam
+            {
+                CompetitionTeamId = 10, CompetitionId = 100, Name = "T1"
+            });
+            db.CompetitionParticipants.AddRange(
+                new CompetitionParticipant { CompetitionId = 100, PlayerId = 1, TeamId = 10 },
+                new CompetitionParticipant { CompetitionId = 100, PlayerId = 2, TeamId = 10 });
+            // Only P1 has a rating — team is incomplete, so we skip role
+            // suggestions for the whole team.
+            db.PlayerRatingSnapshots.Add(new PlayerRatingSnapshot
+            {
+                PlayerId = 1, CompetitionId = 100, Kind = PlayerRatingSnapshotKind.SeasonStart, Rating = 1500
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var svc = BuildService(factory);
+        var placements = await svc.SuggestRolePlacementsAsync(competitionId: 100);
+
+        Assert.Empty(placements);
+    }
+
+    [Fact]
+    public async Task BulkLoad_ReturnsRatingsForAllParticipants()
+    {
+        var factory = new TestDbContextFactory();
+        using (var db = factory.CreateDbContext())
+        {
+            db.Players.AddRange(
+                new Player { PlayerId = 1, DisplayName = "A" },
+                new Player { PlayerId = 2, DisplayName = "B" },
+                new Player { PlayerId = 3, DisplayName = "C" });
+            db.Competition.Add(new Competition { CompetitionID = 100, CompetitionName = "Parent" });
+            db.Competition.Add(new Competition
+            {
+                CompetitionID = 200, CompetitionName = "Child",
+                SeededFromCompetitionId = 100
+            });
+            db.CompetitionParticipants.AddRange(
+                new CompetitionParticipant { CompetitionId = 200, PlayerId = 1 },
+                new CompetitionParticipant { CompetitionId = 200, PlayerId = 2 },
+                new CompetitionParticipant { CompetitionId = 200, PlayerId = 3 });
+            db.PlayerRatingSnapshots.AddRange(
+                new PlayerRatingSnapshot
+                {
+                    PlayerId = 1, CompetitionId = 100,
+                    Kind = PlayerRatingSnapshotKind.SeasonEnd,
+                    Rating = 1600, RubbersPlayed = 12, IsProvisional = false
+                },
+                new PlayerRatingSnapshot
+                {
+                    PlayerId = 2, CompetitionId = 100,
+                    Kind = PlayerRatingSnapshotKind.SeasonStart,
+                    Rating = 1450, RubbersPlayed = 0, IsProvisional = true
+                });
+            await db.SaveChangesAsync();
+        }
+
+        var svc = BuildService(factory);
+        var ratings = await svc.GetCurrentRatingsForCompetitionAsync(competitionId: 200);
+
+        Assert.True(ratings.ContainsKey(1));
+        Assert.Equal(1600, ratings[1].Value);
+        Assert.False(ratings[1].IsProvisional);
+
+        Assert.True(ratings.ContainsKey(2));
+        Assert.Equal(1450, ratings[2].Value);
+        Assert.True(ratings[2].IsProvisional);
+
+        // Player 3 has no snapshot — bulk-load omits them so the roster falls
+        // back to the per-row null which renders as em-dash.
+        Assert.False(ratings.ContainsKey(3));
+    }
+}

--- a/DropShot.UI/Components/Pages/CompetitionPage.razor
+++ b/DropShot.UI/Components/Pages/CompetitionPage.razor
@@ -775,6 +775,22 @@ else
                     }
                     <MudButton Size="Size.Small" Variant="Variant.Text" StartIcon="@Icons.Material.Filled.FilterAltOff"
                                OnClick="ClearParticipantFilters">Clear</MudButton>
+                    @if (_participants.Any(p => p.RatingSuggestion is not null))
+                    {
+                        <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Primary"
+                                   StartIcon="@Icons.Material.Filled.AutoFixHigh"
+                                   OnClick="AcceptAllParticipantRatings">
+                            Apply all rating suggestions
+                        </MudButton>
+                    }
+                    @if (_participants.Any(p => p.PlacementSuggestion is not null))
+                    {
+                        <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Primary"
+                                   StartIcon="@Icons.Material.Filled.GridOn"
+                                   OnClick="ApplyAllPlacements">
+                            Apply all placement suggestions
+                        </MudButton>
+                    }
                 </MudStack>
 
                 <MudTable T="CompetitionParticipantDto" Items="@_participants" Dense="true" Hover="true"
@@ -783,6 +799,7 @@ else
                         <MudTh><MudTableSortLabel T="CompetitionParticipantDto" SortBy="@(x => x.DisplayName)">Player</MudTableSortLabel></MudTh>
                         <MudTh><MudTableSortLabel T="CompetitionParticipantDto" SortBy="@(x => x.Status)">Status</MudTableSortLabel></MudTh>
                         <MudTh><MudTableSortLabel T="CompetitionParticipantDto" SortBy="@(x => x.RegisteredAt)">Registered</MudTableSortLabel></MudTh>
+                        <MudTh><MudTableSortLabel T="CompetitionParticipantDto" SortBy="@(x => x.Rating?.CurrentRating ?? double.MinValue)">Rating</MudTableSortLabel></MudTh>
                         @if (hasTeamCol)
                         {
                             <MudTh><MudTableSortLabel T="CompetitionParticipantDto" SortBy="@(x => _teams.FirstOrDefault(t => t.CompetitionTeamId == x.TeamId)?.Name ?? "")">@teamColLabel</MudTableSortLabel></MudTh>
@@ -811,6 +828,37 @@ else
                             </MudSelect>
                         </MudTd>
                         <MudTd>@context.RegisteredAt.ToString("dd MMM yyyy")</MudTd>
+                        <MudTd>
+                            <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
+                                <MudNumericField T="int?"
+                                                 Value="@(context.Rating is { } r ? (int)Math.Round(r.CurrentRating) : (int?)null)"
+                                                 ValueChanged="@((int? v) => SetParticipantInitialRating(context, v))"
+                                                 Placeholder="—"
+                                                 Min="0" Max="4000" Step="10"
+                                                 Variant="Variant.Text" Margin="Margin.Dense" HideSpinButtons="true"
+                                                 Style="max-width: 80px;" />
+                                @if (context.Rating is { IsProvisional: true } && context.RatingSuggestion is null)
+                                {
+                                    <MudTooltip Text="Provisional rating — fewer than 10 completed rubbers, or the default starting rating. Type a number to set the initial rating.">
+                                        <MudChip T="string" Size="Size.Small" Color="Color.Default" Variant="Variant.Outlined">prov</MudChip>
+                                    </MudTooltip>
+                                }
+                                @if (context.RatingSuggestion is { } sug)
+                                {
+                                    var up = sug.Delta > 0;
+                                    var down = sug.Delta < 0;
+                                    var arrow = up ? "↑" : down ? "↓" : "→";
+                                    var color = up ? Color.Success : down ? Color.Error : Color.Default;
+                                    <MudTooltip Text="@($"Suggested from previous season — {sug.RubbersPlayed} rubber(s) played. Click Apply to lock in {sug.SuggestedRating:0}.")">
+                                        <MudChip T="string" Size="Size.Small" Color="@color" Variant="Variant.Outlined">
+                                            @arrow @sug.SuggestedRating.ToString("0") (@((sug.Delta >= 0 ? "+" : "") + sug.Delta.ToString("0")))
+                                        </MudChip>
+                                    </MudTooltip>
+                                    <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary"
+                                               OnClick="@(() => AcceptParticipantRating(context))">Apply</MudButton>
+                                }
+                            </MudStack>
+                        </MudTd>
                         @if (hasTeamCol)
                         {
                             <MudTd>
@@ -828,24 +876,48 @@ else
                         {
                             <MudTd>@(context.Sex?.ToString() ?? "—")</MudTd>
                             <MudTd>
-                                <MudAutocomplete T="string" Value="context.Role" Dense="true" Variant="Variant.Text"
-                                                 Clearable="true" CoerceValue="true"
-                                                 SearchFunc="SearchRoles"
-                                                 ValueChanged="@((string? r) => AssignRole(context, r))"
-                                                 ShowProgressIndicator="false" DebounceInterval="0" />
+                                <MudStack Row="false" Spacing="0">
+                                    <MudAutocomplete T="string" Value="context.Role" Dense="true" Variant="Variant.Text"
+                                                     Clearable="true" CoerceValue="true"
+                                                     SearchFunc="SearchRoles"
+                                                     ValueChanged="@((string? r) => AssignRole(context, r))"
+                                                     ShowProgressIndicator="false" DebounceInterval="0" />
+                                    @if (context.PlacementSuggestion is { SuggestedRole: { } sr } && sr != context.Role)
+                                    {
+                                        <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
+                                            <MudChip T="string" Size="Size.Small" Color="Color.Info" Variant="Variant.Outlined">
+                                                → @sr
+                                            </MudChip>
+                                            <MudButton Size="Size.Small" Variant="Variant.Text" Color="Color.Primary"
+                                                       OnClick="@(() => ApplyRolePlacement(context))">Apply</MudButton>
+                                        </MudStack>
+                                    }
+                                </MudStack>
                             </MudTd>
                         }
                         @if (Model.HasDivisions)
                         {
                             <MudTd>
-                                <MudSelect T="int?" Value="context.CompetitionDivisionId" Dense="true" Variant="Variant.Text"
-                                           Clearable="true"
-                                           ValueChanged="@((int? did) => AssignParticipantDivision(context, did))">
-                                    @foreach (var d in _divisions)
+                                <MudStack Row="false" Spacing="0">
+                                    <MudSelect T="int?" Value="context.CompetitionDivisionId" Dense="true" Variant="Variant.Text"
+                                               Clearable="true"
+                                               ValueChanged="@((int? did) => AssignParticipantDivision(context, did))">
+                                        @foreach (var d in _divisions)
+                                        {
+                                            <MudSelectItem T="int?" Value="@((int?)d.CompetitionDivisionId)">@d.Name</MudSelectItem>
+                                        }
+                                    </MudSelect>
+                                    @if (context.PlacementSuggestion is { SuggestedDivisionId: { } sdid } && sdid != context.CompetitionDivisionId)
                                     {
-                                        <MudSelectItem T="int?" Value="@((int?)d.CompetitionDivisionId)">@d.Name</MudSelectItem>
+                                        <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
+                                            <MudChip T="string" Size="Size.Small" Color="Color.Info" Variant="Variant.Outlined">
+                                                → @context.PlacementSuggestion.SuggestedDivisionName
+                                            </MudChip>
+                                            <MudButton Size="Size.Small" Variant="Variant.Text" Color="Color.Primary"
+                                                       OnClick="@(() => ApplyDivisionPlacement(context))">Apply</MudButton>
+                                        </MudStack>
                                     }
-                                </MudSelect>
+                                </MudStack>
                             </MudTd>
                         }
                         <MudTd>
@@ -2791,6 +2863,98 @@ else
                 : null;
             _participants[idx] = cp with { CompetitionDivisionId = divisionId, DivisionName = divName };
         }
+    }
+
+    private async Task SetParticipantInitialRating(CompetitionParticipantDto cp, int? rating)
+    {
+        if (rating is null) return;
+        await Admin.SetParticipantInitialRatingAsync(
+            Id, cp.PlayerId, new SetParticipantInitialRatingRequest(rating.Value));
+        var idx = _participants.IndexOf(cp);
+        if (idx >= 0)
+        {
+            _participants[idx] = cp with
+            {
+                Rating = new PlayerRatingDto(rating.Value, IsProvisional: false),
+                RatingSuggestion = null,
+            };
+        }
+    }
+
+    private async Task AcceptParticipantRating(CompetitionParticipantDto cp)
+    {
+        var s = await Admin.AcceptParticipantRatingAsync(Id, cp.PlayerId);
+        if (s is null) return;
+        var idx = _participants.IndexOf(cp);
+        if (idx >= 0)
+        {
+            _participants[idx] = cp with
+            {
+                Rating = new PlayerRatingDto(s.SuggestedRating, IsProvisional: s.RubbersPlayed < 10),
+                RatingSuggestion = null,
+            };
+        }
+    }
+
+    private async Task AcceptAllParticipantRatings()
+    {
+        var applied = await Admin.AcceptAllParticipantRatingsAsync(Id);
+        if (applied.Count == 0)
+        {
+            SiteAlerts.Add("No rating suggestions to apply.", Severity.Info);
+            return;
+        }
+        await ReloadAfterServerMutationAsync();
+        SiteAlerts.Add($"Applied {applied.Count} rating suggestion(s).", Severity.Success);
+    }
+
+    private async Task ApplyDivisionPlacement(CompetitionParticipantDto cp)
+    {
+        if (cp.PlacementSuggestion?.SuggestedDivisionId is not int did) return;
+        await Admin.ApplyDivisionPlacementAsync(Id, cp.PlayerId, new ApplyDivisionPlacementRequest(did));
+        var idx = _participants.IndexOf(cp);
+        if (idx >= 0)
+        {
+            var name = _divisions.FirstOrDefault(d => d.CompetitionDivisionId == did)?.Name;
+            _participants[idx] = cp with
+            {
+                CompetitionDivisionId = did,
+                DivisionName = name,
+                PlacementSuggestion = cp.PlacementSuggestion with { SuggestedDivisionId = null, SuggestedDivisionName = null },
+            };
+            // Drop the whole suggestion if both fields are now empty.
+            if (_participants[idx].PlacementSuggestion is { SuggestedDivisionId: null, SuggestedRole: null })
+                _participants[idx] = _participants[idx] with { PlacementSuggestion = null };
+        }
+    }
+
+    private async Task ApplyRolePlacement(CompetitionParticipantDto cp)
+    {
+        if (cp.PlacementSuggestion?.SuggestedRole is not string role) return;
+        await Admin.ApplyRolePlacementAsync(Id, cp.PlayerId, new ApplyRolePlacementRequest(role));
+        var idx = _participants.IndexOf(cp);
+        if (idx >= 0)
+        {
+            _participants[idx] = cp with
+            {
+                Role = role,
+                PlacementSuggestion = cp.PlacementSuggestion with { SuggestedRole = null },
+            };
+            if (_participants[idx].PlacementSuggestion is { SuggestedDivisionId: null, SuggestedRole: null })
+                _participants[idx] = _participants[idx] with { PlacementSuggestion = null };
+        }
+    }
+
+    private async Task ApplyAllPlacements()
+    {
+        var count = await Admin.ApplyAllPlacementsAsync(Id);
+        if (count == 0)
+        {
+            SiteAlerts.Add("No placement suggestions to apply.", Severity.Info);
+            return;
+        }
+        await ReloadAfterServerMutationAsync();
+        SiteAlerts.Add($"Applied {count} placement suggestion(s).", Severity.Success);
     }
 
     // ── Participant promote / demote ───────────────────────────────────────

--- a/DropShot.UI/Services/ICompetitionAdminService.cs
+++ b/DropShot.UI/Services/ICompetitionAdminService.cs
@@ -164,6 +164,49 @@ public interface ICompetitionAdminService
         int competitionId, int playerId, SetParticipantDivisionRequest request, CancellationToken ct = default);
 
     /// <summary>
+    /// Set or update a participant's admin-entered initial Elo rating for this
+    /// competition. Writes a <c>SeasonStart</c> snapshot — idempotent on re-call.
+    /// Used to bootstrap a brand-new (non-cloned) competition before any Elo
+    /// replay is possible.
+    /// </summary>
+    Task SetParticipantInitialRatingAsync(
+        int competitionId, int playerId, SetParticipantInitialRatingRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Accept the Elo-replay rating suggestion for one participant. Writes the
+    /// SeasonEnd snapshot on the previous competition and the SeasonStart on
+    /// this one. Returns the suggestion that was applied, or null if there
+    /// wasn't one (e.g. brand-new competition, or player didn't play in parent).
+    /// </summary>
+    Task<PlayerRatingSuggestionDto?> AcceptParticipantRatingAsync(
+        int competitionId, int playerId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Accept every visible rating suggestion in a single round. Returns the
+    /// list of applied suggestions for UI confirmation.
+    /// </summary>
+    Task<List<PlayerRatingSuggestionDto>> AcceptAllParticipantRatingsAsync(
+        int competitionId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Apply the rating-driven division suggestion for one participant.
+    /// </summary>
+    Task ApplyDivisionPlacementAsync(
+        int competitionId, int playerId, ApplyDivisionPlacementRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Apply the rating-driven role suggestion for one participant (TeamMatch).
+    /// </summary>
+    Task ApplyRolePlacementAsync(
+        int competitionId, int playerId, ApplyRolePlacementRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Apply every pending division + role placement suggestion in one round.
+    /// Returns the count of rows written.
+    /// </summary>
+    Task<int> ApplyAllPlacementsAsync(int competitionId, CancellationToken ct = default);
+
+    /// <summary>
     /// Create a "light" Player (no user account) and immediately enrol them as
     /// a participant. Returns the new playerId. <see cref="CreateLightPlayerForCompetitionRequest.HostClubId"/>
     /// is required because light players are scoped to a club.

--- a/DropShot/Controllers/CompetitionsAdminController.cs
+++ b/DropShot/Controllers/CompetitionsAdminController.cs
@@ -275,6 +275,63 @@ public class CompetitionsAdminController(
         catch (KeyNotFoundException) { return NotFound(); }
     }
 
+    [HttpPut("{id:int}/participants/{playerId:int}/initial-rating")]
+    public async Task<IActionResult> SetParticipantInitialRating(
+        int id, int playerId, [FromBody] SetParticipantInitialRatingRequest req, CancellationToken ct)
+    {
+        try { await admin.SetParticipantInitialRatingAsync(id, playerId, req, ct); return NoContent(); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+    }
+
+    [HttpPost("{id:int}/participants/{playerId:int}/accept-rating")]
+    public async Task<ActionResult<PlayerRatingSuggestionDto>> AcceptParticipantRating(
+        int id, int playerId, CancellationToken ct)
+    {
+        try
+        {
+            var s = await admin.AcceptParticipantRatingAsync(id, playerId, ct);
+            return s is null ? NoContent() : Ok(s);
+        }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+    }
+
+    [HttpPost("{id:int}/ratings/apply-all")]
+    public async Task<ActionResult<List<PlayerRatingSuggestionDto>>> AcceptAllParticipantRatings(
+        int id, CancellationToken ct)
+    {
+        try { return await admin.AcceptAllParticipantRatingsAsync(id, ct); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+    }
+
+    [HttpPut("{id:int}/participants/{playerId:int}/division-placement")]
+    public async Task<IActionResult> ApplyDivisionPlacement(
+        int id, int playerId, [FromBody] ApplyDivisionPlacementRequest req, CancellationToken ct)
+    {
+        try { await admin.ApplyDivisionPlacementAsync(id, playerId, req, ct); return NoContent(); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+    }
+
+    [HttpPut("{id:int}/participants/{playerId:int}/role-placement")]
+    public async Task<IActionResult> ApplyRolePlacement(
+        int id, int playerId, [FromBody] ApplyRolePlacementRequest req, CancellationToken ct)
+    {
+        try { await admin.ApplyRolePlacementAsync(id, playerId, req, ct); return NoContent(); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+    }
+
+    [HttpPost("{id:int}/placements/apply-all")]
+    public async Task<ActionResult<int>> ApplyAllPlacements(int id, CancellationToken ct)
+    {
+        try { return await admin.ApplyAllPlacementsAsync(id, ct); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+    }
+
     [HttpPost("{id:int}/light-players")]
     public async Task<ActionResult<int>> CreateLightPlayer(
         int id, [FromBody] CreateLightPlayerForCompetitionRequest req, CancellationToken ct)

--- a/DropShot/Controllers/CompetitionsController.cs
+++ b/DropShot/Controllers/CompetitionsController.cs
@@ -22,6 +22,7 @@ public class CompetitionsController(
     ICompetitionRubberTemplateProvider rubberTemplateProvider,
     CompetitionSchedulerService scheduler,
     ICompetitionService competitionService,
+    PlayerRatingService ratings,
     ILogger<CompetitionsController> logger) : ControllerBase
 {
     [HttpGet]
@@ -105,6 +106,14 @@ public class CompetitionsController(
             .OrderBy(cp => cp.Name)
             .ToListAsync();
 
+        var ratingsByPlayer = await ratings.GetRosterRatingsAsync(id);
+        var ratingSuggestions = (await ratings.GetVisibleSuggestionsAsync(id))
+            .ToDictionary(s => s.PlayerId);
+        var divisionPlacements = (await ratings.SuggestDivisionPlacementsAsync(id))
+            .ToDictionary(p => p.PlayerId);
+        var rolePlacements = (await ratings.SuggestRolePlacementsAsync(id))
+            .ToDictionary(p => p.PlayerId);
+
         return new CompetitionDetailDto(
             c.CompetitionID, c.CompetitionName,
             c.CompetitionFormat,
@@ -123,7 +132,14 @@ public class CompetitionsController(
                 p.Role,
                 p.Player?.Sex,
                 p.CompetitionDivisionId,
-                p.Division?.Name)).ToList(),
+                p.Division?.Name,
+                ratingsByPlayer.TryGetValue(p.PlayerId, out var r)
+                    ? new PlayerRatingDto(r.Value, r.IsProvisional)
+                    : null,
+                ratingSuggestions.TryGetValue(p.PlayerId, out var rs)
+                    ? new PlayerRatingSuggestionDto(rs.PreviousRating, rs.SuggestedRating, rs.Delta, rs.RubbersPlayed)
+                    : null,
+                BuildPlacementSuggestion(p.PlayerId, divisionPlacements, rolePlacements))).ToList(),
             c.IsArchived,
             c.IsStarted,
             c.CreatorUserId,
@@ -1301,6 +1317,20 @@ public class CompetitionsController(
         c.HostClubId, c.HostClub?.Name, c.RulesSetId, c.Rules?.Name,
         c.EventId, c.Event?.Name, c.IsArchived, c.IsStarted,
         c.CreatorUserId, c.IsRestricted, c.RegisterByDate);
+
+    private static PlacementSuggestionDto? BuildPlacementSuggestion(
+        int playerId,
+        Dictionary<int, PlayerRatingService.DivisionPlacement> divisions,
+        Dictionary<int, PlayerRatingService.RolePlacement> roles)
+    {
+        var hasDivision = divisions.TryGetValue(playerId, out var d);
+        var hasRole = roles.TryGetValue(playerId, out var r);
+        if (!hasDivision && !hasRole) return null;
+        return new PlacementSuggestionDto(
+            SuggestedDivisionId: hasDivision ? d!.SuggestedDivisionId : null,
+            SuggestedDivisionName: hasDivision ? d!.SuggestedDivisionName : null,
+            SuggestedRole: hasRole ? r!.SuggestedRole : null);
+    }
 
     private static CompetitionFixtureDto ToFixtureDto(CompetitionFixture f) => new(
         f.CompetitionFixtureId, f.CompetitionId,

--- a/DropShot/Data/Migrations/20260515114259_AddPlayerRatingSnapshot.Designer.cs
+++ b/DropShot/Data/Migrations/20260515114259_AddPlayerRatingSnapshot.Designer.cs
@@ -4,16 +4,19 @@ using DropShot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace DropShot.Migrations
+namespace DropShot.Data.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260515114259_AddPlayerRatingSnapshot")]
+    partial class AddPlayerRatingSnapshot
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DropShot/Data/Migrations/20260515114259_AddPlayerRatingSnapshot.cs
+++ b/DropShot/Data/Migrations/20260515114259_AddPlayerRatingSnapshot.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropShot.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPlayerRatingSnapshot : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PlayerRatingSnapshots",
+                columns: table => new
+                {
+                    PlayerRatingSnapshotId = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    PlayerId = table.Column<int>(type: "int", nullable: false),
+                    CompetitionId = table.Column<int>(type: "int", nullable: false),
+                    Kind = table.Column<byte>(type: "tinyint", nullable: false),
+                    Rating = table.Column<double>(type: "float", nullable: false),
+                    RubbersPlayed = table.Column<int>(type: "int", nullable: false),
+                    IsProvisional = table.Column<bool>(type: "bit", nullable: false),
+                    ComputedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    AcceptedByUserId = table.Column<string>(type: "nvarchar(450)", maxLength: 450, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PlayerRatingSnapshots", x => x.PlayerRatingSnapshotId);
+                    table.ForeignKey(
+                        name: "FK_PlayerRatingSnapshots_Competition_CompetitionId",
+                        column: x => x.CompetitionId,
+                        principalTable: "Competition",
+                        principalColumn: "CompetitionID");
+                    table.ForeignKey(
+                        name: "FK_PlayerRatingSnapshots_Players_PlayerId",
+                        column: x => x.PlayerId,
+                        principalTable: "Players",
+                        principalColumn: "PlayerId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PlayerRatingSnapshots_CompetitionId",
+                table: "PlayerRatingSnapshots",
+                column: "CompetitionId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PlayerRatingSnapshots_PlayerId_CompetitionId_Kind",
+                table: "PlayerRatingSnapshots",
+                columns: new[] { "PlayerId", "CompetitionId", "Kind" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PlayerRatingSnapshots");
+        }
+    }
+}

--- a/DropShot/Data/MyDbContext.cs
+++ b/DropShot/Data/MyDbContext.cs
@@ -44,6 +44,7 @@ namespace DropShot.Data
         public DbSet<PlayerInvitation> PlayerInvitations { get; set; }
         public DbSet<ClubLinkRequest> ClubLinkRequests { get; set; }
         public DbSet<CompetitionAllowedPlayer> CompetitionAllowedPlayers { get; set; }
+        public DbSet<PlayerRatingSnapshot> PlayerRatingSnapshots { get; set; }
 
         protected override void OnModelCreating(ModelBuilder builder)
         {
@@ -652,6 +653,24 @@ namespace DropShot.Data
                       .WithMany(t => t.Rubbers)
                       .HasForeignKey(r => r.CompetitionRubberTemplateId)
                       .OnDelete(DeleteBehavior.Cascade);
+            });
+
+            // ── PlayerRatingSnapshot ────────────────────────────────────────────
+            builder.Entity<PlayerRatingSnapshot>(entity =>
+            {
+                entity.Property(s => s.Kind).HasConversion<byte>();
+                entity.Property(s => s.AcceptedByUserId).HasMaxLength(450);
+                entity.HasIndex(s => new { s.PlayerId, s.CompetitionId, s.Kind }).IsUnique();
+
+                entity.HasOne(s => s.Player)
+                      .WithMany()
+                      .HasForeignKey(s => s.PlayerId)
+                      .OnDelete(DeleteBehavior.Cascade);
+
+                entity.HasOne(s => s.Competition)
+                      .WithMany()
+                      .HasForeignKey(s => s.CompetitionId)
+                      .OnDelete(DeleteBehavior.NoAction);
             });
 
             // ── RoleSwitchLog ───────────────────────────────────────────────────

--- a/DropShot/Models/PlayerRatingSnapshot.cs
+++ b/DropShot/Models/PlayerRatingSnapshot.cs
@@ -1,0 +1,19 @@
+using DropShot.Shared;
+
+namespace DropShot.Models;
+
+public class PlayerRatingSnapshot
+{
+    public int PlayerRatingSnapshotId { get; set; }
+    public int PlayerId { get; set; }
+    public int CompetitionId { get; set; }
+    public PlayerRatingSnapshotKind Kind { get; set; }
+    public double Rating { get; set; }
+    public int RubbersPlayed { get; set; }
+    public bool IsProvisional { get; set; }
+    public DateTime ComputedAt { get; set; } = DateTime.UtcNow;
+    public string? AcceptedByUserId { get; set; }
+
+    public Player Player { get; set; } = null!;
+    public Competition Competition { get; set; } = null!;
+}

--- a/DropShot/Program.cs
+++ b/DropShot/Program.cs
@@ -147,6 +147,7 @@ builder.Services.AddSingleton<ContactRateLimiter>();
 builder.Services.AddScoped<FuzzySearchService>();
 builder.Services.AddScoped<ICompetitionRubberTemplateProvider, CompetitionRubberTemplateProvider>();
 builder.Services.AddScoped<RubberResolutionService>();
+builder.Services.AddScoped<PlayerRatingService>();
 builder.Services.AddScoped<FixtureSimulationService>();
 builder.Services.AddScoped<CompetitionSchedulerService>();
 builder.Services.AddSingleton<QrLoginService>();

--- a/DropShot/Services/PlayerRatingService.cs
+++ b/DropShot/Services/PlayerRatingService.cs
@@ -1,0 +1,543 @@
+using DropShot.Data;
+using DropShot.Models;
+using DropShot.Shared;
+using Microsoft.EntityFrameworkCore;
+
+namespace DropShot.Services;
+
+/// <summary>
+/// Reads / resolves player Elo ratings scoped to a competition lineage (chain of
+/// competitions linked via <see cref="Competition.SeededFromCompetitionId"/>).
+/// Snapshots are written by the per-season Apply flow (slice 2); slice 1 only
+/// reads them.
+/// </summary>
+public sealed class PlayerRatingService(IDbContextFactory<MyDbContext> dbFactory)
+{
+    public const double DefaultRating = 1500.0;
+    public const int ProvisionalThreshold = 10;
+
+    public record Rating(double Value, bool IsProvisional);
+
+    /// <summary>
+    /// Resolve the rating that player should bring into <paramref name="competitionId"/>.
+    /// Walks <c>SeededFromCompetitionId</c> exactly once — does not recurse further
+    /// back into the lineage. Order of preference on the parent competition:
+    /// 1. SeasonEnd snapshot (player completed the parent season and was accepted)
+    /// 2. SeasonStart snapshot (player carried a rating into the parent but didn't play)
+    /// 3. Default rating (1500, provisional)
+    /// </summary>
+    public async Task<Rating> GetCurrentRatingAsync(int playerId, int competitionId, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var parentId = await db.Competition
+            .AsNoTracking()
+            .Where(c => c.CompetitionID == competitionId)
+            .Select(c => c.SeededFromCompetitionId)
+            .FirstOrDefaultAsync(ct);
+
+        if (parentId is null) return new Rating(DefaultRating, IsProvisional: true);
+
+        var parentSnapshots = await db.PlayerRatingSnapshots
+            .AsNoTracking()
+            .Where(s => s.CompetitionId == parentId && s.PlayerId == playerId)
+            .ToListAsync(ct);
+
+        var seasonEnd = parentSnapshots.FirstOrDefault(s => s.Kind == PlayerRatingSnapshotKind.SeasonEnd);
+        if (seasonEnd is not null) return new Rating(seasonEnd.Rating, seasonEnd.IsProvisional);
+
+        var seasonStart = parentSnapshots.FirstOrDefault(s => s.Kind == PlayerRatingSnapshotKind.SeasonStart);
+        if (seasonStart is not null) return new Rating(seasonStart.Rating, seasonStart.IsProvisional);
+
+        return new Rating(DefaultRating, IsProvisional: true);
+    }
+
+    /// <summary>
+    /// Bulk-load all snapshots for every participant of <paramref name="competitionId"/>,
+    /// resolved against the parent competition. Used by the roster page to render
+    /// each row's "current rating" without per-row queries. Returns a map of
+    /// PlayerId → resolved Rating.
+    /// </summary>
+    public async Task<Dictionary<int, Rating>> GetCurrentRatingsForCompetitionAsync(
+        int competitionId, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+
+        var comp = await db.Competition
+            .AsNoTracking()
+            .Where(c => c.CompetitionID == competitionId)
+            .Select(c => new { c.CompetitionID, c.SeededFromCompetitionId })
+            .FirstOrDefaultAsync(ct);
+        if (comp is null) return new Dictionary<int, Rating>();
+
+        var participantIds = await db.CompetitionParticipants
+            .AsNoTracking()
+            .Where(p => p.CompetitionId == competitionId)
+            .Select(p => p.PlayerId)
+            .ToListAsync(ct);
+
+        if (participantIds.Count == 0 || comp.SeededFromCompetitionId is null)
+            return new Dictionary<int, Rating>();
+
+        var parentId = comp.SeededFromCompetitionId.Value;
+        var snapshots = await db.PlayerRatingSnapshots
+            .AsNoTracking()
+            .Where(s => s.CompetitionId == parentId && participantIds.Contains(s.PlayerId))
+            .ToListAsync(ct);
+
+        var result = new Dictionary<int, Rating>(participantIds.Count);
+        foreach (var playerId in participantIds)
+        {
+            var forPlayer = snapshots.Where(s => s.PlayerId == playerId).ToList();
+            var seasonEnd = forPlayer.FirstOrDefault(s => s.Kind == PlayerRatingSnapshotKind.SeasonEnd);
+            if (seasonEnd is not null)
+            {
+                result[playerId] = new Rating(seasonEnd.Rating, seasonEnd.IsProvisional);
+                continue;
+            }
+            var seasonStart = forPlayer.FirstOrDefault(s => s.Kind == PlayerRatingSnapshotKind.SeasonStart);
+            if (seasonStart is not null)
+            {
+                result[playerId] = new Rating(seasonStart.Rating, seasonStart.IsProvisional);
+            }
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Bulk-load that also looks at <c>SeasonStart</c> snapshots on the current
+    /// competition itself — used by the roster after an admin has typed initial
+    /// ratings inline, since those write a SeasonStart on the current comp (not
+    /// the parent). Resolution order per player: current SeasonStart → parent
+    /// SeasonEnd → parent SeasonStart → omit.
+    /// </summary>
+    public async Task<Dictionary<int, Rating>> GetRosterRatingsAsync(
+        int competitionId, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+
+        var comp = await db.Competition
+            .AsNoTracking()
+            .Where(c => c.CompetitionID == competitionId)
+            .Select(c => new { c.CompetitionID, c.SeededFromCompetitionId })
+            .FirstOrDefaultAsync(ct);
+        if (comp is null) return new Dictionary<int, Rating>();
+
+        var participantIds = await db.CompetitionParticipants
+            .AsNoTracking()
+            .Where(p => p.CompetitionId == competitionId)
+            .Select(p => p.PlayerId)
+            .ToListAsync(ct);
+        if (participantIds.Count == 0) return new Dictionary<int, Rating>();
+
+        var compIdsToCheck = new List<int> { competitionId };
+        if (comp.SeededFromCompetitionId is int parentId) compIdsToCheck.Add(parentId);
+
+        var snapshots = await db.PlayerRatingSnapshots
+            .AsNoTracking()
+            .Where(s => compIdsToCheck.Contains(s.CompetitionId) && participantIds.Contains(s.PlayerId))
+            .ToListAsync(ct);
+
+        var result = new Dictionary<int, Rating>(participantIds.Count);
+        foreach (var playerId in participantIds)
+        {
+            var forPlayer = snapshots.Where(s => s.PlayerId == playerId).ToList();
+
+            var currentStart = forPlayer.FirstOrDefault(s =>
+                s.CompetitionId == competitionId && s.Kind == PlayerRatingSnapshotKind.SeasonStart);
+            if (currentStart is not null)
+            {
+                result[playerId] = new Rating(currentStart.Rating, currentStart.IsProvisional);
+                continue;
+            }
+            if (comp.SeededFromCompetitionId is null) continue;
+
+            var parentEnd = forPlayer.FirstOrDefault(s =>
+                s.CompetitionId == comp.SeededFromCompetitionId && s.Kind == PlayerRatingSnapshotKind.SeasonEnd);
+            if (parentEnd is not null)
+            {
+                result[playerId] = new Rating(parentEnd.Rating, parentEnd.IsProvisional);
+                continue;
+            }
+            var parentStart = forPlayer.FirstOrDefault(s =>
+                s.CompetitionId == comp.SeededFromCompetitionId && s.Kind == PlayerRatingSnapshotKind.SeasonStart);
+            if (parentStart is not null)
+            {
+                result[playerId] = new Rating(parentStart.Rating, parentStart.IsProvisional);
+            }
+        }
+        return result;
+    }
+
+    public record PendingSuggestion(
+        int PlayerId,
+        double PreviousRating,
+        double SuggestedRating,
+        double Delta,
+        int RubbersPlayed);
+
+    /// <summary>
+    /// Suggestions visible to the admin: <see cref="ComputePendingSuggestionsAsync"/>
+    /// minus any player who already has a <c>SeasonStart</c> snapshot on the
+    /// current competition (manually-entered initial rating, or a previously
+    /// accepted suggestion). The roster page uses this; an admin who has
+    /// already applied a suggestion doesn't see the same arrow again.
+    /// </summary>
+    public async Task<IReadOnlyList<PendingSuggestion>> GetVisibleSuggestionsAsync(
+        int competitionId, CancellationToken ct = default)
+    {
+        var raw = await ComputePendingSuggestionsAsync(competitionId, ct);
+        if (raw.Count == 0) return raw;
+
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var applied = await db.PlayerRatingSnapshots
+            .AsNoTracking()
+            .Where(s => s.CompetitionId == competitionId
+                     && s.Kind == PlayerRatingSnapshotKind.SeasonStart)
+            .Select(s => s.PlayerId)
+            .ToListAsync(ct);
+        if (applied.Count == 0) return raw;
+        var appliedSet = applied.ToHashSet();
+        return raw.Where(s => !appliedSet.Contains(s.PlayerId)).ToList();
+    }
+
+    /// <summary>
+    /// Replays the parent competition's completed rubbers through Elo to derive
+    /// each participant's suggested post-season rating. Returns one entry per
+    /// player who actually played rubbers in the parent. Players with no parent
+    /// or no rubbers played are omitted.
+    /// </summary>
+    public async Task<IReadOnlyList<PendingSuggestion>> ComputePendingSuggestionsAsync(
+        int competitionId, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+
+        var comp = await db.Competition
+            .AsNoTracking()
+            .Where(c => c.CompetitionID == competitionId)
+            .Select(c => new { c.CompetitionID, c.SeededFromCompetitionId })
+            .FirstOrDefaultAsync(ct);
+        if (comp?.SeededFromCompetitionId is not int parentId) return Array.Empty<PendingSuggestion>();
+
+        var participantIds = await db.CompetitionParticipants
+            .AsNoTracking()
+            .Where(p => p.CompetitionId == competitionId)
+            .Select(p => p.PlayerId)
+            .ToListAsync(ct);
+        if (participantIds.Count == 0) return Array.Empty<PendingSuggestion>();
+
+        var preRatings = new Dictionary<int, double>();
+        foreach (var pid in participantIds)
+        {
+            preRatings[pid] = (await GetCurrentRatingAsync(pid, parentId, ct)).Value;
+        }
+
+        // Rubbers, ordered chronologically as best we can. CompletedAt is the
+        // truthiest signal; fall back to scheduled time, then fixture id, then
+        // rubber id for determinism.
+        var rubbers = await db.Rubbers
+            .AsNoTracking()
+            .Include(r => r.Fixture)
+            .Where(r => r.IsComplete
+                     && r.Fixture.HomeTeamId.HasValue
+                     && r.Fixture.AwayTeamId.HasValue
+                     && r.Fixture.CompetitionId == parentId)
+            .ToListAsync(ct);
+
+        var ordered = rubbers
+            .OrderBy(r => r.Fixture.CompletedAt ?? r.Fixture.ScheduledAt ?? DateTime.MaxValue)
+            .ThenBy(r => r.CompetitionFixtureId)
+            .ThenBy(r => r.RubberId)
+            .ToList();
+
+        var current = new Dictionary<int, double>(preRatings);
+        var played = new Dictionary<int, int>();
+
+        foreach (var r in ordered)
+        {
+            var home = new[] { r.HomePlayer1Id, r.HomePlayer2Id }
+                .Where(id => id.HasValue).Select(id => id!.Value).ToList();
+            var away = new[] { r.AwayPlayer1Id, r.AwayPlayer2Id }
+                .Where(id => id.HasValue).Select(id => id!.Value).ToList();
+            if (home.Count == 0 || away.Count == 0) continue;
+
+            // Use the rating of each side as the pair's mean. Players outside
+            // the current competition's participants (e.g. opponents from the
+            // parent who didn't roster again) still need a rating to score
+            // against — pull a parent snapshot or default.
+            double SideRating(IEnumerable<int> ids) =>
+                ids.Average(id =>
+                {
+                    if (current.TryGetValue(id, out var v)) return v;
+                    var fallback = preRatings.TryGetValue(id, out var f) ? f : DefaultRating;
+                    return fallback;
+                });
+
+            var homeRating = SideRating(home);
+            var awayRating = SideRating(away);
+            var expectedHome = EloCalculator.ExpectedScore(homeRating, awayRating);
+            var expectedAway = 1.0 - expectedHome;
+
+            bool homeWon = r.WinnerTeamId == r.Fixture.HomeTeamId;
+            bool awayWon = r.WinnerTeamId == r.Fixture.AwayTeamId;
+            if (!homeWon && !awayWon) continue; // no recorded winner — skip
+
+            double scoreHome = homeWon ? 1.0 : 0.0;
+            double scoreAway = 1.0 - scoreHome;
+
+            void UpdateOne(int pid, double sideRating, double opponentRating, double expected, double score)
+            {
+                if (!current.ContainsKey(pid)) current[pid] = preRatings.GetValueOrDefault(pid, DefaultRating);
+                played.TryGetValue(pid, out var n);
+                double k = n < ProvisionalThreshold ? 40.0 : 20.0;
+                current[pid] = EloCalculator.UpdateRating(current[pid], expected, score, k);
+                played[pid] = n + 1;
+            }
+
+            foreach (var pid in home) UpdateOne(pid, homeRating, awayRating, expectedHome, scoreHome);
+            foreach (var pid in away) UpdateOne(pid, awayRating, homeRating, expectedAway, scoreAway);
+        }
+
+        var result = new List<PendingSuggestion>();
+        foreach (var pid in participantIds)
+        {
+            if (!played.TryGetValue(pid, out var n) || n == 0) continue;
+            var pre = preRatings[pid];
+            var post = current[pid];
+            result.Add(new PendingSuggestion(
+                PlayerId: pid,
+                PreviousRating: pre,
+                SuggestedRating: post,
+                Delta: post - pre,
+                RubbersPlayed: n));
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Persists the suggestion for one player: writes a <c>SeasonEnd</c>
+    /// snapshot on the previous competition and a <c>SeasonStart</c> snapshot
+    /// on the current competition. Both are upserts, so calling again with
+    /// new computed values overwrites the prior accepted state.
+    /// </summary>
+    public async Task<PendingSuggestion?> AcceptSuggestionAsync(
+        int competitionId, int playerId, string? acceptedByUserId, CancellationToken ct = default)
+    {
+        var suggestions = await ComputePendingSuggestionsAsync(competitionId, ct);
+        var s = suggestions.FirstOrDefault(x => x.PlayerId == playerId);
+        if (s is null) return null;
+        await PersistAcceptanceAsync(competitionId, s, acceptedByUserId, ct);
+        return s;
+    }
+
+    public async Task<IReadOnlyList<PendingSuggestion>> AcceptAllSuggestionsAsync(
+        int competitionId, string? acceptedByUserId, CancellationToken ct = default)
+    {
+        var suggestions = await ComputePendingSuggestionsAsync(competitionId, ct);
+        foreach (var s in suggestions)
+            await PersistAcceptanceAsync(competitionId, s, acceptedByUserId, ct);
+        return suggestions;
+    }
+
+    private async Task PersistAcceptanceAsync(
+        int competitionId, PendingSuggestion s, string? userId, CancellationToken ct)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var parentId = await db.Competition
+            .Where(c => c.CompetitionID == competitionId)
+            .Select(c => c.SeededFromCompetitionId)
+            .FirstOrDefaultAsync(ct);
+        if (parentId is null) return;
+
+        bool provisional = s.RubbersPlayed < ProvisionalThreshold;
+        await UpsertSnapshotAsync(db, competitionId: parentId.Value, playerId: s.PlayerId,
+            kind: PlayerRatingSnapshotKind.SeasonEnd, rating: s.SuggestedRating,
+            rubbersPlayed: s.RubbersPlayed, isProvisional: provisional, userId: userId, ct: ct);
+        await UpsertSnapshotAsync(db, competitionId: competitionId, playerId: s.PlayerId,
+            kind: PlayerRatingSnapshotKind.SeasonStart, rating: s.SuggestedRating,
+            rubbersPlayed: 0, isProvisional: provisional, userId: userId, ct: ct);
+        await db.SaveChangesAsync(ct);
+    }
+
+    private static async Task UpsertSnapshotAsync(
+        MyDbContext db, int competitionId, int playerId, PlayerRatingSnapshotKind kind,
+        double rating, int rubbersPlayed, bool isProvisional, string? userId, CancellationToken ct)
+    {
+        var existing = await db.PlayerRatingSnapshots
+            .FirstOrDefaultAsync(s =>
+                s.CompetitionId == competitionId
+                && s.PlayerId == playerId
+                && s.Kind == kind, ct);
+        if (existing is null)
+        {
+            db.PlayerRatingSnapshots.Add(new Models.PlayerRatingSnapshot
+            {
+                CompetitionId = competitionId,
+                PlayerId = playerId,
+                Kind = kind,
+                Rating = rating,
+                RubbersPlayed = rubbersPlayed,
+                IsProvisional = isProvisional,
+                ComputedAt = DateTime.UtcNow,
+                AcceptedByUserId = userId,
+            });
+        }
+        else
+        {
+            existing.Rating = rating;
+            existing.RubbersPlayed = rubbersPlayed;
+            existing.IsProvisional = isProvisional;
+            existing.ComputedAt = DateTime.UtcNow;
+            existing.AcceptedByUserId = userId;
+        }
+    }
+
+    public record DivisionPlacement(int PlayerId, int SuggestedDivisionId, string SuggestedDivisionName);
+    public record RolePlacement(int PlayerId, string SuggestedRole);
+
+    /// <summary>
+    /// Sort participants who have a rating by rating-desc and partition them
+    /// across the competition's divisions (ranked 1 = top). Equal partitioning;
+    /// remainder players go to the bottom division. Only returns entries where
+    /// the suggested division differs from the participant's current division.
+    /// Players without a rating are excluded — admin must assign manually.
+    /// </summary>
+    public async Task<IReadOnlyList<DivisionPlacement>> SuggestDivisionPlacementsAsync(
+        int competitionId, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var divisions = await db.CompetitionDivisions
+            .AsNoTracking()
+            .Where(d => d.CompetitionId == competitionId)
+            .OrderBy(d => d.Rank)
+            .ToListAsync(ct);
+        if (divisions.Count == 0) return Array.Empty<DivisionPlacement>();
+
+        var participants = await db.CompetitionParticipants
+            .AsNoTracking()
+            .Where(p => p.CompetitionId == competitionId)
+            .Select(p => new { p.PlayerId, p.CompetitionDivisionId })
+            .ToListAsync(ct);
+        if (participants.Count == 0) return Array.Empty<DivisionPlacement>();
+
+        var ratings = await GetRosterRatingsAsync(competitionId, ct);
+
+        var ranked = participants
+            .Where(p => ratings.ContainsKey(p.PlayerId))
+            .OrderByDescending(p => ratings[p.PlayerId].Value)
+            .ThenBy(p => p.PlayerId)
+            .ToList();
+        if (ranked.Count == 0) return Array.Empty<DivisionPlacement>();
+
+        int perDivision = ranked.Count / divisions.Count;
+        int remainder = ranked.Count % divisions.Count;
+        // Distribute the remainder into the top divisions so the strongest
+        // tier is slightly larger if it doesn't divide evenly. Admin can
+        // override row-by-row regardless.
+        var result = new List<DivisionPlacement>();
+        int cursor = 0;
+        for (int i = 0; i < divisions.Count; i++)
+        {
+            int take = perDivision + (i < remainder ? 1 : 0);
+            for (int j = 0; j < take && cursor < ranked.Count; j++, cursor++)
+            {
+                var p = ranked[cursor];
+                if (p.CompetitionDivisionId == divisions[i].CompetitionDivisionId) continue;
+                result.Add(new DivisionPlacement(p.PlayerId,
+                    divisions[i].CompetitionDivisionId, divisions[i].Name));
+            }
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// For each team, run the rating-aware MTT assigner over its members and
+    /// surface any role that would differ from the participant's current role.
+    /// TeamMatch competitions only — returns empty for other formats. Teams
+    /// where any member lacks a rating are skipped so we don't half-assign.
+    /// </summary>
+    public async Task<IReadOnlyList<RolePlacement>> SuggestRolePlacementsAsync(
+        int competitionId, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var comp = await db.Competition
+            .AsNoTracking()
+            .FirstOrDefaultAsync(c => c.CompetitionID == competitionId, ct);
+        if (comp is null || comp.CompetitionFormat != CompetitionFormat.TeamMatch)
+            return Array.Empty<RolePlacement>();
+
+        var ratings = await GetRosterRatingsAsync(competitionId, ct);
+
+        var participants = await db.CompetitionParticipants
+            .AsNoTracking()
+            .Include(p => p.Player)
+            .Where(p => p.CompetitionId == competitionId && p.TeamId.HasValue)
+            .ToListAsync(ct);
+        if (participants.Count == 0) return Array.Empty<RolePlacement>();
+
+        var assigner = RubberTemplateRegistry.GetRoleAssigner(RubberTemplateRegistry.MttRatedKey);
+        if (assigner is null) return Array.Empty<RolePlacement>();
+
+        var result = new List<RolePlacement>();
+        foreach (var teamGroup in participants.GroupBy(p => p.TeamId!.Value))
+        {
+            var members = teamGroup.ToList();
+            if (members.Any(m => !ratings.ContainsKey(m.PlayerId))) continue;
+
+            var candidates = members.Select(m => new RubberTemplateRegistry.AssignmentCandidate(
+                m.PlayerId,
+                m.Player?.DisplayName ?? "",
+                m.Player?.Sex,
+                ratings[m.PlayerId].Value)).ToList();
+            var assignments = assigner(candidates);
+            foreach (var m in members)
+            {
+                if (!assignments.TryGetValue(m.PlayerId, out var suggested)) continue;
+                if (m.Role == suggested) continue;
+                result.Add(new RolePlacement(m.PlayerId, suggested));
+            }
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Persist a division placement suggestion to the participant row. No
+    /// validation here beyond row existence — the caller (admin service) gates
+    /// edit permission.
+    /// </summary>
+    public async Task ApplyDivisionPlacementAsync(
+        int competitionId, int playerId, int divisionId, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var row = await db.CompetitionParticipants.FindAsync([competitionId, playerId], ct)
+            ?? throw new KeyNotFoundException("Participant not found.");
+        row.CompetitionDivisionId = divisionId;
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task ApplyRolePlacementAsync(
+        int competitionId, int playerId, string role, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var row = await db.CompetitionParticipants.FindAsync([competitionId, playerId], ct)
+            ?? throw new KeyNotFoundException("Participant not found.");
+        row.Role = role;
+        await db.SaveChangesAsync(ct);
+    }
+
+    /// <summary>
+    /// Upserts a <c>SeasonStart</c> snapshot on the current competition for the
+    /// given player. Used to set the admin-controlled initial rating before any
+    /// season has been played. Idempotent — re-calling with a new value just
+    /// updates the existing row.
+    /// </summary>
+    public async Task SetInitialRatingAsync(
+        int competitionId, int playerId, double rating, string? acceptedByUserId,
+        CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        await UpsertSnapshotAsync(db, competitionId, playerId,
+            kind: PlayerRatingSnapshotKind.SeasonStart, rating: rating,
+            rubbersPlayed: 0, isProvisional: false, userId: acceptedByUserId, ct: ct);
+        await db.SaveChangesAsync(ct);
+    }
+}

--- a/DropShot/Services/WebCompetitionAdminService.cs
+++ b/DropShot/Services/WebCompetitionAdminService.cs
@@ -20,7 +20,8 @@ public sealed class WebCompetitionAdminService(
     ICompetitionRubberTemplateProvider rubberTemplateProvider,
     AdminEmailService adminEmailService,
     CompetitionSchedulerService scheduler,
-    FixtureSimulationService fixtureSimulator) : ICompetitionAdminService
+    FixtureSimulationService fixtureSimulator,
+    PlayerRatingService playerRatings) : ICompetitionAdminService
 {
     // IHttpContextAccessor.HttpContext is null in interactive Blazor Server mode (SignalR
     // circuit). Fall back to AuthenticationStateProvider, which works in both SSR and
@@ -1042,6 +1043,75 @@ public sealed class WebCompetitionAdminService(
         await db.SaveChangesAsync(ct);
     }
 
+    public async Task SetParticipantInitialRatingAsync(
+        int competitionId, int playerId, SetParticipantInitialRatingRequest request, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        await LoadAndAuthorizeAsync(db, competitionId, ct);
+        _ = await db.CompetitionParticipants.FindAsync([competitionId, playerId], ct)
+            ?? throw new KeyNotFoundException("Participant not found.");
+        var userId = userManager.GetUserId(await GetCurrentPrincipalAsync());
+        await playerRatings.SetInitialRatingAsync(competitionId, playerId, request.Rating, userId, ct);
+    }
+
+    public async Task<PlayerRatingSuggestionDto?> AcceptParticipantRatingAsync(
+        int competitionId, int playerId, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        await LoadAndAuthorizeAsync(db, competitionId, ct);
+        var userId = userManager.GetUserId(await GetCurrentPrincipalAsync());
+        var s = await playerRatings.AcceptSuggestionAsync(competitionId, playerId, userId, ct);
+        return s is null ? null : new PlayerRatingSuggestionDto(
+            s.PreviousRating, s.SuggestedRating, s.Delta, s.RubbersPlayed);
+    }
+
+    public async Task<List<PlayerRatingSuggestionDto>> AcceptAllParticipantRatingsAsync(
+        int competitionId, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        await LoadAndAuthorizeAsync(db, competitionId, ct);
+        var userId = userManager.GetUserId(await GetCurrentPrincipalAsync());
+        var ss = await playerRatings.AcceptAllSuggestionsAsync(competitionId, userId, ct);
+        return ss.Select(s => new PlayerRatingSuggestionDto(
+                s.PreviousRating, s.SuggestedRating, s.Delta, s.RubbersPlayed)).ToList();
+    }
+
+    public async Task ApplyDivisionPlacementAsync(
+        int competitionId, int playerId, ApplyDivisionPlacementRequest request, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        await LoadAndAuthorizeAsync(db, competitionId, ct);
+        await playerRatings.ApplyDivisionPlacementAsync(competitionId, playerId, request.CompetitionDivisionId, ct);
+    }
+
+    public async Task ApplyRolePlacementAsync(
+        int competitionId, int playerId, ApplyRolePlacementRequest request, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        await LoadAndAuthorizeAsync(db, competitionId, ct);
+        await playerRatings.ApplyRolePlacementAsync(competitionId, playerId, request.Role, ct);
+    }
+
+    public async Task<int> ApplyAllPlacementsAsync(int competitionId, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        await LoadAndAuthorizeAsync(db, competitionId, ct);
+        var divs = await playerRatings.SuggestDivisionPlacementsAsync(competitionId, ct);
+        var roles = await playerRatings.SuggestRolePlacementsAsync(competitionId, ct);
+        int applied = 0;
+        foreach (var d in divs)
+        {
+            await playerRatings.ApplyDivisionPlacementAsync(competitionId, d.PlayerId, d.SuggestedDivisionId, ct);
+            applied++;
+        }
+        foreach (var r in roles)
+        {
+            await playerRatings.ApplyRolePlacementAsync(competitionId, r.PlayerId, r.SuggestedRole, ct);
+            applied++;
+        }
+        return applied;
+    }
+
     public async Task<int> CreateLightPlayerAsync(
         int competitionId, CreateLightPlayerForCompetitionRequest request, CancellationToken ct = default)
     {
@@ -1423,14 +1493,24 @@ public sealed class WebCompetitionAdminService(
         // For TeamMatch, derive role assigner from the persisted preset key (or
         // the format default). The page also looks at the in-memory rubber
         // template state; here we use the source-of-truth columns on Competition.
+        // When the resolved preset is plain MTT, swap to the rating-aware
+        // variant — AssignMttByRating degrades to alphabetical ordering when
+        // no players have ratings, so the output is unchanged in that case,
+        // but the A slot goes to the higher-rated player when ratings exist.
         RubberTemplateRegistry.RoleAssigner? assigner = null;
         if (isTeamMatch)
         {
             var presetKey = !string.IsNullOrEmpty(comp.RubberTemplateKey)
                 ? comp.RubberTemplateKey
                 : RubberTemplateRegistry.GetFormatDefaultKey(format);
+            if (presetKey == RubberTemplateRegistry.MttKey)
+                presetKey = RubberTemplateRegistry.MttRatedKey;
             assigner = RubberTemplateRegistry.GetRoleAssigner(presetKey);
         }
+
+        var ratingsByPlayer = isTeamMatch
+            ? await playerRatings.GetRosterRatingsAsync(competitionId, ct)
+            : new Dictionary<int, PlayerRatingService.Rating>();
 
         var useMttSplit = isTeamMatch
             && (comp.RubberTemplateKey == RubberTemplateRegistry.MttKey
@@ -1469,7 +1549,7 @@ public sealed class WebCompetitionAdminService(
         {
             GenerateBucket(bucketMembers, divId, divName, format,
                 useMttSplit || (request.BalanceByGender && format == CompetitionFormat.MixedDoubles),
-                teamSize, itemLabel, assigner, rng, preview, warnings);
+                teamSize, itemLabel, assigner, ratingsByPlayer, rng, preview, warnings);
         }
         return new GenerateTeamsResultDto(preview, warnings);
     }
@@ -1479,7 +1559,9 @@ public sealed class WebCompetitionAdminService(
         int? divisionId, string? divisionName,
         CompetitionFormat? format, bool splitByGender,
         int teamSize, string itemLabel,
-        RubberTemplateRegistry.RoleAssigner? assigner, Random rng,
+        RubberTemplateRegistry.RoleAssigner? assigner,
+        IReadOnlyDictionary<int, PlayerRatingService.Rating> ratingsByPlayer,
+        Random rng,
         List<GeneratedTeamPreviewDto> preview, List<string> warnings)
     {
         string TeamName(int idx) => $"{itemLabel} {(char)('A' + idx)}";
@@ -1517,7 +1599,7 @@ public sealed class WebCompetitionAdminService(
                 preview.Add(new GeneratedTeamPreviewDto(
                     TeamName(i),
                     members.Select(m => m.PlayerId).ToList(),
-                    AssignRoles(assigner, members),
+                    AssignRoles(assigner, members, ratingsByPlayer),
                     divisionId, divisionName));
             }
         }
@@ -1539,19 +1621,22 @@ public sealed class WebCompetitionAdminService(
                 preview.Add(new GeneratedTeamPreviewDto(
                     TeamName(i),
                     members.Select(m => m.PlayerId).ToList(),
-                    AssignRoles(assigner, members),
+                    AssignRoles(assigner, members, ratingsByPlayer),
                     divisionId, divisionName));
             }
         }
     }
 
     private static IReadOnlyDictionary<int, string> AssignRoles(
-        RubberTemplateRegistry.RoleAssigner? assigner, List<CompetitionParticipant> members)
+        RubberTemplateRegistry.RoleAssigner? assigner,
+        List<CompetitionParticipant> members,
+        IReadOnlyDictionary<int, PlayerRatingService.Rating> ratingsByPlayer)
     {
         if (assigner is null) return new Dictionary<int, string>();
         var candidates = members
             .Select(m => new RubberTemplateRegistry.AssignmentCandidate(
-                m.PlayerId, m.Player?.DisplayName ?? "", m.Player?.Sex))
+                m.PlayerId, m.Player?.DisplayName ?? "", m.Player?.Sex,
+                ratingsByPlayer.TryGetValue(m.PlayerId, out var r) ? r.Value : (double?)null))
             .ToList();
         return assigner(candidates).ToDictionary(kv => kv.Key, kv => kv.Value);
     }

--- a/DropShot/Services/WebCompetitionService.cs
+++ b/DropShot/Services/WebCompetitionService.cs
@@ -24,7 +24,8 @@ public sealed class WebCompetitionService(
     AuthenticationStateProvider authStateProvider,
     ICurrentUser currentUser,
     BackgroundTaskQueue backgroundTasks,
-    RubberResolutionService rubberResolver) : ICompetitionService
+    RubberResolutionService rubberResolver,
+    PlayerRatingService ratings) : ICompetitionService
 {
     /// <summary>
     /// Best-available principal: HttpContext.User on prerender, controllers,
@@ -126,6 +127,14 @@ public sealed class WebCompetitionService(
                 .FirstOrDefault(p => p.Player?.UserId == currentUser.UserId)?.PlayerId;
         }
 
+        var ratingsByPlayer = await ratings.GetRosterRatingsAsync(id, ct);
+        var ratingSuggestions = (await ratings.GetVisibleSuggestionsAsync(id, ct))
+            .ToDictionary(s => s.PlayerId);
+        var divisionPlacements = (await ratings.SuggestDivisionPlacementsAsync(id, ct))
+            .ToDictionary(p => p.PlayerId);
+        var rolePlacements = (await ratings.SuggestRolePlacementsAsync(id, ct))
+            .ToDictionary(p => p.PlayerId);
+
         return new CompetitionDetailDto(
             c.CompetitionID, c.CompetitionName,
             c.CompetitionFormat,
@@ -144,7 +153,14 @@ public sealed class WebCompetitionService(
                 p.Role,
                 p.Player?.Sex,
                 p.CompetitionDivisionId,
-                p.Division?.Name)).ToList(),
+                p.Division?.Name,
+                ratingsByPlayer.TryGetValue(p.PlayerId, out var r)
+                    ? new PlayerRatingDto(r.Value, r.IsProvisional)
+                    : null,
+                ratingSuggestions.TryGetValue(p.PlayerId, out var rs)
+                    ? new PlayerRatingSuggestionDto(rs.PreviousRating, rs.SuggestedRating, rs.Delta, rs.RubbersPlayed)
+                    : null,
+                BuildPlacementSuggestion(p.PlayerId, divisionPlacements, rolePlacements))).ToList(),
             c.IsArchived,
             c.IsStarted,
             c.CreatorUserId,
@@ -171,6 +187,20 @@ public sealed class WebCompetitionService(
                 cp.Name)).ToList(),
             c.LeagueScoring,
             myPlayerId);
+    }
+
+    private static PlacementSuggestionDto? BuildPlacementSuggestion(
+        int playerId,
+        Dictionary<int, PlayerRatingService.DivisionPlacement> divisions,
+        Dictionary<int, PlayerRatingService.RolePlacement> roles)
+    {
+        var hasDivision = divisions.TryGetValue(playerId, out var d);
+        var hasRole = roles.TryGetValue(playerId, out var r);
+        if (!hasDivision && !hasRole) return null;
+        return new PlacementSuggestionDto(
+            SuggestedDivisionId: hasDivision ? d!.SuggestedDivisionId : null,
+            SuggestedDivisionName: hasDivision ? d!.SuggestedDivisionName : null,
+            SuggestedRole: hasRole ? r!.SuggestedRole : null);
     }
 
     private static CompetitionFixtureDto ToFixtureDto(DropShot.Models.CompetitionFixture f) => new(


### PR DESCRIPTION
## Summary
- New `PlayerRatingSnapshot` table + `PlayerRatingService` introduce per-player Elo ratings scoped to a competition lineage (`SeededFromCompetitionId` chain). Two snapshot kinds (`SeasonStart` / `SeasonEnd`) on a unique `(PlayerId, CompetitionId, Kind)` index keep every Apply idempotent.
- Roster row in `CompetitionPage.razor` becomes the single surface for: inline-editing initial ratings on a brand-new competition, accepting season-over-season Elo deltas after cloning, and applying rating-driven division and role suggestions.
- Team generation now uses the new `mtt-rated` role assigner: the higher-rated male/female in each MTT team takes the A slot (MA/FA). Degrades to alphabetical ordering when no ratings exist, so behavior is unchanged for competitions that don't opt in to ratings.

## How it works

**Brand-new competition** (no parent):
1. Type initial Elo into the rating cell for each participant (defaults to 1500, "prov" tag).
2. **Apply all placement suggestions** populates divisions based on rating-desc partitioning; roles follow once teams exist.

**Cloned new season** (has parent):
1. Open the new roster. Each player who played in the parent shows `current → suggested` with a colored ↑/↓ chip.
2. **Apply** per row, or **Apply all rating suggestions**. Writes `SeasonEnd` on the parent + `SeasonStart` on the new comp in one transaction.
3. **Apply all placement suggestions** to slot players into divisions and roles.

Elo math: pair-average for doubles attribution, K=40 while a player has <10 rubbers in the replay, then K=20. Suggestions for a player who didn't play in the parent are simply not generated.

## Critical files
- New: `DropShot/Models/PlayerRatingSnapshot.cs`, `DropShot/Services/PlayerRatingService.cs`, EF migration `20260515114259_AddPlayerRatingSnapshot`.
- Modified: `DropShot.Shared/RubberTemplateRegistry.cs` (added optional `Rating` to `AssignmentCandidate`, new `mtt-rated` assigner); `DropShot/Services/WebCompetitionAdminService.cs` (team gen now passes ratings through); `DropShot.UI/Components/Pages/CompetitionPage.razor` (rating column + placement chips + Apply / Apply-all buttons).

## Test plan
- [x] `dotnet build DropShot.sln` clean — all targets (Maui too).
- [x] `dotnet test --filter "FullyQualifiedName~PlayerRatingServiceTests"` — 19/19 pass, covering: default-rating fallback, parent-SeasonEnd lookup, "chain skips parent → returns parent's start not grandparent", initial-rating upsert idempotency, Elo replay deltas (single rubber, no-rubbers-played, opponent), Apply idempotency, hidden-after-applied suggestions, division partitioning, rating-aware role assignment, alphabetical fallback when no ratings, team-with-missing-rating skipped.
- [ ] Manual: clone a finished competition; verify `1500 → X` suggestions appear, Apply persists ratings, **Apply all placement suggestions** moves participants into the right division, regenerating teams picks `mtt-rated` and assigns MA/MB by rating.
- [ ] Manual: brand-new competition; type ratings inline; placement suggestions populate divisions.
- [ ] Apply EF migration in dev (`dotnet ef database update`) and confirm the `PlayerRatingSnapshots` table is created with the unique index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)