### PR TITLE
Push competition title bar down for site alerts

### DIFF
--- a/DropShot.Maui/wwwroot/index.html
+++ b/DropShot.Maui/wwwroot/index.html
@@ -30,6 +30,7 @@
     <script src="_content/DropShot.UI/js/fuzzySearch.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/qrcode-generator@1.4.4/qrcode.min.js"></script>
     <script src="_content/DropShot.UI/js/qrcode-helper.js"></script>
+    <script src="_content/DropShot.UI/js/site-alert-host.js"></script>
     <script src="_framework/blazor.webview.js" autostart="false"></script>
 
 </body>

--- a/DropShot.UI/Components/Shared/SiteAlertHost.razor
+++ b/DropShot.UI/Components/Shared/SiteAlertHost.razor
@@ -1,13 +1,15 @@
-@implements IDisposable
+@implements IAsyncDisposable
 @inject ISiteAlertService SiteAlerts
+@inject IJSRuntime JS
 @using DropShot.UI.Services
+@using Microsoft.JSInterop
 
 @* Site-wide alert banner. Renders inline at the top of the page so alerts
    push content down rather than overlaying it. The grid wrapper stays mounted
    at all times so the open/close height transition runs. Multiple alerts
    stack vertically and dismiss independently. *@
 
-<div class="site-alert-host @(_visible ? "is-visible" : "")">
+<div @ref="_hostRef" class="site-alert-host @(_visible ? "is-visible" : "")">
     <div class="site-alert-inner">
         @foreach (var entry in _rendered)
         {
@@ -40,12 +42,32 @@
     private IReadOnlyList<SiteAlertEntry> _rendered = Array.Empty<SiteAlertEntry>();
     private bool _visible;
     private CancellationTokenSource? _exitCts;
+    private ElementReference _hostRef;
+    private bool _observerAttached;
 
     protected override void OnInitialized()
     {
         SiteAlerts.OnChange += HandleChange;
         _rendered = SiteAlerts.Entries;
         _visible = _rendered.Count > 0;
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender && !_observerAttached)
+        {
+            try
+            {
+                await JS.InvokeVoidAsync("dropshotSiteAlert.attach", _hostRef);
+                _observerAttached = true;
+            }
+            catch (JSException)
+            {
+                // Site-alert-host.js isn't loaded yet (or the host page doesn't
+                // include it). Silently no-op: alerts still render, they just
+                // won't push other sticky bands down.
+            }
+        }
     }
 
     private void HandleChange()
@@ -95,10 +117,21 @@
         await entry.ActionCallback();
     }
 
-    public void Dispose()
+    public async ValueTask DisposeAsync()
     {
         SiteAlerts.OnChange -= HandleChange;
         _exitCts?.Cancel();
         _exitCts?.Dispose();
+
+        if (_observerAttached)
+        {
+            try
+            {
+                await JS.InvokeVoidAsync("dropshotSiteAlert.detach", _hostRef);
+            }
+            catch (JSException) { }
+            catch (JSDisconnectedException) { }
+            catch (TaskCanceledException) { }
+        }
     }
 }

--- a/DropShot.UI/Components/Shared/SiteAlertHost.razor.css
+++ b/DropShot.UI/Components/Shared/SiteAlertHost.razor.css
@@ -2,6 +2,15 @@
     display: grid;
     grid-template-rows: 0fr;
     transition: grid-template-rows 240ms ease;
