### PR TITLE
Add competition setup wizard and reorder edit form

### DIFF
--- a/DropShot.UI/Components/Competitions/CompetitionFormModel.cs
+++ b/DropShot.UI/Components/Competitions/CompetitionFormModel.cs
@@ -1,0 +1,66 @@
+using System.ComponentModel.DataAnnotations;
+using DropShot.Shared;
+
+namespace DropShot.UI.Components.Competitions;
+
+public sealed class CompetitionFormModel
+{
+    [Required(ErrorMessage = "Competition name is required!")]
+    [StringLength(200, ErrorMessage = "Name must be 200 characters or fewer.")]
+    public string CompetitionName { get; set; } = "";
+    public CompetitionCategoryUi? Category { get; set; }
+    public CompetitionFormatUi? Format { get; set; }
+    public int? MaxParticipants { get; set; }
+    public DateTime? StartDateDt { get; set; }
+    public DateTime? EndDateDt { get; set; }
+    public DateTime? RegisterByDateDt { get; set; }
+    public int? MaxAge { get; set; }
+    public int? MinAge { get; set; }
+    public int? HostClubId { get; set; }
+    public int? RulesSetId { get; set; }
+    public int? EventId { get; set; }
+    public int BestOf { get; set; } = 3;
+    public bool RequireVerification { get; set; } = false;
+    public int? TeamSize { get; set; }
+    public MatchFormatType MatchFormat { get; set; } = MatchFormatType.BestOf;
+    public int NumberOfSets { get; set; } = 3;
+    public int GamesPerSet { get; set; } = 6;
+    public SetWinMode SetWinMode { get; set; } = SetWinMode.WinBy2;
+    public LeagueScoringMode LeagueScoring { get; set; } = LeagueScoringMode.WinPoints;
+    public RubberTieBreakMode RubberTieBreak { get; set; } = RubberTieBreakMode.AdminDecides;
+    public int? MinDaysBetweenPlayerMatches { get; set; }
+    public bool HasDivisions { get; set; }
+    public int? SeededFromCompetitionId { get; set; }
+}
+
+// UI-only enums that separate category (Male/Female/Mixed) from the format shown in the
+// dropdown (Singles/Doubles/Team). The persisted CompetitionFormat + EligibleSex pair is
+// derived from these two on save.
+public enum CompetitionCategoryUi { Male, Female, Mixed }
+public enum CompetitionFormatUi { Singles, Doubles, Team }
+
+public static class CompetitionFormHelpers
+{
+    public static IEnumerable<CompetitionFormatUi> AllowedFormats(CompetitionCategoryUi? category) =>
+        category == CompetitionCategoryUi.Mixed
+            ? new[] { CompetitionFormatUi.Doubles, CompetitionFormatUi.Team }
+            : new[] { CompetitionFormatUi.Singles, CompetitionFormatUi.Doubles, CompetitionFormatUi.Team };
+
+    public static CompetitionFormat? EffectivePersistedFormat(CompetitionCategoryUi? category, CompetitionFormatUi? format) =>
+        (category, format) switch
+        {
+            (CompetitionCategoryUi.Mixed, CompetitionFormatUi.Doubles) => CompetitionFormat.MixedDoubles,
+            (CompetitionCategoryUi.Mixed, CompetitionFormatUi.Team)    => CompetitionFormat.TeamMatch,
+            (_, CompetitionFormatUi.Singles) => CompetitionFormat.Singles,
+            (_, CompetitionFormatUi.Doubles) => CompetitionFormat.Doubles,
+            (_, CompetitionFormatUi.Team)    => CompetitionFormat.Team,
+            _ => null
+        };
+
+    public static PlayerSex? EffectiveEligibleSex(CompetitionCategoryUi? category) => category switch
+    {
+        CompetitionCategoryUi.Male   => PlayerSex.Male,
+        CompetitionCategoryUi.Female => PlayerSex.Female,
+        _ => null
+    };
+}

--- a/DropShot.UI/Components/Pages/CompetitionPage.razor
+++ b/DropShot.UI/Components/Pages/CompetitionPage.razor
@@ -2,6 +2,7 @@
 @using DropShot.Shared
 @using DropShot.Shared.Dtos
 @using DropShot.Shared.Extensions
+@using DropShot.UI.Components.Competitions
 @using DropShot.UI.Components.Competitions.Setup
 @using DropShot.UI.Services
 @using DropShot.UI.Services.Auth
@@ -12,7 +13,7 @@
 @inject IRulesSetService RulesSetService
 @inject ICurrentUser CurrentUser
 @inject NavigationManager Nav
-@inject ISiteAlertService SiteAlerts
+@inject ISnackbar Snackbar
 @inject AuthenticationStateProvider AuthStateProvider
 @inject IDialogService DialogService
 @inject IJSRuntime JS
@@ -29,133 +30,113 @@ else
     <div style="position: absolute; inset: 0; background-color: rgba(18, 18, 18, 0.85); pointer-events: none;"></div>
     <div style="position: relative; z-index: 1; padding: 1rem 0.5rem 2rem;">
 
-<CascadingValue Value="this" IsFixed="true">
-@* ── Sticky header ─────────────────────────────────────────────
-   Pins the title, action buttons + section nav to the top of the
-   page so the user can scroll the detail sections below and still
-   navigate between tabs. *@
-<div class="competition-sticky-header">
+<MudStack Class="mb-4" Spacing="2">
     @* ── Title row ───────────────────────────────────────────── *@
-    <MudPaper Elevation="0" Class="frosted-card mb-3 competition-title-card"
-              Style="border-radius: 12px; padding: 0.75rem;">
-        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
-            @if (_nameOverride)
+    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+        @if (_nameOverride)
+        {
+            <MudTextField T="string" @bind-Value="Model.CompetitionName" Variant="Variant.Text"
+                          Typo="Typo.h4" Class="competition-title" Style="flex:1" Immediate="true" Placeholder="Competition Name"
+                          Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.Check"
+                          OnAdornmentClick="@(() => _nameOverride = false)" />
+        }
+        else
+        {
+            <MudText Typo="Typo.h4" Class="competition-title" Style="flex:1" Color="@(string.IsNullOrWhiteSpace(Model.CompetitionName) ? Color.Secondary : Color.Default)">
+                @(string.IsNullOrWhiteSpace(Model.CompetitionName) ? "New Competition" : Model.CompetitionName)
+            </MudText>
+            <MudTooltip Text="Edit name manually">
+                <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="Size.Small" OnClick="@(() => { _nameOverride = true; _nameManuallySet = true; })" />
+            </MudTooltip>
+        }
+    </MudStack>
+
+    @* ── Action button row ───────────────────────────────────── *@
+    @* AlignItems=Stretch + height:100% on each button ensures the Clone
+       button (and its tooltip wrapper) grows to match the tallest sibling
+       when text wraps onto two lines on narrow viewports. *@
+    @if (IsEdit)
+    {
+        <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Stretch" Class="competition-action-row" Style="flex-wrap: wrap;">
+            @if (_canEdit)
             {
-                <MudTextField T="string" @bind-Value="Model.CompetitionName" Variant="Variant.Text"
-                              Typo="Typo.h4" Class="competition-title" Style="flex:1" Immediate="true" Placeholder="Competition Name"
-                              Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.Check"
-                              OnAdornmentClick="@(() => _nameOverride = false)" />
+                <MudButton Variant="@(_isStarted ? Variant.Outlined : Variant.Filled)"
+                           Color="@(_isStarted ? Color.Warning : Color.Success)"
+                           StartIcon="@(_isStarted ? Icons.Material.Filled.Stop : Icons.Material.Filled.PlayArrow)"
+                           Class="px-4"
+                           Style="height: 100%;"
+                           OnClick="ToggleStartedAsync">
+                    @(_isStarted ? "Stop Competition" : "Start Competition")
+                </MudButton>
             }
-            else
+            else if (!_isStarted)
             {
-                <MudText Typo="Typo.h4" Class="competition-title" Style="flex:1" Color="@(string.IsNullOrWhiteSpace(Model.CompetitionName) ? Color.Secondary : Color.Default)">
-                    @(string.IsNullOrWhiteSpace(Model.CompetitionName) ? "New Competition" : Model.CompetitionName)
-                </MudText>
-                <MudTooltip Text="Edit name manually">
-                    <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="Size.Small" OnClick="@(() => { _nameOverride = true; _nameManuallySet = true; })" />
+                <MudChip T="string" Color="Color.Warning" Variant="Variant.Outlined">Not Started</MudChip>
+            }
+            @if (_canEdit && IsEdit)
+            {
+                <MudTooltip Text="Create a new competition based on this one" Style="display: flex; align-self: stretch;">
+                    <MudButton Variant="Variant.Outlined" Color="Color.Secondary"
+                               StartIcon="@Icons.Material.Filled.ContentCopy"
+                               Class="px-4"
+                               Style="height: 100%;"
+                               OnClick="OpenCloneDialog">
+                        Clone
+                    </MudButton>
                 </MudTooltip>
             }
+            <MudButton Variant="Variant.Outlined" Color="Color.Info" StartIcon="@Icons.Material.Filled.Visibility"
+                       Class="px-4"
+                       Style="height: 100%;"
+                       OnClick="@(() => Nav.NavigateTo($"/competition/{Id}/view"))">
+                View Competition
+            </MudButton>
         </MudStack>
-    </MudPaper>
+    }
+</MudStack>
 
-    @* ── Combined control bar ─────────────────────────────────
-       Wraps the action buttons + section nav. On desktop they sit in
-       a single combined band (nav chips on the left, action buttons on
-       the right). On mobile the wrapper drops back to normal flow so
-       each MudPaper renders as its own frosted card — preserving the
-       two-section look but keeping the chip-styled buttons. *@
-    <div class="competition-control-bar">
-        @* ── Action button row ───────────────────────────────────
-           Buttons share the pill / chip styling via .competition-action-button
-           so they read as a coordinated set with the section nav chips.
-           AlignItems=Center keeps the pills vertically centred next to the
-           chip row when both sit in the desktop combined band. *@
+<CascadingValue Value="this" IsFixed="true">
+@* ── Section nav (replaces MudTabs) ──────────────────────────
+   Chip / pill row with the same frosted look as the list cards.
+   Tab indices preserved: 0=Setup, 1=Roster, 2=Fixtures, 3=Email.
+   Wraps onto multiple lines on narrow screens instead of forcing
+   a horizontal scroll. *@
+<MudPaper Elevation="0" Class="frosted-card mb-6 competition-section-nav"
+          Style="border-radius: 12px; padding: 0.75rem;">
+    <MudStack Row="true" Spacing="2" Style="flex-wrap: wrap;">
+        <MudChip T="int" Value="0"
+                 Icon="@Icons.Material.Filled.Settings"
+                 Color="@(_activeTabIndex == 0 ? Color.Primary : Color.Default)"
+                 Variant="@(_activeTabIndex == 0 ? Variant.Filled : Variant.Outlined)"
+                 OnClick="@(() => _activeTabIndex = 0)">Setup</MudChip>
         @if (IsEdit)
         {
-            <MudPaper Elevation="0" Class="frosted-card competition-action-row"
-                      Style="border-radius: 12px; padding: 0.75rem;">
-                <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Style="flex-wrap: wrap;">
-                    @if (_canEdit)
-                    {
-                        <MudButton Variant="@(_isStarted ? Variant.Outlined : Variant.Filled)"
-                                   Color="@(_isStarted ? Color.Warning : Color.Success)"
-                                   StartIcon="@(_isStarted ? Icons.Material.Filled.Stop : Icons.Material.Filled.PlayArrow)"
-                                   Class="competition-action-button"
-                                   OnClick="ToggleStartedAsync">
-                            @(_isStarted ? "Stop Competition" : "Start Competition")
-                        </MudButton>
-                    }
-                    else if (!_isStarted)
-                    {
-                        <MudChip T="string" Color="Color.Warning" Variant="Variant.Outlined">Not Started</MudChip>
-                    }
-                    @if (_canEdit && IsEdit)
-                    {
-                        <MudTooltip Text="Create a new competition based on this one">
-                            <MudButton Variant="Variant.Outlined" Color="Color.Secondary"
-                                       StartIcon="@Icons.Material.Filled.ContentCopy"
-                                       Class="competition-action-button"
-                                       OnClick="OpenCloneDialog">
-                                Clone
-                            </MudButton>
-                        </MudTooltip>
-                    }
-                    <MudButton Variant="Variant.Outlined" Color="Color.Info" StartIcon="@Icons.Material.Filled.Visibility"
-                               Class="competition-action-button"
-                               OnClick="@(() => Nav.NavigateTo($"/competition/{Id}/view"))">
-                        View Competition
-                    </MudButton>
-                </MudStack>
-            </MudPaper>
+            <MudChip T="int" Value="1"
+                     Icon="@Icons.Material.Filled.Group"
+                     Color="@(_activeTabIndex == 1 ? Color.Primary : Color.Default)"
+                     Variant="@(_activeTabIndex == 1 ? Variant.Filled : Variant.Outlined)"
+                     OnClick="@(() => _activeTabIndex = 1)">Roster</MudChip>
+            <MudChip T="int" Value="2"
+                     Icon="@Icons.Material.Filled.EventNote"
+                     Color="@(_activeTabIndex == 2 ? Color.Primary : Color.Default)"
+                     Variant="@(_activeTabIndex == 2 ? Variant.Filled : Variant.Outlined)"
+                     OnClick="@(() => _activeTabIndex = 2)">Fixtures/Results</MudChip>
         }
+        @* Email chip hidden for now — feature not yet in use. Restore by
+           re-enabling this block (and the _emailDisabled flag above). *@
+        @*
+        <MudChip T="int" Value="3"
+                 Icon="@Icons.Material.Filled.Email"
+                 Disabled="@_emailDisabled"
+                 Color="@(_activeTabIndex == 3 ? Color.Primary : Color.Default)"
+                 Variant="@(_activeTabIndex == 3 ? Variant.Filled : Variant.Outlined)"
+                 OnClick="@(() => { if (!_emailDisabled) _activeTabIndex = 3; })">Email</MudChip>
+        *@
+    </MudStack>
+</MudPaper>
 
