### PR TITLE
Allow Mixed + Singles and move Format before Age in wizard

### DIFF
--- a/DropShot.UI/Components/Competitions/CompetitionFormModel.cs
+++ b/DropShot.UI/Components/Competitions/CompetitionFormModel.cs
@@ -42,9 +42,7 @@ public enum CompetitionFormatUi { Singles, Doubles, Team }
 public static class CompetitionFormHelpers
 {
     public static IEnumerable<CompetitionFormatUi> AllowedFormats(CompetitionCategoryUi? category) =>
-        category == CompetitionCategoryUi.Mixed
-            ? new[] { CompetitionFormatUi.Doubles, CompetitionFormatUi.Team }
-            : new[] { CompetitionFormatUi.Singles, CompetitionFormatUi.Doubles, CompetitionFormatUi.Team };
+        new[] { CompetitionFormatUi.Singles, CompetitionFormatUi.Doubles, CompetitionFormatUi.Team };
 
     public static CompetitionFormat? EffectivePersistedFormat(CompetitionCategoryUi? category, CompetitionFormatUi? format) =>
         (category, format) switch

--- a/DropShot.UI/Components/Pages/CompetitionPage.razor
+++ b/DropShot.UI/Components/Pages/CompetitionPage.razor
@@ -2173,9 +2173,7 @@ else
     public enum CompetitionFormatUi { Singles, Doubles, Team }
 
     private static IEnumerable<CompetitionFormatUi> AllowedFormats(CompetitionCategoryUi? category) =>
-        category == CompetitionCategoryUi.Mixed
-            ? new[] { CompetitionFormatUi.Doubles, CompetitionFormatUi.Team }
-            : new[] { CompetitionFormatUi.Singles, CompetitionFormatUi.Doubles, CompetitionFormatUi.Team };
+        new[] { CompetitionFormatUi.Singles, CompetitionFormatUi.Doubles, CompetitionFormatUi.Team };
 
     private CompetitionFormat? EffectivePersistedFormat() =>
         (Model.Category, Model.Format) switch
@@ -2226,9 +2224,6 @@ else
     {
         Model.Category = value;
         _categoryError = value == null ? "Please select a category." : null;
-        // Mixed doesn't allow Singles; clear an incompatible selection so the user re-picks.
-        if (Model.Format.HasValue && !AllowedFormats(value).Contains(Model.Format.Value))
-            Model.Format = null;
         AutoGenerateName();
     }
 

--- a/DropShot.UI/Components/Pages/CompetitionWizardPage.razor
+++ b/DropShot.UI/Components/Pages/CompetitionWizardPage.razor
@@ -67,48 +67,16 @@ else
                 </MudPaper>
             }
 
-            @* ── Step 1: Age ────────────────────────────────── *@
+            @* ── Step 1: Format ─────────────────────────────── *@
             @if (_currentStep > 1)
-            {
-                <StepSummary Label="Age range"
-                             Icon="@Icons.Material.Filled.Cake"
-                             AccentColor="#7c4dff"
-                             Summary="@AgeSummary()"
-                             OnEdit="@(() => GoToStep(1))" />
-            }
-            else if (_currentStep == 1)
-            {
-                <MudPaper Class="pa-4 wizard-step" Elevation="0">
-                    <MudText Typo="Typo.h6" Class="mb-2">Age options</MudText>
-                    @StepIntro("Set the age range for eligible players. Leave either field blank for no upper or lower limit.")
-
-                    <MudGrid Spacing="2" Class="mt-3">
-                        <MudItem xs="12" sm="6">
-                            <MudNumericField T="int?" Label="Min Age (optional)"
-                                             Min="1" Max="120" Variant="Variant.Outlined"
-                                             @bind-Value="Model.MinAge" />
-                        </MudItem>
-                        <MudItem xs="12" sm="6">
-                            <MudNumericField T="int?" Label="Max Age (optional)"
-                                             Min="1" Max="120" Variant="Variant.Outlined"
-                                             @bind-Value="Model.MaxAge" />
-                        </MudItem>
-                    </MudGrid>
-
-                    @StepActions(canBack: true, advance: TryAdvance)
-                </MudPaper>
-            }
-
-            @* ── Step 2: Format ─────────────────────────────── *@
-            @if (_currentStep > 2)
             {
                 <StepSummary Label="Format"
                              Icon="@Icons.Material.Filled.SportsTennis"
                              AccentColor="#00b4d8"
                              Summary="@(Model.Format?.ToString() ?? "Not set")"
-                             OnEdit="@(() => GoToStep(2))" />
+                             OnEdit="@(() => GoToStep(1))" />
             }
-            else if (_currentStep == 2)
+            else if (_currentStep == 1)
             {
                 <MudPaper Class="pa-4 wizard-step" Elevation="0">
                     <MudText Typo="Typo.h6" Class="mb-2">Format</MudText>
@@ -145,6 +113,38 @@ else
                     }
 
                     @StepActions(canBack: true, advance: TryAdvanceFromFormat)
