### PR TITLE
Balance each sex across divisions when auto-placing

### DIFF
--- a/DropShot.Tests/Helpers/PlayerRatingServiceTests.cs
+++ b/DropShot.Tests/Helpers/PlayerRatingServiceTests.cs
@@ -537,6 +537,122 @@ public class PlayerRatingServiceTests
     }
 
     [Fact]
+    public async Task SuggestDivisions_BalancesEachSexAcrossDivisions()
+    {
+        // 4 men + 4 women, 2 divisions. Pure rating-desc would put the top 4
+        // overall (whichever sex) in Div 1 — easily skewing the split. The
+        // sex-balanced partition gives Div 1 the top 2 men AND the top 2
+        // women; Div 2 gets the bottom 2 of each.
+        var factory = new TestDbContextFactory();
+        using (var db = factory.CreateDbContext())
+        {
+            db.Players.AddRange(
+                new Player { PlayerId = 1, DisplayName = "M1", Sex = PlayerSex.Male },
+                new Player { PlayerId = 2, DisplayName = "M2", Sex = PlayerSex.Male },
+                new Player { PlayerId = 3, DisplayName = "M3", Sex = PlayerSex.Male },
+                new Player { PlayerId = 4, DisplayName = "M4", Sex = PlayerSex.Male },
+                new Player { PlayerId = 5, DisplayName = "F1", Sex = PlayerSex.Female },
+                new Player { PlayerId = 6, DisplayName = "F2", Sex = PlayerSex.Female },
+                new Player { PlayerId = 7, DisplayName = "F3", Sex = PlayerSex.Female },
+                new Player { PlayerId = 8, DisplayName = "F4", Sex = PlayerSex.Female });
+            db.Competition.Add(new Competition { CompetitionID = 100, CompetitionName = "C" });
+            db.CompetitionDivisions.AddRange(
+                new CompetitionDivision { CompetitionDivisionId = 1, CompetitionId = 100, Rank = 1, Name = "Top" },
+                new CompetitionDivision { CompetitionDivisionId = 2, CompetitionId = 100, Rank = 2, Name = "Bot" });
+            db.CompetitionParticipants.AddRange(
+                Enumerable.Range(1, 8).Select(i => new CompetitionParticipant
+                {
+                    CompetitionId = 100, PlayerId = i
+                }));
+            // Men: M1=1800, M2=1700, M3=1600, M4=1500
+            // Women: F1=1750, F2=1650, F3=1550, F4=1450
+            // Pure rating-desc would interleave; sex-balanced should still
+            // give Div 1 = {M1, M2, F1, F2}, Div 2 = {M3, M4, F3, F4}.
+            db.PlayerRatingSnapshots.AddRange(
+                new PlayerRatingSnapshot { PlayerId = 1, CompetitionId = 100, Kind = PlayerRatingSnapshotKind.SeasonStart, Rating = 1800 },
+                new PlayerRatingSnapshot { PlayerId = 2, CompetitionId = 100, Kind = PlayerRatingSnapshotKind.SeasonStart, Rating = 1700 },
+                new PlayerRatingSnapshot { PlayerId = 3, CompetitionId = 100, Kind = PlayerRatingSnapshotKind.SeasonStart, Rating = 1600 },
+                new PlayerRatingSnapshot { PlayerId = 4, CompetitionId = 100, Kind = PlayerRatingSnapshotKind.SeasonStart, Rating = 1500 },
+                new PlayerRatingSnapshot { PlayerId = 5, CompetitionId = 100, Kind = PlayerRatingSnapshotKind.SeasonStart, Rating = 1750 },
+                new PlayerRatingSnapshot { PlayerId = 6, CompetitionId = 100, Kind = PlayerRatingSnapshotKind.SeasonStart, Rating = 1650 },
+                new PlayerRatingSnapshot { PlayerId = 7, CompetitionId = 100, Kind = PlayerRatingSnapshotKind.SeasonStart, Rating = 1550 },
+                new PlayerRatingSnapshot { PlayerId = 8, CompetitionId = 100, Kind = PlayerRatingSnapshotKind.SeasonStart, Rating = 1450 });
+            await db.SaveChangesAsync();
+        }
+
+        var svc = BuildService(factory);
+        var placements = (await svc.SuggestDivisionPlacementsAsync(competitionId: 100))
+            .ToDictionary(p => p.PlayerId);
+
+        // Top men + top women → Div 1.
+        Assert.Equal(1, placements[1].SuggestedDivisionId); // M1
+        Assert.Equal(1, placements[2].SuggestedDivisionId); // M2
+        Assert.Equal(1, placements[5].SuggestedDivisionId); // F1
+        Assert.Equal(1, placements[6].SuggestedDivisionId); // F2
+        // Bottom of each sex → Div 2.
+        Assert.Equal(2, placements[3].SuggestedDivisionId); // M3
+        Assert.Equal(2, placements[4].SuggestedDivisionId); // M4
+        Assert.Equal(2, placements[7].SuggestedDivisionId); // F3
+        Assert.Equal(2, placements[8].SuggestedDivisionId); // F4
+    }
+
+    [Fact]
+    public async Task SuggestDivisions_SkewedSexCounts_DistributesAcrossDivisions()
+    {
+        // 5 men + 3 women across 2 divisions. Each sex partitioned
+        // independently: men 5 → (3, 2), women 3 → (2, 1). Div 1 gets top
+        // 3 men + top 2 women; Div 2 gets bottom 2 men + bottom 1 woman.
+        var factory = new TestDbContextFactory();
+        using (var db = factory.CreateDbContext())
+        {
+            db.Players.AddRange(
+                new Player { PlayerId = 1, DisplayName = "M1", Sex = PlayerSex.Male },
+                new Player { PlayerId = 2, DisplayName = "M2", Sex = PlayerSex.Male },
+                new Player { PlayerId = 3, DisplayName = "M3", Sex = PlayerSex.Male },
+                new Player { PlayerId = 4, DisplayName = "M4", Sex = PlayerSex.Male },
+                new Player { PlayerId = 5, DisplayName = "M5", Sex = PlayerSex.Male },
+                new Player { PlayerId = 6, DisplayName = "F1", Sex = PlayerSex.Female },
+                new Player { PlayerId = 7, DisplayName = "F2", Sex = PlayerSex.Female },
+                new Player { PlayerId = 8, DisplayName = "F3", Sex = PlayerSex.Female });
+            db.Competition.Add(new Competition { CompetitionID = 100, CompetitionName = "C" });
+            db.CompetitionDivisions.AddRange(
+                new CompetitionDivision { CompetitionDivisionId = 1, CompetitionId = 100, Rank = 1, Name = "Top" },
+                new CompetitionDivision { CompetitionDivisionId = 2, CompetitionId = 100, Rank = 2, Name = "Bot" });
+            db.CompetitionParticipants.AddRange(
+                Enumerable.Range(1, 8).Select(i => new CompetitionParticipant
+                {
+                    CompetitionId = 100, PlayerId = i
+                }));
+            // M ratings 1800..1400 (desc by PlayerId), F ratings 1750..1550.
+            db.PlayerRatingSnapshots.AddRange(
+                new PlayerRatingSnapshot { PlayerId = 1, CompetitionId = 100, Kind = PlayerRatingSnapshotKind.SeasonStart, Rating = 1800 },
+                new PlayerRatingSnapshot { PlayerId = 2, CompetitionId = 100, Kind = PlayerRatingSnapshotKind.SeasonStart, Rating = 1700 },
+                new PlayerRatingSnapshot { PlayerId = 3, CompetitionId = 100, Kind = PlayerRatingSnapshotKind.SeasonStart, Rating = 1600 },
+                new PlayerRatingSnapshot { PlayerId = 4, CompetitionId = 100, Kind = PlayerRatingSnapshotKind.SeasonStart, Rating = 1500 },
+                new PlayerRatingSnapshot { PlayerId = 5, CompetitionId = 100, Kind = PlayerRatingSnapshotKind.SeasonStart, Rating = 1400 },
+                new PlayerRatingSnapshot { PlayerId = 6, CompetitionId = 100, Kind = PlayerRatingSnapshotKind.SeasonStart, Rating = 1750 },
+                new PlayerRatingSnapshot { PlayerId = 7, CompetitionId = 100, Kind = PlayerRatingSnapshotKind.SeasonStart, Rating = 1650 },
+                new PlayerRatingSnapshot { PlayerId = 8, CompetitionId = 100, Kind = PlayerRatingSnapshotKind.SeasonStart, Rating = 1550 });
+            await db.SaveChangesAsync();
+        }
+
+        var svc = BuildService(factory);
+        var placements = (await svc.SuggestDivisionPlacementsAsync(competitionId: 100))
+            .ToDictionary(p => p.PlayerId);
+
+        // 5 men: 3 to Div 1, 2 to Div 2 (remainder to top).
+        Assert.Equal(1, placements[1].SuggestedDivisionId); // M1
+        Assert.Equal(1, placements[2].SuggestedDivisionId); // M2
+        Assert.Equal(1, placements[3].SuggestedDivisionId); // M3
+        Assert.Equal(2, placements[4].SuggestedDivisionId); // M4
+        Assert.Equal(2, placements[5].SuggestedDivisionId); // M5
+        // 3 women: 2 to Div 1, 1 to Div 2.
+        Assert.Equal(1, placements[6].SuggestedDivisionId); // F1
+        Assert.Equal(1, placements[7].SuggestedDivisionId); // F2
+        Assert.Equal(2, placements[8].SuggestedDivisionId); // F3
+    }
+
+    [Fact]
     public async Task SuggestDivisions_NoRatings_DefaultsAllPlayersAndPartitions()
     {
         // With everyone at the default 1500, partitioning is by secondary

--- a/DropShot/Services/PlayerRatingService.cs
+++ b/DropShot/Services/PlayerRatingService.cs
@@ -395,14 +395,16 @@ public sealed class PlayerRatingService(IDbContextFactory<MyDbContext> dbFactory
     public record RolePlacement(int PlayerId, string SuggestedRole);
 
     /// <summary>
-    /// Sort participants by rating-desc and partition them across the
-    /// competition's divisions (ranked 1 = top). Equal partitioning; remainder
-    /// players go to the top divisions so the strongest tier is slightly
-    /// larger when it doesn't divide evenly. Only returns entries where the
-    /// suggested division differs from the participant's current division.
-    /// Players without an explicit rating snapshot are treated as the default
-    /// (1500), so a brand-new roster still gets a useful auto-assignment
-    /// (admin overrides row-by-row).
+    /// Partition each sex independently across the competition's divisions
+    /// (ranked 1 = top), so each division ends up with a balanced sex mix —
+    /// critical for TeamMatch/MixedDoubles where a team needs both sexes.
+    /// Within each sex, players are sorted by rating-desc and split into
+    /// equal-sized groups, with any remainder going to the top divisions.
+    /// Players without a rating snapshot are treated as the default (1500);
+    /// players with no sex set are pooled together and partitioned the same
+    /// way (they'll usually end up unteamed but at least land in a division).
+    /// Only entries where the suggested division differs from the
+    /// participant's current division are returned.
     /// </summary>
     public async Task<IReadOnlyList<DivisionPlacement>> SuggestDivisionPlacementsAsync(
         int competitionId, CancellationToken ct = default)
@@ -418,34 +420,48 @@ public sealed class PlayerRatingService(IDbContextFactory<MyDbContext> dbFactory
         var participants = await db.CompetitionParticipants
             .AsNoTracking()
             .Where(p => p.CompetitionId == competitionId)
-            .Select(p => new { p.PlayerId, p.CompetitionDivisionId })
+            .Select(p => new
+            {
+                p.PlayerId,
+                p.CompetitionDivisionId,
+                Sex = p.Player == null ? (PlayerSex?)null : p.Player.Sex
+            })
             .ToListAsync(ct);
         if (participants.Count == 0) return Array.Empty<DivisionPlacement>();
 
         var ratings = await GetRosterRatingsAsync(competitionId, ct);
 
-        var ranked = participants
-            .OrderByDescending(p => ratings.TryGetValue(p.PlayerId, out var r) ? r.Value : DefaultRating)
-            .ThenBy(p => p.PlayerId)
-            .ToList();
-
-        int perDivision = ranked.Count / divisions.Count;
-        int remainder = ranked.Count % divisions.Count;
-        // Distribute the remainder into the top divisions so the strongest
-        // tier is slightly larger if it doesn't divide evenly. Admin can
-        // override row-by-row regardless.
-        var result = new List<DivisionPlacement>();
-        int cursor = 0;
-        for (int i = 0; i < divisions.Count; i++)
+        // Sex-balanced partition: each sex group is sorted by rating-desc and
+        // split into N equal-ish slices independently, so every division gets
+        // roughly the same number of men and women regardless of how rating
+        // skews across sexes. Remainders go to the top divisions.
+        var assignments = new Dictionary<int, int>();
+        foreach (var group in participants.GroupBy(p => p.Sex))
         {
-            int take = perDivision + (i < remainder ? 1 : 0);
-            for (int j = 0; j < take && cursor < ranked.Count; j++, cursor++)
+            var sorted = group
+                .OrderByDescending(p => ratings.TryGetValue(p.PlayerId, out var r) ? r.Value : DefaultRating)
+                .ThenBy(p => p.PlayerId)
+                .ToList();
+            int perDivision = sorted.Count / divisions.Count;
+            int remainder = sorted.Count % divisions.Count;
+            int cursor = 0;
+            for (int i = 0; i < divisions.Count; i++)
             {
-                var p = ranked[cursor];
-                if (p.CompetitionDivisionId == divisions[i].CompetitionDivisionId) continue;
-                result.Add(new DivisionPlacement(p.PlayerId,
-                    divisions[i].CompetitionDivisionId, divisions[i].Name));
+                int take = perDivision + (i < remainder ? 1 : 0);
+                for (int j = 0; j < take && cursor < sorted.Count; j++, cursor++)
+                {
+                    assignments[sorted[cursor].PlayerId] = divisions[i].CompetitionDivisionId;
+                }
             }
+        }
+
+        var divNameById = divisions.ToDictionary(d => d.CompetitionDivisionId, d => d.Name);
+        var result = new List<DivisionPlacement>();
+        foreach (var p in participants)
+        {
+            if (!assignments.TryGetValue(p.PlayerId, out var divId)) continue;
+            if (p.CompetitionDivisionId == divId) continue;
+            result.Add(new DivisionPlacement(p.PlayerId, divId, divNameById[divId]));
         }
         return result;
     }


### PR DESCRIPTION
## Summary
Auto-division placement now partitions each sex *independently* across divisions instead of pure rating-desc across the whole roster. So every division gets a fair share of men and women — and the top half of each sex within the division still ends up in the A role slot.

### Why
Rating-desc partitioning could put the top 4 overall (whichever sex) in Div 1 and leave a bottom division short of one sex entirely. That's fine for ratings parity but breaks MTT / MixedDoubles team formation, which needs both sexes in every division.

### How
For each sex bucket (Male / Female / null-or-Other), sort by rating-desc and split equal-sized across divisions, remainder going to the top divisions. Each player carries through to a final per-player assignment. Existing per-division role engine then naturally produces balanced MA/MB/FA/FB counts, so team generation can form more complete teams.

## Critical files
- `DropShot/Services/PlayerRatingService.cs` — `SuggestDivisionPlacementsAsync` rewritten to group-by-sex before partitioning.

## Test plan
- [x] `dotnet test --filter "FullyQualifiedName~PlayerRatingServiceTests"` — 21/21 pass.
- [x] Two new tests:
  - `SuggestDivisions_BalancesEachSexAcrossDivisions` (4M + 4F → Div 1 has top 2 of each sex, Div 2 has bottom 2 of each).
  - `SuggestDivisions_SkewedSexCounts_DistributesAcrossDivisions` (5M + 3F → 3+2 split for men, 2+1 split for women, each sex partitioned independently).
- [ ] Manual: roster with uneven sex counts and three divisions. Click **Apply all placement suggestions** — confirm each division ends up with roughly the same male / female count (off by at most one due to remainder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)