-        @* ── Section nav (replaces MudTabs) ──────────────────────────
-           Chip / pill row with the same frosted look as the list cards.
-           Tab indices preserved: 0=Setup, 1=Roster, 2=Fixtures, 3=Email.
-           Clicking a chip smooth-scrolls the matching anchor into view;
-           all sections render simultaneously so users can also scroll
-           manually between them. *@
-        <MudPaper Elevation="0" Class="frosted-card competition-section-nav"
-                  Style="border-radius: 12px; padding: 0.75rem;">
-            <MudStack Row="true" Spacing="2" Style="flex-wrap: wrap;">
-                <MudChip T="int" Value="0"
-                         Icon="@Icons.Material.Filled.Settings"
-                         Color="@(_activeTabIndex == 0 ? Color.Primary : Color.Default)"
-                         Variant="@(_activeTabIndex == 0 ? Variant.Filled : Variant.Outlined)"
-                         OnClick="@(() => ScrollToSectionAsync(0, "nav-anchor-setup"))">Setup</MudChip>
-                @if (IsEdit)
-                {
-                    <MudChip T="int" Value="1"
-                             Icon="@Icons.Material.Filled.Group"
-                             Color="@(_activeTabIndex == 1 ? Color.Primary : Color.Default)"
-                             Variant="@(_activeTabIndex == 1 ? Variant.Filled : Variant.Outlined)"
-                             OnClick="@(() => ScrollToSectionAsync(1, "nav-anchor-roster"))">Roster</MudChip>
-                    <MudChip T="int" Value="2"
-                             Icon="@Icons.Material.Filled.EventNote"
-                             Color="@(_activeTabIndex == 2 ? Color.Primary : Color.Default)"
-                             Variant="@(_activeTabIndex == 2 ? Variant.Filled : Variant.Outlined)"
-                             OnClick="@(() => ScrollToSectionAsync(2, "nav-anchor-fixtures"))">Fixtures/Results</MudChip>
-                }
-                @* Email chip hidden for now — feature not yet in use. Restore by
-                   re-enabling this block (and the _emailDisabled flag above). *@
-                @*
-                <MudChip T="int" Value="3"
-                         Icon="@Icons.Material.Filled.Email"
-                         Disabled="@_emailDisabled"
-                         Color="@(_activeTabIndex == 3 ? Color.Primary : Color.Default)"
-                         Variant="@(_activeTabIndex == 3 ? Variant.Filled : Variant.Outlined)"
-                         OnClick="@(() => { if (!_emailDisabled) ScrollToSectionAsync(3, "nav-anchor-email"); })">Email</MudChip>
-                *@
-            </MudStack>
-        </MudPaper>
-    </div>
-</div>
-
-@* All sections render simultaneously; the section nav chips smooth-scroll
-   the matching `nav-anchor-*` div into view (sticky-header offset is handled
-   by .section-anchor's scroll-margin-top). Edit-only sections retain their
-   IsEdit / _canEdit guards below. *@
-<div id="nav-anchor-setup" class="section-anchor"></div>
+@if (_activeTabIndex == 0)
+{
     @* ── Details form ───────────────────────────────────────── *@
     <MudPaper id="section-details" Class="pa-4 mb-4 setup-section" Elevation="0"
                  Style="background: rgba(255,255,255,0.08); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border: 1px solid rgba(255,255,255,0.12); border-radius: 12px; color: white;">
@@ -168,6 +149,7 @@ else
                         var _derivedSex = DeriveCategoryFromRubberRoles(_availableRoles);
                     }
 
+                    @* ── 1. Category ────────────────────────────────── *@
                     @if (_isTeamMatch)
                     {
                         @* For TeamMatch the rubber template drives player eligibility (roles like MA/MB
@@ -194,7 +176,8 @@ else
                     else
                     {
                         <MudField Label="Category" Variant="Variant.Text"
-                                  Error="@(_categoryError != null)" ErrorText="@_categoryError">
+                                  Error="@(_categoryError != null)" ErrorText="@_categoryError"
+                                  HelperText="Who is considered for entry — this controls who will be offered a spot.">
                             <MudRadioGroup T="CompetitionCategoryUi?" Value="Model.Category"
                                            ValueChanged="OnCategoryChanged">
                                 <MudRadio T="CompetitionCategoryUi?" Value="@((CompetitionCategoryUi?)CompetitionCategoryUi.Male)" Color="Color.Primary">Male</MudRadio>
@@ -204,10 +187,28 @@ else
                         </MudField>
                     }
 
+                    @* ── 2. Age options ─────────────────────────────── *@
+                    <MudGrid Spacing="2">
+                        <MudItem xs="12" sm="6">
+                            <MudNumericField T="int?" Label="Min Age (optional)"
+                                             Min="1" Max="120" Variant="Variant.Text"
+                                             Value="Model.MinAge"
+                                             ValueChanged="@(v => { Model.MinAge = v; AutoGenerateName(); })" />
+                        </MudItem>
+                        <MudItem xs="12" sm="6">
+                            <MudNumericField T="int?" Label="Max Age (optional)"
+                                             Min="1" Max="120" Variant="Variant.Text"
+                                             Value="Model.MaxAge"
+                                             ValueChanged="@(v => { Model.MaxAge = v; AutoGenerateName(); })" />
+                        </MudItem>
+                    </MudGrid>
+
+                    @* ── 3. Format ──────────────────────────────────── *@
                     <MudSelect T="CompetitionFormatUi?" Label="Format" Variant="Variant.Text"
                                Required="true" RequiredError="Please select a competition format."
                                Disabled="@(Model.Category == null)"
                                Value="Model.Format"
+                               HelperText="Singles = 1v1. Doubles = 2v2 pairs. Team = squad format with multiple rubbers per fixture."
                                ValueChanged="@(v => { Model.Format = v; AutoGenerateName(); })">
                         @foreach (var f in AllowedFormats(Model.Category))
                         {
@@ -215,6 +216,7 @@ else
                         }
                     </MudSelect>
 
+                    @* ── 4. Rule set (with host club + event) ───────── *@
                     @if (!_hideHostClub)
                     {
                         <MudStack Row="true" AlignItems="AlignItems.End" Spacing="0">
@@ -283,6 +285,7 @@ else
                         </MudTooltip>
                     </MudStack>
 
+                    @* ── 5. Dates and max participants ──────────────── *@
                     <MudGrid Spacing="2">
                         <MudItem xs="12" sm="6">
                             <MudDatePicker @bind-Date="Model.StartDateDt" Label="Start Date (optional)" DateFormat="dd/MM/yyyy" />
@@ -298,21 +301,19 @@ else
                     <MudNumericField @bind-Value="Model.MaxParticipants" Label="Max Participants (optional)"
                                      Min="2" Variant="Variant.Text" />
 
-                    <MudGrid Spacing="2">
-                        <MudItem xs="12" sm="6">
-                            <MudNumericField T="int?" Label="Min Age (optional)"
-                                             Min="1" Max="120" Variant="Variant.Text"
-                                             Value="Model.MinAge"
-                                             ValueChanged="@(v => { Model.MinAge = v; AutoGenerateName(); })" />
-                        </MudItem>
-                        <MudItem xs="12" sm="6">
-                            <MudNumericField T="int?" Label="Max Age (optional)"
-                                             Min="1" Max="120" Variant="Variant.Text"
-                                             Value="Model.MaxAge"
-                                             ValueChanged="@(v => { Model.MaxAge = v; AutoGenerateName(); })" />
-                        </MudItem>
-                    </MudGrid>
+                    @* ── 6. Split into divisions ────────────────────── *@
+                    <MudCheckBox @bind-Value="Model.HasDivisions"
+                                 Label="Split this competition into ranked divisions"
+                                 Class="mt-1" />
+                    @if (Model.HasDivisions)
+                    {
+                        <MudText Typo="Typo.caption" Class="mb-2" Style="opacity:0.75">
+                            Teams will only play others in their own division and league tables render per-division.
+                            Manage each division (plus its teams, match windows and fixtures) in the <b>Divisions</b> section further down this page.
+                        </MudText>
+                    }
 
+                    @* ── 7. Match / rubber scoring ──────────────────── *@
                     <MudText Typo="Typo.subtitle2" Class="mt-2 mb-1">Match / Rubber Format</MudText>
                     <MudText Typo="Typo.caption" Class="mb-2" Style="opacity:0.75">
                         For singles or doubles, controls the whole match. For TeamMatch,
@@ -357,18 +358,6 @@ else
                         </MudStack>
                     </MudRadioGroup>
 
-                    <MudText Typo="Typo.subtitle2" Class="mt-3 mb-1">League Scoring</MudText>
-                    <MudText Typo="Typo.caption" Class="mb-2" Style="opacity:0.75">
-                        For TeamMatch competitions, sets and games aggregate across every rubber in the fixture.
-                    </MudText>
-                    <MudRadioGroup @bind-Value="Model.LeagueScoring">
-                        <MudStack Spacing="1">
-                            <MudRadio Value="LeagueScoringMode.WinPoints" Color="Color.Primary">3 points for a win, 1 for a draw</MudRadio>
-                            <MudRadio Value="LeagueScoringMode.SetsWon" Color="Color.Primary">1 point per set won</MudRadio>
-                            <MudRadio Value="LeagueScoringMode.GamesWon" Color="Color.Primary">1 point per game won</MudRadio>
-                        </MudStack>
-                    </MudRadioGroup>
-
                     @if (EffectivePersistedFormat() == CompetitionFormat.TeamMatch)
                     {
                         <MudText Typo="Typo.subtitle2" Class="mt-3 mb-1">Rubber tie-break</MudText>
@@ -385,6 +374,20 @@ else
                         </MudRadioGroup>
                     }
 
+                    @* ── 8. League Scoring ──────────────────────────── *@
+                    <MudText Typo="Typo.subtitle2" Class="mt-3 mb-1">League Scoring</MudText>
+                    <MudText Typo="Typo.caption" Class="mb-2" Style="opacity:0.75">
+                        For TeamMatch competitions, sets and games aggregate across every rubber in the fixture.
+                    </MudText>
+                    <MudRadioGroup @bind-Value="Model.LeagueScoring">
+                        <MudStack Spacing="1">
+                            <MudRadio Value="LeagueScoringMode.WinPoints" Color="Color.Primary">3 points for a win, 1 for a draw</MudRadio>
+                            <MudRadio Value="LeagueScoringMode.SetsWon" Color="Color.Primary">1 point per set won</MudRadio>
+                            <MudRadio Value="LeagueScoringMode.GamesWon" Color="Color.Primary">1 point per game won</MudRadio>
+                        </MudStack>
+                    </MudRadioGroup>
+
+                    @* ── 9. Misc settings ───────────────────────────── *@
                     <MudText Typo="Typo.subtitle2" Class="mt-3 mb-1">Minimum days between matches</MudText>
                     <MudText Typo="Typo.caption" Class="mb-2" Style="opacity:0.75">
                         Auto-scheduling will try to keep each player's matches this many days apart.
@@ -395,17 +398,6 @@ else
                                      Style="max-width: 160px" />
 
                     <MudCheckBox @bind-Value="Model.RequireVerification" Label="Require admin verification of results" Class="mt-2" />
-
-                    <MudCheckBox @bind-Value="Model.HasDivisions"
-                                 Label="Split this competition into ranked divisions"
-                                 Class="mt-1" />
-                    @if (Model.HasDivisions)
-                    {
-                        <MudText Typo="Typo.caption" Class="mb-2" Style="opacity:0.75">
-                            Teams will only play others in their own division and league tables render per-division.
-                            Manage each division (plus its teams, match windows and fixtures) in the <b>Divisions</b> section further down this page.
-                        </MudText>
-                    }
                 </MudStack>
 
                 @if (!string.IsNullOrWhiteSpace(_serverError))
@@ -461,32 +453,7 @@ else
                 OnOpenAddDialog="OpenAddStageDialog"
                 OnDeleteStage="DeleteStage" />
 
-            @* ── Match Windows (hidden when HasDivisions — per-division UI lives in the Divisions section below) *@
-            @if (!Model.HasDivisions)
-            {
-                <MatchWindowsSection
-                    Windows="_matchWindows"
-                    Courts="_courts"
-                    ClubTemplates="_clubTemplates"
-                    SelectedTemplateId="_selectedTemplateId"
-                    NewWindowDay="_newMatchWindowDay"
-                    NewWindowDayChanged="@(v => _newMatchWindowDay = v)"
-                    NewWindowCourtId="_newMatchWindowCourtId"
-                    NewWindowCourtIdChanged="@(v => _newMatchWindowCourtId = v)"
-                    NewWindowStart="_newMatchWindowStart"
-                    NewWindowStartChanged="@(v => _newMatchWindowStart = v)"
-                    NewWindowEnd="_newMatchWindowEnd"
-                    NewWindowEndChanged="@(v => _newMatchWindowEnd = v)"
-                    EditingWindowId="_editingMatchWindowId"
-                    OnAdd="AddMatchWindow"
-                    OnCancelEdit="CancelEditMatchWindow"
-                    OnCopyToForm="CopyMatchWindowToForm"
-                    OnEdit="EditMatchWindow"
-                    OnDelete="DeleteMatchWindow"
-                    OnImportFromTemplate="ImportFromTemplate" />
-            }
-
-            @* ── Rubber Template ─────────────────────────────── *@
+            @* ── Rubber Template (TeamMatch only) ─────────────── *@
             @if (EffectivePersistedFormat() == CompetitionFormat.TeamMatch)
             {
                 <RubberTemplateSection
@@ -521,6 +488,31 @@ else
                 }
             }
 
+            @* ── Match Windows (hidden when HasDivisions — per-division UI lives in the Divisions section below) *@
+            @if (!Model.HasDivisions)
+            {
+                <MatchWindowsSection
+                    Windows="_matchWindows"
+                    Courts="_courts"
+                    ClubTemplates="_clubTemplates"
+                    SelectedTemplateId="_selectedTemplateId"
+                    NewWindowDay="_newMatchWindowDay"
+                    NewWindowDayChanged="@(v => _newMatchWindowDay = v)"
+                    NewWindowCourtId="_newMatchWindowCourtId"
+                    NewWindowCourtIdChanged="@(v => _newMatchWindowCourtId = v)"
+                    NewWindowStart="_newMatchWindowStart"
+                    NewWindowStartChanged="@(v => _newMatchWindowStart = v)"
+                    NewWindowEnd="_newMatchWindowEnd"
+                    NewWindowEndChanged="@(v => _newMatchWindowEnd = v)"
+                    EditingWindowId="_editingMatchWindowId"
+                    OnAdd="AddMatchWindow"
+                    OnCancelEdit="CancelEditMatchWindow"
+                    OnCopyToForm="CopyMatchWindowToForm"
+                    OnEdit="EditMatchWindow"
+                    OnDelete="DeleteMatchWindow"
+                    OnImportFromTemplate="ImportFromTemplate" />
+            }
+
             @* ── Apply Competition Template ───────────────────── *@
             @if (_competitionTemplates.Count > 0)
             {
@@ -530,47 +522,28 @@ else
                     OnApplyTemplate="ApplyCompetitionTemplate" />
             }
         }
+}
 
-<div id="nav-anchor-roster" class="section-anchor"></div>
-@if (IsEdit)
+@if (_activeTabIndex == 1 && IsEdit)
 {
             @* ── Participants ────────────────────────────────── *@
             <MudPaper id="section-participants" Class="pa-4 mb-4 setup-section frosted-card" Elevation="0"
                  Style="color: white;">
-                @* Header is split into three vertical rows so the title, the
-                   add-player + add-as pair, and the "Add new" button each get
-                   their own line and stop competing for width in narrow
-                   viewports. AlignItems.Start on the outer stack keeps the
-                   "Add new" button at its natural width instead of stretching
-                   to fill the row. *@
-                <MudStack Spacing="2" AlignItems="AlignItems.Start" Class="mb-3">
-                    <MudText Typo="Typo.h6">Participants</MudText>
-                    <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Style="flex-wrap: wrap;">
-                        <MudAutocomplete T="PlayerSearchResultDto" Label="Add player" SearchFunc="SearchPlayers"
-                                         @ref="_participantAutocomplete"
-                                         ToStringFunc="@(p => p?.DisplayName ?? "")"
-                                         ValueChanged="AddParticipant" ResetValueOnEmptyText="true"
-                                         MaxItems="null"
-                                         Variant="Variant.Outlined" Dense="true" Style="max-width:260px" />
-                        <MudSelect T="ParticipantStatus" @bind-Value="_addParticipantStatus"
-                                   Label="Add as" Variant="Variant.Outlined" Dense="true"
-                                   Style="max-width:160px">
-                            <MudSelectItem Value="@ParticipantStatus.Registered">Registered</MudSelectItem>
-                            <MudSelectItem Value="@ParticipantStatus.FullPlayer">Full Player</MudSelectItem>
-                            <MudSelectItem Value="@ParticipantStatus.Substitute">Substitute</MudSelectItem>
-                        </MudSelect>
-                        <MudTooltip Text="Pick multiple players from a filtered list and add them in one go">
-                            <MudButton Variant="Variant.Outlined" Color="Color.Primary"
-                                       StartIcon="@Icons.Material.Filled.GroupAdd"
-                                       OnClick="OpenBulkAddDialog">Add multiple</MudButton>
-                        </MudTooltip>
-                        @if (_participants.Count > 0)
-                        {
-                            <MudButton Variant="Variant.Outlined" Color="Color.Error"
-                                       StartIcon="@Icons.Material.Filled.DeleteSweep"
-                                       OnClick="@(() => _showDeleteAllParticipantsConfirm = true)">Delete All Participants</MudButton>
-                        }
-                    </MudStack>
+                <MudStack Row="true" AlignItems="AlignItems.Center" Class="mb-3">
+                    <MudText Typo="Typo.h6" Style="flex:1">Participants</MudText>
+                    <MudAutocomplete T="PlayerSearchResultDto" Label="Add player" SearchFunc="SearchPlayers"
+                                     @ref="_participantAutocomplete"
+                                     ToStringFunc="@(p => p?.DisplayName ?? "")"
+                                     ValueChanged="AddParticipant" ResetValueOnEmptyText="true"
+                                     MaxItems="null"
+                                     Variant="Variant.Outlined" Dense="true" Style="max-width:260px" />
+                    <MudSelect T="ParticipantStatus" @bind-Value="_addParticipantStatus"
+                               Label="Add as" Variant="Variant.Outlined" Dense="true"
+                               Style="max-width:160px">
+                        <MudSelectItem Value="@ParticipantStatus.Registered">Registered</MudSelectItem>
+                        <MudSelectItem Value="@ParticipantStatus.FullPlayer">Full Player</MudSelectItem>
+                        <MudSelectItem Value="@ParticipantStatus.Substitute">Substitute</MudSelectItem>
+                    </MudSelect>
                     @if (Model.HostClubId.HasValue)
                     {
                         <MudTooltip Text="Add a new light player to this club and competition">
@@ -580,18 +553,6 @@ else
                         </MudTooltip>
                     }
                 </MudStack>
-
-                @if (_showDeleteAllParticipantsConfirm)
-                {
-                    <MudAlert Severity="Severity.Warning" Class="mb-3" ShowCloseIcon="true"
-                              CloseIconClicked="@(() => _showDeleteAllParticipantsConfirm = false)">
-                        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
-                            <MudText Typo="Typo.body2">Delete all @_participants.Count participant(s)? This cannot be undone.</MudText>
-                            <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Error"
-                                       OnClick="DeleteAllParticipants">Confirm Delete</MudButton>
-                        </MudStack>
-                    </MudAlert>
-                }
 
                 <MudDialog @bind-Visible="_showNewPlayerDialog">
                     <TitleContent>@(_editingLightPlayerId.HasValue ? "Edit Player" : "Add New Club Player")</TitleContent>
@@ -641,164 +602,11 @@ else
                     </DialogActions>
                 </MudDialog>
 
-                @* Bulk-add dialog: full list of eligible players (already-enrolled
-                   excluded server-side), filterable, multi-select. The server-side
-                   SearchPlayers endpoint already applies club-scope + eligibility
-                   filters; we just pass a generous MaxResults and filter further
-                   by free-text + sex on the client. *@
-                <MudDialog @bind-Visible="_showBulkAddDialog" Options="@(new DialogOptions { MaxWidth = MaxWidth.Medium, FullWidth = true })">
-                    <TitleContent>Add multiple players</TitleContent>
-                    <DialogContent>
-                        <MudStack Spacing="2">
-                            <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Style="flex-wrap: wrap;">
-                                <MudTextField T="string" @bind-Value="_bulkAddSearch" DebounceInterval="150"
-                                              Placeholder="Search by name" Variant="Variant.Outlined" Margin="Margin.Dense"
-                                              Clearable="true"
-                                              Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search"
-                                              Style="min-width:240px" />
-                                <MudSelect T="PlayerSex?" @bind-Value="_bulkAddSexFilter"
-                                           Label="Sex" Variant="Variant.Outlined" Margin="Margin.Dense" Clearable="true"
-                                           ToStringFunc="@(s => s.HasValue ? s.Value.ToString() : "Any")"
-                                           Style="min-width:140px">
-                                    <MudSelectItem T="PlayerSex?" Value="@((PlayerSex?)null)">Any</MudSelectItem>
-                                    <MudSelectItem T="PlayerSex?" Value="@((PlayerSex?)PlayerSex.Male)">Male</MudSelectItem>
-                                    <MudSelectItem T="PlayerSex?" Value="@((PlayerSex?)PlayerSex.Female)">Female</MudSelectItem>
-                                </MudSelect>
-                                <MudSelect T="ParticipantStatus" @bind-Value="_bulkAddStatus"
-                                           Label="Add as" Variant="Variant.Outlined" Margin="Margin.Dense"
-                                           Style="min-width:160px">
-                                    <MudSelectItem Value="@ParticipantStatus.Registered">Registered</MudSelectItem>
-                                    <MudSelectItem Value="@ParticipantStatus.FullPlayer">Full Player</MudSelectItem>
-                                    <MudSelectItem Value="@ParticipantStatus.Substitute">Substitute</MudSelectItem>
-                                </MudSelect>
-                            </MudStack>
-                            @if (_bulkAddLoading)
-                            {
-                                <MudProgressLinear Indeterminate="true" />
-                            }
-                            else if (_bulkAddCandidates.Count == 0)
-                            {
-                                <MudText Typo="Typo.body2" Color="Color.Secondary">No eligible players found. (Already-enrolled players and ineligible ones are excluded.)</MudText>
-                            }
-                            else
-                            {
-                                <MudTable T="PlayerSearchResultDto" Items="@FilteredBulkAddCandidates" Dense="true" Hover="true"
-                                          MultiSelection="true" SelectOnRowClick="true"
-                                          @bind-SelectedItems="_bulkAddSelected"
-                                          FixedHeader="true" Height="380px">
-                                    <HeaderContent>
-                                        <MudTh>Name</MudTh>
-                                        <MudTh>Sex</MudTh>
-                                        <MudTh>DOB</MudTh>
-                                        <MudTh>Club</MudTh>
-                                    </HeaderContent>
-                                    <RowTemplate>
-                                        <MudTd>@context.DisplayName @(context.IsLight ? " (light)" : "")</MudTd>
-                                        <MudTd>@(context.Sex?.ToString() ?? "—")</MudTd>
-                                        <MudTd>@(context.DateOfBirth?.ToString("dd MMM yyyy") ?? "—")</MudTd>
-                                        <MudTd>@(context.ClubName ?? "—")</MudTd>
-                                    </RowTemplate>
-                                </MudTable>
-                                <MudText Typo="Typo.caption" Color="Color.Secondary">@(_bulkAddSelected.Count) selected.</MudText>
-                            }
-                        </MudStack>
-                    </DialogContent>
-                    <DialogActions>
-                        <MudButton OnClick="@(() => _showBulkAddDialog = false)">Cancel</MudButton>
-                        <MudButton Variant="Variant.Filled" Color="Color.Primary"
-                                   Disabled="@(_bulkAddSelected.Count == 0 || _bulkAddSubmitting)"
-                                   OnClick="ConfirmBulkAddAsync">
-                            @($"Add {_bulkAddSelected.Count} player{(_bulkAddSelected.Count == 1 ? "" : "s")}")
-                        </MudButton>
-                    </DialogActions>
-                </MudDialog>
-
                 @{
                     var pFormat = EffectivePersistedFormat();
                     var hasTeamCol = pFormat is CompetitionFormat.Team or CompetitionFormat.TeamMatch or CompetitionFormat.Doubles or CompetitionFormat.MixedDoubles;
                     var isTeamMatchFmt = pFormat == CompetitionFormat.TeamMatch;
                     var teamColLabel = pFormat is CompetitionFormat.Doubles or CompetitionFormat.MixedDoubles ? "Pair" : "Team";
-                }
-
-                @* Role-mix summary: counts FullPlayer participants per role per
-                   division so the admin sees at a glance whether the pool is
-                   balanced enough to generate teams. Validity chip is green when
-                   every role has the same count >= 1 (the team generator needs
-                   one of each role per team); amber otherwise with the missing
-                   counts spelled out. *@
-                @if (isTeamMatchFmt && _availableRoles.Count > 0)
-                {
-                    var summaryFullPlayers = _participants
-                        .Where(p => p.Status == ParticipantStatus.FullPlayer)
-                        .ToList();
-                    var summaryBuckets = Model.HasDivisions
-                        ? _divisions.OrderBy(d => d.Rank)
-                            .Select(d => ((int?)d.CompetitionDivisionId, d.Name))
-                            .ToList()
-                        : new List<(int?, string)> { (null, "All participants") };
-                    if (Model.HasDivisions && summaryFullPlayers.Any(p => p.CompetitionDivisionId is null))
-                    {
-                        summaryBuckets.Add((null, "No division"));
-                    }
-                    <MudPaper Class="pa-3 mb-3" Elevation="0"
-                              Style="background: rgba(255,255,255,0.05); border: 1px solid rgba(255,255,255,0.1); border-radius: 8px; color: white;">
-                        <MudText Typo="Typo.subtitle2" Class="mb-2">Pool by role</MudText>
-                        <MudStack Spacing="2">
-                            @foreach (var (bucketDivId, bucketName) in summaryBuckets)
-                            {
-                                var bucketPlayers = summaryFullPlayers
-                                    .Where(p => p.CompetitionDivisionId == bucketDivId)
-                                    .ToList();
-                                var bucketCounts = _availableRoles
-                                    .Select(r => (Role: r, Count: bucketPlayers.Count(p => string.Equals(p.Role, r, StringComparison.Ordinal))))
-                                    .ToList();
-                                var bucketNoRole = bucketPlayers.Count(p => string.IsNullOrEmpty(p.Role));
-                                var bucketAllZero = bucketCounts.All(rc => rc.Count == 0);
-                                var bucketMax = bucketCounts.Max(rc => rc.Count);
-                                var bucketAllEqual = !bucketAllZero && bucketCounts.All(rc => rc.Count == bucketMax);
-
-                                <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Style="flex-wrap: wrap;">
-                                    <MudText Typo="Typo.body2" Style="min-width:110px; font-weight:500;">@bucketName</MudText>
-                                    @foreach (var (role, count) in bucketCounts)
-                                    {
-                                        <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Color="Color.Default">
-                                            @role × @count
-                                        </MudChip>
-                                    }
-                                    @if (bucketAllZero)
-                                    {
-                                        <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Color="Color.Default">
-                                            No full players yet
-                                        </MudChip>
-                                    }
-                                    else if (bucketAllEqual)
-                                    {
-                                        <MudChip T="string" Size="Size.Small" Variant="Variant.Filled" Color="Color.Success"
-                                                 Icon="@Icons.Material.Filled.CheckCircle">
-                                            @bucketMax team@(bucketMax == 1 ? "" : "s") possible
-                                        </MudChip>
-                                    }
-                                    else
-                                    {
-                                        var bucketShortages = bucketCounts
-                                            .Where(rc => rc.Count < bucketMax)
-                                            .Select(rc => $"{bucketMax - rc.Count} more {rc.Role}")
-                                            .ToList();
-                                        <MudChip T="string" Size="Size.Small" Variant="Variant.Filled" Color="Color.Warning"
-                                                 Icon="@Icons.Material.Filled.Warning">
-                                            Imbalanced — needs @string.Join(", ", bucketShortages)
-                                        </MudChip>
-                                    }
-                                    @if (bucketNoRole > 0)
-                                    {
-                                        <MudText Typo="Typo.caption" Style="opacity:0.75;">
-                                            @bucketNoRole without role
-                                        </MudText>
-                                    }
-                                </MudStack>
-                            }
-                        </MudStack>
-                    </MudPaper>
                 }
 
                 <MudStack Row="true" Spacing="2" Class="mb-2" AlignItems="AlignItems.Center" Wrap="Wrap.Wrap">
@@ -816,39 +624,29 @@ else
                             <MudSelectItem T="ParticipantStatus" Value="@s">@ParticipantStatusLabel(s)</MudSelectItem>
                         }
                     </MudSelect>
-                    @* Each multi-select carries an "(Unassigned)" option so the admin can
-                       isolate participants missing a team / sex / role / division. Filter
-                       set element types are nullable so null is the natural sentinel — the
-                       Role filter sticks with empty-string instead because Role is itself
-                       a nullable string already coerced via `cp.Role ?? ""`. *@
                     @if (hasTeamCol)
                     {
-                        <MudSelect T="int?" MultiSelection="true" @bind-SelectedValues="_filterTeamIds"
+                        <MudSelect T="int" MultiSelection="true" @bind-SelectedValues="_filterTeamIds"
                                    Label="@teamColLabel" Variant="Variant.Outlined" Margin="Margin.Dense" Clearable="true"
-                                   ToStringFunc="@(id => id.HasValue ? (_teams.FirstOrDefault(t => t.CompetitionTeamId == id.Value)?.Name ?? id.Value.ToString()) : "(Unassigned)")"
+                                   ToStringFunc="@(id => _teams.FirstOrDefault(t => t.CompetitionTeamId == id)?.Name ?? id.ToString())"
                                    Style="min-width:160px">
-                            <MudSelectItem T="int?" Value="@((int?)null)">(Unassigned)</MudSelectItem>
                             @foreach (var t in _teams)
                             {
-                                <MudSelectItem T="int?" Value="@((int?)t.CompetitionTeamId)">@t.Name</MudSelectItem>
+                                <MudSelectItem T="int" Value="@t.CompetitionTeamId">@t.Name</MudSelectItem>
                             }
                         </MudSelect>
                     }
                     @if (isTeamMatchFmt)
                     {
-                        <MudSelect T="PlayerSex?" MultiSelection="true" @bind-SelectedValues="_filterSexes"
+                        <MudSelect T="PlayerSex" MultiSelection="true" @bind-SelectedValues="_filterSexes"
                                    Label="Sex" Variant="Variant.Outlined" Margin="Margin.Dense" Clearable="true"
-                                   ToStringFunc="@(s => s?.ToString() ?? "(Unassigned)")"
                                    Style="min-width:120px">
-                            <MudSelectItem T="PlayerSex?" Value="@((PlayerSex?)null)">(Unassigned)</MudSelectItem>
-                            <MudSelectItem T="PlayerSex?" Value="@((PlayerSex?)PlayerSex.Male)">Male</MudSelectItem>
-                            <MudSelectItem T="PlayerSex?" Value="@((PlayerSex?)PlayerSex.Female)">Female</MudSelectItem>
+                            <MudSelectItem T="PlayerSex" Value="@PlayerSex.Male">Male</MudSelectItem>
+                            <MudSelectItem T="PlayerSex" Value="@PlayerSex.Female">Female</MudSelectItem>
                         </MudSelect>
                         <MudSelect T="string" MultiSelection="true" @bind-SelectedValues="_filterRoles"
                                    Label="Role" Variant="Variant.Outlined" Margin="Margin.Dense" Clearable="true"
-                                   ToStringFunc="@(r => string.IsNullOrEmpty(r) ? "(Unassigned)" : r)"
                                    Style="min-width:130px">
-                            <MudSelectItem T="string" Value="@("")">(Unassigned)</MudSelectItem>
                             @foreach (var r in _availableRoles)
                             {
                                 <MudSelectItem T="string" Value="@r">@r</MudSelectItem>
@@ -857,35 +655,18 @@ else
                     }
                     @if (Model.HasDivisions)
                     {
-                        <MudSelect T="int?" MultiSelection="true" @bind-SelectedValues="_filterDivisionIds"
+                        <MudSelect T="int" MultiSelection="true" @bind-SelectedValues="_filterDivisionIds"
                                    Label="Division" Variant="Variant.Outlined" Margin="Margin.Dense" Clearable="true"
-                                   ToStringFunc="@(id => id.HasValue ? (_divisions.FirstOrDefault(d => d.CompetitionDivisionId == id.Value)?.Name ?? id.Value.ToString()) : "(Unassigned)")"
+                                   ToStringFunc="@(id => _divisions.FirstOrDefault(d => d.CompetitionDivisionId == id)?.Name ?? id.ToString())"
                                    Style="min-width:160px">
-                            <MudSelectItem T="int?" Value="@((int?)null)">(Unassigned)</MudSelectItem>
                             @foreach (var d in _divisions)
                             {
-                                <MudSelectItem T="int?" Value="@((int?)d.CompetitionDivisionId)">@d.Name</MudSelectItem>
+                                <MudSelectItem T="int" Value="@d.CompetitionDivisionId">@d.Name</MudSelectItem>
                             }
                         </MudSelect>
                     }
                     <MudButton Size="Size.Small" Variant="Variant.Text" StartIcon="@Icons.Material.Filled.FilterAltOff"
                                OnClick="ClearParticipantFilters">Clear</MudButton>
-                    @if (_participants.Any(p => p.RatingSuggestion is not null))
-                    {
-                        <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Primary"
-                                   StartIcon="@Icons.Material.Filled.AutoFixHigh"
-                                   OnClick="AcceptAllParticipantRatings">
-                            Apply all rating suggestions
-                        </MudButton>
-                    }
-                    @if (_participants.Any(p => p.PlacementSuggestion is not null))
-                    {
-                        <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Primary"
-                                   StartIcon="@Icons.Material.Filled.GridOn"
-                                   OnClick="ApplyAllPlacements">
-                            Apply all placement suggestions
-                        </MudButton>
-                    }
                 </MudStack>
 
                 <MudTable T="CompetitionParticipantDto" Items="@_participants" Dense="true" Hover="true"
@@ -894,7 +675,6 @@ else
                         <MudTh><MudTableSortLabel T="CompetitionParticipantDto" SortBy="@(x => x.DisplayName)">Player</MudTableSortLabel></MudTh>
                         <MudTh><MudTableSortLabel T="CompetitionParticipantDto" SortBy="@(x => x.Status)">Status</MudTableSortLabel></MudTh>
                         <MudTh><MudTableSortLabel T="CompetitionParticipantDto" SortBy="@(x => x.RegisteredAt)">Registered</MudTableSortLabel></MudTh>
-                        <MudTh><MudTableSortLabel T="CompetitionParticipantDto" SortBy="@(x => x.Rating?.CurrentRating ?? double.MinValue)">Rating</MudTableSortLabel></MudTh>
                         @if (hasTeamCol)
                         {
                             <MudTh><MudTableSortLabel T="CompetitionParticipantDto" SortBy="@(x => _teams.FirstOrDefault(t => t.CompetitionTeamId == x.TeamId)?.Name ?? "")">@teamColLabel</MudTableSortLabel></MudTh>
@@ -923,45 +703,6 @@ else
                             </MudSelect>
                         </MudTd>
                         <MudTd>@context.RegisteredAt.ToString("dd MMM yyyy")</MudTd>
-                        <MudTd>
-                            @{
-                                var displayedRating = context.Rating is { } r
-                                    ? (int)Math.Round(r.CurrentRating)
-                                    : DefaultStartingRating;
-                                var isDefaultDisplay = context.Rating is null;
-                                var isProvisional = context.Rating?.IsProvisional ?? false;
-                            }
-                            <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
-                                <MudNumericField T="int?"
-                                                 Value="@((int?)displayedRating)"
-                                                 ValueChanged="@((int? v) => SetParticipantInitialRating(context, v))"
-                                                 Min="0" Max="4000" Step="10"
-                                                 Variant="Variant.Text" Margin="Margin.Dense" HideSpinButtons="true"
-                                                 Style="max-width: 80px;" />
-                                @if ((isDefaultDisplay || isProvisional) && context.RatingSuggestion is null)
-                                {
-                                    <MudTooltip Text="@(isDefaultDisplay
-                                        ? "Default starting rating (1500). Type a number to set the initial rating for this player."
-                                        : "Provisional rating — fewer than 10 completed rubbers.")">
-                                        <MudChip T="string" Size="Size.Small" Color="Color.Default" Variant="Variant.Outlined">prov</MudChip>
-                                    </MudTooltip>
-                                }
-                                @if (context.RatingSuggestion is { } sug)
-                                {
-                                    var up = sug.Delta > 0;
-                                    var down = sug.Delta < 0;
-                                    var arrow = up ? "↑" : down ? "↓" : "→";
-                                    var color = up ? Color.Success : down ? Color.Error : Color.Default;
-                                    <MudTooltip Text="@($"Suggested from previous season — {sug.RubbersPlayed} rubber(s) played. Click Apply to lock in {sug.SuggestedRating:0}.")">
-                                        <MudChip T="string" Size="Size.Small" Color="@color" Variant="Variant.Outlined">
-                                            @arrow @sug.SuggestedRating.ToString("0") (@((sug.Delta >= 0 ? "+" : "") + sug.Delta.ToString("0")))
-                                        </MudChip>
-                                    </MudTooltip>
-                                    <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary"
-                                               OnClick="@(() => AcceptParticipantRating(context))">Apply</MudButton>
-                                }
-                            </MudStack>
-                        </MudTd>
                         @if (hasTeamCol)
                         {
                             <MudTd>
@@ -979,71 +720,27 @@ else
                         {
                             <MudTd>@(context.Sex?.ToString() ?? "—")</MudTd>
                             <MudTd>
-                                <MudStack Row="false" Spacing="0">
-                                    <MudAutocomplete T="string" Value="context.Role" Dense="true" Variant="Variant.Text"
-                                                     Clearable="true" CoerceValue="true"
-                                                     SearchFunc="SearchRoles"
-                                                     ValueChanged="@((string? r) => AssignRole(context, r))"
-                                                     ShowProgressIndicator="false" DebounceInterval="0" />
-                                    @if (context.PlacementSuggestion is { SuggestedRole: { } sr } && sr != context.Role)
-                                    {
-                                        <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
-                                            <MudChip T="string" Size="Size.Small" Color="Color.Info" Variant="Variant.Outlined">
-                                                → @sr
-                                            </MudChip>
-                                            <MudButton Size="Size.Small" Variant="Variant.Text" Color="Color.Primary"
-                                                       OnClick="@(() => ApplyRolePlacement(context))">Apply</MudButton>
-                                        </MudStack>
-                                    }
-                                </MudStack>
+                                <MudAutocomplete T="string" Value="context.Role" Dense="true" Variant="Variant.Text"
+                                                 Clearable="true" CoerceValue="true"
+                                                 SearchFunc="SearchRoles"
+                                                 ValueChanged="@((string? r) => AssignRole(context, r))"
+                                                 ShowProgressIndicator="false" DebounceInterval="0" />
                             </MudTd>
                         }
                         @if (Model.HasDivisions)
                         {
                             <MudTd>
-                                <MudStack Row="false" Spacing="0">
-                                    <MudSelect T="int?" Value="context.CompetitionDivisionId" Dense="true" Variant="Variant.Text"
-                                               Clearable="true"
-                                               ValueChanged="@((int? did) => AssignParticipantDivision(context, did))">
-                                        @foreach (var d in _divisions)
-                                        {
-                                            <MudSelectItem T="int?" Value="@((int?)d.CompetitionDivisionId)">@d.Name</MudSelectItem>
-                                        }
-                                    </MudSelect>
-                                    @if (context.PlacementSuggestion is { SuggestedDivisionId: { } sdid } && sdid != context.CompetitionDivisionId)
+                                <MudSelect T="int?" Value="context.CompetitionDivisionId" Dense="true" Variant="Variant.Text"
+                                           Clearable="true"
+                                           ValueChanged="@((int? did) => AssignParticipantDivision(context, did))">
+                                    @foreach (var d in _divisions)
                                     {
-                                        <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
-                                            <MudChip T="string" Size="Size.Small" Color="Color.Info" Variant="Variant.Outlined">
-                                                → @context.PlacementSuggestion.SuggestedDivisionName
-                                            </MudChip>
-                                            <MudButton Size="Size.Small" Variant="Variant.Text" Color="Color.Primary"
-                                                       OnClick="@(() => ApplyDivisionPlacement(context))">Apply</MudButton>
-                                        </MudStack>
+                                        <MudSelectItem T="int?" Value="@((int?)d.CompetitionDivisionId)">@d.Name</MudSelectItem>
                                     }
-                                </MudStack>
+                                </MudSelect>
                             </MudTd>
                         }
                         <MudTd>
-                            @* Promote / demote walks the (division, role) ladder built in
-                               GetPromotionTarget. TeamMatch-only because that's the only
-                               format where participants carry roles. *@
-                            @if (isTeamMatchFmt)
-                            {
-                                var rowPromote = GetPromotionTarget(context, +1);
-                                var rowDemote = GetPromotionTarget(context, -1);
-                                <MudTooltip Text="@(rowPromote is {} p ? $"Promote to {DescribeLadderPos(p.DivisionId, p.Role)}" : "Already at top of ladder")">
-                                    <MudIconButton Icon="@Icons.Material.Filled.KeyboardDoubleArrowUp" Size="Size.Small"
-                                                   Color="Color.Success"
-                                                   Disabled="@(rowPromote is null)"
-                                                   OnClick="@(() => PromoteParticipantAsync(context, +1))" />
-                                </MudTooltip>
-                                <MudTooltip Text="@(rowDemote is {} d ? $"Demote to {DescribeLadderPos(d.DivisionId, d.Role)}" : "Already at bottom of ladder")">
-                                    <MudIconButton Icon="@Icons.Material.Filled.KeyboardDoubleArrowDown" Size="Size.Small"
-                                                   Color="Color.Default"
-                                                   Disabled="@(rowDemote is null)"
-                                                   OnClick="@(() => PromoteParticipantAsync(context, -1))" />
-                                </MudTooltip>
-                            }
                             @* Light-player edit chip — DTO doesn't surface IsLight, so always show.
                                Server-side SaveLightPlayerAsync rejects non-light players. *@
                             <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="Size.Small"
@@ -1092,10 +789,7 @@ else
                     OnSaveDivision="SaveDivisionDialog"
                     OnStartInlineEditDivision="StartInlineEditDivision"
                     OnCancelInlineEditDivision="CancelInlineEditDivision"
-                    OnDeleteDivision="RequestDeleteDivision"
-                    PendingDeleteDivisionId="_pendingDeleteDivisionId"
-                    OnConfirmDeleteDivision="ConfirmDeleteDivision"
-                    OnCancelDeleteDivision="CancelDeleteDivision"
+                    OnDeleteDivision="DeleteDivision"
                     OnOpenSeedDivisionsDialog="OpenSeedDivisionsDialog"
                     OnRunSeedDivisions="RunSeedDivisions"
                     OnOpenGenerateDialog="OpenGenerateDialog"
@@ -1137,8 +831,7 @@ else
             }
 }
 
-<div id="nav-anchor-fixtures" class="section-anchor"></div>
-@if (IsEdit)
+@if (_activeTabIndex == 2 && IsEdit)
 {
             @if (!Model.HasDivisions)
             {
@@ -1178,12 +871,8 @@ else
                 @* ── Divisional fixtures: scheduling controls + per-division grouping ─────── *@
                 <MudPaper Class="pa-4 mb-4 setup-section" Elevation="0"
                      Style="background: rgba(255,255,255,0.08); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border: 1px solid rgba(255,255,255,0.12); border-radius: 12px; color: white;">
-                    @* Title sits on its own row and each action button drops onto its
-                       own line below it (mirrors FixturesSection.razor for the
-                       non-divisions branch). AlignItems.Start keeps each button at
-                       its natural content width. *@
-                    <MudStack Spacing="2" AlignItems="AlignItems.Start" Class="mb-3">
-                        <MudText Typo="Typo.h6">Fixtures/Results</MudText>
+                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="mb-3" Wrap="Wrap.Wrap">
+                        <MudText Typo="Typo.h6" Style="flex:1">Fixtures/Results</MudText>
                         @if (_isSuperAdmin && _stages.Any(s => s.StageType == StageType.RoundRobin))
                         {
                             <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Tertiary"
@@ -1679,14 +1368,6 @@ else
                 }
             }
 
-            @if (!string.IsNullOrEmpty(_generateError))
-            {
-                <MudAlert Severity="Severity.Error" Dense="true" ShowCloseIcon="true"
-                          CloseIconClicked="@(() => _generateError = null)">
-                    @_generateError
-                </MudAlert>
-            }
-
             @if (_generateWarnings.Count > 0)
             {
                 <MudAlert Severity="Severity.Warning" Dense="true">
@@ -1696,38 +1377,6 @@ else
                             <MudText Typo="Typo.body2">@w</MudText>
                         }
                     </MudStack>
-                </MudAlert>
-            }
-
-            @* Regenerating teams replaces the current team pool, which invalidates
-               any fixtures that reference the old teams via HomeTeamId / AwayTeamId.
-               Surface the impact before the admin clicks Create so completed
-               results aren't deleted by surprise. *@
-            @{
-                var teamFixtureCount = _fixtures.Count(f => f.HomeTeamId.HasValue || f.AwayTeamId.HasValue);
-                var completedTeamFixtureCount = _fixtures.Count(f =>
-                    (f.HomeTeamId.HasValue || f.AwayTeamId.HasValue)
-                    && f.Status is FixtureStatus.Completed or FixtureStatus.AwaitingVerification);
-            }
-            @if (teamFixtureCount > 0)
-            {
-                <MudAlert Severity="@(completedTeamFixtureCount > 0 ? Severity.Warning : Severity.Info)" Dense="true">
-                    @if (completedTeamFixtureCount > 0)
-                    {
-                        <text>
-                            <b>@completedTeamFixtureCount completed</b> of @teamFixtureCount existing
-                            team fixture@(teamFixtureCount == 1 ? "" : "s") will be deleted —
-                            <b>this wipes the recorded results</b>. Continue only if you intend to
-                            start scoring from scratch.
-                        </text>
-                    }
-                    else
-                    {
-                        <text>
-                            @teamFixtureCount existing team fixture@(teamFixtureCount == 1 ? "" : "s")
-                            will be deleted when the new teams are created.
-                        </text>
-                    }
                 </MudAlert>
             }
 
@@ -1914,23 +1563,6 @@ else
     private bool _isStarted;
     private int _activeTabIndex;
 
-    // Section-nav chips no longer hide/show sections — every section renders
-    // at once and clicking a chip smooth-scrolls its anchor div into view.
-    // _activeTabIndex still drives the chip's filled/outlined highlight so
-    // users see which section they last navigated to.
-    //
-    // Why JS measures the sticky band live instead of using CSS
-    // `scroll-margin-top`: the sticky header height varies (mobile splits the
-    // band into two stacked cards; long competition titles wrap; the role
-    // banner pushes everything down). A live measurement keeps the landed
-    // section flush below the band on every layout.
-    private async Task ScrollToSectionAsync(int idx, string anchorId)
-    {
-        _activeTabIndex = idx;
-        await JS.InvokeVoidAsync("eval",
-            $"(()=>{{const a=document.getElementById('{anchorId}');if(!a)return;const s=document.querySelector('.competition-sticky-header');const o=s?s.getBoundingClientRect().bottom:0;window.scrollTo({{top:a.getBoundingClientRect().top+window.scrollY-o-12,behavior:'smooth'}});}})()");
-    }
-
     private CompetitionFormModel Model { get; set; } = new();
 
     private List<ClubDto> _clubs = [];
@@ -1950,25 +1582,18 @@ else
     // when their value is in every active set (empty set = filter inactive).
     private string? _participantSearch;
     private IReadOnlyCollection<ParticipantStatus> _filterStatuses = new HashSet<ParticipantStatus>();
-    // Nullable element types let null act as the "(Unassigned)" sentinel — selecting it
-    // matches participants whose corresponding field is null. Role keeps a non-nullable
-    // string set because the existing filter coerces `cp.Role ?? ""` and we use "" as the
-    // unassigned sentinel there.
-    private IReadOnlyCollection<int?> _filterTeamIds = new HashSet<int?>();
-    private IReadOnlyCollection<PlayerSex?> _filterSexes = new HashSet<PlayerSex?>();
+    private IReadOnlyCollection<int> _filterTeamIds = new HashSet<int>();
+    private IReadOnlyCollection<PlayerSex> _filterSexes = new HashSet<PlayerSex>();
     private IReadOnlyCollection<string> _filterRoles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-    private IReadOnlyCollection<int?> _filterDivisionIds = new HashSet<int?>();
+    private IReadOnlyCollection<int> _filterDivisionIds = new HashSet<int>();
 
     private bool FilterParticipant(CompetitionParticipantDto cp)
     {
         if (_filterStatuses.Any() && !_filterStatuses.Contains(cp.Status)) return false;
-        // Nullable filter sets let `Contains(cp.Field)` work for both populated values
-        // and null — selecting the "(Unassigned)" option in the UI puts null in the set
-        // and matches participants whose field is null.
-        if (_filterTeamIds.Any() && !_filterTeamIds.Contains(cp.TeamId)) return false;
-        if (_filterSexes.Any() && !_filterSexes.Contains(cp.Sex)) return false;
+        if (_filterTeamIds.Any() && (cp.TeamId is null || !_filterTeamIds.Contains(cp.TeamId.Value))) return false;
+        if (_filterSexes.Any() && (cp.Sex is null || !_filterSexes.Contains(cp.Sex.Value))) return false;
         if (_filterRoles.Any() && !_filterRoles.Contains(cp.Role ?? "", StringComparer.OrdinalIgnoreCase)) return false;
-        if (_filterDivisionIds.Any() && !_filterDivisionIds.Contains(cp.CompetitionDivisionId)) return false;
+        if (_filterDivisionIds.Any() && (cp.CompetitionDivisionId is null || !_filterDivisionIds.Contains(cp.CompetitionDivisionId.Value))) return false;
 
         if (!string.IsNullOrWhiteSpace(_participantSearch))
         {
@@ -1991,10 +1616,10 @@ else
     {
         _participantSearch = null;
         _filterStatuses = new HashSet<ParticipantStatus>();
-        _filterTeamIds = new HashSet<int?>();
-        _filterSexes = new HashSet<PlayerSex?>();
+        _filterTeamIds = new HashSet<int>();
+        _filterSexes = new HashSet<PlayerSex>();
         _filterRoles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        _filterDivisionIds = new HashSet<int?>();
+        _filterDivisionIds = new HashSet<int>();
     }
 
     // Division form state — inline add at the top of the Divisions section
@@ -2053,7 +1678,6 @@ else
     // Schedule confirm dialog
     private bool _showScheduleConfirm;
     private bool _showDeleteAllFixturesConfirm;
-    private bool _showDeleteAllParticipantsConfirm;
     private bool _showSeedConfirm;
 
     // Fixture dialog
@@ -2066,18 +1690,12 @@ else
     private CompetitionTeamDto? _editingTeam;
     private string _teamName = "";
     private bool _showDeleteAllTeamsConfirm;
-    private int? _pendingDeleteDivisionId;
 
     // Auto-generate teams/pairings dialog
     private bool _showGenerateDialog;
     private int _generateTeamSize = 4;
     private bool _generateGenderBalance = true;
     private List<string> _generateWarnings = [];
-    // Surfaced inline inside the generate dialog so failure messages stay
-    // visible — the SiteAlertHost banner is covered by the dialog's modal
-    // overlay, which made the previous "create teams failed" alert
-    // invisible to the user.
-    private string? _generateError;
     private List<GeneratedTeamPreviewDto> _generatedPreview = [];
     private bool _generating;
 
@@ -2123,42 +1741,6 @@ else
     private string _newEventDescription = "";
     private DateTime? _newEventStartDate;
     private DateTime? _newEventEndDate;
-
-    public sealed class CompetitionFormModel
-    {
-        [Required(ErrorMessage = "Competition name is required!")]
-        [StringLength(200, ErrorMessage = "Name must be 200 characters or fewer.")]
-        public string CompetitionName { get; set; } = "";
-        public CompetitionCategoryUi? Category { get; set; }
-        public CompetitionFormatUi? Format { get; set; }
-        public int? MaxParticipants { get; set; }
-        public DateTime? StartDateDt { get; set; }
-        public DateTime? EndDateDt { get; set; }
-        public DateTime? RegisterByDateDt { get; set; }
-        public int? MaxAge { get; set; }
-        public int? MinAge { get; set; }
-        public int? HostClubId { get; set; }
-        public int? RulesSetId { get; set; }
-        public int? EventId { get; set; }
-        public int BestOf { get; set; } = 3;
-        public bool RequireVerification { get; set; } = false;
-        public int? TeamSize { get; set; }
-        public MatchFormatType MatchFormat { get; set; } = MatchFormatType.BestOf;
-        public int NumberOfSets { get; set; } = 3;
-        public int GamesPerSet { get; set; } = 6;
-        public SetWinMode SetWinMode { get; set; } = SetWinMode.WinBy2;
-        public LeagueScoringMode LeagueScoring { get; set; } = LeagueScoringMode.WinPoints;
-        public DropShot.Shared.RubberTieBreakMode RubberTieBreak { get; set; } = DropShot.Shared.RubberTieBreakMode.AdminDecides;
-        public int? MinDaysBetweenPlayerMatches { get; set; }
-        public bool HasDivisions { get; set; }
-        public int? SeededFromCompetitionId { get; set; }
-    }
-
-    // UI-only enums that separate category (Male/Female/Mixed) from the format shown in the
-    // dropdown (Singles/Doubles/Team). The persisted CompetitionFormat + EligibleSex pair is
-    // derived from these two on save; see EffectivePersistedFormat / EffectiveEligibleSex.
-    public enum CompetitionCategoryUi { Male, Female, Mixed }
-    public enum CompetitionFormatUi { Singles, Doubles, Team }
 
     private static IEnumerable<CompetitionFormatUi> AllowedFormats(CompetitionCategoryUi? category) =>
         category == CompetitionCategoryUi.Mixed
@@ -2461,7 +2043,7 @@ else
                 _templateWindowsApplied = false;
             }
 
-            SiteAlerts.Add("Competition saved.", Severity.Success);
+            Snackbar.Add("Competition saved.", Severity.Success);
         }
         catch (InvalidOperationException ex) { _serverError = ex.Message; }
         catch (Exception ex) { _serverError = ex.Message; }
@@ -2478,7 +2060,7 @@ else
     private async Task ToggleStartedAsync()
     {
         _isStarted = await Admin.ToggleStartedAsync(Id);
-        SiteAlerts.Add(_isStarted ? "Competition started." : "Competition stopped.", Severity.Success);
+        Snackbar.Add(_isStarted ? "Competition started." : "Competition stopped.", Severity.Success);
     }
 
     // ── Add New Entity Helpers ─────────────────────────────────────────────
@@ -2492,7 +2074,7 @@ else
     private void SaveNewClub()
     {
         _showAddClubDialog = false;
-        SiteAlerts.Add("Adding clubs from this page is no longer supported — use Admin → Clubs.", Severity.Warning);
+        Snackbar.Add("Adding clubs from this page is no longer supported — use Admin → Clubs.", Severity.Warning);
     }
 
     private async Task OnHostClubChanged(int? clubId)
@@ -2549,7 +2131,7 @@ else
         // Defensive: + button is gated on HostClubId so this should always pass.
         if (Model.HostClubId is null)
         {
-            SiteAlerts.Add("Select a host club first — rules sets are club-scoped.", Severity.Warning);
+            Snackbar.Add("Select a host club first — rules sets are club-scoped.", Severity.Warning);
             return;
         }
 
@@ -2593,7 +2175,7 @@ else
     private void SaveNewEvent()
     {
         _showAddEventDialog = false;
-        SiteAlerts.Add("Adding events from this page is no longer supported — use Admin → Events.", Severity.Warning);
+        Snackbar.Add("Adding events from this page is no longer supported — use Admin → Events.", Severity.Warning);
     }
 
     private void AutoGenerateName()
@@ -2655,7 +2237,7 @@ else
         var available = GetAvailableStageTypes();
         if (available.Count == 0)
         {
-            SiteAlerts.Add("All stage types have been added.", Severity.Info);
+            Snackbar.Add("All stage types have been added.", Severity.Info);
             return;
         }
         _stageForm = new StageForm { StageType = available[0] };
@@ -2668,7 +2250,7 @@ else
         await ReloadAfterServerMutationAsync();
         _showStageDialog = false;
         var addedOrder = _stages.FirstOrDefault(s => s.StageType == _stageForm.StageType)?.StageOrder ?? 0;
-        SiteAlerts.Add("Stage added.", Severity.Success);
+        Snackbar.Add("Stage added.", Severity.Success);
         OfferFollowOnStages(_stageForm.StageType, addedOrder);
     }
 
