### PR TITLE
Add competition Description (Markdown) field

### DIFF
--- a/DropShot.Shared/Dtos/CompetitionAdminDtos.cs
+++ b/DropShot.Shared/Dtos/CompetitionAdminDtos.cs
@@ -69,7 +69,8 @@ public record CompetitionEditDto(
     IReadOnlyList<EventDto> Events,
     IReadOnlyList<int> AllowedPlayerIds,
     bool CanEdit,
-    bool IsSuperAdmin);
+    bool IsSuperAdmin,
+    string? Description = null);
 
 public record CompetitionMatchWindowDto(
     int CompetitionMatchWindowId,
@@ -200,7 +201,8 @@ public record SaveCompetitionEditRequest(
     bool HasDivisions,
     int? SeededFromCompetitionId,
     bool IsRestricted = false,
-    IReadOnlyList<int>? AllowedPlayerIds = null);
+    IReadOnlyList<int>? AllowedPlayerIds = null,
+    string? Description = null);
 
 public record ApplyStageFollowUpRequest(IReadOnlyList<StageType> StageTypes);
 

--- a/DropShot.Shared/Dtos/CompetitionDtos.cs
+++ b/DropShot.Shared/Dtos/CompetitionDtos.cs
@@ -51,7 +51,8 @@ public record CompetitionDetailDto(
     List<CompetitionTeamDto>? Teams = null,
     List<CourtPairDto>? CourtPairs = null,
     LeagueScoringMode LeagueScoring = LeagueScoringMode.WinPoints,
-    int? MyPlayerId = null);
+    int? MyPlayerId = null,
+    string? Description = null);
 
 public record CompetitionStageDto(
     int CompetitionStageId,

--- a/DropShot.UI/Components/Competitions/CompetitionFormModel.cs
+++ b/DropShot.UI/Components/Competitions/CompetitionFormModel.cs
@@ -31,6 +31,7 @@ public sealed class CompetitionFormModel
     public int? MinDaysBetweenPlayerMatches { get; set; }
     public bool HasDivisions { get; set; }
     public int? SeededFromCompetitionId { get; set; }
+    public string? Description { get; set; }
 }
 
 // UI-only enums that separate category (Male/Female/Mixed) from the format shown in the

--- a/DropShot.UI/Components/Competitions/Setup/GeneralInfoSection.razor
+++ b/DropShot.UI/Components/Competitions/Setup/GeneralInfoSection.razor
@@ -1,0 +1,53 @@
+@using DropShot.UI.Services
+
+@* Free-form Markdown description shown at the top of the player-facing
+   competition view. Edit mode renders a textarea with an Edit/Preview
+   toggle; the rendered HTML uses MarkdownRenderer so HTML embedded in the
+   input is stripped. *@
+
+<MudPaper id="section-general-info" Class="pa-4 mb-4 setup-section" Elevation="0"
+     Style="background: rgba(255,255,255,0.08); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border: 1px solid rgba(255,255,255,0.12); border-radius: 12px; color: white;">
+    <MudStack Row="true" AlignItems="AlignItems.Center" Class="mb-2">
+        <MudText Typo="Typo.h6" Style="flex:1">General info</MudText>
+        <MudToggleGroup T="bool" Value="_showPreview"
+                        ValueChanged="@((bool v) => _showPreview = v)"
+                        SelectionMode="SelectionMode.SingleSelection" Size="Size.Small">
+            <MudToggleItem Value="@false">Edit</MudToggleItem>
+            <MudToggleItem Value="@true">Preview</MudToggleItem>
+        </MudToggleGroup>
+    </MudStack>
+
+    <MudText Typo="Typo.caption" Class="mb-2" Style="opacity:0.75">
+        Shown at the top of this competition's page for everyone who can view it.
+        Supports Markdown — <b>**bold**</b>, <i>*italic*</i>, lists, links, headings.
+    </MudText>
+
+    @if (_showPreview)
+    {
+        <MudPaper Class="pa-3 markdown-body" Elevation="0"
+                  Style="background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.10); border-radius: 8px; min-height: 6rem;">
+            @if (string.IsNullOrWhiteSpace(Description))
+            {
+                <MudText Typo="Typo.caption" Color="Color.Secondary">Nothing to preview yet.</MudText>
+            }
+            else
+            {
+                @((MarkupString)MarkdownRenderer.ToHtml(Description))
+            }
+        </MudPaper>
+    }
+    else
+    {
+        <MudTextField T="string" Value="Description"
+                      ValueChanged="@(v => DescriptionChanged.InvokeAsync(v))"
+                      Variant="Variant.Outlined" Lines="8" Immediate="true"
+                      Placeholder="e.g. **Welcome to the 2026 Winter League!**&#10;&#10;Matches run Mondays and Thursdays from 19:00. Please RSVP via the club calendar." />
+    }
+</MudPaper>
+
+@code {
+    [Parameter] public string? Description { get; set; }
+    [Parameter] public EventCallback<string?> DescriptionChanged { get; set; }
+
+    private bool _showPreview;
+}

