### PR TITLE
Reorder edit page: Divisions -> Participants -> Teams

### DIFF
--- a/DropShot.UI/Components/Competitions/Setup/DivisionsSection.razor
+++ b/DropShot.UI/Components/Competitions/Setup/DivisionsSection.razor
@@ -7,19 +7,6 @@
         <MudText Typo="Typo.h6" Style="flex:1">Divisions</MudText>
         <MudButton Size="Size.Small" Variant="Variant.Outlined" StartIcon="@Icons.Material.Filled.Add"
                    OnClick="@(() => OnStartAddDivision.InvokeAsync())">Add Division</MudButton>
-        @if (Divisions.Count > 0 && Format is CompetitionFormat.Team or CompetitionFormat.TeamMatch or CompetitionFormat.Doubles or CompetitionFormat.MixedDoubles)
-        {
-            <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Primary"
-                       StartIcon="@Icons.Material.Filled.Add"
-                       OnClick="@(() => OnOpenAddTeamDialog.InvokeAsync())">
-                Add @(Format is CompetitionFormat.Doubles or CompetitionFormat.MixedDoubles ? "Pairing" : "Team")
-            </MudButton>
-            <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary"
-                       StartIcon="@Icons.Material.Filled.AutoFixHigh"
-                       OnClick="@(() => OnOpenGenerateDialog.InvokeAsync())">
-                Generate @(Format is CompetitionFormat.Doubles or CompetitionFormat.MixedDoubles ? "Pairings" : "Teams")
-            </MudButton>
-        }
         @if (SeedSourceCandidates.Count > 0 && Divisions.Count == 0)
         {
             <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary"
@@ -399,8 +386,6 @@
     [Parameter] public EventCallback OnCancelDeleteDivision { get; set; }
     [Parameter] public EventCallback OnOpenSeedDivisionsDialog { get; set; }
     [Parameter] public EventCallback OnRunSeedDivisions { get; set; }
-    [Parameter] public EventCallback OnOpenGenerateDialog { get; set; }
-    [Parameter] public EventCallback OnOpenAddTeamDialog { get; set; }
     [Parameter] public EventCallback<int> OnAddDivisionMatchWindow { get; set; }
     [Parameter] public EventCallback<int> OnCancelEditDivisionMatchWindow { get; set; }
     [Parameter] public EventCallback<CompetitionMatchWindowDto> OnCopyDivisionMatchWindowToForm { get; set; }

--- a/DropShot.UI/Components/Pages/CompetitionPage.razor
+++ b/DropShot.UI/Components/Pages/CompetitionPage.razor
@@ -523,7 +523,21 @@ else
                 }
             }
 