@@ -2754,7 +2336,7 @@ else
         await Admin.ApplyStageFollowUpAsync(Id, new ApplyStageFollowUpRequest(stages.Select(s => s.Type).ToList()));
         await ReloadAfterServerMutationAsync();
         _showStageFollowUpDialog = false;
-        SiteAlerts.Add($"{stages.Count} stage(s) added.", Severity.Success);
+        Snackbar.Add($"{stages.Count} stage(s) added.", Severity.Success);
     }
 
     private async Task DeleteStage(CompetitionStageDto stage)
@@ -2763,7 +2345,7 @@ else
         // mutation surface is ApplyStageFollowUp (additive). Until that
         // changes, surface a snackbar — admin needs to delete via DB.
         await Task.CompletedTask;
-        SiteAlerts.Add($"Stage delete is not yet wired into the admin service.", Severity.Warning);
+        Snackbar.Add($"Stage delete is not yet wired into the admin service.", Severity.Warning);
     }
 
     // ── Participants ─────────────────────────────────────────────────────────
@@ -2801,83 +2383,6 @@ else
         _showNewPlayerDialog = true;
     }
 
-    // Display-side mirror of PlayerRatingService.DefaultRating — used when a
-    // participant has no recorded rating, so the roster cell shows 1500 with a
-    // "prov" chip rather than a blank field. Server-side default lives on
-    // PlayerRatingService and is the source of truth for math/persistence.
-    private const int DefaultStartingRating = 1500;
-
-    // ── Bulk-add dialog ──────────────────────────────────────────────────────
-    private bool _showBulkAddDialog;
-    private bool _bulkAddLoading;
-    private bool _bulkAddSubmitting;
-    private string _bulkAddSearch = "";
-    private PlayerSex? _bulkAddSexFilter;
-    private ParticipantStatus _bulkAddStatus = ParticipantStatus.Registered;
-    private List<PlayerSearchResultDto> _bulkAddCandidates = new();
-    private HashSet<PlayerSearchResultDto> _bulkAddSelected = new();
-
-    private IEnumerable<PlayerSearchResultDto> FilteredBulkAddCandidates =>
-        _bulkAddCandidates.Where(p =>
-            (string.IsNullOrWhiteSpace(_bulkAddSearch)
-                || p.DisplayName.Contains(_bulkAddSearch, StringComparison.OrdinalIgnoreCase))
-            && (!_bulkAddSexFilter.HasValue || p.Sex == _bulkAddSexFilter));
-
-    private async Task OpenBulkAddDialog()
-    {
-        _bulkAddSearch = "";
-        _bulkAddSexFilter = null;
-        _bulkAddStatus = ParticipantStatus.Registered;
-        _bulkAddSelected = new();
-        _showBulkAddDialog = true;
-        _bulkAddLoading = true;
-        try
-        {
-            // Empty query + generous cap returns every eligible, not-yet-enrolled
-            // player. The server still applies club-scope and eligibility filters.
-            var results = await Admin.SearchPlayersAsync(Id, new SearchPlayersForAddRequest(
-                Query: "", HostClubId: Model.HostClubId, MaxResults: 500));
-            _bulkAddCandidates = results
-                .OrderBy(p => p.DisplayName, StringComparer.OrdinalIgnoreCase)
-                .ToList();
-        }
-        catch (Exception ex)
-        {
-            SiteAlerts.Add($"Failed to load player list: {ex.Message}", Severity.Error);
-            _bulkAddCandidates = new();
-        }
-        finally
-        {
-            _bulkAddLoading = false;
-        }
-    }
-
-    private async Task ConfirmBulkAddAsync()
-    {
-        if (_bulkAddSelected.Count == 0) return;
-        _bulkAddSubmitting = true;
-        try
-        {
-            var playerIds = _bulkAddSelected.Select(p => p.PlayerId).ToList();
-            var result = await Admin.BulkAddParticipantsAsync(Id,
-                new BulkAddParticipantsRequest(playerIds, _bulkAddStatus));
-            _showBulkAddDialog = false;
-            await ReloadAfterServerMutationAsync();
-            var msg = result.Skipped > 0
-                ? $"Added {result.Added} player{(result.Added == 1 ? "" : "s")} ({result.Skipped} skipped)."
-                : $"Added {result.Added} player{(result.Added == 1 ? "" : "s")}.";
-            SiteAlerts.Add(msg, Severity.Success);
-        }
-        catch (Exception ex)
-        {
-            SiteAlerts.Add($"Failed to add players: {ex.Message}", Severity.Error);
-        }
-        finally
-        {
-            _bulkAddSubmitting = false;
-        }
-    }
-
     private void OpenEditLightPlayerDialog(CompetitionParticipantDto cp)
     {
         _editingLightPlayerId = cp.PlayerId;
@@ -2909,7 +2414,7 @@ else
 
         await ReloadAfterServerMutationAsync();
         _showNewPlayerDialog = false;
-        SiteAlerts.Add("Player updated.", Severity.Success);
+        Snackbar.Add("Player updated.", Severity.Success);
     }
 
     private async Task CreateAndAddClubPlayer()