--- a/DropShot.UI/Components/Pages/CompetitionPage.razor
+++ b/DropShot.UI/Components/Pages/CompetitionPage.razor
@@ -441,6 +441,14 @@ else
             </MudForm>
         </MudPaper>
 
+        @* ── General info (Markdown description shown atop the view page) ── *@
+        @if (IsEdit)
+        {
+            <DropShot.UI.Components.Competitions.Setup.GeneralInfoSection
+                Description="@Model.Description"
+                DescriptionChanged="@(v => Model.Description = v)" />
+        }
+
         @* ── Competition Admins ───────────────────────────── *@
         @if (IsEdit && _canEdit)
         {
@@ -2190,6 +2198,7 @@ else
         public int? MinDaysBetweenPlayerMatches { get; set; }
         public bool HasDivisions { get; set; }
         public int? SeededFromCompetitionId { get; set; }
+        public string? Description { get; set; }
     }
 
     // UI-only enums that separate category (Male/Female/Mixed) from the format shown in the
@@ -2381,7 +2390,8 @@ else
                 RubberTieBreak = view.RubberTieBreak,
                 MinDaysBetweenPlayerMatches = view.MinDaysBetweenPlayerMatches,
                 HasDivisions = view.HasDivisions,
-                SeededFromCompetitionId = view.SeededFromCompetitionId
+                SeededFromCompetitionId = view.SeededFromCompetitionId,
+                Description = view.Description
             };
             _stages = view.Stages.ToList();
             _participants = view.Participants.ToList();
@@ -2476,7 +2486,8 @@ else
                 HasDivisions: Model.HasDivisions,
                 SeededFromCompetitionId: Model.SeededFromCompetitionId,
                 IsRestricted: false,
-                AllowedPlayerIds: _allowedPlayerIds);
+                AllowedPlayerIds: _allowedPlayerIds,
+                Description: Model.Description);
 
             var savedId = await Admin.SaveCompetitionAsync(IsEdit ? Id : null, request);
 

--- a/DropShot.UI/Components/Pages/ViewCompetition.razor
+++ b/DropShot.UI/Components/Pages/ViewCompetition.razor
@@ -65,6 +65,14 @@ else
         }
     </MudStack>
 
+    @if (!string.IsNullOrWhiteSpace(_competition.Description))
+    {
+        <MudPaper Class="pa-4 mb-4 markdown-body" Elevation="0"
+                  Style="background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.10); border-radius: 8px;">
+            @((MarkupString)DropShot.UI.Services.MarkdownRenderer.ToHtml(_competition.Description))
+        </MudPaper>
+    }
+
     <MudGrid Spacing="3" Class="mb-4">
         <MudItem xs="6" sm="3">
             <MudText Typo="Typo.caption" Color="Color.Secondary">Format</MudText>

--- a/DropShot.UI/DropShot.UI.csproj
+++ b/DropShot.UI/DropShot.UI.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Markdig" Version="1.2.0" />
     <SupportedPlatform Include="browser" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.1" />

--- a/DropShot.UI/Services/MarkdownRenderer.cs
+++ b/DropShot.UI/Services/MarkdownRenderer.cs
@@ -1,0 +1,27 @@
+using Markdig;
+
+namespace DropShot.UI.Services;
+
+/// <summary>
+/// Renders the competition Description field (and any future Markdown user
+/// content) into safe HTML for display via Blazor <c>MarkupString</c>.
+///
+/// HTML embedded in the input is disabled so that user-supplied content can't
+/// inject <c>&lt;script&gt;</c> tags or arbitrary markup. Soft line breaks
+/// render as <c>&lt;br&gt;</c> so plain newlines work without forcing two
+/// trailing spaces per line.
+/// </summary>
+public static class MarkdownRenderer
+{
+    private static readonly MarkdownPipeline _pipeline = new MarkdownPipelineBuilder()
+        .DisableHtml()
+        .UseSoftlineBreakAsHardlineBreak()
+        .UseAutoLinks()
+        .UseEmphasisExtras()
+        .UsePipeTables()
+        .UseTaskLists()
+        .Build();
+
+    public static string ToHtml(string? markdown) =>
+        string.IsNullOrWhiteSpace(markdown) ? "" : Markdown.ToHtml(markdown, _pipeline);
+}

--- a/DropShot/Controllers/CompetitionsController.cs
+++ b/DropShot/Controllers/CompetitionsController.cs
@@ -164,7 +164,8 @@ public class CompetitionsController(
                 cp.Court1Id, cp.Court1.Name,
                 cp.Court2Id, cp.Court2.Name,
                 cp.Name)).ToList(),
-            c.LeagueScoring);
+            c.LeagueScoring,
+            Description: c.Description);
     }
 
     [HttpPost]

--- a/DropShot/Data/Migrations/20260517202746_AddCompetitionDescription.Designer.cs
+++ b/DropShot/Data/Migrations/20260517202746_AddCompetitionDescription.Designer.cs
@@ -4,16 +4,19 @@ using DropShot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace DropShot.Migrations
+namespace DropShot.Data.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260517202746_AddCompetitionDescription")]
+    partial class AddCompetitionDescription
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DropShot/Data/Migrations/20260517202746_AddCompetitionDescription.cs
+++ b/DropShot/Data/Migrations/20260517202746_AddCompetitionDescription.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropShot.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCompetitionDescription : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Description",
+                table: "Competition",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Description",
+                table: "Competition");
+        }
+    }
+}

