### PR TITLE
Use 1500 default in placement suggestions for unrated players

### DIFF
--- a/DropShot.Tests/Helpers/PlayerRatingServiceTests.cs
+++ b/DropShot.Tests/Helpers/PlayerRatingServiceTests.cs
@@ -537,25 +537,44 @@ public class PlayerRatingServiceTests
     }
 
     [Fact]
-    public async Task SuggestDivisions_NoRatings_ReturnsEmpty()
+    public async Task SuggestDivisions_NoRatings_DefaultsAllPlayersAndPartitions()
     {
+        // With everyone at the default 1500, partitioning is by secondary
+        // sort (PlayerId asc). Critically, the engine must still produce a
+        // suggestion for every participant whose current division differs —
+        // otherwise the "Apply all placement suggestions" button never appears
+        // on a brand-new roster.
         var factory = new TestDbContextFactory();
         using (var db = factory.CreateDbContext())
         {
-            db.Players.Add(new Player { PlayerId = 1, DisplayName = "P1" });
+            db.Players.AddRange(
+                new Player { PlayerId = 1, DisplayName = "P1" },
+                new Player { PlayerId = 2, DisplayName = "P2" },
+                new Player { PlayerId = 3, DisplayName = "P3" },
+                new Player { PlayerId = 4, DisplayName = "P4" });
             db.Competition.Add(new Competition { CompetitionID = 100, CompetitionName = "C" });
             db.CompetitionDivisions.AddRange(
                 new CompetitionDivision { CompetitionDivisionId = 1, CompetitionId = 100, Rank = 1, Name = "A" },
                 new CompetitionDivision { CompetitionDivisionId = 2, CompetitionId = 100, Rank = 2, Name = "B" });
-            db.CompetitionParticipants.Add(
-                new CompetitionParticipant { CompetitionId = 100, PlayerId = 1 });
+            db.CompetitionParticipants.AddRange(
+                new CompetitionParticipant { CompetitionId = 100, PlayerId = 1 },
+                new CompetitionParticipant { CompetitionId = 100, PlayerId = 2 },
+                new CompetitionParticipant { CompetitionId = 100, PlayerId = 3 },
+                new CompetitionParticipant { CompetitionId = 100, PlayerId = 4 });
             await db.SaveChangesAsync();
         }
 
         var svc = BuildService(factory);
-        var placements = await svc.SuggestDivisionPlacementsAsync(competitionId: 100);
+        var placements = (await svc.SuggestDivisionPlacementsAsync(competitionId: 100))
+            .ToDictionary(p => p.PlayerId);
 
-        Assert.Empty(placements);
+        // 4 players / 2 divisions → 2 each. PlayerId ascending breaks the
+        // all-equal tie, so P1+P2 land in Div 1, P3+P4 in Div 2.
+        Assert.Equal(4, placements.Count);
+        Assert.Equal(1, placements[1].SuggestedDivisionId);
+        Assert.Equal(1, placements[2].SuggestedDivisionId);
+        Assert.Equal(2, placements[3].SuggestedDivisionId);
+        Assert.Equal(2, placements[4].SuggestedDivisionId);
     }
 
     [Fact]
@@ -627,8 +646,12 @@ public class PlayerRatingServiceTests
     }
 
     [Fact]
-    public async Task SuggestRoles_TeamWithMissingRating_Skipped()
+    public async Task SuggestRoles_PartialRatings_StillAssignsUsingDefault()
     {
+        // Only P1 has an explicit rating; P2 takes the 1500 default. The
+        // engine must still produce role suggestions for the team — the
+        // rating-aware assigner sorts P1 (1700) above P2 (1500), so the
+        // higher-rated male gets MA.
         var factory = new TestDbContextFactory();
         using (var db = factory.CreateDbContext())
         {
@@ -645,21 +668,21 @@ public class PlayerRatingServiceTests
                 CompetitionTeamId = 10, CompetitionId = 100, Name = "T1"
             });
             db.CompetitionParticipants.AddRange(
-                new CompetitionParticipant { CompetitionId = 100, PlayerId = 1, TeamId = 10 },
-                new CompetitionParticipant { CompetitionId = 100, PlayerId = 2, TeamId = 10 });
-            // Only P1 has a rating — team is incomplete, so we skip role
-            // suggestions for the whole team.
+                new CompetitionParticipant { CompetitionId = 100, PlayerId = 1, TeamId = 10, Role = "MB" },
+                new CompetitionParticipant { CompetitionId = 100, PlayerId = 2, TeamId = 10, Role = "MA" });
             db.PlayerRatingSnapshots.Add(new PlayerRatingSnapshot
             {
-                PlayerId = 1, CompetitionId = 100, Kind = PlayerRatingSnapshotKind.SeasonStart, Rating = 1500
+                PlayerId = 1, CompetitionId = 100, Kind = PlayerRatingSnapshotKind.SeasonStart, Rating = 1700
             });
             await db.SaveChangesAsync();
         }
 
         var svc = BuildService(factory);
-        var placements = await svc.SuggestRolePlacementsAsync(competitionId: 100);
+        var placements = (await svc.SuggestRolePlacementsAsync(competitionId: 100))
+            .ToDictionary(p => p.PlayerId);
 
-        Assert.Empty(placements);
+        Assert.Equal("MA", placements[1].SuggestedRole);
+        Assert.Equal("MB", placements[2].SuggestedRole);
     }
 
     [Fact]