+    /* Sticky just below the navbar (web .top-navbar is 3.5rem, MAUI MudAppBar
+       ~4rem) so the alert stays visible regardless of scroll position. Pages
+       with their own sticky bands read --site-alert-height (set by
+       site-alert-host.js from a ResizeObserver) and offset their own top by it
+       so they slide down out of the alert's way. z-index sits above the
+       competition title bar (5) and below the navbar (100). */
+    position: sticky;
+    top: 4rem;
+    z-index: 10;
 }
 
 .site-alert-host.is-visible {

--- a/DropShot.UI/wwwroot/css/shared.css
+++ b/DropShot.UI/wwwroot/css/shared.css
@@ -63,7 +63,10 @@
    padding so the band spans the full content width. */
 .competition-sticky-header {
     position: sticky;
-    top: 4rem;
+    /* `--site-alert-height` is published by site-alert-host.js (a ResizeObserver
+       on .site-alert-host) and animates in sync with the alert's grid expansion,
+       sliding this band down out of the alert's way and back up on dismiss. */
+    top: calc(4rem + var(--site-alert-height, 0px));
     z-index: 5;
     background-image:
         linear-gradient(rgba(18, 18, 18, 0.85), rgba(18, 18, 18, 0.85)),
@@ -86,7 +89,7 @@
    single-line banner case; multi-line wrapping on very narrow viewports
    will produce a small overlap. */
 body:has(.role-banner) .competition-sticky-header {
-    top: 5.5rem;
+    top: calc(5.5rem + var(--site-alert-height, 0px));
 }
 
 /* ── Competition control bar (action row + section nav) ────────────────

--- a/DropShot.UI/wwwroot/js/site-alert-host.js
+++ b/DropShot.UI/wwwroot/js/site-alert-host.js
@@ -1,0 +1,35 @@
+// Publishes the SiteAlertHost element's live content height as the CSS custom
+// property `--site-alert-height` on :root. Page-level sticky bands (e.g. the
+// competition title bar) read this variable to offset their own `top` so the
+// alert pushes them down instead of overlapping. A ResizeObserver tracks the
+// 0fr↔1fr grid transition on .site-alert-host so the variable animates in sync.
+(function () {
+    const observers = new WeakMap();
+
+    function setHeight(px) {
+        document.documentElement.style.setProperty('--site-alert-height', px + 'px');
+    }
+
+    function attach(element) {
+        if (!element || observers.has(element)) return;
+        const ro = new ResizeObserver(entries => {
+            for (const entry of entries) {
+                setHeight(entry.contentRect.height);
+            }
+        });
+        ro.observe(element);
+        observers.set(element, ro);
+    }
+
+    function detach(element) {
+        if (!element) return;
+        const ro = observers.get(element);
+        if (ro) {
+            ro.disconnect();
+            observers.delete(element);
+        }
+        setHeight(0);
+    }
+
+    window.dropshotSiteAlert = { attach, detach };
+})();

--- a/DropShot/Components/App.razor
+++ b/DropShot/Components/App.razor
@@ -36,6 +36,7 @@
     <script src="_content/DropShot.UI/js/fuzzySearch.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/qrcode-generator@1.4.4/qrcode.min.js"></script>
     <script src="_content/DropShot.UI/js/qrcode-helper.js"></script>
+    <script src="_content/DropShot.UI/js/site-alert-host.js"></script>
     <script src="js/paypal-interop.js"></script>
     <script src="_framework/blazor.web.js"></script>
     <script src="js/theme-switcher.js"></script>


### PR DESCRIPTION
## Summary
- `SiteAlertHost` is now `position: sticky; top: 4rem; z-index: 10`, so the alert banner stays visible below the navbar regardless of scroll position (previously it sat at the very top of document flow and was off-screen whenever a user triggered an action mid-page).
- A new `site-alert-host.js` `ResizeObserver` publishes the host's live pixel height as `--site-alert-height` on `:root`, animating in sync with the existing 240ms grid expansion.
- `.competition-sticky-header` now reads that variable: `top: calc(4rem + var(--site-alert-height, 0px))` (and `5.5rem + …` for the role-banner variant), so the title bar slides down to clear the alert and back up on dismiss with no overlap.

## Test plan
- [ ] Open a competition for editing, scroll to Fixtures, hit Save → alert pins below navbar and title bar slides down with no overlap; both animate together; title bar returns to `top: 4rem` after auto-dismiss.
- [ ] Force an error (break network during save) → taller wrapped banner pushes the title bar by the right amount.
- [ ] Trigger Save twice quickly → stacked alerts still keep the title bar clear of the band.
- [ ] Multi-role user with `.role-banner` showing → title bar offsets correctly from `5.5rem`.
- [ ] Mobile width (≤640px) → alert + taller stacked title band still cooperate.
- [ ] Smoke-test the MAUI host → alert appears below the MudAppBar; title bar moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)