### PR TITLE
Make AdminClubIds resilient to UserManager DbContext race

### DIFF
--- a/DropShot/Services/WebCurrentUser.cs
+++ b/DropShot/Services/WebCurrentUser.cs
@@ -121,23 +121,50 @@ public sealed class WebCurrentUser : ICurrentUser, IDisposable
 
         if (_userId is null) return;
 
-        var appUser = await _userManager.FindByIdAsync(_userId);
-        if (appUser is not null)
+        // ClubAdministrators is queried via the factory (its own scoped
+        // DbContext) so the "shared scoped DbContext" race that can take
+        // out the UserManager calls below never short-circuits it. Before
+        // this re-ordering, a transient UserManager failure left
+        // _adminClubIds empty and hid the Add Competition / New Event
+        // buttons on /competitions even for legitimate club admins.
+        try
         {
-            _email = appUser.Email;
-            _grantedRoles = (await _userManager.GetRolesAsync(appUser)).ToList();
-            _isSubscribed = appUser.IsSubscribed;
+            await using var db = await _dbFactory.CreateDbContextAsync();
+            _adminClubIds = await db.ClubAdministrators
+                .Where(ca => ca.UserId == _userId)
+                .Select(ca => ca.ClubId)
+                .ToListAsync();
         }
-        else
+        catch
         {
-            _isSubscribed = false;
+            // Leave any previously-populated snapshot in place rather than
+            // wiping it on a transient DB hiccup.
         }
 
-        await using var db = await _dbFactory.CreateDbContextAsync();
-        _adminClubIds = await db.ClubAdministrators
-            .Where(ca => ca.UserId == _userId)
-            .Select(ca => ca.ClubId)
-            .ToListAsync();
+        try
+        {
+            var appUser = await _userManager.FindByIdAsync(_userId);
+            if (appUser is not null)
+            {
+                _email = appUser.Email;
+                _grantedRoles = (await _userManager.GetRolesAsync(appUser)).ToList();
+                _isSubscribed = appUser.IsSubscribed;
+            }
+            else
+            {
+                _isSubscribed = false;
+            }
+        }
+        catch
+        {
+            // UserManager shares the scoped DbContext with whatever else
+            // is running in this circuit, and can throw "A second
+            // operation was started on this context" during prerender.
+            // CanCreateUserCompetition already falls back to the HTTP
+            // principal's Role claims when _grantedRoles is empty, so a
+            // failure here is recoverable — but only if AdminClubIds
+            // above isn't ALSO trapped behind the same throw.
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
Club admins reported the **Add Competition** and **New Event** buttons missing on `/competitions` even with valid `ClubAdministrators` rows. Root cause: `WebCurrentUser.ApplyStateAsync` queried `UserManager` (which uses the scoped DbContext) *before* populating `_adminClubIds` (which uses a fresh DbContext from the factory). When `UserManager` threw `"A second operation was started on this context"` — a race already documented for `_grantedRoles` — execution exited the method, leaving `_adminClubIds` empty. The `_hasEditableClubs` check (`AdminClubIds.Count > 0`) then evaluated false and hid the buttons.

## Fix
- Run the `ClubAdministrators` query *first*, in its own try/catch.
- Wrap the `UserManager` block in its own try/catch so transient DbContext contention on either side preserves the previously-populated snapshot.
- The factory-created DbContext is independent of the scoped one, so the AdminClubIds query is no longer trapped behind the same throw.

`CanCreateUserCompetition` already had an HTTP-principal fallback for the missing `_grantedRoles` case; the buttons-gate path was the unfallback-able branch and is the one this PR addresses.

## Critical files
- `DropShot/Services/WebCurrentUser.cs` — re-ordered + try/catch'd `ApplyStateAsync` blocks.

## Test plan
- [x] `dotnet build DropShot.csproj` clean.
- [ ] Manual: log in as a club admin (no SuperAdmin / Admin role), navigate to `/competitions`. Buttons appear immediately on first load — including the prerender → interactive transition that previously raced.
- [ ] Manual: navigate as a plain User — no buttons (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)