### PR TITLE
Add delete-all-participants button to roster section

### DIFF
--- a/DropShot.UI/Components/Pages/CompetitionPage.razor
+++ b/DropShot.UI/Components/Pages/CompetitionPage.razor
@@ -564,6 +564,12 @@ else
                                        StartIcon="@Icons.Material.Filled.GroupAdd"
                                        OnClick="OpenBulkAddDialog">Add multiple</MudButton>
                         </MudTooltip>
+                        @if (_participants.Count > 0)
+                        {
+                            <MudButton Variant="Variant.Outlined" Color="Color.Error"
+                                       StartIcon="@Icons.Material.Filled.DeleteSweep"
+                                       OnClick="@(() => _showDeleteAllParticipantsConfirm = true)">Delete All Participants</MudButton>
+                        }
                     </MudStack>
                     @if (Model.HostClubId.HasValue)
                     {
@@ -574,6 +580,18 @@ else
                         </MudTooltip>
                     }
                 </MudStack>
+
+                @if (_showDeleteAllParticipantsConfirm)
+                {
+                    <MudAlert Severity="Severity.Warning" Class="mb-3" ShowCloseIcon="true"
+                              CloseIconClicked="@(() => _showDeleteAllParticipantsConfirm = false)">
+                        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                            <MudText Typo="Typo.body2">Delete all @_participants.Count participant(s)? This cannot be undone.</MudText>
+                            <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Error"
+                                       OnClick="DeleteAllParticipants">Confirm Delete</MudButton>
+                        </MudStack>
+                    </MudAlert>
+                }
 
                 <MudDialog @bind-Visible="_showNewPlayerDialog">
                     <TitleContent>@(_editingLightPlayerId.HasValue ? "Edit Player" : "Add New Club Player")</TitleContent>
@@ -2035,6 +2053,7 @@ else
     // Schedule confirm dialog
     private bool _showScheduleConfirm;
     private bool _showDeleteAllFixturesConfirm;
+    private bool _showDeleteAllParticipantsConfirm;
     private bool _showSeedConfirm;
 
     // Fixture dialog
@@ -2971,6 +2990,18 @@ else
         await Admin.RemoveParticipantAsync(Id, cp.PlayerId);
         _participants.Remove(cp);
         SiteAlerts.Add("Participant removed.", Severity.Warning);
+    }
+
+    private async Task DeleteAllParticipants()
+    {
+        _showDeleteAllParticipantsConfirm = false;
+        var count = _participants.Count;
+        foreach (var cp in _participants.ToList())
+        {
+            await Admin.RemoveParticipantAsync(Id, cp.PlayerId);
+        }
+        _participants.Clear();
+        SiteAlerts.Add($"{count} participant(s) removed.", Severity.Warning);
     }
 
     private async Task AssignTeam(CompetitionParticipantDto cp, int? teamId)


### PR DESCRIPTION
## Summary
- Adds a "Delete All Participants" button to the Roster section of the competition page, mirroring the existing "Delete All Fixtures" pattern.
- Button is hidden when the roster is empty; clicking surfaces an inline `MudAlert` warning with the participant count and a "Confirm Delete" action.
- Handler loops the existing `Admin.RemoveParticipantAsync` over a snapshot of `_participants`, then clears the local list and shows a summary alert. No new backend endpoint.

## Test plan
- [ ] Roster with 0 participants: button is hidden.
- [ ] Roster with N participants: button visible; clicking shows confirmation alert with correct count.
- [ ] Clicking "Confirm Delete" empties the table and shows "N participant(s) removed."
- [ ] Closing the alert (X icon) dismisses without deleting.
- [ ] Page refresh confirms server-side state matches the cleared roster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)