@@ -2928,7 +2433,7 @@ else
 
         await ReloadAfterServerMutationAsync();
         _showNewPlayerDialog = false;
-        SiteAlerts.Add($"{_newPlayerForm.DisplayName} added to club and competition.", Severity.Success);
+        Snackbar.Add($"{_newPlayerForm.DisplayName} added to club and competition.", Severity.Success);
     }
 
     private async Task AddParticipant(PlayerSearchResultDto? player)
@@ -2937,7 +2442,7 @@ else
 
         if (Model.MaxParticipants.HasValue && _participants.Count >= Model.MaxParticipants.Value)
         {
-            SiteAlerts.Add($"Maximum of {Model.MaxParticipants.Value} participants reached.", Severity.Warning);
+            Snackbar.Add($"Maximum of {Model.MaxParticipants.Value} participants reached.", Severity.Warning);
             if (_participantAutocomplete != null)
                 await _participantAutocomplete.ClearAsync();
             return;
@@ -2973,7 +2478,7 @@ else
             new UpdateParticipantStatusRequest(_addParticipantStatus));
 
         await ReloadAfterServerMutationAsync();
-        SiteAlerts.Add($"{player.DisplayName} added as {ParticipantStatusLabel(_addParticipantStatus)}.", Severity.Success);
+        Snackbar.Add($"{player.DisplayName} added as {ParticipantStatusLabel(_addParticipantStatus)}.", Severity.Success);
         if (_participantAutocomplete != null)
             await _participantAutocomplete.ClearAsync();
     }