--- a/DropShot/DropShot.csproj
+++ b/DropShot/DropShot.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Communication.Email" Version="1.1.0" />
+    <PackageReference Include="Markdig" Version="1.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="10.0.*" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="10.0.*" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.*" />

--- a/DropShot/Models/Competition.cs
+++ b/DropShot/Models/Competition.cs
@@ -8,6 +8,14 @@ namespace DropShot.Models
         public string CompetitionName { get; set; } = "";
         public CompetitionFormat CompetitionFormat { get; set; }
 
+        /// <summary>
+        /// Free-form general information about the competition, written in
+        /// Markdown. Rendered to HTML for display by both the edit-mode
+        /// preview and the player-facing view page. Null/empty hides the
+        /// "About" panel entirely.
+        /// </summary>
+        public string? Description { get; set; }
+
         public int? MaxParticipants { get; set; }
         public DateTime? StartDate { get; set; }
         public DateTime? EndDate { get; set; }

--- a/DropShot/Services/WebCompetitionAdminService.cs
+++ b/DropShot/Services/WebCompetitionAdminService.cs
@@ -261,7 +261,8 @@ public sealed class WebCompetitionAdminService(
             Clubs: clubs, RulesSets: rulesSets, Events: events,
             AllowedPlayerIds: comp.AllowedPlayers.Select(ap => ap.PlayerId).ToList(),
             CanEdit: canEdit,
-            IsSuperAdmin: isSuperAdmin);
+            IsSuperAdmin: isSuperAdmin,
+            Description: comp.Description);
     }
 
     public async Task<List<CompetitionSeedSourceDto>> GetSeedSourceCandidatesAsync(
@@ -414,6 +415,7 @@ public sealed class WebCompetitionAdminService(
         comp.HasDivisions = req.HasDivisions;
         comp.SeededFromCompetitionId = req.SeededFromCompetitionId;
         comp.IsRestricted = req.IsRestricted;
+        comp.Description = string.IsNullOrWhiteSpace(req.Description) ? null : req.Description;
     }
 
     public async Task<CloneCompetitionResultDto> CloneCompetitionAsync(

--- a/DropShot/Services/WebCompetitionService.cs
+++ b/DropShot/Services/WebCompetitionService.cs
@@ -186,7 +186,8 @@ public sealed class WebCompetitionService(
                 cp.Court2Id, cp.Court2.Name,
                 cp.Name)).ToList(),
             c.LeagueScoring,
-            myPlayerId);
+            myPlayerId,
+            c.Description);
     }
 
     private static PlacementSuggestionDto? BuildPlacementSuggestion(


### PR DESCRIPTION
## Summary
Adds a free-form, Markdown-formatted **General info** description to each competition. Edited via a new section at the top of the competition setup page (above Competition Admins) and rendered in a panel at the top of the player-facing `ViewCompetition` page.

## Changes
- **DB**: new `Competition.Description` column (`nvarchar(max)`, nullable) + migration `AddCompetitionDescription` (20260517202746).
- **DTOs**: extends `CompetitionEditDto`, `SaveCompetitionEditRequest` and `CompetitionDetailDto` with a `Description` field (optional/last-arg defaulting to null, so existing callers keep compiling).
- **Server**: `WebCompetitionAdminService.ToFixtureDto`/`ApplyRequestToEntity` and `WebCompetitionService.GetCompetition`/`CompetitionsController.GetCompetition` now read/write the column. Whitespace-only descriptions are normalised to null.
- **Markdown renderer**: `DropShot.UI/Services/MarkdownRenderer.cs` wraps Markdig with `DisableHtml()` (no script-tag injection), `UseSoftlineBreakAsHardlineBreak()`, autolinks, pipe tables, task lists, emphasis extras.
- **Edit UI**: `GeneralInfoSection.razor` — paper card with an Edit/Preview toggle, multi-line MudTextField, MudPaper preview rendering MarkupString.
- **View UI**: `ViewCompetition.razor` renders the description in a frosted panel immediately under the competition title when present.

## Test plan
- [ ] On a fresh competition, open the edit page → **General info** section appears at the top above Competition Admins; textbox is empty.
- [ ] Type `**Welcome!**\n- Match nights run Mon/Thu\n- See [club site](https://example.com)` → Preview tab shows bold heading, bullets, autolink.
- [ ] Save → reopen → text is persisted.
- [ ] Open the competition as a viewer (`/view-competition/{id}`) → frosted panel appears under the title with the rendered Markdown.
- [ ] Try injecting `<script>alert(1)</script>` in the description → rendered output shows the literal text (not executed); HTML is escaped/stripped by `DisableHtml()`.
- [ ] Clear the description → save → view page no longer shows the panel.
- [ ] Migration `dotnet ef database update` adds the `Description` column to the `Competition` table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
