### PR TITLE
Fix edit-mode set-scores dialog: populate rubbers in admin DTO

### DIFF
--- a/DropShot.UI/Components/Shared/MatchSetScoresDialog.razor
+++ b/DropShot.UI/Components/Shared/MatchSetScoresDialog.razor
@@ -118,8 +118,12 @@
     [Parameter] public EventCallback<bool> VisibleChanged { get; set; }
     [Parameter] public CompetitionFixtureDto? Fixture { get; set; }
 
+    // Only treat as a team match (rubber-based) if completed rubbers are
+    // attached. Doubles fixtures may carry HomeTeamId/AwayTeamId but have no
+    // rubbers — for those the per-set breakdown lives in ResultSummary.
     private bool IsTeamMatch => Fixture is not null
-        && (Fixture.HomeTeamId.HasValue || Fixture.AwayTeamId.HasValue);
+        && (Fixture.HomeTeamId.HasValue || Fixture.AwayTeamId.HasValue)
+        && (Fixture.Rubbers?.Any(r => r.IsComplete) ?? false);
 
     private string SideAName
     {

--- a/DropShot/Services/WebCompetitionAdminService.cs
+++ b/DropShot/Services/WebCompetitionAdminService.cs
@@ -114,6 +114,10 @@ public sealed class WebCompetitionAdminService(
             .Include(c => c.Fixtures).ThenInclude(f => f.AwayTeam)
             .Include(c => c.Fixtures).ThenInclude(f => f.CourtPair).ThenInclude(cp => cp!.Court1)
             .Include(c => c.Fixtures).ThenInclude(f => f.CourtPair).ThenInclude(cp => cp!.Court2)
+            .Include(c => c.Fixtures).ThenInclude(f => f.Rubbers).ThenInclude(r => r.HomePlayer1)
+            .Include(c => c.Fixtures).ThenInclude(f => f.Rubbers).ThenInclude(r => r.HomePlayer2)
+            .Include(c => c.Fixtures).ThenInclude(f => f.Rubbers).ThenInclude(r => r.AwayPlayer1)
+            .Include(c => c.Fixtures).ThenInclude(f => f.Rubbers).ThenInclude(r => r.AwayPlayer2)
             .Include(c => c.Teams).ThenInclude(t => t.Captain)
             .Include(c => c.MatchWindows).ThenInclude(w => w.Court)
             .Include(c => c.MatchWindows).ThenInclude(w => w.Division)
@@ -872,7 +876,20 @@ public sealed class WebCompetitionAdminService(
             f.CourtPair != null
                 ? (f.CourtPair.Name ?? $"{f.CourtPair.Court1?.Name} + {f.CourtPair.Court2?.Name}")
                 : null,
-            null, // Rubbers — admin view doesn't need them at this granularity
+            f.Rubbers?
+                .OrderBy(r => r.Order)
+                .Select(r => new RubberDto(
+                    r.RubberId, r.CompetitionFixtureId, r.Order, r.Name, r.CourtNumber,
+                    r.HomeRoles, r.AwayRoles,
+                    r.HomePlayer1Id, r.HomePlayer1?.DisplayName,
+                    r.HomePlayer2Id, r.HomePlayer2?.DisplayName,
+                    r.AwayPlayer1Id, r.AwayPlayer1?.DisplayName,
+                    r.AwayPlayer2Id, r.AwayPlayer2?.DisplayName,
+                    r.HomeGames, r.AwayGames, r.WinnerTeamId,
+                    r.IsComplete, r.SavedMatchId,
+                    r.HomeSetsWon, r.AwaySetsWon, r.HomeGamesTotal, r.AwayGamesTotal,
+                    r.SetScores.Select(s => new RubberSetScoreDto(s.Home, s.Away)).ToList()))
+                .ToList(),
             f.CompletedAt,
             f.OriginalResultSummary,
             f.ResultModifiedByAdmin,
@@ -2148,6 +2165,10 @@ public sealed class WebCompetitionAdminService(
             .Include(f => f.HomeTeam)
             .Include(f => f.AwayTeam)
             .Include(f => f.Competition)
+            .Include(f => f.Rubbers).ThenInclude(r => r.HomePlayer1)
+            .Include(f => f.Rubbers).ThenInclude(r => r.HomePlayer2)
+            .Include(f => f.Rubbers).ThenInclude(r => r.AwayPlayer1)
+            .Include(f => f.Rubbers).ThenInclude(r => r.AwayPlayer2)
             .FirstOrDefaultAsync(f => f.CompetitionFixtureId == fixtureId && f.CompetitionId == competitionId, ct);
         return f is null ? null : ToFixtureDto(f);
     }


### PR DESCRIPTION
## Summary
Fixes a regression in the new set-scores dialog: in **edit mode**, clicking a completed team-match score showed "no completed rubbers yet" even though the fixture had completed rubbers.

Two reasons:
1. `WebCompetitionAdminService.ToFixtureDto` passed `null` for `Rubbers` (with a comment "admin view doesn't need them at this granularity"). The new dialog *does* need them. Both admin load paths (`GetCompetitionForEditAsync` and `LoadFixtureForDialogAsync`) now eager-load `Rubbers` with their players, and `ToFixtureDto` maps each rubber (including `SetScores`).
2. `MatchSetScoresDialog.IsTeamMatch` returned `true` whenever the fixture had a `HomeTeamId`/`AwayTeamId`. Doubles fixtures may have team IDs but no rubbers — for those, the per-set breakdown lives in `ResultSummary`. The check now also requires at least one completed rubber, so Doubles fixtures fall through to the `ResultSummary` parser.

## Test plan
- [ ] In **edit mode**, open a competition with a completed team-match fixture → click the score → dialog lists each rubber's set scores (no more "no completed rubbers yet").
- [ ] In **edit mode**, completed singles or doubles fixture → dialog still parses ResultSummary into per-set columns.
- [ ] In **view mode** (ViewCompetition page) → behaviour unchanged.
- [ ] `LoadFixtureForDialog` callers (admin fixture-edit dialog) still load correctly after the new `.Include`s — no breakage on the existing fixture-edit flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