@@ -2989,19 +2494,7 @@ else
     {
         await Admin.RemoveParticipantAsync(Id, cp.PlayerId);
         _participants.Remove(cp);
-        SiteAlerts.Add("Participant removed.", Severity.Warning);
-    }
-
-    private async Task DeleteAllParticipants()
-    {
-        _showDeleteAllParticipantsConfirm = false;
-        var count = _participants.Count;
-        foreach (var cp in _participants.ToList())
-        {
-            await Admin.RemoveParticipantAsync(Id, cp.PlayerId);
-        }
-        _participants.Clear();
-        SiteAlerts.Add($"{count} participant(s) removed.", Severity.Warning);
+        Snackbar.Add("Participant removed.", Severity.Warning);
     }
 
     private async Task AssignTeam(CompetitionParticipantDto cp, int? teamId)
@@ -3042,7 +2535,7 @@ else
     {
         var assigned = await Admin.AutoAssignCaptainsAsync(Id);
         await ReloadAfterServerMutationAsync();
-        SiteAlerts.Add($"Assigned {assigned} captain(s).", Severity.Success);
+        Snackbar.Add($"Assigned {assigned} captain(s).", Severity.Success);
     }
 
     private async Task AssignParticipantDivision(CompetitionParticipantDto cp, int? divisionId)
@@ -3055,256 +2548,6 @@ else
                 ? _divisions.FirstOrDefault(d => d.CompetitionDivisionId == divisionId)?.Name
                 : null;
             _participants[idx] = cp with { CompetitionDivisionId = divisionId, DivisionName = divName };
-        }
-    }
-
-    private async Task SetParticipantInitialRating(CompetitionParticipantDto cp, int? rating)
-    {
-        if (rating is null) return;
-        await Admin.SetParticipantInitialRatingAsync(
-            Id, cp.PlayerId, new SetParticipantInitialRatingRequest(rating.Value));
-        var idx = _participants.IndexOf(cp);
-        if (idx >= 0)
-        {
-            _participants[idx] = cp with
-            {
-                Rating = new PlayerRatingDto(rating.Value, IsProvisional: false),
-                RatingSuggestion = null,
-            };
-        }
-    }
-
-    private async Task AcceptParticipantRating(CompetitionParticipantDto cp)
-    {
-        var s = await Admin.AcceptParticipantRatingAsync(Id, cp.PlayerId);
-        if (s is null) return;
-        var idx = _participants.IndexOf(cp);
-        if (idx >= 0)
-        {
-            _participants[idx] = cp with
-            {
-                Rating = new PlayerRatingDto(s.SuggestedRating, IsProvisional: s.RubbersPlayed < 10),
-                RatingSuggestion = null,
-            };
-        }
-    }
-
-    private async Task AcceptAllParticipantRatings()
-    {
-        var applied = await Admin.AcceptAllParticipantRatingsAsync(Id);
-        if (applied.Count == 0)
-        {
-            SiteAlerts.Add("No rating suggestions to apply.", Severity.Info);
-            return;
-        }
-        await ReloadAfterServerMutationAsync();
-        SiteAlerts.Add($"Applied {applied.Count} rating suggestion(s).", Severity.Success);
-    }
-
-    private async Task ApplyDivisionPlacement(CompetitionParticipantDto cp)
-    {
-        if (cp.PlacementSuggestion?.SuggestedDivisionId is not int did) return;
-        await Admin.ApplyDivisionPlacementAsync(Id, cp.PlayerId, new ApplyDivisionPlacementRequest(did));
-        var idx = _participants.IndexOf(cp);
-        if (idx >= 0)
-        {
-            var name = _divisions.FirstOrDefault(d => d.CompetitionDivisionId == did)?.Name;
-            _participants[idx] = cp with
-            {
-                CompetitionDivisionId = did,
-                DivisionName = name,
-                PlacementSuggestion = cp.PlacementSuggestion with { SuggestedDivisionId = null, SuggestedDivisionName = null },
-            };
-            // Drop the whole suggestion if both fields are now empty.
-            if (_participants[idx].PlacementSuggestion is { SuggestedDivisionId: null, SuggestedRole: null })
-                _participants[idx] = _participants[idx] with { PlacementSuggestion = null };
-        }
-    }
-
-    private async Task ApplyRolePlacement(CompetitionParticipantDto cp)
-    {
-        if (cp.PlacementSuggestion?.SuggestedRole is not string role) return;
-        await Admin.ApplyRolePlacementAsync(Id, cp.PlayerId, new ApplyRolePlacementRequest(role));
-        var idx = _participants.IndexOf(cp);
-        if (idx >= 0)
-        {
-            _participants[idx] = cp with
-            {
-                Role = role,
-                PlacementSuggestion = cp.PlacementSuggestion with { SuggestedRole = null },
-            };
-            if (_participants[idx].PlacementSuggestion is { SuggestedDivisionId: null, SuggestedRole: null })
-                _participants[idx] = _participants[idx] with { PlacementSuggestion = null };
-        }
-    }
-
-    private async Task ApplyAllPlacements()
-    {
-        var count = await Admin.ApplyAllPlacementsAsync(Id);
-        if (count == 0)
-        {
-            SiteAlerts.Add("No placement suggestions to apply.", Severity.Info);
-            return;
-        }
-        await ReloadAfterServerMutationAsync();
-        SiteAlerts.Add($"Applied {count} placement suggestion(s).", Severity.Success);
-    }
-
-    // ── Participant promote / demote ───────────────────────────────────────
-    // The ladder walks (division rank, role rank within a "lane") where a
-    // lane is the subset of _availableRoles sharing the same prefix (every
-    // char except the last) as the participant's current role. For MTT
-    // (roles MA/MB/FA/FB) this keeps male players on {MA, MB} and female on
-    // {FA, FB}; for County Doubles (D1A/D1B/D2A/D2B) it keeps pair-1 players
-    // on {D1A, D1B} and pair-2 on {D2A, D2B}. Within a lane, the role with
-    // the alphabetically earlier suffix is the higher rank (A < B). Across
-    // lanes we never cross — a male player cannot promote into FA.
-    //
-    // Suffix-letter ordering is implicit in the role strings shipped by the
-    // built-in rubber presets; a custom template that breaks the convention
-    // (e.g. roles "Captain"/"Reserve") would put each player in their own
-    // singleton lane and the promote/demote buttons would simply stay
-    // disabled — safe fallback, not silently wrong.
-    private List<string> RoleLaneFor(string? role)
-    {
-        if (string.IsNullOrEmpty(role)) return [];
-        var prefix = role[..^1];
-        return _availableRoles
-            .Where(r => r.Length == role.Length && r.StartsWith(prefix, StringComparison.Ordinal))
-            .OrderBy(r => r, StringComparer.Ordinal)
-            .ToList();
-    }
-
-    // Returns the (division, role) one step in the given direction along
-    // the ladder, or null if already at the end. direction = +1 promotes
-    // (higher rank), -1 demotes. Promoting past the top role in a division
-    // carries up to the next-higher division and resets to the bottom role
-    // (so Div 2 A → Div 1 B); demoting past the bottom carries down and
-    // resets to the top role.
-    //
-    // Entry cases (only when promoting):
-    //   - Participant has no role yet → place them at the bottom of the
-    //     ladder. Lane is inferred from Sex (M/F prefix match) when the
-    //     role naming supports it, else falls back to all roles.
-    //   - Participant has a role but no division while divisions are
-    //     enabled → drop them into the lowest division at their current
-    //     role so the normal ladder applies from there.
-    private (int? DivisionId, string Role)? GetPromotionTarget(
-        CompetitionParticipantDto cp, int direction)
-    {
-        if (string.IsNullOrEmpty(cp.Role))
-        {
-            if (direction < 0) return null;
-            var entryLane = InferEntryLane(cp);
-            if (entryLane.Count == 0) return null;
-
-            int? entryDiv;
-            if (cp.CompetitionDivisionId.HasValue)
-            {
-                entryDiv = cp.CompetitionDivisionId;
-            }
-            else if (Model.HasDivisions && _divisions.Count > 0)
-            {
-                entryDiv = _divisions.OrderByDescending(d => d.Rank).First().CompetitionDivisionId;
-            }
-            else
-            {
-                entryDiv = null;
-            }
-            return (entryDiv, entryLane[^1]);
-        }
-
-        if (direction > 0 && Model.HasDivisions && cp.CompetitionDivisionId is null && _divisions.Count > 0)
-        {
-            // Has a role but isn't in any division yet — promote drops them
-            // into the lowest division at their existing role.
-            var bottomDiv = _divisions.OrderByDescending(d => d.Rank).First();
-            return (bottomDiv.CompetitionDivisionId, cp.Role!);
-        }
-
-        var lane = RoleLaneFor(cp.Role);
-        var roleIdx = lane.IndexOf(cp.Role!);
-        if (roleIdx < 0) return null;
-
-        var newRoleIdx = roleIdx - direction;
-        if (newRoleIdx >= 0 && newRoleIdx < lane.Count)
-        {
-            return (cp.CompetitionDivisionId, lane[newRoleIdx]);
-        }
-
-        // Out of lane bounds → carry across divisions (only meaningful when
-        // divisions are enabled and the participant is already in one).
-        if (!Model.HasDivisions) return null;
-        var divisions = _divisions.OrderBy(d => d.Rank).ToList();
-        var divIdx = divisions.FindIndex(d => d.CompetitionDivisionId == cp.CompetitionDivisionId);
-        if (divIdx < 0) return null;
-
-        if (newRoleIdx < 0)
-        {
-            // Promoting past the top role → up to next-higher division, bottom role.
-            if (divIdx == 0) return null;
-            return (divisions[divIdx - 1].CompetitionDivisionId, lane[^1]);
-        }
-        // newRoleIdx >= lane.Count: demoting past the bottom role.
-        if (divIdx >= divisions.Count - 1) return null;
-        return (divisions[divIdx + 1].CompetitionDivisionId, lane[0]);
-    }
-
-    // Picks the lane a role-less participant should enter on promote. The
-    // ladder doesn't know which lane they belong to, so we lean on Sex: an
-    // M-prefixed role exists in _availableRoles → male players enter that
-    // lane; F-prefixed → female. When the role naming has no gender prefix
-    // (e.g. County Doubles' D1*/D2*) or Sex isn't set, we fall back to all
-    // available roles — bottom-of-ladder will be the alphabetically-last
-    // role, which the admin can re-target with further promotes.
-    private List<string> InferEntryLane(CompetitionParticipantDto cp)
-    {
-        if (cp.Sex is { } sex)
-        {
-            var letter = sex == PlayerSex.Male ? "M" : "F";
-            var gendered = _availableRoles
-                .Where(r => r.StartsWith(letter, StringComparison.Ordinal))
-                .OrderBy(r => r, StringComparer.Ordinal)
-                .ToList();
-            if (gendered.Count > 0) return gendered;
-        }
-        return _availableRoles.OrderBy(r => r, StringComparer.Ordinal).ToList();
-    }
-
-    private string DescribeLadderPos(int? divisionId, string role)
-    {
-        if (Model.HasDivisions && divisionId.HasValue)
-        {
-            var divName = _divisions.FirstOrDefault(d => d.CompetitionDivisionId == divisionId)?.Name ?? "Division";
-            return $"{divName} • {role}";
-        }
-        return role;
-    }
-
-    private async Task PromoteParticipantAsync(CompetitionParticipantDto cp, int direction)
-    {
-        var target = GetPromotionTarget(cp, direction);
-        if (target is null) return;
-        var (newDivisionId, newRole) = target.Value;
-
-        if (newDivisionId != cp.CompetitionDivisionId)
-        {
-            await Admin.AssignParticipantDivisionAsync(Id, cp.PlayerId, new SetParticipantDivisionRequest(newDivisionId));
-        }
-        await Admin.AssignParticipantRoleAsync(Id, cp.PlayerId, new SetParticipantRoleRequest(newRole));
-
-        var idx = _participants.IndexOf(cp);
-        if (idx >= 0)
-        {
-            var divName = newDivisionId.HasValue
-                ? _divisions.FirstOrDefault(d => d.CompetitionDivisionId == newDivisionId)?.Name
-                : null;
-            _participants[idx] = cp with
-            {
-                CompetitionDivisionId = newDivisionId,
-                DivisionName = divName,
-                Role = newRole,
-            };
         }
     }
 
@@ -3357,7 +2600,7 @@ else
         }
         catch (InvalidOperationException ex)
         {
-            SiteAlerts.Add(ex.Message, Severity.Error);
+            Snackbar.Add(ex.Message, Severity.Error);
             return;
         }
 
@@ -3367,45 +2610,11 @@ else
         _editingDivision = null;
     }
 
-    private void RequestDeleteDivision(CompetitionDivisionDto d)
+    private async Task DeleteDivision(CompetitionDivisionDto d)
     {
-        _pendingDeleteDivisionId = d.CompetitionDivisionId;
-    }
-
-    private void CancelDeleteDivision()
-    {
-        _pendingDeleteDivisionId = null;
-    }
-
-    private async Task ConfirmDeleteDivision()
-    {
-        if (!_pendingDeleteDivisionId.HasValue) return;
-        var divisionId = _pendingDeleteDivisionId.Value;
-        _pendingDeleteDivisionId = null;
-
-        var teamsInDivision = _teams
-            .Where(t => t.CompetitionDivisionId == divisionId)
-            .ToList();
-        foreach (var team in teamsInDivision)
-        {
-            await Admin.DeleteTeamAsync(Id, team.CompetitionTeamId);
-        }
-
-        await Admin.DeleteDivisionAsync(Id, divisionId);
-        _divisionWindowForms.Remove(divisionId);
+        await Admin.DeleteDivisionAsync(Id, d.CompetitionDivisionId);
+        _divisionWindowForms.Remove(d.CompetitionDivisionId);
         await ReloadAfterServerMutationAsync();
-
-        if (teamsInDivision.Count > 0)
-        {
-            var label = IsDoublesFormat()
-                ? (teamsInDivision.Count == 1 ? "pairing" : "pairings")
-                : (teamsInDivision.Count == 1 ? "team" : "teams");
-            SiteAlerts.Add($"Division deleted along with {teamsInDivision.Count} {label}.", Severity.Warning);
-        }
-        else
-        {
-            SiteAlerts.Add("Division deleted.", Severity.Warning);
-        }
     }
 
     // ── Clone competition ───────────────────────────────────────────────────
