### PR TITLE
Fix "Back to Competition" navigation from team-match scoring

### DIFF
--- a/DropShot.UI/Components/Pages/TeamMatchScoring.razor
+++ b/DropShot.UI/Components/Pages/TeamMatchScoring.razor
@@ -44,7 +44,7 @@ else if (_resolutionError != null)
             @if (_context is not null)
             {
                 <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.ArrowBack"
-                           Href="@($"/competitions/{_context.CompetitionId}/view")">
+                           Href="@($"/competition/{_context.CompetitionId}")">
                     Back to Competition
                 </MudButton>
             }
@@ -109,7 +109,7 @@ else
         }
 
         <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.ArrowBack"
-                   Href="@($"/competitions/{_context.CompetitionId}/view")">
+                   Href="@($"/competition/{_context.CompetitionId}")">
             Back to Competition
         </MudButton>
     </MudContainer>


### PR DESCRIPTION
## Summary
- Both "Back to Competition" buttons in [TeamMatchScoring.razor](DropShot.UI/Components/Pages/TeamMatchScoring.razor) linked to `/competitions/{id}/view` (plural), which is not a registered page route — clicking either 404s.
- Page routes are singular (`/competition/{id}` edit, `/competition/{id}/view` view); the plural slug only exists on API routes (`api/competitions/...`).
- Pointed both buttons at the edit page (`/competition/{id}`) since the user arrives at the team-match page from there.

## Test plan
- [ ] As a competition admin, open a competition with a team-match fixture and click the "Play Team Match" icon to land on `/team-match/{fixtureId}`.
- [ ] Enter rubber scores and click "Back to Competition" — should navigate to `/competition/{id}` with no error.
- [ ] Open a team-match fixture whose roster is missing required role tags so the resolution-error alert renders, then click its "Back to Competition" — same edit-page navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)