-            @* ── Divisions ────────────────────────────────────── *@
+            @* ── Apply Competition Template ───────────────────── *@
+            @if (_competitionTemplates.Count > 0)
+            {
+                <TemplatesSection
+                    Templates="_competitionTemplates"
+                    SelectedTemplateId="_selectedCompetitionTemplateId"
+                    OnApplyTemplate="ApplyCompetitionTemplate" />
+            }
+        }
+
+<div id="nav-anchor-roster" class="section-anchor"></div>
+@if (IsEdit)
+{
+            @* ── Divisions (above Participants so the division select on each
+               participant row + each team row has options to bind to) *@
             @if (Model.HasDivisions)
             {
                 <DivisionsSection
@@ -565,8 +579,6 @@ else
                     OnCancelDeleteDivision="CancelDeleteDivision"
                     OnOpenSeedDivisionsDialog="OpenSeedDivisionsDialog"
                     OnRunSeedDivisions="RunSeedDivisions"
-                    OnOpenGenerateDialog="OpenGenerateDialog"
-                    OnOpenAddTeamDialog="OpenAddTeamDialog"
                     OnAddDivisionMatchWindow="AddDivisionMatchWindow"
                     OnCancelEditDivisionMatchWindow="CancelEditDivisionMatchWindow"
                     OnCopyDivisionMatchWindowToForm="CopyDivisionMatchWindowToForm"
@@ -578,19 +590,6 @@ else
                     OnDeleteTeam="DeleteTeam" />
             }
 
-            @* ── Apply Competition Template ───────────────────── *@
-            @if (_competitionTemplates.Count > 0)
-            {
-                <TemplatesSection
-                    Templates="_competitionTemplates"
-                    SelectedTemplateId="_selectedCompetitionTemplateId"
-                    OnApplyTemplate="ApplyCompetitionTemplate" />
-            }
-        }
-
-<div id="nav-anchor-roster" class="section-anchor"></div>
-@if (IsEdit)
-{
             @* ── Participants ────────────────────────────────── *@
             <MudPaper id="section-participants" Class="pa-4 mb-4 setup-section frosted-card" Elevation="0"
                  Style="color: white;">
@@ -1124,8 +1123,12 @@ else
             </MudPaper>
 
 
-            @* ── Teams / Pairings (hidden when HasDivisions — per-division UI in the Divisions section below) *@
-            @if (!Model.HasDivisions && EffectivePersistedFormat() is CompetitionFormat.Team or CompetitionFormat.TeamMatch or CompetitionFormat.Doubles or CompetitionFormat.MixedDoubles)
+            @* ── Teams / Pairings — single source of team creation for both
+               divisional and non-divisional competitions. When HasDivisions is
+               true, DivisionsSection above also lists each division's teams
+               read-only-ish (captain / validate / edit / delete still work
+               from the per-division panel). *@
+            @if (EffectivePersistedFormat() is CompetitionFormat.Team or CompetitionFormat.TeamMatch or CompetitionFormat.Doubles or CompetitionFormat.MixedDoubles)
             {
                 <TeamsSection
                     Teams="_teams"


### PR DESCRIPTION
## Summary
Restores the natural setup-flow ordering on the competition edit page:

1. **Divisions** first (so they exist to assign to)
2. **Participants** in the middle (each row picks a division + role)
3. **Teams** last (using divisions + roles to assemble teams)

## Changes
- **DivisionsSection moved** from the Setup region to the top of the Roster region, above the Participants panel. Visibility (`@if (Model.HasDivisions)`) and all bound state are unchanged.
- **TeamsSection now always shows** for team-capable formats (`Team`, `TeamMatch`, `Doubles`, `MixedDoubles`) — the `!Model.HasDivisions &&` guard is gone. Team creation is now a single source again.
- **Removed the Add Team / Generate Teams buttons** from DivisionsSection (added in PR [#657](https://github.com/kingbeazer/DropShot/pull/657) as a workaround for the hidden TeamsSection — wrong fix). The per-division Teams sub-table inside DivisionsSection stays as a display, with the existing captain / validate / edit / delete actions still working per-row.
- Dropped the now-unused `OnOpenAddTeamDialog` and `OnOpenGenerateDialog` parameters from DivisionsSection.

## Test plan
- [ ] **Singles + HasDivisions=true** → Divisions above Participants in Roster region; no TeamsSection (correct, Singles isn't team-capable).
- [ ] **TeamMatch + HasDivisions=true** → Divisions → Participants → TeamsSection. Add Team and Generate Teams buttons only appear in TeamsSection. Per-division Teams sub-table inside Divisions panels still shows existing teams with edit/validate/delete/captain.
- [ ] **TeamMatch + HasDivisions=false** → Participants → TeamsSection (no Divisions section).
- [ ] **Doubles / MixedDoubles + HasDivisions=true** → labels say "Pairing" / "Pairings" in TeamsSection.
- [ ] Add a team via TeamsSection's Add Team dialog with a division selected → team appears in TeamsSection list **and** inside the right DivisionsSection division panel.
- [ ] Generate Teams in TeamsSection still works.
- [ ] Setup / Roster / Fixtures nav chips still scroll to their respective regions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
