### PR TITLE
Super-admin wizard: auto-generate standard club match windows

### DIFF
--- a/DropShot.UI/Components/Competitions/Setup/AutoMatchWindowsWizard.razor
+++ b/DropShot.UI/Components/Competitions/Setup/AutoMatchWindowsWizard.razor
@@ -1,0 +1,117 @@
+@using System.Text.RegularExpressions
+@using DropShot.Shared.Dtos
+
+@* ── Super-admin-only wizard ───────────────────────────────────────────
+   Pre-canned set of match windows (Mon 19:30-21:30 on indoor 1+2,
+   Thu 19:00-21:00 on indoor 3+4, Sun 13:00-15:00 on indoor 3+4) the
+   host-club committee uses for every league. Match windows are
+   competition-level (not stage-level) — the windows added here apply to
+   every stage in the competition. *@
+
+<MudPaper id="section-match-windows-wizard" Class="pa-4 mb-4 setup-section" Elevation="0"
+     Style="background: rgba(255,255,255,0.08); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border: 1px solid rgba(255,255,255,0.12); border-radius: 12px; color: white;">
+    <MudStack Row="true" AlignItems="AlignItems.Center" Class="mb-2">
+        <MudIcon Icon="@Icons.Material.Filled.AutoFixHigh" Size="Size.Small" />
+        <MudText Typo="Typo.h6" Style="flex:1">Auto-Generate Match Windows</MudText>
+        <MudChip T="string" Size="Size.Small" Color="Color.Warning" Variant="Variant.Outlined">Super admin</MudChip>
+    </MudStack>
+
+    <MudText Typo="Typo.caption" Class="mb-2">
+        Creates the standard club windows in one click:
+    </MudText>
+    <MudSimpleTable Dense="true" Class="mb-3">
+        <thead>
+            <tr><th>Day</th><th>From</th><th>To</th><th>Courts</th></tr>
+        </thead>
+        <tbody>
+            @foreach (var preset in Presets)
+            {
+                <tr>
+                    <td>@preset.Day</td>
+                    <td>@preset.Start.ToString(@"hh\:mm")</td>
+                    <td>@preset.End.ToString(@"hh\:mm")</td>
+                    <td>@string.Join(", ", preset.CourtNumbers.Select(n => $"Indoor {n}"))</td>
+                </tr>
+            }
+        </tbody>
+    </MudSimpleTable>
+
+    <MudButton Variant="Variant.Filled" Color="Color.Primary" Size="Size.Small"
+               StartIcon="@Icons.Material.Filled.AutoFixHigh"
+               Disabled="_running"
+               OnClick="OnRunAsync">
+        @(_running ? "Generating…" : "Generate windows")
+    </MudButton>
+</MudPaper>
+
+@code {
+    [Parameter, EditorRequired] public IReadOnlyList<CourtDto> Courts { get; set; } = [];
+    [Parameter, EditorRequired] public IReadOnlyList<CompetitionMatchWindowDto> ExistingWindows { get; set; } = [];
+    [Parameter, EditorRequired] public EventCallback<IReadOnlyList<SaveMatchWindowRequest>> OnGenerate { get; set; }
+
+    // (day, start, end, court numbers within the indoor set) — `CourtNumbers`
+    // are matched against the trailing integer of each indoor court's Name.
+    public sealed record Preset(DayOfWeek Day, TimeSpan Start, TimeSpan End, int[] CourtNumbers);
+
+    public static readonly IReadOnlyList<Preset> Presets =
+    [
+        new(DayOfWeek.Monday,   new TimeSpan(19, 30, 0), new TimeSpan(21, 30, 0), [1, 2]),
+        new(DayOfWeek.Thursday, new TimeSpan(19,  0, 0), new TimeSpan(21,  0, 0), [3, 4]),
+        new(DayOfWeek.Sunday,   new TimeSpan(13,  0, 0), new TimeSpan(15,  0, 0), [3, 4]),
+    ];
+
+    private bool _running;
+
+    private async Task OnRunAsync()
+    {
+        if (_running) return;
+        _running = true;
+        try
+        {
+            var indoorByNumber = Courts
+                .Where(c => c.IsIndoor)
+                .Select(c => (Court: c, Number: ExtractCourtNumber(c.Name)))
+                .Where(t => t.Number.HasValue)
+                .GroupBy(t => t.Number!.Value)
+                .ToDictionary(g => g.Key, g => g.First().Court);
+
+            var requests = new List<SaveMatchWindowRequest>();
+            foreach (var preset in Presets)
+            {
+                foreach (var n in preset.CourtNumbers)
+                {
+                    if (!indoorByNumber.TryGetValue(n, out var court)) continue;
+
+                    // Skip duplicates — same (day, start, end, court, no division).
+                    var dup = ExistingWindows.Any(w =>
+                        w.CompetitionDivisionId == null
+                        && w.CourtId == court.CourtId
+                        && w.DayOfWeek == preset.Day
+                        && w.StartTime == preset.Start
+                        && w.EndTime == preset.End);
+                    if (dup) continue;
+
+                    requests.Add(new SaveMatchWindowRequest(
+                        DayOfWeek: preset.Day,
+                        StartTime: preset.Start,
+                        EndTime: preset.End,
+                        CourtId: court.CourtId,
+                        CompetitionDivisionId: null));
+                }
+            }
+
+            await OnGenerate.InvokeAsync(requests);
+        }
+        finally
+        {
+            _running = false;
+        }
+    }
+
+    private static int? ExtractCourtNumber(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name)) return null;
+        var m = Regex.Match(name, @"(\d+)\s*$");
+        return m.Success && int.TryParse(m.Groups[1].Value, out var n) ? n : null;
+    }
+}

