### PR TITLE
Click match score to view set-by-set breakdown

### DIFF
--- a/DropShot.Shared/Dtos/CompetitionDtos.cs
+++ b/DropShot.Shared/Dtos/CompetitionDtos.cs
@@ -313,7 +313,8 @@ public record RubberDto(
     int? HomeSetsWon = null,
     int? AwaySetsWon = null,
     int? HomeGamesTotal = null,
-    int? AwayGamesTotal = null);
+    int? AwayGamesTotal = null,
+    IReadOnlyList<RubberSetScoreDto>? SetScores = null);
 
 public record TeamLeagueTableEntryDto(
     int TeamId,

--- a/DropShot.UI/Components/Competitions/Setup/FixturesSection.razor
+++ b/DropShot.UI/Components/Competitions/Setup/FixturesSection.razor
@@ -107,7 +107,13 @@
                 }
                 @if (!string.IsNullOrEmpty(fixtureResult))
                 {
-                    <MudText Typo="Typo.body2">@fixtureResult</MudText>
+                    <MudTooltip Text="Click for set-by-set scores">
+                        <MudLink Typo="Typo.body2" Underline="Underline.Hover" Color="Color.Default"
+                                 Style="cursor:pointer"
+                                 OnClick="@(() => OnShowSetScores.InvokeAsync(context))">
+                            @fixtureResult
+                        </MudLink>
+                    </MudTooltip>
                     @if (context.ResultModifiedByAdmin)
                     {
                         <MudTooltip Text="@($"Original: {context.OriginalResultSummary}")">
@@ -194,4 +200,5 @@
     [Parameter] public EventCallback<CompetitionFixtureDto> OnShowQr { get; set; }
     [Parameter] public EventCallback<CompetitionFixtureDto> OnOpenEditDialog { get; set; }
     [Parameter] public EventCallback<CompetitionFixtureDto> OnDeleteFixture { get; set; }
+    [Parameter] public EventCallback<CompetitionFixtureDto> OnShowSetScores { get; set; }
 }

--- a/DropShot.UI/Components/Pages/CompetitionPage.razor
+++ b/DropShot.UI/Components/Pages/CompetitionPage.razor
@@ -1183,7 +1183,8 @@ else
                     OnOverrideResult="OpenOverrideResultAsync"
                     OnShowQr="ShowQrCode"
                     OnOpenEditDialog="OpenEditFixtureDialog"
-                    OnDeleteFixture="DeleteFixture" />
+                    OnDeleteFixture="DeleteFixture"
+                    OnShowSetScores="OpenSetScoresDialog" />
             }
             else
             {
@@ -1318,7 +1319,20 @@ else
                                                             @{
                                                                 var resultText = FixtureResultDisplay(f);
                                                             }
-                                                            @(!string.IsNullOrEmpty(resultText) ? resultText : "—")
+                                                            @if (!string.IsNullOrEmpty(resultText))
+                                                            {
+                                                                <MudTooltip Text="Click for set-by-set scores">
+                                                                    <MudLink Typo="Typo.body2" Underline="Underline.Hover" Color="Color.Default"
+                                                                             Style="cursor:pointer"
+                                                                             OnClick="@(() => OpenSetScoresDialog(f))">
+                                                                        @resultText
+                                                                    </MudLink>
+                                                                </MudTooltip>
+                                                            }
+                                                            else
+                                                            {
+                                                                @("—")
+                                                            }
                                                         </td>
                                                         <td>
                                                             <MudChip T="string" Size="Size.Small" Color="@StatusColor(f.Status)">@f.Status</MudChip>
@@ -1470,6 +1484,12 @@ else
         <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="SaveStage">Add</MudButton>
     </DialogActions>
 </MudDialog>
+
+@* ── Set Scores Dialog ──────────────────────────────────────── *@
+<DropShot.UI.Components.Shared.MatchSetScoresDialog
+    Visible="_showSetScoresDialog"
+    VisibleChanged="@(v => _showSetScoresDialog = v)"
+    Fixture="_setScoresFixture" />
 
 @* ── Stage Follow-Up Dialog ────────────────────────────────── *@
 <MudDialog @bind-Visible="_showStageFollowUpDialog">
@@ -4565,6 +4585,15 @@ else
         // the persisted result summary. The previous code recomputed rubber
         // scores client-side; the server now persists the resolved aggregate.
         return f.ResultSummary ?? "";
+    }
+
+    private bool _showSetScoresDialog;
+    private CompetitionFixtureDto? _setScoresFixture;
+
+    private void OpenSetScoresDialog(CompetitionFixtureDto f)
+    {
+        _setScoresFixture = f;
+        _showSetScoresDialog = true;
     }
 
     private static Color StatusColor(FixtureStatus s) => s switch