--- a/DropShot/Services/PlayerRatingService.cs
+++ b/DropShot/Services/PlayerRatingService.cs
@@ -395,11 +395,14 @@ public sealed class PlayerRatingService(IDbContextFactory<MyDbContext> dbFactory
     public record RolePlacement(int PlayerId, string SuggestedRole);
 
     /// <summary>
-    /// Sort participants who have a rating by rating-desc and partition them
-    /// across the competition's divisions (ranked 1 = top). Equal partitioning;
-    /// remainder players go to the bottom division. Only returns entries where
-    /// the suggested division differs from the participant's current division.
-    /// Players without a rating are excluded — admin must assign manually.
+    /// Sort participants by rating-desc and partition them across the
+    /// competition's divisions (ranked 1 = top). Equal partitioning; remainder
+    /// players go to the top divisions so the strongest tier is slightly
+    /// larger when it doesn't divide evenly. Only returns entries where the
+    /// suggested division differs from the participant's current division.
+    /// Players without an explicit rating snapshot are treated as the default
+    /// (1500), so a brand-new roster still gets a useful auto-assignment
+    /// (admin overrides row-by-row).
     /// </summary>
     public async Task<IReadOnlyList<DivisionPlacement>> SuggestDivisionPlacementsAsync(
         int competitionId, CancellationToken ct = default)
@@ -422,11 +425,9 @@ public sealed class PlayerRatingService(IDbContextFactory<MyDbContext> dbFactory
         var ratings = await GetRosterRatingsAsync(competitionId, ct);
 
         var ranked = participants
-            .Where(p => ratings.ContainsKey(p.PlayerId))
-            .OrderByDescending(p => ratings[p.PlayerId].Value)
+            .OrderByDescending(p => ratings.TryGetValue(p.PlayerId, out var r) ? r.Value : DefaultRating)
             .ThenBy(p => p.PlayerId)
             .ToList();
-        if (ranked.Count == 0) return Array.Empty<DivisionPlacement>();
 
         int perDivision = ranked.Count / divisions.Count;
         int remainder = ranked.Count % divisions.Count;
@@ -452,8 +453,10 @@ public sealed class PlayerRatingService(IDbContextFactory<MyDbContext> dbFactory
     /// <summary>
     /// For each team, run the rating-aware MTT assigner over its members and
     /// surface any role that would differ from the participant's current role.
-    /// TeamMatch competitions only — returns empty for other formats. Teams
-    /// where any member lacks a rating are skipped so we don't half-assign.
+    /// TeamMatch competitions only — returns empty for other formats. Players
+    /// without an explicit rating snapshot are treated as the default (1500)
+    /// so a fresh roster gets a usable assignment (with all-equal ratings
+    /// the assigner falls back to alphabetical, matching the legacy AssignMtt).
     /// </summary>
     public async Task<IReadOnlyList<RolePlacement>> SuggestRolePlacementsAsync(
         int competitionId, CancellationToken ct = default)
@@ -481,13 +484,11 @@ public sealed class PlayerRatingService(IDbContextFactory<MyDbContext> dbFactory
         foreach (var teamGroup in participants.GroupBy(p => p.TeamId!.Value))
         {
             var members = teamGroup.ToList();
-            if (members.Any(m => !ratings.ContainsKey(m.PlayerId))) continue;
-
             var candidates = members.Select(m => new RubberTemplateRegistry.AssignmentCandidate(
                 m.PlayerId,
                 m.Player?.DisplayName ?? "",
                 m.Player?.Sex,
-                ratings[m.PlayerId].Value)).ToList();
+                ratings.TryGetValue(m.PlayerId, out var r) ? r.Value : DefaultRating)).ToList();
             var assignments = assigner(candidates);
             foreach (var m in members)
             {


### PR DESCRIPTION
## Summary
Fixes the case where a brand-new competition shows every player at the 1500 provisional default but **Apply all placement suggestions** never appears — because the suggestion engine was filtering out anyone without an explicit `SeasonStart` snapshot.

- `SuggestDivisionPlacementsAsync` now partitions the **whole** roster, falling back to `DefaultRating` (1500) for players without a snapshot. Ties break on `PlayerId` ascending, so the placement is deterministic; admins still override row-by-row.
- `SuggestRolePlacementsAsync` no longer skips teams where one or more members lack a rating — same fallback. With all-equal ratings, the existing `AssignMttByRating` degrades to alphabetical ordering (matching the legacy `AssignMtt`), so behaviour for never-rated competitions is unchanged in spirit but now actually surfaces.

## Critical files
- `DropShot/Services/PlayerRatingService.cs` — removed the `ratings.ContainsKey(...)` filter in division placement; removed the "any member missing rating → skip team" guard in role placement; both now use `ratings.TryGetValue(..., out var r) ? r.Value : DefaultRating`.

## Test plan
- [x] `dotnet test --filter "FullyQualifiedName~PlayerRatingServiceTests"` — 19/19 pass. Two existing tests updated to reflect new behaviour:
  - `SuggestDivisions_NoRatings_ReturnsEmpty` → `SuggestDivisions_NoRatings_DefaultsAllPlayersAndPartitions`
  - `SuggestRoles_TeamWithMissingRating_Skipped` → `SuggestRoles_PartialRatings_StillAssignsUsingDefault`
- [ ] Manual: add a fresh competition with divisions, add several players (no rating snapshots), confirm the **Apply all placement suggestions** button appears and partitions the roster across divisions. After Applying, the button disappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)