### PR TITLE
Default roster rating cell to 1500 instead of blank

### DIFF
--- a/DropShot.UI/Components/Pages/CompetitionPage.razor
+++ b/DropShot.UI/Components/Pages/CompetitionPage.razor
@@ -906,17 +906,25 @@ else
                         </MudTd>
                         <MudTd>@context.RegisteredAt.ToString("dd MMM yyyy")</MudTd>
                         <MudTd>
+                            @{
+                                var displayedRating = context.Rating is { } r
+                                    ? (int)Math.Round(r.CurrentRating)
+                                    : DefaultStartingRating;
+                                var isDefaultDisplay = context.Rating is null;
+                                var isProvisional = context.Rating?.IsProvisional ?? false;
+                            }
                             <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
                                 <MudNumericField T="int?"
-                                                 Value="@(context.Rating is { } r ? (int)Math.Round(r.CurrentRating) : (int?)null)"
+                                                 Value="@((int?)displayedRating)"
                                                  ValueChanged="@((int? v) => SetParticipantInitialRating(context, v))"
-                                                 Placeholder="—"
                                                  Min="0" Max="4000" Step="10"
                                                  Variant="Variant.Text" Margin="Margin.Dense" HideSpinButtons="true"
                                                  Style="max-width: 80px;" />
-                                @if (context.Rating is { IsProvisional: true } && context.RatingSuggestion is null)
+                                @if ((isDefaultDisplay || isProvisional) && context.RatingSuggestion is null)
                                 {
-                                    <MudTooltip Text="Provisional rating — fewer than 10 completed rubbers, or the default starting rating. Type a number to set the initial rating.">
+                                    <MudTooltip Text="@(isDefaultDisplay
+                                        ? "Default starting rating (1500). Type a number to set the initial rating for this player."
+                                        : "Provisional rating — fewer than 10 completed rubbers.")">
                                         <MudChip T="string" Size="Size.Small" Color="Color.Default" Variant="Variant.Outlined">prov</MudChip>
                                     </MudTooltip>
                                 }
@@ -2773,6 +2781,12 @@ else
         _newPlayerForm = new NewPlayerForm();
         _showNewPlayerDialog = true;
     }
+
+    // Display-side mirror of PlayerRatingService.DefaultRating — used when a
+    // participant has no recorded rating, so the roster cell shows 1500 with a
+    // "prov" chip rather than a blank field. Server-side default lives on
+    // PlayerRatingService and is the source of truth for math/persistence.
+    private const int DefaultStartingRating = 1500;
 
     // ── Bulk-add dialog ──────────────────────────────────────────────────────
     private bool _showBulkAddDialog;


### PR DESCRIPTION
## Summary
Newly-added participants had no rating snapshot, so the roster rating cell rendered as an empty field with an em-dash placeholder — visually indistinguishable from a bug. The cell now shows the default starting rating (`1500`) plus the existing **prov** chip, signalling "this is the default until you set one". Server-side semantics are unchanged: the snapshot table is still empty for unset players, so placement suggestions continue to skip them (1500 across the board would partition meaninglessly).

## Critical files
- `DropShot.UI/Components/Pages/CompetitionPage.razor` — rating cell now resolves `displayedRating = Rating?.CurrentRating ?? 1500` and shows the **prov** chip whenever the rating is null *or* provisional. Added a private `DefaultStartingRating = 1500` const next to the bulk-add fields, with a comment pointing at the server-side source of truth (`PlayerRatingService.DefaultRating`).

## Test plan
- [x] `dotnet build DropShot.UI.csproj` clean.
- [ ] Manual: add a fresh player to a competition — rating cell now reads `1500` with a **prov** chip. Type a different number → snapshot is written, chip disappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)