### PR TITLE
TeamMatch ResultSummary honours LeagueScoring mode

### DIFF
--- a/DropShot/Services/FixtureSimulationService.cs
+++ b/DropShot/Services/FixtureSimulationService.cs
@@ -81,16 +81,23 @@ public class FixtureSimulationService(RubberResolutionService rubberResolver)
 
         if (!RubberResolutionService.AllComplete(allRubbers)) return;
 
-        var (homeScore, awayScore) = RubberResolutionService.ComputeScore(
+        var (homeRubbers, awayRubbers) = RubberResolutionService.ComputeScore(
             allRubbers, fx.HomeTeamId!.Value, fx.AwayTeamId!.Value);
+
+        // ResultSummary uses the LeagueScoring metric so SetsWon / GamesWon
+        // competitions display the actual scoring count, not rubber count.
+        var scoringMode = fx.Competition?.LeagueScoring ?? LeagueScoringMode.WinPoints;
+        var (homeScore, awayScore, _) = RubberResolutionService.ComputeLeagueScore(
+            allRubbers, fx.HomeTeamId.Value, fx.AwayTeamId.Value, scoringMode);
 
         // Simulation is a super-admin test tool — always completes immediately,
         // bypassing RequireVerification regardless of the competition setting.
         fx.Status = FixtureStatus.Completed;
         fx.CompletedAt = DateTime.UtcNow;
         fx.ResultSummary = $"{homeScore}-{awayScore}";
-        fx.WinnerTeamId = homeScore > awayScore ? fx.HomeTeamId
-                         : awayScore > homeScore ? fx.AwayTeamId
+        // Winner determined by RUBBER count (matches team league table W/D/L).
+        fx.WinnerTeamId = homeRubbers > awayRubbers ? fx.HomeTeamId
+                         : awayRubbers > homeRubbers ? fx.AwayTeamId
                          : null;
         fx.HomeSetsWon = allRubbers.Sum(r => r.HomeSetsWon ?? 0);
         fx.AwaySetsWon = allRubbers.Sum(r => r.AwaySetsWon ?? 0);

--- a/DropShot/Services/WebCompetitionService.cs
+++ b/DropShot/Services/WebCompetitionService.cs
@@ -507,18 +507,40 @@ public sealed class WebCompetitionService(
         if (fx.HomeTeamId.HasValue && fx.AwayTeamId.HasValue
             && RubberResolutionService.AllComplete(allRubbers))
         {
-            var (homeScore, awayScore) = RubberResolutionService.ComputeScore(
+            var (homeRubbers, awayRubbers) = RubberResolutionService.ComputeScore(
                 allRubbers, fx.HomeTeamId.Value, fx.AwayTeamId.Value);
+
+            // ResultSummary should reflect the competition's LeagueScoring mode
+            // rather than always showing rubber count. For SetsWon, this keeps
+            // the displayed "X-Y" in line with the totalled sets across all
+            // rubbers (so a fixture with three tied 1-1 rubbers and one 2-0
+            // shows as "5-3" sets, not "1-0" rubbers).
+            var scoringMode = fx.Competition?.LeagueScoring ?? LeagueScoringMode.WinPoints;
+            var (homeScore, awayScore, _) = RubberResolutionService.ComputeLeagueScore(
+                allRubbers, fx.HomeTeamId.Value, fx.AwayTeamId.Value, scoringMode);
 
             bool alreadyFinalised = fx.Status == FixtureStatus.AwaitingVerification
                 || fx.Status == FixtureStatus.Completed;
 
             fx.ResultSummary = $"{homeScore}-{awayScore}";
-            int? winner = homeScore > awayScore ? fx.HomeTeamId
-                        : awayScore > homeScore ? fx.AwayTeamId
+
+            // Persist fixture-level aggregates so downstream consumers (rating
+            // replay, league table, result cards) don't have to re-walk the
+            // rubber rows. Match FixtureSimulationService which already does this.
+            fx.HomeSetsWon = allRubbers.Sum(r => r.HomeSetsWon ?? 0);
+            fx.AwaySetsWon = allRubbers.Sum(r => r.AwaySetsWon ?? 0);
+            fx.HomeGamesTotal = allRubbers.Sum(r => r.HomeGamesTotal ?? 0);
+            fx.AwayGamesTotal = allRubbers.Sum(r => r.AwayGamesTotal ?? 0);
+
+            // Winner is still determined by RUBBER count — that's what the team
+            // league table uses for W/D/L (the LeagueScoring metric only drives
+            // points). Keeping these aligned avoids "won the table row but lost
+            // the fixture" weirdness.
+            int? winner = homeRubbers > awayRubbers ? fx.HomeTeamId
+                        : awayRubbers > homeRubbers ? fx.AwayTeamId
                         : null;
 
-            if (!winner.HasValue && homeScore == awayScore)
+            if (!winner.HasValue && homeRubbers == awayRubbers)
             {
                 var mode = fx.Competition?.RubberTieBreak ?? DropShot.Shared.RubberTieBreakMode.AdminDecides;
                 winner = await RubberResolutionService.ResolveTieBreakAsync(db, fx, allRubbers, mode);


### PR DESCRIPTION
## Summary
A TeamMatch fixture's `ResultSummary` was always built as `"{rubbersWon}-{rubbersWon}"` regardless of the competition's `LeagueScoring` mode. In a `SetsWon` competition where rubbers can tie (e.g. 2 fixed sets per rubber, 1–1 draws), this misrepresents the outcome.

**Example from the bug report:** 4 rubbers, 2 sets each. 3 rubbers ended 1–1 (tied, no rubber winner). 1 rubber ended 2–0 to home. Page header chip showed `5 — 3 sets` (correct, uses `ComputeLeagueScore`). Fixture `ResultSummary` showed `1-0` (wrong — that's the rubber count, ignoring the `SetsWon` mode), so the results list / FixtureResultCard rendered the misleading "1–0".

## Changes
- `WebCompetitionService.SubmitRubberScoresAsync` (live submission path) now calls `RubberResolutionService.ComputeLeagueScore` with the competition's `LeagueScoring` and uses those values for `fx.ResultSummary`. Also populates `fx.HomeSetsWon / AwaySetsWon / HomeGamesTotal / AwayGamesTotal` from rubber sums — previously only the simulator did this, leaving real submissions with null fixture-level aggregates.
- `FixtureSimulationService.SimulateTeamMatch...` mirrors the same change.
- `fx.WinnerTeamId` still derives from **rubber count** to stay aligned with the team league-table W/D/L logic (the table uses sets/games for points only, not for win/loss).

## Test plan
- [x] `dotnet build DropShot.csproj` clean.
- [ ] Manual: SetsWon TeamMatch with 3 tied rubbers + 1 decisive; submit all → `ResultSummary` reads `5-3`, league-table W/D/L unchanged, points column still reflects sets.
- [ ] Manual: WinPoints (default) TeamMatch — `ResultSummary` still reads as rubber count (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)