### PR TITLE
Add simulate participant selection helper to roster section

### DIFF
--- a/DropShot.UI/Components/Pages/CompetitionPage.razor
+++ b/DropShot.UI/Components/Pages/CompetitionPage.razor
@@ -570,6 +570,16 @@ else
                                        StartIcon="@Icons.Material.Filled.DeleteSweep"
                                        OnClick="@(() => _showDeleteAllParticipantsConfirm = true)">Delete All Participants</MudButton>
                         }
+                        @if (_isSuperAdmin && _divisions.Count > 0 && Model.HostClubId.HasValue)
+                        {
+                            var simTargets = ComputeSimulationTargets();
+                            <MudTooltip Text="@($"Randomly select {simTargets.male} male + {simTargets.female} female club players (7 teams x {_divisions.Count} division(s))")">
+                                <MudButton Variant="Variant.Outlined" Color="Color.Secondary"
+                                           StartIcon="@Icons.Material.Filled.Casino"
+                                           Disabled="_simulating"
+                                           OnClick="SimulateParticipantSelectionAsync">Simulate participant selection</MudButton>
+                            </MudTooltip>
+                        }
                     </MudStack>
                     @if (Model.HostClubId.HasValue)
                     {
@@ -2055,6 +2065,7 @@ else
     private bool _showDeleteAllFixturesConfirm;
     private bool _showDeleteAllParticipantsConfirm;
     private bool _showSeedConfirm;
+    private bool _simulating;
 
     // Fixture dialog
     private bool _showFixtureDialog;
@@ -3002,6 +3013,110 @@ else
         }
         _participants.Clear();
         SiteAlerts.Add($"{count} participant(s) removed.", Severity.Warning);
+    }
+
+    // Computes how many male/female club players are needed to fill 7 teams per
+    // division for every division already created. Total is split 50/50; an odd
+    // remainder (e.g. Singles with an odd team count) goes to the male side.
+    private (int male, int female) ComputeSimulationTargets()
+    {
+        int divisions = _divisions.Count;
+        if (divisions == 0) return (0, 0);
+
+        int teamSize = Model.TeamSize ?? (Model.Format switch
+        {
+            CompetitionFormatUi.Team    => 4,
+            CompetitionFormatUi.Doubles => 2,
+            _                           => 1, // Singles
+        });
+
+        int totalPlayers = 7 * divisions * teamSize;
+        int male   = totalPlayers / 2 + (totalPlayers % 2);
+        int female = totalPlayers / 2;
+        return (male, female);
+    }
+
+    private async Task SimulateParticipantSelectionAsync()
+    {
+        if (_simulating) return;
+        if (!_isSuperAdmin)
+        {
+            SiteAlerts.Add("Only super admins can simulate participant selection.", Severity.Warning);
+            return;
+        }
+        if (!Model.HostClubId.HasValue)
+        {
+            SiteAlerts.Add("Competition must have a host club before simulating.", Severity.Warning);
+            return;
+        }
+        if (_divisions.Count == 0)
+        {
+            SiteAlerts.Add("Create at least one division before simulating.", Severity.Warning);
+            return;
+        }
+
+        var (targetMale, targetFemale) = ComputeSimulationTargets();
+        if (targetMale + targetFemale == 0) return;
+
+        _simulating = true;
+        try
+        {
+            // 1) Clear existing participants ("clear first" semantics).
+            foreach (var cp in _participants.ToList())
+            {
+                await Admin.RemoveParticipantAsync(Id, cp.PlayerId);
+            }
+            _participants.Clear();
+
+            // 2) Pull the host-club candidate pool. Server already filters by
+            //    HostClubId + eligibility (mirrors OpenBulkAddDialog).
+            var candidates = await Admin.SearchPlayersAsync(Id, new SearchPlayersForAddRequest(
+                Query: "", HostClubId: Model.HostClubId, MaxResults: 500));
+
+            // 3) Random sample per sex.
+            var rng = new Random();
+            var males = candidates.Where(p => p.Sex == PlayerSex.Male)
+                .OrderBy(_ => rng.Next()).Take(targetMale).ToList();
+            var females = candidates.Where(p => p.Sex == PlayerSex.Female)
+                .OrderBy(_ => rng.Next()).Take(targetFemale).ToList();
+
+            int shortM = targetMale - males.Count;
+            int shortF = targetFemale - females.Count;
+
+            var playerIds = males.Concat(females).Select(p => p.PlayerId).ToList();
+            if (playerIds.Count == 0)
+            {
+                SiteAlerts.Add("No eligible club players to draw from.", Severity.Warning);
+                return;
+            }
+
+            var result = await Admin.BulkAddParticipantsAsync(Id,
+                new BulkAddParticipantsRequest(playerIds, ParticipantStatus.Registered));
+
+            // 4) Refresh view so PlacementSuggestion / Role suggestions appear,
+            //    which makes the existing "Apply all placement suggestions"
+            //    button visible above the participants table.
+            await ReloadAfterServerMutationAsync();
+
+            var msg = $"Simulated roster: {males.Count}M + {females.Count}F added (target {targetMale}M + {targetFemale}F).";
+            if (shortM > 0 || shortF > 0)
+            {
+                msg += $" Short by {shortM}M / {shortF}F - add more club players or fewer divisions.";
+                SiteAlerts.Add(msg, Severity.Warning);
+            }
+            else
+            {
+                SiteAlerts.Add(msg, Severity.Success);
+            }
+        }
+        catch (Exception ex)
+        {
+            SiteAlerts.Add($"Simulation failed: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _simulating = false;
+        }
     }
 
     private async Task AssignTeam(CompetitionParticipantDto cp, int? teamId)


### PR DESCRIPTION
## Summary
- Adds a super-admin-only **Simulate participant selection** button to the Participants section of the competition admin page.
- Clears existing participants, then randomly draws the right male/female counts from the host club roster to fill 7 teams per division (using `Model.Format` + `Model.TeamSize` + `_divisions.Count`).
- Reuses the existing bulk-add + reload paths so placement and role suggestions populate immediately — the existing **Apply all placement suggestions** button picks up from there for a one-click follow-up to ready teams for generation.

## Test plan
- [ ] Sign in as a super admin, open a TeamMatch competition with a host club that has ample male + female club players.
- [ ] Add two divisions; verify the button appears next to **Delete All Participants** with tooltip "Randomly select 28 male + 28 female club players (7 teams x 2 division(s))".
- [ ] Click the button: existing participants are cleared, 56 fresh participants are added, success toast confirms the split.
- [ ] Verify each new participant shows a division + role suggestion, then click **Apply all placement suggestions** and confirm every row gets a Division + Role (MA/MB/FA/FB).
- [ ] Sign in as a non-super-admin and confirm the button is hidden.
- [ ] Edge: try with 0 divisions (button hidden) and with a club short on female players (warning toast reports shortfall, suggestions still load).

🤖 Generated with [Claude Code](https://claude.com/claude-code)