--- a/DropShot.UI/Components/Pages/CompetitionPage.razor
+++ b/DropShot.UI/Components/Pages/CompetitionPage.razor
@@ -464,6 +464,13 @@ else
             @* ── Match Windows (hidden when HasDivisions — per-division UI lives in the Divisions section below) *@
             @if (!Model.HasDivisions)
             {
+                @if (_isSuperAdmin)
+                {
+                    <AutoMatchWindowsWizard
+                        Courts="_courts"
+                        ExistingWindows="_matchWindows"
+                        OnGenerate="AutoGenerateMatchWindowsAsync" />
+                }
                 <MatchWindowsSection
                     Windows="_matchWindows"
                     Courts="_courts"
@@ -4077,6 +4084,44 @@ else
         // Intentionally do NOT clear the form — admins often add multiple similar
         // windows differing in only one field (different day, different court).
         SiteAlerts.Add("Window added.", Severity.Success);
+    }
+
+    private async Task AutoGenerateMatchWindowsAsync(IReadOnlyList<SaveMatchWindowRequest> requests)
+    {
+        if (!_isSuperAdmin)
+        {
+            SiteAlerts.Add("Only super admins can auto-generate match windows.", Severity.Warning);
+            return;
+        }
+        if (requests.Count == 0)
+        {
+            SiteAlerts.Add("No new windows to add — required indoor courts may be missing or already scheduled.", Severity.Info);
+            return;
+        }
+
+        var added = 0;
+        foreach (var req in requests)
+        {
+            try
+            {
+                await Admin.AddMatchWindowAsync(Id, req);
+                added++;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Auto-generate match window failed for {Day} {Start}-{End} court {CourtId}",
+                    req.DayOfWeek, req.StartTime, req.EndTime, req.CourtId);
+            }
+        }
+        await ReloadAfterServerMutationAsync();
+
+        var skipped = requests.Count - added;
+        if (added > 0 && skipped == 0)
+            SiteAlerts.Add($"Added {added} match window(s).", Severity.Success);
+        else if (added > 0 && skipped > 0)
+            SiteAlerts.Add($"Added {added} match window(s); {skipped} failed — see logs.", Severity.Warning);
+        else
+            SiteAlerts.Add("Failed to add match windows — see logs.", Severity.Error);
     }
 
     private void CopyMatchWindowToForm(CompetitionMatchWindowDto w)


### PR DESCRIPTION
## Summary
- New super-admin-only wizard on the Match Windows section creates the standard club windows in one click: Mon 19:30-21:30 on Indoor Courts 1 & 2, Thu 19:00-21:00 on Indoor Courts 3 & 4, Sun 13:00-15:00 on Indoor Courts 3 & 4.
- Resolves courts from the host club by `IsIndoor=true` and the trailing number in the court `Name` (so "Indoor Court 1", "Court 1", "Indoor 1" all match). Missing court numbers are skipped silently.
- Skips windows that already exist for the same (day, start, end, court) so the wizard is safe to re-run.

## Test plan
- [ ] Open a non-divisional competition as a super admin → wizard panel renders above Match Windows.
- [ ] Open as a regular admin → wizard panel is not rendered.
- [ ] Click **Generate windows** with all four indoor courts present → 6 new windows appear; alert reports the count.
- [ ] Click **Generate windows** a second time → "No new windows to add" alert; no duplicates created.
- [ ] Remove Indoor Court 4 and re-run → only the windows for courts 1, 2, 3 are added; the wizard quietly skips the missing court.
- [ ] Switch a competition to **Has divisions** → wizard hides (per-division UI owns windows for those).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