@@ -3431,7 +2640,7 @@ else
         }
         catch (Exception ex)
         {
-            SiteAlerts.Add($"Failed to clone competition: {ex.Message}", Severity.Error);
+            Snackbar.Add($"Failed to clone competition: {ex.Message}", Severity.Error);
         }
         finally
         {
@@ -3471,12 +2680,12 @@ else
             await ReloadAfterServerMutationAsync();
             Model.HasDivisions = true;
             Model.SeededFromCompetitionId = _seedSourceCompetitionId.Value;
-            SiteAlerts.Add($"Divisions seeded.", Severity.Success);
+            Snackbar.Add($"Divisions seeded.", Severity.Success);
             _showSeedDivisionsDialog = false;
         }
         catch (InvalidOperationException ex)
         {
-            SiteAlerts.Add(ex.Message, Severity.Error);
+            Snackbar.Add(ex.Message, Severity.Error);
         }
         finally
         {
@@ -3488,9 +2697,9 @@ else
     {
         var result = await Admin.ValidateTeamAsync(Id, team.CompetitionTeamId);
         if (result.Errors.Count == 0 && result.Warnings.Count == 0)
-            SiteAlerts.Add($"{team.Name}: Valid", Severity.Success);
+            Snackbar.Add($"{team.Name}: Valid", Severity.Success);
         else
-            SiteAlerts.Add($"{team.Name}: {string.Join("; ", result.Errors.Concat(result.Warnings))}", Severity.Warning);
+            Snackbar.Add($"{team.Name}: {string.Join("; ", result.Errors.Concat(result.Warnings))}", Severity.Warning);
     }
 
     // ── Teams ────────────────────────────────────────────────────────────────
@@ -3514,7 +2723,7 @@ else
         if (string.IsNullOrWhiteSpace(_teamName)) return;
         await Admin.SaveTeamAsync(Id, _editingTeam?.CompetitionTeamId, new SaveTeamRequest(_teamName.Trim()));
         await ReloadAfterServerMutationAsync();
-        SiteAlerts.Add(_editingTeam == null ? "Team added." : "Team updated.", Severity.Success);
+        Snackbar.Add(_editingTeam == null ? "Team added." : "Team updated.", Severity.Success);
         _showTeamDialog = false;
     }
 
@@ -3522,7 +2731,7 @@ else
     {
         await Admin.DeleteTeamAsync(Id, team.CompetitionTeamId);
         await ReloadAfterServerMutationAsync();
-        SiteAlerts.Add("Team removed.", Severity.Warning);
+        Snackbar.Add("Team removed.", Severity.Warning);
     }
 
     private async Task DeleteAllTeams()
@@ -3532,7 +2741,7 @@ else
         var removed = _teams.Count;
         await Admin.DeleteAllTeamsAsync(Id);
         await ReloadAfterServerMutationAsync();
-        SiteAlerts.Add($"Deleted {removed} team(s).", Severity.Warning);
+        Snackbar.Add($"Deleted {removed} team(s).", Severity.Warning);
     }
 
     private bool IsDoublesFormat() =>
@@ -3561,7 +2770,6 @@ else
 
         _generateWarnings = [];
         _generatedPreview = [];
-        _generateError = null;
         _generating = false;
         _showGenerateDialog = true;
     }
@@ -3570,38 +2778,29 @@ else
     {
         _generateWarnings = [];
         _generatedPreview = [];
-        _generateError = null;
 
         // The admin service generates per-division. When divisions are off,
         // pass null and use the global pool.
-        try
+        if (Model.HasDivisions && _divisions.Count > 0)
         {
-            if (Model.HasDivisions && _divisions.Count > 0)
-            {
-                foreach (var div in _divisions.OrderBy(d => d.Rank))
-                {
-                    var result = await Admin.GenerateTeamsPreviewAsync(Id, new GenerateTeamsRequest(
-                        TeamSize: _generateTeamSize,
-                        BalanceByGender: _generateGenderBalance,
-                        CompetitionDivisionId: div.CompetitionDivisionId));
-                    _generatedPreview.AddRange(result.Preview);
-                    foreach (var w in result.Warnings) _generateWarnings.Add($"[{div.Name}] {w}");
-                }
-            }
-            else
+            foreach (var div in _divisions.OrderBy(d => d.Rank))
             {
                 var result = await Admin.GenerateTeamsPreviewAsync(Id, new GenerateTeamsRequest(
                     TeamSize: _generateTeamSize,
                     BalanceByGender: _generateGenderBalance,
-                    CompetitionDivisionId: null));
+                    CompetitionDivisionId: div.CompetitionDivisionId));
                 _generatedPreview.AddRange(result.Preview);
-                _generateWarnings.AddRange(result.Warnings);
+                foreach (var w in result.Warnings) _generateWarnings.Add($"[{div.Name}] {w}");
             }
         }
-        catch (Exception ex)
+        else
         {
-            Logger.LogError(ex, "Failed to preview generated teams for competition {CompetitionId}.", Id);
-            _generateError = $"Failed to preview teams: {FormatExceptionChain(ex)}";
+            var result = await Admin.GenerateTeamsPreviewAsync(Id, new GenerateTeamsRequest(
+                TeamSize: _generateTeamSize,
+                BalanceByGender: _generateGenderBalance,
+                CompetitionDivisionId: null));
+            _generatedPreview.AddRange(result.Preview);
+            _generateWarnings.AddRange(result.Warnings);
         }
     }
 
@@ -3609,7 +2808,6 @@ else
     {
         if (_generatedPreview.Count == 0 || _generating) return;
         _generating = true;
-        _generateError = null;
 
         try
         {
@@ -3618,43 +2816,12 @@ else
             await ReloadAfterServerMutationAsync();
             _showGenerateDialog = false;
             var label = EffectivePersistedFormat() is CompetitionFormat.Doubles or CompetitionFormat.MixedDoubles ? "pairings" : "teams";
-            SiteAlerts.Add($"{_generatedPreview.Count} {label} created.", Severity.Success);
-        }
-        catch (Exception ex)
-        {
-            // Surface the error both inline (visible inside the still-open
-            // dialog) and via Logger.LogError (full stack trace in the server
-            // log). The SiteAlertHost banner sits above the page content and
-            // is covered by the modal dialog overlay, so an alert there is
-            // invisible to the user while the dialog is open — which made
-            // the previous fix look like "nothing happens" when it actually
-            // failed.
-            Logger.LogError(ex, "Failed to confirm team generation for competition {CompetitionId}.", Id);
-            _generateError = $"Failed to create teams: {FormatExceptionChain(ex)}";
+            Snackbar.Add($"{_generatedPreview.Count} {label} created.", Severity.Success);
         }
         finally
         {
             _generating = false;
         }
-    }
-
-    // EF Core's DbUpdateException wraps the actual SQL failure (FK violation,
-    // unique constraint, etc.) in its InnerException — the outer message is
-    // just "An error occurred while saving the entity changes." which tells
-    // the admin nothing actionable. Walk the chain so the inline alert
-    // includes the real reason.
-    private static string FormatExceptionChain(Exception ex)
-    {
-        var parts = new List<string>();
-        Exception? current = ex;
-        var seen = new HashSet<Exception>();
-        while (current != null && seen.Add(current))
-        {
-            if (!string.IsNullOrWhiteSpace(current.Message))
-                parts.Add(current.Message);
-            current = current.InnerException;
-        }
-        return parts.Count > 0 ? string.Join(" → ", parts) : ex.GetType().Name;
     }
 
     // ── Fixtures ─────────────────────────────────────────────────────────────
@@ -3696,7 +2863,7 @@ else
             .Where(id => id.HasValue).Select(id => id!.Value).ToHashSet();
         if (side1.Overlaps(side2))
         {
-            SiteAlerts.Add("A player cannot appear on both sides of a fixture.", Severity.Error);
+            Snackbar.Add("A player cannot appear on both sides of a fixture.", Severity.Error);
             return;
         }
 
@@ -3720,7 +2887,7 @@ else
 
         await Admin.SaveFixtureAsync(Id, _editingFixture?.CompetitionFixtureId, saveRequest);
         await ReloadAfterServerMutationAsync();
-        SiteAlerts.Add(_editingFixture == null ? "Fixture added." : "Fixture updated.", Severity.Success);
+        Snackbar.Add(_editingFixture == null ? "Fixture added." : "Fixture updated.", Severity.Success);
         _showFixtureDialog = false;
     }
 
@@ -3808,7 +2975,7 @@ else
     private async Task CopyQrUrl()
     {
         await JS.InvokeVoidAsync("copyToClipboard", _qrUrl);
-        SiteAlerts.Add("Link copied to clipboard.", Severity.Success);
+        Snackbar.Add("Link copied to clipboard.", Severity.Success);
     }
 
     // ── Fixture helpers used by the per-division Fixtures table ──────────
@@ -3872,11 +3039,11 @@ else
             }
             catch (InvalidOperationException ex)
             {
-                SiteAlerts.Add(ex.Message, Severity.Error);
+                Snackbar.Add(ex.Message, Severity.Error);
                 return;
             }
             await ReloadAfterServerMutationAsync();
-            SiteAlerts.Add("Result deleted. Match returned to upcoming.", Severity.Success);
+            Snackbar.Add("Result deleted. Match returned to upcoming.", Severity.Success);
         }
         else
         {
@@ -3888,7 +3055,7 @@ else
 
             await Admin.DeleteFixtureAsync(Id, fixture.CompetitionFixtureId);
             _fixtures.Remove(fixture);
-            SiteAlerts.Add("Fixture removed.", Severity.Warning);
+            Snackbar.Add("Fixture removed.", Severity.Warning);
         }
     }
 
@@ -3898,7 +3065,7 @@ else
         var count = _fixtures.Count;
         await Admin.DeleteAllFixturesAsync(Id);
         _fixtures.Clear();
-        SiteAlerts.Add($"{count} fixture(s) deleted.", Severity.Warning);
+        Snackbar.Add($"{count} fixture(s) deleted.", Severity.Warning);
     }
 
     private async Task SimulateRoundRobinAsync()
@@ -3910,15 +3077,15 @@ else
         {
             var result = await Admin.SimulateRoundRobinAsync(Id);
             if (result.FixturesUpdated > 0)
-                SiteAlerts.Add($"Simulated {result.FixturesUpdated} round-robin fixture(s).", Severity.Success);
+                Snackbar.Add($"Simulated {result.FixturesUpdated} round-robin fixture(s).", Severity.Success);
             else
-                SiteAlerts.Add("No eligible round-robin fixtures to simulate.", Severity.Info);
+                Snackbar.Add("No eligible round-robin fixtures to simulate.", Severity.Info);
 
             await OnParametersSetAsync();
         }
         catch (Exception ex)
         {
-            SiteAlerts.Add($"Simulation failed: {ex.Message}", Severity.Error);
+            Snackbar.Add($"Simulation failed: {ex.Message}", Severity.Error);
         }
         finally
         {
@@ -3941,7 +3108,7 @@ else
             catch (KeyNotFoundException)
             {
                 _editingMatchWindowId = null;
-                SiteAlerts.Add("That window no longer exists.", Severity.Warning);
+                Snackbar.Add("That window no longer exists.", Severity.Warning);
                 return;
             }
             await Admin.AddMatchWindowAsync(Id, new SaveMatchWindowRequest(
@@ -3952,7 +3119,7 @@ else
                 CompetitionDivisionId: null));
             await ReloadAfterServerMutationAsync();
             _editingMatchWindowId = null;
-            SiteAlerts.Add("Window updated.", Severity.Success);
+            Snackbar.Add("Window updated.", Severity.Success);
             return;
         }
 
@@ -3965,7 +3132,7 @@ else
         await ReloadAfterServerMutationAsync();
         // Intentionally do NOT clear the form — admins often add multiple similar
         // windows differing in only one field (different day, different court).
-        SiteAlerts.Add("Window added.", Severity.Success);
+        Snackbar.Add("Window added.", Severity.Success);
     }
 
     private void CopyMatchWindowToForm(CompetitionMatchWindowDto w)
@@ -4002,7 +3169,7 @@ else
         {
             form.EditingId = null;
         }
-        SiteAlerts.Add("Window removed.", Severity.Warning);
+        Snackbar.Add("Window removed.", Severity.Warning);
     }
 
     // ── Per-division match windows ──────────────────────────────────────────
@@ -4032,7 +3199,7 @@ else
             catch (KeyNotFoundException)
             {
                 form.EditingId = null;
-                SiteAlerts.Add("That window no longer exists.", Severity.Warning);
+                Snackbar.Add("That window no longer exists.", Severity.Warning);
                 return;
             }
         }
@@ -4045,7 +3212,7 @@ else
             CompetitionDivisionId: divisionId));
         await ReloadAfterServerMutationAsync();
         form.EditingId = null;
-        SiteAlerts.Add(form.EditingId.HasValue ? "Window updated." : "Division window added.", Severity.Success);
+        Snackbar.Add(form.EditingId.HasValue ? "Window updated." : "Division window added.", Severity.Success);
     }
 
     private void CopyDivisionMatchWindowToForm(CompetitionMatchWindowDto w)
@@ -4085,9 +3252,9 @@ else
         _selectedTemplateId = null;
         await ReloadAfterServerMutationAsync();
         if (imported == 0)
-            SiteAlerts.Add("All windows from that template are already present.", Severity.Info);
+            Snackbar.Add("All windows from that template are already present.", Severity.Info);
         else
-            SiteAlerts.Add($"Imported {imported} window(s) from template.", Severity.Success);
+            Snackbar.Add($"Imported {imported} window(s) from template.", Severity.Success);
     }
 
     // ── Competition Templates ────────────────────────────────────────────────
@@ -4126,11 +3293,11 @@ else
                 StartTime: w.StartTime,
                 EndTime: w.EndTime)).ToList();
             _templateWindowsApplied = true;
-            SiteAlerts.Add($"Template '{t.Name}' applied. Save to persist.", Severity.Info);
+            Snackbar.Add($"Template '{t.Name}' applied. Save to persist.", Severity.Info);
         }
         else
         {
-            SiteAlerts.Add($"Template '{t.Name}' applied.", Severity.Success);
+            Snackbar.Add($"Template '{t.Name}' applied.", Severity.Success);
         }
     }
 
@@ -4150,7 +3317,7 @@ else
     {
         await Admin.ApplyRubberPresetAsync(Id, new ApplyRubberPresetRequest(string.IsNullOrWhiteSpace(key) ? null : key));
         await ReloadRubberTemplateAsync();
-        SiteAlerts.Add("Rubber preset applied.", Severity.Success);
+        Snackbar.Add("Rubber preset applied.", Severity.Success);
     }
 
     private async Task ConvertToCustomTemplate()
@@ -4158,7 +3325,7 @@ else
         if (_rubberTemplateDefs.Count == 0) return;
         await Admin.ConvertToCustomTemplateAsync(Id);
         await ReloadRubberTemplateAsync();
-        SiteAlerts.Add("Template snapshot saved. You can now edit it.", Severity.Success);
+        Snackbar.Add("Template snapshot saved. You can now edit it.", Severity.Success);
     }
 
     private async Task AddCustomRubberRow()
@@ -4206,7 +3373,7 @@ else
     {
         await Admin.RevertToDefaultTemplateAsync(Id);
         await ReloadRubberTemplateAsync();
-        SiteAlerts.Add("Reverted to default rubber template.", Severity.Info);
+        Snackbar.Add("Reverted to default rubber template.", Severity.Info);
     }
 
     private static List<string> ParseRoles(string csv) =>
@@ -4233,19 +3400,19 @@ else
         {
             await Admin.AddCompetitionAdminAsync(Id, new AddCompetitionAdminRequest(_newAdminEmail.Trim()));
         }
-        catch (KeyNotFoundException) { SiteAlerts.Add("No user found with that email.", Severity.Warning); return; }
-        catch (InvalidOperationException) { SiteAlerts.Add("Already an admin.", Severity.Info); return; }
+        catch (KeyNotFoundException) { Snackbar.Add("No user found with that email.", Severity.Warning); return; }
+        catch (InvalidOperationException) { Snackbar.Add("Already an admin.", Severity.Info); return; }
 
         _newAdminEmail = "";
         _competitionAdmins = (await Admin.GetCompetitionAdminsAsync(Id)).ToList();
-        SiteAlerts.Add("Admin added.", Severity.Success);
+        Snackbar.Add("Admin added.", Severity.Success);
     }
 
     private async Task RemoveCompetitionAdmin(CompetitionAdminRowDto row)
     {
         await Admin.RemoveCompetitionAdminAsync(Id, row.UserId);
         _competitionAdmins.RemoveAll(a => a.UserId == row.UserId);
-        SiteAlerts.Add("Admin removed.", Severity.Warning);
+        Snackbar.Add("Admin removed.", Severity.Warning);
     }
 
     // ── Send Email ───────────────────────────────────────────────────────────
@@ -4275,7 +3442,7 @@ else
             FixtureId: _emailFixtureId.Value,
             Subject: _emailSubject,
             Body: _emailBody));
-        SiteAlerts.Add("Emails sent to fixture players.", Severity.Success);
+        Snackbar.Add("Emails sent to fixture players.", Severity.Success);
     }
 
     private async Task SendCompetitionEmail()
@@ -4284,7 +3451,7 @@ else
         await Admin.SendCompetitionEmailAsync(Id, new SendCompetitionEmailRequest(
             Subject: _compEmailSubject,
             Body: _compEmailBody));
-        SiteAlerts.Add($"Emails sent to participants.", Severity.Success);
+        Snackbar.Add($"Emails sent to participants.", Severity.Success);
     }
 
     private void OpenScheduleConfirm()
@@ -4302,22 +3469,22 @@ else
         await ReloadAfterServerMutationAsync();
 
         if (result.FixturesSkipped > 0)