--- a/DropShot.UI/Components/Pages/ViewCompetition.razor
+++ b/DropShot.UI/Components/Pages/ViewCompetition.razor
@@ -452,6 +452,11 @@ else
     }
 
     </MudExpansionPanels>
+
+    <DropShot.UI.Components.Shared.MatchSetScoresDialog
+        Visible="_showSetScoresDialog"
+        VisibleChanged="@(v => _showSetScoresDialog = v)"
+        Fixture="_setScoresFixture" />
 }
 
 @code {
@@ -460,7 +465,15 @@ else
     private bool _loading = true;
     private bool _canEdit;
     private bool _canView;
+    private bool _showSetScoresDialog;
+    private CompetitionFixtureDto? _setScoresFixture;
     private CompetitionDetailDto? _competition;
+
+    private void OpenSetScoresDialog(CompetitionFixtureDto f)
+    {
+        _setScoresFixture = f;
+        _showSetScoresDialog = true;
+    }
     private List<CompetitionFixtureDto> _fixtures = [];
     private List<CompetitionParticipantDto> _participants = [];
     private List<CompetitionTeamDto> _teams = [];
@@ -875,24 +888,28 @@ else
                     }
                     @if (hasResult && isTeamFixtureRow && rubbers.Any(r => r.IsComplete))
                     {
-                        <MudStack Spacing="0" Style="min-width:160px">
-                            <MudStack Row="true" Justify="Justify.SpaceBetween" Spacing="2">
-                                <MudText Typo="Typo.body2" Style="@(homeWon ? "font-weight:700" : "opacity:0.85")">
-                                    @(context.HomeTeamName ?? "Home")
-                                </MudText>
-                                <MudText Typo="Typo.body2" Style="@(homeWon ? "font-weight:700" : "opacity:0.85")">
-                                    @teamResult.homeFor
-                                </MudText>
-                            </MudStack>
-                            <MudStack Row="true" Justify="Justify.SpaceBetween" Spacing="2">
-                                <MudText Typo="Typo.body2" Style="@(awayWon ? "font-weight:700" : "opacity:0.85")">
-                                    @(context.AwayTeamName ?? "Away")
-                                </MudText>
-                                <MudText Typo="Typo.body2" Style="@(awayWon ? "font-weight:700" : "opacity:0.85")">
-                                    @teamResult.awayFor
-                                </MudText>
-                            </MudStack>
-                        </MudStack>
+                        <MudTooltip Text="Click for set-by-set scores">
+                            <div style="cursor:pointer; min-width:160px" @onclick="@(() => OpenSetScoresDialog(context))">
+                                <MudStack Spacing="0">
+                                    <MudStack Row="true" Justify="Justify.SpaceBetween" Spacing="2">
+                                        <MudText Typo="Typo.body2" Style="@(homeWon ? "font-weight:700" : "opacity:0.85")">
+                                            @(context.HomeTeamName ?? "Home")
+                                        </MudText>
+                                        <MudText Typo="Typo.body2" Style="@(homeWon ? "font-weight:700" : "opacity:0.85")">
+                                            @teamResult.homeFor
+                                        </MudText>
+                                    </MudStack>
+                                    <MudStack Row="true" Justify="Justify.SpaceBetween" Spacing="2">
+                                        <MudText Typo="Typo.body2" Style="@(awayWon ? "font-weight:700" : "opacity:0.85")">
+                                            @(context.AwayTeamName ?? "Away")
+                                        </MudText>
+                                        <MudText Typo="Typo.body2" Style="@(awayWon ? "font-weight:700" : "opacity:0.85")">
+                                            @teamResult.awayFor
+                                        </MudText>
+                                    </MudStack>
+                                </MudStack>
+                            </div>
+                        </MudTooltip>
                         @if (context.Status == FixtureStatus.AwaitingVerification)
                         {
                             <MudChip T="string" Size="Size.Small" Color="Color.Secondary" Variant="Variant.Text">Pending</MudChip>
@@ -900,7 +917,11 @@ else
                     }
                     else if (hasResult && !isTeamFixtureRow && !string.IsNullOrEmpty(context.ResultSummary))
                     {
-                        <FixtureResultCard Fixture="context" Compact="true" />
+                        <MudTooltip Text="Click for set-by-set scores">
+                            <div style="cursor:pointer" @onclick="@(() => OpenSetScoresDialog(context))">
+                                <FixtureResultCard Fixture="context" Compact="true" />
+                            </div>
+                        </MudTooltip>
                         @if (context.ResultModifiedByAdmin)
                         {
                             <MudTooltip Text="@($"Original: {context.OriginalResultSummary}")">

--- a/DropShot.UI/Components/Shared/MatchSetScoresDialog.razor
+++ b/DropShot.UI/Components/Shared/MatchSetScoresDialog.razor
@@ -1,0 +1,192 @@
+@* Per-match set-score breakdown dialog.
+
+   Singles / doubles: parses `Fixture.ResultSummary` into per-set columns.
+   Team match: lists each rubber with its per-set scores (falls back to the
+   set-count aggregate when a rubber has no per-set rows). *@
+
+@using DropShot.Shared
+@using DropShot.Shared.Dtos
+
+<MudDialog Visible="Visible" VisibleChanged="VisibleChanged"
+           Options="@(new DialogOptions { MaxWidth = MaxWidth.Small, FullWidth = true, CloseOnEscapeKey = true })">
+    <TitleContent>
+        <MudText Typo="Typo.h6">Set scores</MudText>
+        @if (Fixture is not null)
+        {
+            <MudText Typo="Typo.caption" Style="opacity:0.75">@HeaderSubtitle</MudText>
+        }
+    </TitleContent>
+    <DialogContent>
+        @if (Fixture is null)
+        {
+            <MudText Typo="Typo.body2" Color="Color.Secondary">No fixture selected.</MudText>
+        }
+        else if (IsTeamMatch)
+        {
+            var rubbers = Fixture.Rubbers ?? new List<RubberDto>();
+            var completed = rubbers.Where(r => r.IsComplete).ToList();
+            if (completed.Count == 0)
+            {
+                <MudText Typo="Typo.body2" Color="Color.Secondary">No completed rubbers yet.</MudText>
+            }
+            else
+            {
+                <MudSimpleTable Dense="true" Hover="true" Class="set-scores-table">
+                    <thead>
+                        <tr>
+                            <th>Rubber</th>
+                            <th>@(Fixture.HomeTeamName ?? "Home")</th>
+                            <th>@(Fixture.AwayTeamName ?? "Away")</th>
+                            <th style="text-align:right">Sets</th>
+                            <th>Per-set</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var r in completed)
+                        {
+                            var homePair = JoinNames(r.HomePlayer1Name, r.HomePlayer2Name);
+                            var awayPair = JoinNames(r.AwayPlayer1Name, r.AwayPlayer2Name);
+                            <tr>
+                                <td>@r.Name</td>
+                                <td>@homePair</td>
+                                <td>@awayPair</td>
+                                <td style="text-align:right; white-space:nowrap;">
+                                    @(r.HomeSetsWon ?? 0)–@(r.AwaySetsWon ?? 0)
+                                </td>
+                                <td style="white-space:nowrap;">
+                                    @if (r.SetScores is { Count: > 0 } sets)
+                                    {
+                                        @string.Join(" ", sets.Select(s => $"{s.Home}–{s.Away}"))
+                                    }
+                                    else
+                                    {
+                                        <MudText Typo="Typo.caption" Color="Color.Secondary">—</MudText>
+                                    }
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </MudSimpleTable>
+            }
+        }
+        else
+        {
+            var sets = ParseResultSummary(Fixture.ResultSummary);
+            if (sets.Count == 0)
+            {
+                <MudText Typo="Typo.body2" Color="Color.Secondary">No set scores recorded.</MudText>
+            }
+            else
+            {
+                <MudSimpleTable Dense="true" Hover="true" Class="set-scores-table">
+                    <thead>
+                        <tr>
+                            <th></th>
+                            @for (var i = 0; i < sets.Count; i++)
+                            {
+                                <th style="text-align:center">Set @(i + 1)</th>
+                            }
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td style="font-weight:@(IsP1Winner ? "700" : "400")">@SideAName</td>
+                            @foreach (var s in sets)
+                            {
+                                <td style="text-align:center">@s.P1</td>
+                            }
+                        </tr>
+                        <tr>
+                            <td style="font-weight:@(IsP2Winner ? "700" : "400")">@SideBName</td>
+                            @foreach (var s in sets)
+                            {
+                                <td style="text-align:center">@s.P2</td>
+                            }
+                        </tr>
+                    </tbody>
+                </MudSimpleTable>
+            }
+        }
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@(() => VisibleChanged.InvokeAsync(false))">Close</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [Parameter] public bool Visible { get; set; }
+    [Parameter] public EventCallback<bool> VisibleChanged { get; set; }
+    [Parameter] public CompetitionFixtureDto? Fixture { get; set; }
+
+    private bool IsTeamMatch => Fixture is not null
+        && (Fixture.HomeTeamId.HasValue || Fixture.AwayTeamId.HasValue);
+
+    private string SideAName
+    {
+        get
+        {
+            if (Fixture is null) return "Side A";
+            if (IsTeamMatch) return Fixture.HomeTeamName ?? "Home";
+            return Fixture.Player3Id is not null
+                ? $"{Fixture.Player1Name ?? "TBD"} & {Fixture.Player3Name ?? "TBD"}"
+                : Fixture.Player1Name ?? "Side A";
+        }
+    }
+
+    private string SideBName
+    {
+        get
+        {
+            if (Fixture is null) return "Side B";
+            if (IsTeamMatch) return Fixture.AwayTeamName ?? "Away";
+            return Fixture.Player4Id is not null
+                ? $"{Fixture.Player2Name ?? "TBD"} & {Fixture.Player4Name ?? "TBD"}"
+                : Fixture.Player2Name ?? "Side B";
+        }
+    }
+
+    private bool IsP1Winner => Fixture is not null
+        && Fixture.WinnerPlayerId.HasValue && Fixture.WinnerPlayerId == Fixture.Player1Id;
+
+    private bool IsP2Winner => Fixture is not null
+        && Fixture.WinnerPlayerId.HasValue && Fixture.WinnerPlayerId == Fixture.Player2Id;
+
+    private string HeaderSubtitle
+    {
+        get
+        {
+            if (Fixture is null) return "";
+            var label = !string.IsNullOrEmpty(Fixture.FixtureLabel)
+                ? Fixture.FixtureLabel
+                : Fixture.StageName ?? "";
+            var when = Fixture.ScheduledAt?.ToString("dd MMM yyyy") ?? "";
+            return string.Join(" · ", new[] { label, when }
+                .Where(s => !string.IsNullOrWhiteSpace(s)));
+        }
+    }
+
+    private static string JoinNames(string? a, string? b) => (a, b) switch
+    {
+        (null or "", null or "") => "—",
+        (null or "", _) => b!,
+        (_, null or "") => a!,
+        _ => $"{a} & {b}"
+    };
+
+    private static List<(string P1, string P2)> ParseResultSummary(string? summary)
+    {
+        // Canonical format is space-separated en-dash ("6–3 7–5"); legacy
+        // comma-separated hyphen ("6-3, 7-5") was migrated server-side but
+        // accept both shapes defensively (matches FixtureResultCard).
+        if (string.IsNullOrWhiteSpace(summary)) return [];
+        var result = new List<(string, string)>();
+        var parts = summary.Split([' ', ','], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        foreach (var part in parts)
+        {
+            var scores = part.Split(['-', '–'], 2);
+            if (scores.Length == 2)
+                result.Add((scores[0].Trim(), scores[1].Trim()));
+        }
+        return result;
+    }
+}

--- a/DropShot/Controllers/CompetitionsController.cs
+++ b/DropShot/Controllers/CompetitionsController.cs
@@ -1635,7 +1635,9 @@ public class CompetitionsController(
             r.AwayPlayer1Id, r.AwayPlayer1?.DisplayName,
             r.AwayPlayer2Id, r.AwayPlayer2?.DisplayName,
             r.HomeGames, r.AwayGames, r.WinnerTeamId,
-            r.IsComplete, r.SavedMatchId)).ToList();
+            r.IsComplete, r.SavedMatchId,
+            r.HomeSetsWon, r.AwaySetsWon, r.HomeGamesTotal, r.AwayGamesTotal,
+            r.SetScores.Select(s => new RubberSetScoreDto(s.Home, s.Away)).ToList())).ToList();
     }
 
     // ── Team League Table ────────────────────────────────────────────────────