+                </MudPaper>
+            }
+
+            @* ── Step 2: Age ────────────────────────────────── *@
+            @if (_currentStep > 2)
+            {
+                <StepSummary Label="Age range"
+                             Icon="@Icons.Material.Filled.Cake"
+                             AccentColor="#7c4dff"
+                             Summary="@AgeSummary()"
+                             OnEdit="@(() => GoToStep(2))" />
+            }
+            else if (_currentStep == 2)
+            {
+                <MudPaper Class="pa-4 wizard-step" Elevation="0">
+                    <MudText Typo="Typo.h6" Class="mb-2">Age options</MudText>
+                    @StepIntro("Set the age range for eligible players. Leave either field blank for no upper or lower limit.")
+
+                    <MudGrid Spacing="2" Class="mt-3">
+                        <MudItem xs="12" sm="6">
+                            <MudNumericField T="int?" Label="Min Age (optional)"
+                                             Min="1" Max="120" Variant="Variant.Outlined"
+                                             @bind-Value="Model.MinAge" />
+                        </MudItem>
+                        <MudItem xs="12" sm="6">
+                            <MudNumericField T="int?" Label="Max Age (optional)"
+                                             Min="1" Max="120" Variant="Variant.Outlined"
+                                             @bind-Value="Model.MaxAge" />
+                        </MudItem>
+                    </MudGrid>
+
+                    @StepActions(canBack: true, advance: TryAdvance)
                 </MudPaper>
             }
 
@@ -543,9 +543,6 @@ else
     {
         Model.Category = value;
         _categoryError = value == null ? "Please select a category." : null;
-        // Mixed doesn't allow Singles; clear an incompatible selection.
-        if (Model.Format.HasValue && !CompetitionFormHelpers.AllowedFormats(value).Contains(Model.Format.Value))
-            Model.Format = null;
     }
 
     private async Task OnHostClubChanged(int? clubId)
@@ -577,7 +574,7 @@ else
         if (Model.Format == null)
         {
             _serverError = "Please pick a format.";
-            GoToStep(2);
+            GoToStep(1);
             return;
         }
 
@@ -693,8 +690,8 @@ else
     private static string StepTitle(int step) => step switch
     {
         0 => "Name & Category",
-        1 => "Age options",
-        2 => "Format",
+        1 => "Format",
+        2 => "Age options",
         3 => "Rule set",
         4 => "Dates & participants",
         5 => "Divisions",

--- a/DropShot.UI/Components/Shared/CreateEventDialog.razor
+++ b/DropShot.UI/Components/Shared/CreateEventDialog.razor
@@ -152,9 +152,7 @@
     public enum FormatUi { Singles, Doubles, Team }
 
     private static IEnumerable<FormatUi> AllowedFormats(CategoryUi category) =>
-        category == CategoryUi.Mixed
-            ? new[] { FormatUi.Doubles, FormatUi.Team }
-            : new[] { FormatUi.Singles, FormatUi.Doubles, FormatUi.Team };
+        new[] { FormatUi.Singles, FormatUi.Doubles, FormatUi.Team };
 
     private static (CompetitionFormat Format, PlayerSex? EligibleSex) MapToPersisted(
         CategoryUi category, FormatUi format) => (category, format) switch
@@ -195,10 +193,6 @@
 
     private string BuildAutoName()
     {
-        // Clamp an incompatible Format (e.g. user picked Mixed then Singles is no longer listed).
-        if (!AllowedFormats(_buildCategory).Contains(_buildFormatUi))
-            _buildFormatUi = AllowedFormats(_buildCategory).First();
-
         var parts = new List<string>();
         if (_buildAgeBracket.Label != "Open") parts.Add(_buildAgeBracket.Label);
 


### PR DESCRIPTION
## Summary
- Mixed category now permits Singles (open singles, no sex restriction). Previously the wizard's Format step hid Singles whenever Mixed was selected; the same restriction is removed from the edit page (`CompetitionPage.razor`) and `CreateEventDialog` for consistency. Mixed + Singles persists as `CompetitionFormat.Singles` with `EligibleSex = null` via the existing fall-through in `EffectivePersistedFormat`.
- Wizard step order swapped so Format comes before Age (Name & Category → Format → Age → Rule set → …). Step titles, `OnEdit` targets, and the missing-format error nav updated accordingly.

## Test plan
- [ ] Create a competition via the wizard with category = Mixed and confirm Singles, Doubles, and Team all appear in the Format dropdown.
- [ ] Saving a Mixed + Singles competition lands on the edit page and shows the expected open singles setup.
- [ ] Wizard progression goes Name & Category → Format → Age and StepSummary Edit buttons jump to the correct steps.
- [ ] Editing an existing Mixed competition on `CompetitionPage` also offers Singles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)