-            SiteAlerts.Add($"{result.FixturesScheduled} fixtures scheduled. {result.FixturesSkipped} could not be scheduled — not enough available slots in the match windows.", Severity.Warning);
+            Snackbar.Add($"{result.FixturesScheduled} fixtures scheduled. {result.FixturesSkipped} could not be scheduled — not enough available slots in the match windows.", Severity.Warning);
         else
-            SiteAlerts.Add($"{result.FixturesScheduled} fixtures scheduled.", Severity.Success);
+            Snackbar.Add($"{result.FixturesScheduled} fixtures scheduled.", Severity.Success);
 
         // Headline summary first when nothing got scheduled — gives the user
         // immediate context for the per-participant warnings that follow.
         if (result.FixturesScheduled == 0 && result.Warnings.Count > 0)
         {
-            SiteAlerts.Add(
+            Snackbar.Add(
                 $"No fixtures scheduled — {result.Warnings.Count} participant(s) skipped because they are not Full Players. See per-player warnings below.",
                 Severity.Warning,
-                autoDismissAfter: TimeSpan.FromSeconds(20));
+                c => c.VisibleStateDuration = 20000);
         }
 
         foreach (var w in result.Warnings)
-            SiteAlerts.Add(w, Severity.Warning, autoDismissAfter: TimeSpan.FromSeconds(12));
+            Snackbar.Add(w, Severity.Warning, c => c.VisibleStateDuration = 12000);
     }
 
     private async Task SeedKnockoutFromStandingsAsync()
@@ -4327,11 +3494,11 @@ else
         await ReloadAfterServerMutationAsync();
         if (result.FixturesSeeded == 0 && result.Warnings.Count > 0)
         {
-            foreach (var w in result.Warnings) SiteAlerts.Add(w, Severity.Warning);
+            foreach (var w in result.Warnings) Snackbar.Add(w, Severity.Warning);
         }
         else
         {
-            SiteAlerts.Add($"Quarter-final fixtures seeded from standings.", Severity.Success);
+            Snackbar.Add($"Quarter-final fixtures seeded from standings.", Severity.Success);
         }
     }
 

--- a/DropShot.UI/Components/Pages/CompetitionWizardPage.razor
+++ b/DropShot.UI/Components/Pages/CompetitionWizardPage.razor
@@ -1,0 +1,735 @@
+@using System.ComponentModel.DataAnnotations
+@using DropShot.Shared
+@using DropShot.Shared.Dtos
+@using DropShot.UI.Components.Competitions
+@using DropShot.UI.Services
+@using DropShot.UI.Services.Auth
+
+@inject ICompetitionAdminService Admin
+@inject NavigationManager Nav
+@inject ISnackbar Snackbar
+@inject Microsoft.Extensions.Logging.ILogger<CompetitionWizardPage> Logger
+
+@if (!_loaded)
+{
+    <MudProgressLinear Indeterminate="true" Color="Color.Primary" Class="my-4" />
+}
+else
+{
+<div style="position: relative; min-height: 100vh; background-image: url('images/background.png'); background-repeat: no-repeat; background-size: cover; background-position: center; margin: -24px; padding: 0;">
+    <div style="position: absolute; inset: 0; background-color: rgba(18, 18, 18, 0.85); pointer-events: none;"></div>
+    <div style="position: relative; z-index: 1; padding: 1rem 0.5rem 2rem;">
+
+        <MudStack Spacing="2" Class="mb-4">
+            <MudText Typo="Typo.h4" Class="competition-title"
+                     Color="@(string.IsNullOrWhiteSpace(Model.CompetitionName) ? Color.Secondary : Color.Default)">
+                @(string.IsNullOrWhiteSpace(Model.CompetitionName) ? "New Competition" : Model.CompetitionName)
+            </MudText>
+            <MudText Typo="Typo.body2" Style="opacity:0.75">
+                Step @(_currentStep + 1) of @TotalSteps — @StepTitle(_currentStep)
+            </MudText>
+            <MudProgressLinear Value="@StepProgress" Color="Color.Primary" Class="mt-1" />
+        </MudStack>
+
+        <MudStack Spacing="3">
+
+            @* ── Step 0: Name + Category ───────────────────── *@
+            @if (_currentStep > 0)
+            {
+                <StepSummary Label="Name & Category"
+                             Icon="@Icons.Material.Filled.Person"
+                             AccentColor="#26a69a"
+                             Summary="@($"{(string.IsNullOrWhiteSpace(Model.CompetitionName) ? "Unnamed" : Model.CompetitionName)} — {Model.Category}")"
+                             OnEdit="@(() => GoToStep(0))" />
+            }
+            else
+            {
+                <MudPaper Class="pa-4 wizard-step" Elevation="0">
+                    <MudText Typo="Typo.h6" Class="mb-2">Name & Category</MudText>
+                    @StepIntro("Category controls who is considered for entry and who will be offered a spot. Male / Female restricts by registered sex; Mixed is open to all.")
+
+                    <MudTextField T="string" @bind-Value="Model.CompetitionName"
+                                  Label="Competition name" Variant="Variant.Outlined"
+                                  Required="true" RequiredError="Please enter a name."
+                                  Class="mt-3" />
+
+                    <MudField Label="Category" Variant="Variant.Text" Class="mt-3"
+                              Error="@(_categoryError != null)" ErrorText="@_categoryError">
+                        <MudRadioGroup T="CompetitionCategoryUi?" Value="Model.Category"
+                                       ValueChanged="OnCategoryChanged">
+                            <MudRadio T="CompetitionCategoryUi?" Value="@((CompetitionCategoryUi?)CompetitionCategoryUi.Male)" Color="Color.Primary">Male</MudRadio>
+                            <MudRadio T="CompetitionCategoryUi?" Value="@((CompetitionCategoryUi?)CompetitionCategoryUi.Female)" Color="Color.Primary">Female</MudRadio>
+                            <MudRadio T="CompetitionCategoryUi?" Value="@((CompetitionCategoryUi?)CompetitionCategoryUi.Mixed)" Color="Color.Primary">Mixed</MudRadio>
+                        </MudRadioGroup>
+                    </MudField>
+
+                    @StepActions(canBack: false, advance: TryAdvanceFromCategory)
+                </MudPaper>
+            }
+
+            @* ── Step 1: Age ────────────────────────────────── *@
+            @if (_currentStep > 1)
+            {
+                <StepSummary Label="Age range"
+                             Icon="@Icons.Material.Filled.Cake"
+                             AccentColor="#7c4dff"
+                             Summary="@AgeSummary()"
+                             OnEdit="@(() => GoToStep(1))" />
+            }
+            else if (_currentStep == 1)
+            {
+                <MudPaper Class="pa-4 wizard-step" Elevation="0">
+                    <MudText Typo="Typo.h6" Class="mb-2">Age options</MudText>
+                    @StepIntro("Set the age range for eligible players. Leave either field blank for no upper or lower limit.")
+
+                    <MudGrid Spacing="2" Class="mt-3">
+                        <MudItem xs="12" sm="6">
+                            <MudNumericField T="int?" Label="Min Age (optional)"
+                                             Min="1" Max="120" Variant="Variant.Outlined"
+                                             @bind-Value="Model.MinAge" />
+                        </MudItem>
+                        <MudItem xs="12" sm="6">
+                            <MudNumericField T="int?" Label="Max Age (optional)"
+                                             Min="1" Max="120" Variant="Variant.Outlined"
+                                             @bind-Value="Model.MaxAge" />
+                        </MudItem>
+                    </MudGrid>
+
+                    @StepActions(canBack: true, advance: TryAdvance)
+                </MudPaper>
+            }
+
+            @* ── Step 2: Format ─────────────────────────────── *@
+            @if (_currentStep > 2)
+            {
+                <StepSummary Label="Format"
+                             Icon="@Icons.Material.Filled.SportsTennis"
+                             AccentColor="#00b4d8"
+                             Summary="@(Model.Format?.ToString() ?? "Not set")"
+                             OnEdit="@(() => GoToStep(2))" />
+            }
+            else if (_currentStep == 2)
+            {
+                <MudPaper Class="pa-4 wizard-step" Elevation="0">
+                    <MudText Typo="Typo.h6" Class="mb-2">Format</MudText>
+                    @StepIntro("Singles is 1 vs 1. Doubles is 2 vs 2 fixed pairs. Team is a squad-vs-squad format with multiple rubbers in each fixture.")
+
+                    <MudSelect T="CompetitionFormatUi?" Label="Format" Variant="Variant.Outlined"
+                               Required="true" RequiredError="Please pick a format."
+                               Value="Model.Format"
+                               ValueChanged="@(v => Model.Format = v)"
+                               Class="mt-3">
+                        @foreach (var f in CompetitionFormHelpers.AllowedFormats(Model.Category))
+                        {
+                            <MudSelectItem T="CompetitionFormatUi?" Value="@((CompetitionFormatUi?)f)">@FormatLabel(f)</MudSelectItem>
+                        }
+                    </MudSelect>
+
+                    @if (Model.Format == CompetitionFormatUi.Singles)
+                    {
+                        <MudText Typo="Typo.caption" Class="mt-2" Style="opacity:0.75">
+                            Singles: each player faces every other player one-on-one.
+                        </MudText>
+                    }
+                    else if (Model.Format == CompetitionFormatUi.Doubles)
+                    {
+                        <MudText Typo="Typo.caption" Class="mt-2" Style="opacity:0.75">
+                            Doubles: fixed pairs play other pairs. Each pairing acts as a single competitor.
+                        </MudText>
+                    }
+                    else if (Model.Format == CompetitionFormatUi.Team)
+                    {
+                        <MudText Typo="Typo.caption" Class="mt-2" Style="opacity:0.75">
+                            Team: squads play head-to-head fixtures made up of several rubbers. Rubber roles and scoring are configured later via the rubber template.
+                        </MudText>
+                    }
+
+                    @StepActions(canBack: true, advance: TryAdvanceFromFormat)
+                </MudPaper>
+            }
+
+            @* ── Step 3: Rule set ──────────────────────────── *@
+            @if (_currentStep > 3)
+            {
+                <StepSummary Label="Rule set"
+                             Icon="@Icons.Material.Filled.Gavel"
+                             AccentColor="#f77f00"
+                             Summary="@RuleSetSummary()"
+                             OnEdit="@(() => GoToStep(3))" />
+            }
+            else if (_currentStep == 3)
+            {
+                <MudPaper Class="pa-4 wizard-step" Elevation="0">
+                    <MudText Typo="Typo.h6" Class="mb-2">Rule set</MudText>
+                    @StepIntro("Pick the host club (whose courts and admins apply) and an optional rules set that defines defaults like tie-break rules and ball type. Linking the comp to an event is also optional.")
+
+                    @if (!_hideHostClub)
+                    {
+                        <MudSelect T="int?" Value="Model.HostClubId"
+                                   ValueChanged="OnHostClubChanged"
+                                   Label="@(_lockHostClub ? "Host Club" : "Host Club (optional)")"
+                                   Variant="Variant.Outlined"
+                                   Clearable="@(!_lockHostClub)"
+                                   ReadOnly="@_lockHostClub"
+                                   Disabled="@_lockHostClub"
+                                   Class="mt-3">
+                            @foreach (var c in _clubs)
+                            {
+                                <MudSelectItem T="int?" Value="@((int?)c.ClubId)">@c.Name</MudSelectItem>
+                            }
+                        </MudSelect>
+                    }
+
+                    <MudSelect @bind-Value="Model.RulesSetId" Label="Rules Set (optional)"
+                               Variant="Variant.Outlined" Clearable="true" Class="mt-3"
+                               Disabled="@(Model.HostClubId == null)">
+                        @foreach (var r in VisibleRulesSets())
+                        {
+                            <MudSelectItem T="int?" Value="@((int?)r.RulesSetId)">@r.Name</MudSelectItem>
+                        }
+                    </MudSelect>
+
+                    <MudSelect @bind-Value="Model.EventId" Label="Event (optional)"
+                               Variant="Variant.Outlined" Clearable="true" Class="mt-3">
+                        @foreach (var e in _events)
+                        {
+                            <MudSelectItem T="int?" Value="@((int?)e.EventId)">@e.Name</MudSelectItem>
+                        }
+                    </MudSelect>
+
+                    @StepActions(canBack: true, advance: TryAdvance)
+                </MudPaper>
+            }
+
+            @* ── Step 4: Dates + max participants ──────────── *@
+            @if (_currentStep > 4)
+            {
+                <StepSummary Label="Dates & participants"
+                             Icon="@Icons.Material.Filled.CalendarMonth"
+                             AccentColor="#26a69a"
+                             Summary="@DatesSummary()"
+                             OnEdit="@(() => GoToStep(4))" />
+            }
+            else if (_currentStep == 4)
+            {
+                <MudPaper Class="pa-4 wizard-step" Elevation="0">
+                    <MudText Typo="Typo.h6" Class="mb-2">Dates and participants</MudText>
+                    @StepIntro("When the competition runs, when registrations close, and the cap on how many players can join. All dates are optional.")
+
+                    <MudGrid Spacing="2" Class="mt-3">
+                        <MudItem xs="12" sm="6">
+                            <MudDatePicker @bind-Date="Model.StartDateDt" Label="Start Date (optional)" DateFormat="dd/MM/yyyy" />
+                        </MudItem>
+                        <MudItem xs="12" sm="6">
+                            <MudDatePicker @bind-Date="Model.EndDateDt" Label="End Date (optional)" DateFormat="dd/MM/yyyy" />
+                        </MudItem>
+                        <MudItem xs="12" sm="6">
+                            <MudDatePicker @bind-Date="Model.RegisterByDateDt" Label="Register By (optional)" DateFormat="dd/MM/yyyy" />
+                        </MudItem>
+                    </MudGrid>
+
+                    <MudNumericField @bind-Value="Model.MaxParticipants" Label="Max Participants (optional)"
+                                     Min="2" Variant="Variant.Outlined" Class="mt-3" />
+
+                    @StepActions(canBack: true, advance: TryAdvance)
+                </MudPaper>
+            }
+
+            @* ── Step 5: Divisions ─────────────────────────── *@
+            @if (_currentStep > 5)
+            {
+                <StepSummary Label="Divisions"
+                             Icon="@Icons.Material.Filled.AccountTree"
+                             AccentColor="#9c27b0"
+                             Summary="@(Model.HasDivisions ? "Split into ranked divisions" : "Single field, no divisions")"
+                             OnEdit="@(() => GoToStep(5))" />
+            }
+            else if (_currentStep == 5)
+            {
+                <MudPaper Class="pa-4 wizard-step" Elevation="0">
+                    <MudText Typo="Typo.h6" Class="mb-2">Split into divisions?</MudText>
+                    @StepIntro("Divisions let you tier the field (for example Premier / A / B). Teams only play others in their own division and league tables render per-division. You'll create each division after the competition is saved.")
+
+                    <MudCheckBox @bind-Value="Model.HasDivisions"
+                                 Label="Split this competition into ranked divisions"
+                                 Class="mt-3" />
+
+                    @StepActions(canBack: true, advance: TryAdvance)
+                </MudPaper>
+            }
+
+            @* ── Step 6: Match/rubber scoring ──────────────── *@
+            @if (_currentStep > 6)
+            {
+                <StepSummary Label="Match scoring"
+                             Icon="@Icons.Material.Filled.EmojiEvents"
+                             AccentColor="#0077b6"
+                             Summary="@ScoringSummary()"
+                             OnEdit="@(() => GoToStep(6))" />
+            }
+            else if (_currentStep == 6)
+            {
+                <MudPaper Class="pa-4 wizard-step" Elevation="0">
+                    <MudText Typo="Typo.h6" Class="mb-2">Match / rubber scoring</MudText>
+                    @StepIntro("How each individual match is scored. For Team competitions, this controls the format of each rubber inside a fixture.")
+
+                    <MudText Typo="Typo.subtitle2" Class="mt-3 mb-1">Match format</MudText>
+                    <MudRadioGroup @bind-Value="Model.MatchFormat">
+                        <MudStack Row="true" Spacing="2">
+                            <MudRadio Value="MatchFormatType.BestOf" Color="Color.Primary">Best of</MudRadio>
+                            <MudRadio Value="MatchFormatType.FixedSets" Color="Color.Primary">Fixed sets</MudRadio>
+                        </MudStack>
+                    </MudRadioGroup>
+                    @if (Model.MatchFormat == MatchFormatType.BestOf)
+                    {
+                        <MudSelect @bind-Value="Model.BestOf" Label="Best of (sets)" Variant="Variant.Outlined"
+                                   Style="max-width: 160px;" Class="mt-1">
+                            <MudSelectItem T="int" Value="1">1</MudSelectItem>
+                            <MudSelectItem T="int" Value="3">3</MudSelectItem>
+                            <MudSelectItem T="int" Value="5">5</MudSelectItem>
+                            <MudSelectItem T="int" Value="7">7</MudSelectItem>
+                        </MudSelect>
+                    }
+                    else
+                    {
+                        <MudNumericField @bind-Value="Model.NumberOfSets" Label="Number of sets to play"
+                                         Variant="Variant.Outlined" Min="1" Max="20"
+                                         Style="max-width: 160px;" Class="mt-1" />
+                    }
+
+                    <MudNumericField @bind-Value="Model.GamesPerSet" Label="Games per set"
+                                     Variant="Variant.Outlined" Min="1" Max="12"
+                                     Style="max-width: 160px;" Class="mt-3" />
+
+                    <MudText Typo="Typo.subtitle2" Class="mt-3 mb-1">Set wins on</MudText>
+                    <MudRadioGroup @bind-Value="Model.SetWinMode">
+                        <MudStack Row="true" Spacing="2">
+                            <MudTooltip Text="Must win by 2 clear games; tie-break at games-all.">
+                                <MudRadio Value="SetWinMode.WinBy2" Color="Color.Primary">Win by 2</MudRadio>
+                            </MudTooltip>
+                            <MudTooltip Text="First player to reach the games-per-set target wins the set.">
+                                <MudRadio Value="SetWinMode.FirstTo" Color="Color.Primary">First to</MudRadio>
+                            </MudTooltip>
+                        </MudStack>
+                    </MudRadioGroup>
+
+                    @if (CompetitionFormHelpers.EffectivePersistedFormat(Model.Category, Model.Format) == CompetitionFormat.TeamMatch)
+                    {
+                        <MudText Typo="Typo.subtitle2" Class="mt-3 mb-1">Rubber tie-break</MudText>
+                        <MudText Typo="Typo.caption" Class="mb-2" Style="opacity:0.75">
+                            How to resolve knockout fixtures when rubbers are tied.
+                        </MudText>
+                        <MudRadioGroup @bind-Value="Model.RubberTieBreak">
+                            <MudStack Spacing="1">
+                                <MudRadio Value="RubberTieBreakMode.AdminDecides" Color="Color.Primary">Admin picks the winner</MudRadio>
+                                <MudRadio Value="RubberTieBreakMode.MostGamesWon" Color="Color.Primary">Most games won across all rubbers</MudRadio>
+                                <MudRadio Value="RubberTieBreakMode.HeadToHeadRoundRobin" Color="Color.Primary">Winner of the round-robin meeting</MudRadio>
+                                <MudRadio Value="RubberTieBreakMode.MostGamesThenHeadToHead" Color="Color.Primary">Most games won, then round-robin head-to-head</MudRadio>
+                            </MudStack>
+                        </MudRadioGroup>
+                    }
+
+                    @StepActions(canBack: true, advance: TryAdvance)
+                </MudPaper>
+            }
+
+            @* ── Step 7: League scoring ─────────────────────── *@
+            @if (_currentStep > 7)
+            {
+                <StepSummary Label="League scoring"
+                             Icon="@Icons.Material.Filled.Leaderboard"
+                             AccentColor="#d62828"
+                             Summary="@LeagueScoringLabel(Model.LeagueScoring)"
+                             OnEdit="@(() => GoToStep(7))" />
+            }
+            else if (_currentStep == 7)
+            {
+                <MudPaper Class="pa-4 wizard-step" Elevation="0">
+                    <MudText Typo="Typo.h6" Class="mb-2">League scoring</MudText>
+                    @StepIntro("How standings are calculated across the competition. Win Points rewards results; Sets / Games Won reward dominance in close matches. For Team competitions, sets and games aggregate across every rubber in the fixture.")
+
+                    <MudRadioGroup @bind-Value="Model.LeagueScoring" Class="mt-3">
+                        <MudStack Spacing="1">
+                            <MudRadio Value="LeagueScoringMode.WinPoints" Color="Color.Primary">3 points for a win, 1 for a draw</MudRadio>
+                            <MudRadio Value="LeagueScoringMode.SetsWon" Color="Color.Primary">1 point per set won</MudRadio>
+                            <MudRadio Value="LeagueScoringMode.GamesWon" Color="Color.Primary">1 point per game won</MudRadio>
+                        </MudStack>
+                    </MudRadioGroup>
+
+                    @StepActions(canBack: true, advance: TryAdvance)
+                </MudPaper>
+            }
+
+            @* ── Step 8: Misc settings ──────────────────────── *@
+            @if (_currentStep > 8)
+            {
+                <StepSummary Label="Misc"
+                             Icon="@Icons.Material.Filled.Tune"
+                             AccentColor="#4caf50"
+                             Summary="@MiscSummary()"
+                             OnEdit="@(() => GoToStep(8))" />
+            }
+            else if (_currentStep == 8)
+            {
+                <MudPaper Class="pa-4 wizard-step" Elevation="0">
+                    <MudText Typo="Typo.h6" Class="mb-2">Misc settings</MudText>
+                    @StepIntro("Fine controls — minimum gap between a player's matches when auto-scheduling, and whether results need an admin to verify them before counting toward the standings.")
+
+                    <MudText Typo="Typo.subtitle2" Class="mt-3 mb-1">Minimum days between matches</MudText>
+                    <MudText Typo="Typo.caption" Class="mb-2" Style="opacity:0.75">
+                        Auto-scheduling tries to keep each player's matches this many days apart. Leave blank for no restriction.
+                    </MudText>
+                    <MudNumericField T="int?" @bind-Value="Model.MinDaysBetweenPlayerMatches"
+                                     Label="Days" Min="0" Max="30" Variant="Variant.Outlined"
+                                     Style="max-width: 160px" />
+
+                    <MudCheckBox @bind-Value="Model.RequireVerification"
+                                 Label="Require admin verification of results"
+                                 Class="mt-3" />
+
+                    @StepActions(canBack: true, advance: TryAdvance)
+                </MudPaper>
+            }
+
+            @* ── Step 9: Review & create ────────────────────── *@
+            @if (_currentStep == 9)
+            {
+                <MudPaper Class="pa-4 wizard-step" Elevation="0">
+                    <MudText Typo="Typo.h6" Class="mb-2">Review &amp; create</MudText>
+                    @StepIntro("Review your competition. After creating, you'll land on the edit page where you can add admins, stages, the rubber template (for Team competitions), participants, and fixtures.")
+
+                    @if (!string.IsNullOrWhiteSpace(_serverError))
+                    {
+                        <MudAlert Severity="Severity.Error" Class="mt-3">@_serverError</MudAlert>
+                    }
+
+                    <div class="d-flex justify-space-between mt-4">
+                        <MudButton Variant="Variant.Text" Color="Color.Default"
+                                   StartIcon="@Icons.Material.Filled.ArrowBack"
+                                   Disabled="@_isSaving"
+                                   OnClick="GoBack">Back</MudButton>
+                        <MudStack Row="true" Spacing="2">
+                            <MudButton Variant="Variant.Outlined" Color="Color.Default"
+                                       Disabled="@_isSaving"
+                                       OnClick="@(() => Nav.NavigateTo("/Competitions"))">Cancel</MudButton>
+                            <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                                       EndIcon="@Icons.Material.Filled.Check"
+                                       Disabled="@_isSaving"
+                                       OnClick="CreateAsync">
+                                @if (_isSaving)
+                                {
+                                    <MudProgressCircular Indeterminate="true" Size="Size.Small" Class="mr-2" />
+                                }
+                                Create competition
+                            </MudButton>
+                        </MudStack>
+                    </div>
+                </MudPaper>
+            }
+
+        </MudStack>
+    </div>
+</div>
+}
+
+@code {
+    private const int TotalSteps = 10;
+
+    private CompetitionFormModel Model { get; set; } = new();
+
+    private int _currentStep = 0;
+    private bool _loaded;
+    private bool _isSaving;
+    private string? _serverError;
+    private string? _categoryError;
+
+    // Lookup data
+    private List<ClubDto> _clubs = new();
+    private List<RulesSetDto> _rulesSets = new();
+    private List<EventDto> _events = new();
+
+    // Host-club gating mirrors CompetitionPage create flow.
+    private bool _lockHostClub;
+    private bool _hideHostClub;
+
+    private double StepProgress => ((_currentStep + 1) / (double)TotalSteps) * 100;
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            var view = await Admin.GetCompetitionForEditAsync(null);
+            if (view is null || !view.CanEdit)
+            {
+                Nav.NavigateTo("/", replace: true);
+                return;
+            }
+
+            _clubs = view.Clubs.ToList();
+            _rulesSets = view.RulesSets.OrderBy(r => r.Name).ToList();
+            _events = view.Events.ToList();
+
+            Model = new CompetitionFormModel();
+
+            // Same role-aware seeding the existing create flow uses:
+            //  • ClubAdmin (single seeded HostClubId): lock to that club.
+            //  • Premium user (no clubs visible): hide host club entirely.
+            if (view.HostClubId.HasValue)
+            {
+                _lockHostClub = true;
+                Model.HostClubId = view.HostClubId;
+            }
+            else if (_clubs.Count == 0)
+            {
+                _hideHostClub = true;
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to load competition wizard.");
+            _serverError = "Could not load setup data.";
+        }
+        finally
+        {
+            _loaded = true;
+        }
+    }
+
+    private void GoToStep(int step)
+    {
+        if (step < 0 || step >= TotalSteps) return;
+        _currentStep = step;
+        _serverError = null;
+    }
+
+    private void GoBack()
+    {
+        if (_currentStep > 0) _currentStep--;
+        _serverError = null;
+    }
+
+    private void TryAdvance()
+    {
+        if (_currentStep < TotalSteps - 1) _currentStep++;
+    }
+
+    private void TryAdvanceFromCategory()
+    {
+        if (string.IsNullOrWhiteSpace(Model.CompetitionName))
+        {
+            Snackbar.Add("Please enter a competition name.", Severity.Warning);
+            return;
+        }
+        if (Model.Category == null)
+        {
+            _categoryError = "Please select a category.";
+            return;
+        }
+        _categoryError = null;
+        TryAdvance();
+    }
+
+    private void TryAdvanceFromFormat()
+    {
+        if (Model.Format == null)
+        {
+            Snackbar.Add("Please pick a format.", Severity.Warning);
+            return;
+        }
+        TryAdvance();
+    }
+
+    private void OnCategoryChanged(CompetitionCategoryUi? value)
+    {
+        Model.Category = value;
+        _categoryError = value == null ? "Please select a category." : null;
+        // Mixed doesn't allow Singles; clear an incompatible selection.
+        if (Model.Format.HasValue && !CompetitionFormHelpers.AllowedFormats(value).Contains(Model.Format.Value))
+            Model.Format = null;
+    }
+
+    private async Task OnHostClubChanged(int? clubId)
+    {
+        Model.HostClubId = clubId;
+        // Rules sets are club-scoped; the previously-selected one almost
+        // certainly doesn't belong to the new host club.
+        Model.RulesSetId = null;
+        await Task.CompletedTask;
+    }
+
+    private IEnumerable<RulesSetDto> VisibleRulesSets() =>
+        Model.HostClubId is null ? [] : _rulesSets.Where(r => r.ClubId == Model.HostClubId.Value);
+
+    private async Task CreateAsync()
+    {
+        if (string.IsNullOrWhiteSpace(Model.CompetitionName))
+        {
+            _serverError = "Competition name is required.";
+            GoToStep(0);
+            return;
+        }
+        if (Model.Category == null)
+        {
+            _serverError = "Please select a category.";
+            GoToStep(0);
+            return;
+        }
+        if (Model.Format == null)
+        {
+            _serverError = "Please pick a format.";
+            GoToStep(2);
+            return;
+        }
+
+        _isSaving = true;
+        _serverError = null;
+        try
+        {
+            var request = new SaveCompetitionEditRequest(
+                CompetitionName: Model.CompetitionName.Trim(),
+                CompetitionFormat: CompetitionFormHelpers.EffectivePersistedFormat(Model.Category, Model.Format) ?? CompetitionFormat.Singles,
+                EligibleSex: CompetitionFormHelpers.EffectiveEligibleSex(Model.Category),
+                MaxParticipants: Model.MaxParticipants,
+                StartDate: Model.StartDateDt,
+                EndDate: Model.EndDateDt,
+                RegisterByDate: Model.RegisterByDateDt,
+                MaxAge: Model.MaxAge,
+                MinAge: Model.MinAge,
+                HostClubId: Model.HostClubId,
+                RulesSetId: Model.RulesSetId,
+                EventId: Model.EventId,
+                BestOf: Model.BestOf,
+                RequireVerification: Model.RequireVerification,
+                TeamSize: Model.TeamSize,
+                RubberTemplateKey: null,
+                MatchFormat: Model.MatchFormat,
+                NumberOfSets: Model.NumberOfSets,
+                GamesPerSet: Model.GamesPerSet,
+                SetWinMode: Model.SetWinMode,
+                LeagueScoring: Model.LeagueScoring,
+                RubberTieBreak: Model.RubberTieBreak,
+                MinDaysBetweenPlayerMatches: Model.MinDaysBetweenPlayerMatches,
+                HasDivisions: Model.HasDivisions,
+                SeededFromCompetitionId: null,
+                IsRestricted: false,
+                AllowedPlayerIds: null);
+
+            var savedId = await Admin.SaveCompetitionAsync(null, request);
+            Snackbar.Add("Competition created.", Severity.Success);
+            Nav.NavigateTo($"/competition/{savedId}", forceLoad: true);
+        }
+        catch (InvalidOperationException ex) { _serverError = ex.Message; }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to create competition from wizard.");
+            _serverError = ex.Message;
+        }
+        finally
+        {
+            _isSaving = false;
+        }
+    }
+
+    // ── Summary helpers ─────────────────────────────────────────
+    private string AgeSummary()
+    {
+        if (Model.MinAge == null && Model.MaxAge == null) return "No age restriction";
+        if (Model.MinAge != null && Model.MaxAge != null) return $"{Model.MinAge}–{Model.MaxAge}";
+        if (Model.MinAge != null) return $"{Model.MinAge}+";
+        return $"Up to {Model.MaxAge}";
+    }
+
+    private string RuleSetSummary()
+    {
+        var club = _clubs.FirstOrDefault(c => c.ClubId == Model.HostClubId);
+        var rules = _rulesSets.FirstOrDefault(r => r.RulesSetId == Model.RulesSetId);
+        var clubLabel = club?.Name ?? "No host club";
+        var rulesLabel = rules?.Name ?? "No rules set";
+        return $"{clubLabel} · {rulesLabel}";
+    }
+
+    private string DatesSummary()
+    {
+        var start = Model.StartDateDt?.ToString("dd MMM yyyy") ?? "—";
+        var end = Model.EndDateDt?.ToString("dd MMM yyyy") ?? "—";
+        var max = Model.MaxParticipants?.ToString() ?? "no cap";
+        return $"{start} → {end} · {max} max";
+    }
+
+    private string ScoringSummary()
+    {
+        var fmt = Model.MatchFormat == MatchFormatType.BestOf
+            ? $"Best of {Model.BestOf}"
+            : $"{Model.NumberOfSets} fixed sets";
+        var win = Model.SetWinMode == SetWinMode.WinBy2 ? "win by 2" : "first to";
+        return $"{fmt} · {Model.GamesPerSet} games/set · {win}";
+    }
+
+    private string MiscSummary()
+    {
+        var gap = Model.MinDaysBetweenPlayerMatches.HasValue
+            ? $"{Model.MinDaysBetweenPlayerMatches}d between matches"
+            : "no gap";
+        var verify = Model.RequireVerification ? "admin verify" : "auto-accept";
+        return $"{gap} · {verify}";
+    }
+
+    private static string LeagueScoringLabel(LeagueScoringMode mode) => mode switch
+    {
+        LeagueScoringMode.WinPoints => "3 pts win / 1 pt draw",
+        LeagueScoringMode.SetsWon   => "1 pt per set won",
+        LeagueScoringMode.GamesWon  => "1 pt per game won",
+        _ => mode.ToString()
+    };
+
+    private static string FormatLabel(CompetitionFormatUi format) => format switch
+    {
+        CompetitionFormatUi.Singles => "Singles (1 vs 1)",
+        CompetitionFormatUi.Doubles => "Doubles (2 vs 2 fixed pairs)",
+        CompetitionFormatUi.Team    => "Team (squad-vs-squad with rubbers)",
+        _ => format.ToString()
+    };
+
+    private static string StepTitle(int step) => step switch
+    {
+        0 => "Name & Category",
+        1 => "Age options",
+        2 => "Format",
+        3 => "Rule set",
+        4 => "Dates & participants",
+        5 => "Divisions",
+        6 => "Match scoring",
+        7 => "League scoring",
+        8 => "Misc settings",
+        9 => "Review & create",
+        _ => ""
+    };
+
+    // ── Reusable render fragments ───────────────────────────────
+    private RenderFragment StepIntro(string text) => __builder =>
+    {
+        <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" Icon="@Icons.Material.Filled.Info" Class="mt-1">
+            <MudText Typo="Typo.body2">@text</MudText>
+        </MudAlert>
+    };
+
+    private RenderFragment StepActions(bool canBack, Action advance) => __builder =>
+    {
+        <div class="d-flex justify-space-between mt-4">
+            @if (canBack)
+            {
+                <MudButton Variant="Variant.Text" Color="Color.Default"
+                           StartIcon="@Icons.Material.Filled.ArrowBack"
+                           OnClick="GoBack">Back</MudButton>
+            }
+            else
+            {
+                <MudButton Variant="Variant.Text" Color="Color.Default"
+                           OnClick="@(() => Nav.NavigateTo("/Competitions"))">Cancel</MudButton>
+            }
+            <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                       EndIcon="@Icons.Material.Filled.ArrowForward"
+                       OnClick="advance">Next</MudButton>
+        </div>
+    };
+}