--- a/DropShot/Services/WebCompetitionService.cs
+++ b/DropShot/Services/WebCompetitionService.cs
@@ -228,7 +228,8 @@ public sealed class WebCompetitionService(
                 r.AwayPlayer2Id, r.AwayPlayer2?.DisplayName,
                 r.HomeGames, r.AwayGames, r.WinnerTeamId,
                 r.IsComplete, r.SavedMatchId,
-                r.HomeSetsWon, r.AwaySetsWon, r.HomeGamesTotal, r.AwayGamesTotal))
+                r.HomeSetsWon, r.AwaySetsWon, r.HomeGamesTotal, r.AwayGamesTotal,
+                r.SetScores.Select(s => new RubberSetScoreDto(s.Home, s.Away)).ToList()))
             .ToList(),
         f.CompletedAt, f.OriginalResultSummary, f.ResultModifiedByAdmin);
 


### PR DESCRIPTION
## Summary
- Adds a **MatchSetScoresDialog** that opens when the user clicks a completed match's result in the fixtures table.
- **Singles / Doubles**: parses the persisted `ResultSummary` (e.g. `6–3 7–5 6–4`) into a per-set table with one row per side.
- **Team matches**: lists each completed rubber with the home/away pair, the set count (`2-1`), and the per-set breakdown (`6–3 7–5 6–4`). Server now ships `RubberDto.SetScores` so this data is available client-side.
- Clickable result cells added in three places:
  - `FixturesSection` (admin / non-divisional setup fixtures table)
  - `CompetitionPage` divisional fixtures table
  - `ViewCompetition` (player-facing fixtures table — both team and non-team rows)
- No backend behaviour changes other than populating an existing model property (`Rubber.SetScoresJson`) into the DTO. All existing endpoints unaffected.

## Test plan
- [ ] Open a competition with a completed singles fixture → click the score → dialog shows one row per side with each set's games.
- [ ] Same with a completed doubles fixture → side names show both partners.
- [ ] Open a team match competition with a completed fixture → click the team score → dialog lists each rubber's set scores.
- [ ] Open a team match where some rubbers don't have per-set rows recorded → dialog shows `—` in the per-set column for those rows.
- [ ] Verify Singles, Doubles, and Team match all render correctly on the player-facing **ViewCompetition** page.
- [ ] Confirm the cursor is a pointer on hover and the tooltip "Click for set-by-set scores" appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
