### PR TITLE
Fix Mixed category flipping to Male after wizard save (Mixed + Singles)

### DIFF
--- a/DropShot.UI/Components/Pages/CompetitionPage.razor
+++ b/DropShot.UI/Components/Pages/CompetitionPage.razor
@@ -2642,10 +2642,10 @@ else
         _ => (
             eligibleSex switch
             {
+                PlayerSex.Male   => CompetitionCategoryUi.Male,
                 PlayerSex.Female => CompetitionCategoryUi.Female,
-                // Legacy EligibleSex=null Singles/Doubles/Team → default to Male category
-                // (per migration decision). User can change it on edit.
-                _ => CompetitionCategoryUi.Male
+                // No sex filter = Mixed (e.g. Mixed + Singles, which has no dedicated persisted format).
+                _ => CompetitionCategoryUi.Mixed
             },
             persisted switch
             {


### PR DESCRIPTION
## Summary
Selecting Mixed + Singles in the wizard saved correctly but the edit page showed Male afterward.

Root cause: Mixed + Singles persists as `(CompetitionFormat.Singles, EligibleSex=null)` — there is no `MixedSingles` enum value. `SplitPersistedFormat` in `CompetitionPage.razor` defaulted `EligibleSex=null` + plain Singles/Doubles/Team to Male as a legacy migration compromise, so Mixed → Male on round-trip.

Fix: match `Male`/`Female` explicitly and treat `null` (no sex filter) as Mixed — that is its real semantic. Wizard-created competitions now save explicit `Male`/`Female`, so the only rows affected are legacy null-EligibleSex ones, which will now display as Mixed instead of Male (and can still be changed on edit).

## Test plan
- [ ] Wizard: pick Mixed + Singles → after save, edit page shows category = Mixed, format = Singles.
- [ ] Wizard: pick Mixed + Doubles → edit page shows Mixed + Doubles (unchanged; uses `MixedDoubles` persisted format).
- [ ] Wizard: pick Mixed + Team → edit page shows Mixed + Team (unchanged; uses `TeamMatch`).
- [ ] Wizard: pick Male + Singles → edit page shows Male + Singles (explicit `PlayerSex.Male`).
- [ ] Wizard: pick Female + Singles → edit page shows Female + Singles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)