--- a/DropShot.UI/Components/Pages/CompetitionWizardPage.razor.css
+++ b/DropShot.UI/Components/Pages/CompetitionWizardPage.razor.css
@@ -1,0 +1,12 @@
+.wizard-step {
+    background: rgba(255, 255, 255, 0.08);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 12px;
+    color: white;
+}
+
+.competition-title {
+    font-weight: 600;
+}

--- a/DropShot/Components/Pages/CompetitionWizardPage.razor
+++ b/DropShot/Components/Pages/CompetitionWizardPage.razor
@@ -1,0 +1,7 @@
+@page "/competition/0"
+@using Microsoft.AspNetCore.Authorization
+@attribute [Authorize]
+@rendermode InteractiveServer
+
+<MudProviders />
+<DropShot.UI.Components.Pages.CompetitionWizardPage />


### PR DESCRIPTION
## Summary
- New 10-step wizard at `/competition/0` walks admins through creating a competition, with an explainer panel on each step
- Existing edit page (`/competition/{id}`) keeps the long form but reorders the Setup tab to match the wizard flow (Category → Age → Format → Rule set → Dates → Divisions → Match scoring → League scoring → Misc → Admins → Stages → Rubber template → Match windows)
- Extracts `CompetitionFormModel` and the UI category/format enums into `DropShot.UI/Components/Competitions/CompetitionFormModel.cs` so the wizard and edit page share one model

The wizard ends after the core data steps and redirects to the edit page (now scrolled to Admins) so admins, stages, rubber template, participants, and fixtures are still managed in their existing surfaces.

## Test plan
- [ ] From `/competitions`, click **Create Competition** → wizard loads at step 1 (not the old edit page)
- [ ] Walk forward and back through all 10 steps; values persist across navigation
- [ ] On the Format step, switch between Singles / Doubles / Team and confirm the explainer text updates
- [ ] On the Match scoring step, change format to Team (via step 3) and confirm the **Rubber tie-break** block appears
- [ ] On the final step, click **Create competition** → redirects to `/competition/{newId}` with all fields persisted
- [ ] Open an existing competition (`/competition/{existingId}`) → Setup tab renders in the new order
- [ ] Confirm Rubber Template section only renders when the format is TeamMatch
- [ ] Edit one field in each section of the reordered form, save, reload, and verify each field round-trips

🤖 Generated with [Claude Code](https://claude.com/claude-code)