### PR TITLE
Add manual Add Team button inside DivisionsSection

### DIFF
--- a/DropShot.UI/Components/Competitions/Setup/DivisionsSection.razor
+++ b/DropShot.UI/Components/Competitions/Setup/DivisionsSection.razor
@@ -9,6 +9,11 @@
                    OnClick="@(() => OnStartAddDivision.InvokeAsync())">Add Division</MudButton>
         @if (Divisions.Count > 0 && Format is CompetitionFormat.Team or CompetitionFormat.TeamMatch or CompetitionFormat.Doubles or CompetitionFormat.MixedDoubles)
         {
+            <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Primary"
+                       StartIcon="@Icons.Material.Filled.Add"
+                       OnClick="@(() => OnOpenAddTeamDialog.InvokeAsync())">
+                Add @(Format is CompetitionFormat.Doubles or CompetitionFormat.MixedDoubles ? "Pairing" : "Team")
+            </MudButton>
             <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary"
                        StartIcon="@Icons.Material.Filled.AutoFixHigh"
                        OnClick="@(() => OnOpenGenerateDialog.InvokeAsync())">
@@ -395,6 +400,7 @@
     [Parameter] public EventCallback OnOpenSeedDivisionsDialog { get; set; }
     [Parameter] public EventCallback OnRunSeedDivisions { get; set; }
     [Parameter] public EventCallback OnOpenGenerateDialog { get; set; }
+    [Parameter] public EventCallback OnOpenAddTeamDialog { get; set; }
     [Parameter] public EventCallback<int> OnAddDivisionMatchWindow { get; set; }
     [Parameter] public EventCallback<int> OnCancelEditDivisionMatchWindow { get; set; }
     [Parameter] public EventCallback<CompetitionMatchWindowDto> OnCopyDivisionMatchWindowToForm { get; set; }

--- a/DropShot.UI/Components/Pages/CompetitionPage.razor
+++ b/DropShot.UI/Components/Pages/CompetitionPage.razor
@@ -566,6 +566,7 @@ else
                     OnOpenSeedDivisionsDialog="OpenSeedDivisionsDialog"
                     OnRunSeedDivisions="RunSeedDivisions"
                     OnOpenGenerateDialog="OpenGenerateDialog"
+                    OnOpenAddTeamDialog="OpenAddTeamDialog"
                     OnAddDivisionMatchWindow="AddDivisionMatchWindow"
                     OnCancelEditDivisionMatchWindow="CancelEditDivisionMatchWindow"
                     OnCopyDivisionMatchWindowToForm="CopyDivisionMatchWindowToForm"


### PR DESCRIPTION
## Summary
When a competition is split into divisions, the standalone `TeamsSection` (which has both **Add Team** and **Generate Teams** buttons) is hidden. The per-division UI inside `DivisionsSection` only offered **Generate Teams** — there was no way to add a single team manually once divisions were in play.

This adds an **Add Team** / **Add Pairing** button next to Generate, wired to the existing `OpenAddTeamDialog` handler on `CompetitionPage` which already handles division assignment as part of the dialog.

## Test plan
- [ ] Open a competition with `HasDivisions = true` and a team/doubles/team-match format → Divisions section header shows both **Add Team** and **Generate Teams** buttons.
- [ ] Click **Add Team** → existing Add Team dialog opens (with a division picker) → save → team appears in the right division panel.
- [ ] Doubles / MixedDoubles format → button text reads **Add Pairing** / **Generate Pairings**.
- [ ] Singles / non-team format → buttons remain hidden (unchanged).
- [ ] `HasDivisions = false` → standalone TeamsSection still shows with its own Add/Generate buttons (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
