### PR TITLE
Fix Create Competition button — constrain edit route to Id >= 1

### DIFF
--- a/DropShot/Components/Pages/CompetitionPage.razor
+++ b/DropShot/Components/Pages/CompetitionPage.razor
@@ -1,4 +1,4 @@
-@page "/competition/{Id:int}"
+@page "/competition/{Id:int:min(1)}"
 @using Microsoft.AspNetCore.Authorization
 @attribute [Authorize]
 @rendermode InteractiveServer


### PR DESCRIPTION
## Summary
After #641 landed, clicking **Create Competition** silently did nothing because both the wizard wrapper (`/competition/0`) and the existing edit wrapper (`/competition/{Id:int}`) matched the URL `/competition/0`, leaving Blazor with an ambiguous route.

This adds a `min(1)` constraint to the edit wrapper so it only matches real competition IDs (≥ 1), letting the literal `/competition/0` route resolve cleanly to the wizard.

## Test plan
- [ ] Click **Create Competition** on `/competitions` → wizard opens at step 1
- [ ] Open an existing competition (`/competition/{realId}`) → existing edit page still renders
- [ ] Navigate directly to `/competition/0` → wizard loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)