### PR TITLE
Fix Add Division name field showing literal "_divisionName"

### DIFF
--- a/DropShot.UI/Components/Pages/CompetitionPage.razor
+++ b/DropShot.UI/Components/Pages/CompetitionPage.razor
@@ -797,7 +797,7 @@ else
                     AddingDivisionChanged="@(v => _addingDivision = v)"
                     InlineEditDivisionId="_inlineEditDivisionId"
                     InlineEditDivisionIdChanged="@(v => _inlineEditDivisionId = v)"
-                    DivisionName="_divisionName"
+                    DivisionName="@_divisionName"
                     DivisionNameChanged="@(v => _divisionName = v)"
                     DivisionRank="_divisionRank"
                     DivisionRankChanged="@(v => _divisionRank = v)"


### PR DESCRIPTION
## Summary
- The `Add Division` form's name input rendered with the default value `_divisionName` (the field identifier, not its value).
- Cause: `DivisionName="_divisionName"` in [CompetitionPage.razor:1074](DropShot.UI/Components/Pages/CompetitionPage.razor#L1074) was missing the `@` prefix. Razor passes string-typed attribute values as literals unless the value is prefixed with `@`; the other parameters in that block bind to non-string types so they evaluate as C# expressions without the prefix.
- Fix: change `DivisionName="_divisionName"` → `DivisionName="@_divisionName"`.

## Test plan
- [ ] Open a competition edit page, click **Add Division**, and confirm the name input is empty.
- [ ] Type a name, save, then click **Add Division** again — name input should still start empty (the existing `_divisionName = ""` reset in the start-add handler now actually shows through to the input).
- [ ] Edit an existing division inline — name input pre-fills with the division's current name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)