### PR TITLE
Rules dialog: live Add button, Enter submits, wider

### DIFF
--- a/DropShot.UI/Components/Pages/RulesSetItemsDialog.razor
+++ b/DropShot.UI/Components/Pages/RulesSetItemsDialog.razor
@@ -64,6 +64,8 @@
             <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
                 <MudTextField @bind-Value="_newRule" Label="New rule…"
                               Variant="Variant.Outlined" Class="flex-grow-1"
+                              Immediate="true"
+                              OnKeyDown="OnNewRuleKeyDown"
                               Disabled="@(_editingItemId.HasValue)" />
                 <MudIconButton Icon="@Icons.Material.Filled.Add" Color="Color.Primary"
                                Disabled="@(_editingItemId.HasValue || string.IsNullOrWhiteSpace(_newRule))"
@@ -119,6 +121,14 @@
         {
             SiteAlerts.Add(ex.Message, Severity.Error);
         }
+    }
+
+    private async Task OnNewRuleKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key is not ("Enter" or "NumpadEnter")) return;
+        if (_editingItemId.HasValue) return;
+        if (string.IsNullOrWhiteSpace(_newRule)) return;
+        await AddItemAsync();
     }
 
     private void StartEdit(RulesSetItemDto item)

--- a/DropShot.UI/Components/Pages/RulesSets.razor
+++ b/DropShot.UI/Components/Pages/RulesSets.razor
@@ -201,7 +201,8 @@ else
             { x => x.RulesSetId, rs.RulesSetId },
             { x => x.RulesSetName, rs.Name }
         };
-        await Dialog.ShowAsync<RulesSetItemsDialog>($"Rules — {rs.Name}", parameters);
+        var options = new DialogOptions { MaxWidth = MaxWidth.Medium, FullWidth = true };
+        await Dialog.ShowAsync<RulesSetItemsDialog>($"Rules — {rs.Name}", parameters, options);
         // Reload to get updated item count, scoped to the selected club.
         _rulesSets = await RulesSetService.GetRulesSetsAsync(_selectedClubId);
     }


### PR DESCRIPTION
## Summary
- New-rule field updates `_newRule` on every keystroke (`Immediate="true"`), so the **Add** button enables as soon as the user types — no need to blur the input first.
- Enter / NumpadEnter on the new-rule field now submits, mirroring the inline-edit field's existing pattern.
- Dialog widened via `MaxWidth.Medium + FullWidth=true` on the `ShowAsync` call.

## Test plan
- [ ] Open **Rules Sets** -> click **Rules** on any set; dialog renders visibly wider.
- [ ] Type one character in **New rule…**; Add (`+`) button enables immediately, before tabbing or clicking away.
- [ ] Press **Enter** with text -> rule is added, field clears.
- [ ] Press **Enter** with empty/whitespace field -> no-op.
- [ ] While inline-editing an existing row, Enter on the new-rule field does not add (matches existing disabled-while-editing behavior).

Generated with [Claude Code](https://claude.com/claude-code)