### PR TITLE
Assign roles per division and respect them on team generation

### DIFF
--- a/DropShot.Tests/Helpers/PlayerRatingServiceTests.cs
+++ b/DropShot.Tests/Helpers/PlayerRatingServiceTests.cs
@@ -623,6 +623,135 @@ public class PlayerRatingServiceTests
     }
 
     [Fact]
+    public async Task SuggestRoles_UnteamedPlayers_StillGetSuggestions()
+    {
+        // Players don't have to be on a team yet — role assignment is per
+        // division, not per team — so the admin can role-balance the pool
+        // before generating teams.
+        var factory = new TestDbContextFactory();
+        using (var db = factory.CreateDbContext())
+        {
+            db.Players.AddRange(
+                new Player { PlayerId = 1, DisplayName = "M-Strong", Sex = PlayerSex.Male },
+                new Player { PlayerId = 2, DisplayName = "M-Weak",   Sex = PlayerSex.Male },
+                new Player { PlayerId = 3, DisplayName = "F-Strong", Sex = PlayerSex.Female },
+                new Player { PlayerId = 4, DisplayName = "F-Weak",   Sex = PlayerSex.Female });
+            db.Competition.Add(new Competition
+            {
+                CompetitionID = 100, CompetitionName = "C",
+                CompetitionFormat = CompetitionFormat.TeamMatch
+            });
+            // No teams. Participants have no TeamId.
+            db.CompetitionParticipants.AddRange(
+                new CompetitionParticipant { CompetitionId = 100, PlayerId = 1 },
+                new CompetitionParticipant { CompetitionId = 100, PlayerId = 2 },
+                new CompetitionParticipant { CompetitionId = 100, PlayerId = 3 },
+                new CompetitionParticipant { CompetitionId = 100, PlayerId = 4 });
+            db.PlayerRatingSnapshots.AddRange(
+                new PlayerRatingSnapshot { PlayerId = 1, CompetitionId = 100, Kind = PlayerRatingSnapshotKind.SeasonStart, Rating = 1700 },
+                new PlayerRatingSnapshot { PlayerId = 2, CompetitionId = 100, Kind = PlayerRatingSnapshotKind.SeasonStart, Rating = 1400 },
+                new PlayerRatingSnapshot { PlayerId = 3, CompetitionId = 100, Kind = PlayerRatingSnapshotKind.SeasonStart, Rating = 1650 },
+                new PlayerRatingSnapshot { PlayerId = 4, CompetitionId = 100, Kind = PlayerRatingSnapshotKind.SeasonStart, Rating = 1450 });
+            await db.SaveChangesAsync();
+        }
+
+        var svc = BuildService(factory);
+        var placements = (await svc.SuggestRolePlacementsAsync(competitionId: 100))
+            .ToDictionary(p => p.PlayerId);
+
+        Assert.Equal("MA", placements[1].SuggestedRole);
+        Assert.Equal("MB", placements[2].SuggestedRole);
+        Assert.Equal("FA", placements[3].SuggestedRole);
+        Assert.Equal("FB", placements[4].SuggestedRole);
+    }
+
+    [Fact]
+    public async Task SuggestRoles_PerDivision_AssignedSeparately()
+    {
+        // Two divisions, each with its own MA/MB split. P1+P2 in Div 1
+        // (one MA, one MB regardless of cross-division ratings); P3+P4
+        // in Div 2 (same).
+        var factory = new TestDbContextFactory();
+        using (var db = factory.CreateDbContext())
+        {
+            db.Players.AddRange(
+                new Player { PlayerId = 1, DisplayName = "Div1-Strong", Sex = PlayerSex.Male },
+                new Player { PlayerId = 2, DisplayName = "Div1-Weak",   Sex = PlayerSex.Male },
+                new Player { PlayerId = 3, DisplayName = "Div2-Strong", Sex = PlayerSex.Male },
+                new Player { PlayerId = 4, DisplayName = "Div2-Weak",   Sex = PlayerSex.Male });
+            db.Competition.Add(new Competition
+            {
+                CompetitionID = 100, CompetitionName = "C",
+                CompetitionFormat = CompetitionFormat.TeamMatch,
+                HasDivisions = true,
+            });
+            db.CompetitionDivisions.AddRange(
+                new CompetitionDivision { CompetitionDivisionId = 1, CompetitionId = 100, Rank = 1, Name = "Top" },
+                new CompetitionDivision { CompetitionDivisionId = 2, CompetitionId = 100, Rank = 2, Name = "Bot" });
+            db.CompetitionParticipants.AddRange(
+                new CompetitionParticipant { CompetitionId = 100, PlayerId = 1, CompetitionDivisionId = 1 },
+                new CompetitionParticipant { CompetitionId = 100, PlayerId = 2, CompetitionDivisionId = 1 },
+                new CompetitionParticipant { CompetitionId = 100, PlayerId = 3, CompetitionDivisionId = 2 },
+                new CompetitionParticipant { CompetitionId = 100, PlayerId = 4, CompetitionDivisionId = 2 });
+            // Cross-division ratings: P3 (Div 2) is rated higher than P2 (Div 1)
+            // — proves that role assignment is scoped by division, not global.
+            db.PlayerRatingSnapshots.AddRange(
+                new PlayerRatingSnapshot { PlayerId = 1, CompetitionId = 100, Kind = PlayerRatingSnapshotKind.SeasonStart, Rating = 1900 },
+                new PlayerRatingSnapshot { PlayerId = 2, CompetitionId = 100, Kind = PlayerRatingSnapshotKind.SeasonStart, Rating = 1400 },
+                new PlayerRatingSnapshot { PlayerId = 3, CompetitionId = 100, Kind = PlayerRatingSnapshotKind.SeasonStart, Rating = 1700 },
+                new PlayerRatingSnapshot { PlayerId = 4, CompetitionId = 100, Kind = PlayerRatingSnapshotKind.SeasonStart, Rating = 1200 });
+            await db.SaveChangesAsync();
+        }
+
+        var svc = BuildService(factory);
+        var placements = (await svc.SuggestRolePlacementsAsync(competitionId: 100))
+            .ToDictionary(p => p.PlayerId);
+
+        // Div 1: P1 > P2 → P1 MA, P2 MB.
+        // Div 2: P3 > P4 → P3 MA, P4 MB. P3 gets MA despite being weaker than P1.
+        Assert.Equal("MA", placements[1].SuggestedRole);
+        Assert.Equal("MB", placements[2].SuggestedRole);
+        Assert.Equal("MA", placements[3].SuggestedRole);
+        Assert.Equal("MB", placements[4].SuggestedRole);
+    }
+
+    [Fact]
+    public async Task SuggestRoles_OddCount_GivesExtraToASlot()
+    {
+        // 3 males in a single (no-division) pool: top 2 → MA, bottom 1 → MB.
+        var factory = new TestDbContextFactory();
+        using (var db = factory.CreateDbContext())
+        {
+            db.Players.AddRange(
+                new Player { PlayerId = 1, DisplayName = "Strong", Sex = PlayerSex.Male },
+                new Player { PlayerId = 2, DisplayName = "Mid",    Sex = PlayerSex.Male },
+                new Player { PlayerId = 3, DisplayName = "Weak",   Sex = PlayerSex.Male });
+            db.Competition.Add(new Competition
+            {
+                CompetitionID = 100, CompetitionName = "C",
+                CompetitionFormat = CompetitionFormat.TeamMatch,
+            });
+            db.CompetitionParticipants.AddRange(
+                new CompetitionParticipant { CompetitionId = 100, PlayerId = 1 },
+                new CompetitionParticipant { CompetitionId = 100, PlayerId = 2 },
+                new CompetitionParticipant { CompetitionId = 100, PlayerId = 3 });
+            db.PlayerRatingSnapshots.AddRange(
+                new PlayerRatingSnapshot { PlayerId = 1, CompetitionId = 100, Kind = PlayerRatingSnapshotKind.SeasonStart, Rating = 1800 },
+                new PlayerRatingSnapshot { PlayerId = 2, CompetitionId = 100, Kind = PlayerRatingSnapshotKind.SeasonStart, Rating = 1500 },
+                new PlayerRatingSnapshot { PlayerId = 3, CompetitionId = 100, Kind = PlayerRatingSnapshotKind.SeasonStart, Rating = 1200 });
+            await db.SaveChangesAsync();
+        }
+
+        var svc = BuildService(factory);
+        var placements = (await svc.SuggestRolePlacementsAsync(competitionId: 100))
+            .ToDictionary(p => p.PlayerId);
+
+        Assert.Equal("MA", placements[1].SuggestedRole);
+        Assert.Equal("MA", placements[2].SuggestedRole);
+        Assert.Equal("MB", placements[3].SuggestedRole);
+    }
+
+    [Fact]
     public void AssignMttByRating_DegradesToAlphabetical_WhenNoRatings()
     {
         // When no ratings are set, ordering must fall back to DisplayName so

--- a/DropShot/Services/PlayerRatingService.cs
+++ b/DropShot/Services/PlayerRatingService.cs
@@ -451,12 +451,18 @@ public sealed class PlayerRatingService(IDbContextFactory<MyDbContext> dbFactory
     }
 
     /// <summary>
-    /// For each team, run the rating-aware MTT assigner over its members and
-    /// surface any role that would differ from the participant's current role.
-    /// TeamMatch competitions only — returns empty for other formats. Players
-    /// without an explicit rating snapshot are treated as the default (1500)
-    /// so a fresh roster gets a usable assignment (with all-equal ratings
-    /// the assigner falls back to alphabetical, matching the legacy AssignMtt).
+    /// Assign every TeamMatch participant a role based on rating rank within
+    /// their division (or across the whole roster if the competition isn't
+    /// divisioned). Within each sex bucket the top half goes to the A slot
+    /// (MA / FA), the bottom half to the B slot (MB / FB); odd counts give
+    /// the extra slot to A. Players without a rating snapshot are treated
+    /// as the default (1500) — with all-equal ratings ties break on
+    /// DisplayName so the output stays deterministic. Suggestions are only
+    /// returned where the resulting role differs from the participant's
+    /// current Role, so the caller's "any change?" check stays simple.
+    /// Roles are *not* coupled to team membership: a player gets a role
+    /// suggestion regardless of whether they're on a team yet, which lets
+    /// the admin role-balance the pool before generating teams.
     /// </summary>
     public async Task<IReadOnlyList<RolePlacement>> SuggestRolePlacementsAsync(
         int competitionId, CancellationToken ct = default)
@@ -473,31 +479,50 @@ public sealed class PlayerRatingService(IDbContextFactory<MyDbContext> dbFactory
         var participants = await db.CompetitionParticipants
             .AsNoTracking()
             .Include(p => p.Player)
-            .Where(p => p.CompetitionId == competitionId && p.TeamId.HasValue)
+            .Where(p => p.CompetitionId == competitionId)
             .ToListAsync(ct);
         if (participants.Count == 0) return Array.Empty<RolePlacement>();
 
-        var assigner = RubberTemplateRegistry.GetRoleAssigner(RubberTemplateRegistry.MttRatedKey);
-        if (assigner is null) return Array.Empty<RolePlacement>();
-
         var result = new List<RolePlacement>();
-        foreach (var teamGroup in participants.GroupBy(p => p.TeamId!.Value))
+        var groups = comp.HasDivisions
+            ? participants.GroupBy(p => p.CompetitionDivisionId)
+            : new[] { participants.GroupBy(_ => (int?)null).First() };
+
+        foreach (var group in groups)
         {
-            var members = teamGroup.ToList();
-            var candidates = members.Select(m => new RubberTemplateRegistry.AssignmentCandidate(
-                m.PlayerId,
-                m.Player?.DisplayName ?? "",
-                m.Player?.Sex,
-                ratings.TryGetValue(m.PlayerId, out var r) ? r.Value : DefaultRating)).ToList();
-            var assignments = assigner(candidates);
-            foreach (var m in members)
-            {
-                if (!assignments.TryGetValue(m.PlayerId, out var suggested)) continue;
-                if (m.Role == suggested) continue;
-                result.Add(new RolePlacement(m.PlayerId, suggested));
-            }
+            var inGroup = group.ToList();
+            AssignSlotsByRating(inGroup, PlayerSex.Male,
+                RubberTemplateRegistry.Roles.MA, RubberTemplateRegistry.Roles.MB,
+                ratings, result);
+            AssignSlotsByRating(inGroup, PlayerSex.Female,
+                RubberTemplateRegistry.Roles.FA, RubberTemplateRegistry.Roles.FB,
+                ratings, result);
         }
         return result;
+    }
+
+    private static void AssignSlotsByRating(
+        List<CompetitionParticipant> group, PlayerSex sex,
+        string aSlot, string bSlot,
+        IReadOnlyDictionary<int, Rating> ratings,
+        List<RolePlacement> result)
+    {
+        var sorted = group
+            .Where(p => p.Player?.Sex == sex)
+            .OrderByDescending(p => ratings.TryGetValue(p.PlayerId, out var r) ? r.Value : DefaultRating)
+            .ThenBy(p => p.Player?.DisplayName ?? "", StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        if (sorted.Count == 0) return;
+
+        // Odd counts give the extra slot to A — the top tier — so a division
+        // with 5 men ends up 3 MA + 2 MB, not 2 MA + 3 MB.
+        int aCount = (sorted.Count + 1) / 2;
+        for (int i = 0; i < sorted.Count; i++)
+        {
+            var role = i < aCount ? aSlot : bSlot;
+            if (sorted[i].Role != role)
+                result.Add(new RolePlacement(sorted[i].PlayerId, role));
+        }
     }
 
     /// <summary>

--- a/DropShot/Services/WebCompetitionAdminService.cs
+++ b/DropShot/Services/WebCompetitionAdminService.cs
@@ -1640,29 +1640,82 @@ public sealed class WebCompetitionAdminService(
 
         if (splitByGender)
         {
-            var males   = bucketMembers.Where(p => p.Player?.Sex == PlayerSex.Male).OrderBy(_ => rng.Next()).ToList();
-            var females = bucketMembers.Where(p => p.Player?.Sex == PlayerSex.Female).OrderBy(_ => rng.Next()).ToList();
-            var noSex   = bucketMembers.Where(p => p.Player?.Sex is null or PlayerSex.Other).ToList();
+            var malesAll   = bucketMembers.Where(p => p.Player?.Sex == PlayerSex.Male).ToList();
+            var femalesAll = bucketMembers.Where(p => p.Player?.Sex == PlayerSex.Female).ToList();
+            var noSex      = bucketMembers.Where(p => p.Player?.Sex is null or PlayerSex.Other).ToList();
 
             if (noSex.Count > 0)
                 warnings.Add($"{BucketPrefix()}{noSex.Count} player(s) have no gender set and will be skipped.");
+
+            // Pre-assigned-roles path: when every M/F player already has a
+            // valid MTT role, form teams by drawing one of each role rather
+            // than shuffling and re-assigning. Preserves the admin's role
+            // placements (typically set via SuggestRolePlacementsAsync) so
+            // the act of generating teams doesn't undo a deliberate balance.
+            bool isMtt = format == CompetitionFormat.TeamMatch && teamSize == 4;
+            string MA = RubberTemplateRegistry.Roles.MA;
+            string MB = RubberTemplateRegistry.Roles.MB;
+            string FA = RubberTemplateRegistry.Roles.FA;
+            string FB = RubberTemplateRegistry.Roles.FB;
+            bool allRolesSet = isMtt
+                && malesAll.Count > 0 && femalesAll.Count > 0
+                && malesAll.All(m => m.Role == MA || m.Role == MB)
+                && femalesAll.All(f => f.Role == FA || f.Role == FB);
+
+            if (allRolesSet)
+            {
+                var maPool = malesAll.Where(m => m.Role == MA).OrderBy(_ => rng.Next()).ToList();
+                var mbPool = malesAll.Where(m => m.Role == MB).OrderBy(_ => rng.Next()).ToList();
+                var faPool = femalesAll.Where(f => f.Role == FA).OrderBy(_ => rng.Next()).ToList();
+                var fbPool = femalesAll.Where(f => f.Role == FB).OrderBy(_ => rng.Next()).ToList();
+
+                int teamCount = new[] { maPool.Count, mbPool.Count, faPool.Count, fbPool.Count }.Min();
+                if (teamCount == 0)
+                {
+                    warnings.Add($"{BucketPrefix()}Not enough role coverage to form teams (MA:{maPool.Count} MB:{mbPool.Count} FA:{faPool.Count} FB:{fbPool.Count}).");
+                    return;
+                }
+                int leftover = maPool.Count + mbPool.Count + faPool.Count + fbPool.Count - 4 * teamCount;
+                if (leftover > 0)
+                    warnings.Add($"{BucketPrefix()}{leftover} player(s) will be unassigned due to uneven role counts.");
+
+                for (int i = 0; i < teamCount; i++)
+                {
+                    var memberIds = new[] { maPool[i].PlayerId, mbPool[i].PlayerId, faPool[i].PlayerId, fbPool[i].PlayerId };
+                    var roles = new Dictionary<int, string>
+                    {
+                        [maPool[i].PlayerId] = MA,
+                        [mbPool[i].PlayerId] = MB,
+                        [faPool[i].PlayerId] = FA,
+                        [fbPool[i].PlayerId] = FB,
+                    };
+                    preview.Add(new GeneratedTeamPreviewDto(
+                        TeamName(i), memberIds.ToList(), roles, divisionId, divisionName));
+                }
+                return;
+            }
+
+            // Legacy path: roles not pre-set (or not MTT) — shuffle and let
+            // the assigner pick roles after team formation.
+            var males   = malesAll.OrderBy(_ => rng.Next()).ToList();
+            var females = femalesAll.OrderBy(_ => rng.Next()).ToList();
 
             var perGender = teamSize / 2;
             if (teamSize % 2 != 0)
                 warnings.Add($"{BucketPrefix()}Team size {teamSize} is odd — using {perGender} of each gender.");
 
-            var teamCount = Math.Min(males.Count / perGender, females.Count / perGender);
-            if (teamCount == 0)
+            var legacyTeamCount = Math.Min(males.Count / perGender, females.Count / perGender);
+            if (legacyTeamCount == 0)
             {
                 warnings.Add($"{BucketPrefix()}Not enough players: {males.Count} male(s), {females.Count} female(s) for teams of {teamSize}.");
                 return;
             }
-            var leftoverM = males.Count - (teamCount * perGender);
-            var leftoverF = females.Count - (teamCount * perGender);
+            var leftoverM = males.Count - (legacyTeamCount * perGender);
+            var leftoverF = females.Count - (legacyTeamCount * perGender);
             if (leftoverM > 0 || leftoverF > 0)
                 warnings.Add($"{BucketPrefix()}{leftoverM + leftoverF} player(s) will be unassigned ({leftoverM} male, {leftoverF} female).");
 
-            for (int i = 0; i < teamCount; i++)
+            for (int i = 0; i < legacyTeamCount; i++)
             {
                 var members = new List<CompetitionParticipant>();
                 members.AddRange(males.Skip(i * perGender).Take(perGender));


### PR DESCRIPTION
## Summary
Makes the 3-click setup flow actually work: **bulk-add players → Apply all placement suggestions → Generate teams**.

- `SuggestRolePlacementsAsync` now groups by division (or whole roster when there are no divisions) and assigns MA/MB/FA/FB by rating rank within each sex bucket. Players don't need a team — every roster member gets a suggestion. Top half of each sex → A slot, bottom → B; odd counts give the extra slot to A.
- Team generation has a new "honour pre-assigned roles" branch: when every M/F member of an MTT bucket already has a valid MA/MB/FA/FB role, the generator forms teams by drawing one player per role (shuffled within each role group) rather than reshuffling everyone and re-assigning. The admin's role placements survive the generate step.

Falls back to the legacy shuffle-then-assign path if any player in the bucket lacks a valid role — so non-MTT formats and partially-roled rosters behave exactly as before.

## Critical files
- `DropShot/Services/PlayerRatingService.cs` — `SuggestRolePlacementsAsync` rewritten to per-division grouping via a new `AssignSlotsByRating` helper.
- `DropShot/Services/WebCompetitionAdminService.cs` — `GenerateBucket` now branches on `allRolesSet` for MTT splits, drawing one player per role.

## Test plan
- [x] `dotnet test --filter "FullyQualifiedName~PlayerRatingServiceTests"` — 22/22 pass.
- [x] Three new tests added: `SuggestRoles_UnteamedPlayers_StillGetSuggestions`, `SuggestRoles_PerDivision_AssignedSeparately`, `SuggestRoles_OddCount_GivesExtraToASlot`.
- [ ] Manual: fresh MTT competition with divisions; bulk-add players; click **Apply all placement suggestions** — every player should have a division *and* a role on the roster (no team needed). Then click **Generate teams** — confirm the resulting teams use the same MA/MB/FA/FB roles you saw on the roster (i.e. no reshuffle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)