### PR TITLE
Division UseSharedMatchWindows flag + Add Division checkbox

### DIFF
--- a/DropShot.Shared/Dtos/CompetitionDtos.cs
+++ b/DropShot.Shared/Dtos/CompetitionDtos.cs
@@ -348,9 +348,10 @@ public record CompetitionDivisionDto(
     int CompetitionDivisionId,
     int CompetitionId,
     byte Rank,
-    string Name);
+    string Name,
+    bool UseSharedMatchWindows = true);
 
-public record SaveDivisionRequest(string Name, byte Rank);
+public record SaveDivisionRequest(string Name, byte Rank, bool UseSharedMatchWindows = true);
 
 public record SetParticipantDivisionRequest(int? CompetitionDivisionId);
 

--- a/DropShot.UI/Components/Competitions/Setup/DivisionsSection.razor
+++ b/DropShot.UI/Components/Competitions/Setup/DivisionsSection.razor
@@ -51,18 +51,29 @@
     @if (AddingDivision)
     {
         <MudPaper Class="pa-3 mb-3" Elevation="0" Style="background: rgba(255,255,255,0.04); border: 1px dashed rgba(255,255,255,0.2); border-radius: 8px;">
-            <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
-                <MudTextField T="string" Value="DivisionName"
-                              ValueChanged="@((string v) => DivisionNameChanged.InvokeAsync(v))"
-                              Label="Name" Variant="Variant.Outlined" Margin="Margin.Dense" Style="flex:1" />
-                <MudNumericField T="byte" Value="DivisionRank"
-                                 ValueChanged="@((byte v) => DivisionRankChanged.InvokeAsync(v))"
-                                 Label="Rank (1 = top)" Min="1" Max="20" Variant="Variant.Outlined" Margin="Margin.Dense" Style="max-width:180px" />
-                <MudButton Color="Color.Primary" Variant="Variant.Filled" Size="Size.Small"
-                           Disabled="@string.IsNullOrWhiteSpace(DivisionName)"
-                           OnClick="@(() => OnSaveDivision.InvokeAsync())">Save</MudButton>
-                <MudButton Variant="Variant.Text" Size="Size.Small"
-                           OnClick="@(() => OnCancelAddDivision.InvokeAsync())">Cancel</MudButton>
+            <MudStack Spacing="2">
+                <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+                    <MudTextField T="string" Value="DivisionName"
+                                  ValueChanged="@((string v) => DivisionNameChanged.InvokeAsync(v))"
+                                  Label="Name" Variant="Variant.Outlined" Margin="Margin.Dense" Style="flex:1" />
+                    <MudNumericField T="byte" Value="DivisionRank"
+                                     ValueChanged="@((byte v) => DivisionRankChanged.InvokeAsync(v))"
+                                     Label="Rank (1 = top)" Min="1" Max="20" Variant="Variant.Outlined" Margin="Margin.Dense" Style="max-width:180px" />
+                </MudStack>
+                <MudCheckBox T="bool" Value="DivisionUseSharedWindows"
+                             ValueChanged="@((bool v) => DivisionUseSharedWindowsChanged.InvokeAsync(v))"
+                             Label="Use the competition's shared match windows"
+                             Color="Color.Primary" />
+                <MudText Typo="Typo.caption" Color="Color.Secondary" Style="margin-top:-8px;">
+                    Leave ticked to schedule this division using the competition-level windows. Untick to add division-specific windows below after saving.
+                </MudText>
+                <MudStack Row="true" Spacing="2">
+                    <MudButton Color="Color.Primary" Variant="Variant.Filled" Size="Size.Small"
+                               Disabled="@string.IsNullOrWhiteSpace(DivisionName)"
+                               OnClick="@(() => OnSaveDivision.InvokeAsync())">Save</MudButton>
+                    <MudButton Variant="Variant.Text" Size="Size.Small"
+                               OnClick="@(() => OnCancelAddDivision.InvokeAsync())">Cancel</MudButton>
+                </MudStack>
             </MudStack>
         </MudPaper>
     }
@@ -93,30 +104,53 @@
 
                     @* Division identity form *@
                     <MudPaper Class="pa-3 mb-3" Elevation="0" Style="background: rgba(255,255,255,0.04); border-radius: 8px;">
-                        <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+                        <MudStack Spacing="2">
+                            <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+                                @if (editingThis)
+                                {
+                                    <MudTextField T="string" Value="DivisionName"
+                                                  ValueChanged="@((string v) => DivisionNameChanged.InvokeAsync(v))"
+                                                  Label="Name" Variant="Variant.Outlined" Margin="Margin.Dense" Style="flex:1" />
+                                    <MudNumericField T="byte" Value="DivisionRank"
+                                                     ValueChanged="@((byte v) => DivisionRankChanged.InvokeAsync(v))"
+                                                     Label="Rank" Min="1" Max="20" Variant="Variant.Outlined" Margin="Margin.Dense" Style="max-width:140px" />
+                                    <MudButton Color="Color.Primary" Variant="Variant.Filled" Size="Size.Small"
+                                               Disabled="@string.IsNullOrWhiteSpace(DivisionName)"
+                                               OnClick="@(() => OnSaveDivision.InvokeAsync())">Save</MudButton>
+                                    <MudButton Variant="Variant.Text" Size="Size.Small"
+                                               OnClick="@(() => OnCancelInlineEditDivision.InvokeAsync())">Cancel</MudButton>
+                                }
+                                else
+                                {
+                                    <MudText Typo="Typo.body2" Style="flex:1">
+                                        <b>Rank @d.Rank</b> - @d.Name
+                                        @if (d.UseSharedMatchWindows)
+                                        {
+                                            <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Class="ml-2">Uses shared windows</MudChip>
+                                        }
+                                        else if (divWindows.Count == 0)
+                                        {
+                                            <MudChip T="string" Size="Size.Small" Color="Color.Warning" Variant="Variant.Filled" Class="ml-2">No windows defined</MudChip>
+                                        }
+                                    </MudText>
+                                    <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="Size.Small"
+                                                   OnClick="@(() => OnStartInlineEditDivision.InvokeAsync(d))" />
+                                    <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small" Color="Color.Error"
+                                                   OnClick="@(() => OnDeleteDivision.InvokeAsync(d))" />
+                                }
+                            </MudStack>
                             @if (editingThis)
                             {
-                                <MudTextField T="string" Value="DivisionName"
-                                              ValueChanged="@((string v) => DivisionNameChanged.InvokeAsync(v))"
-                                              Label="Name" Variant="Variant.Outlined" Margin="Margin.Dense" Style="flex:1" />
-                                <MudNumericField T="byte" Value="DivisionRank"
-                                                 ValueChanged="@((byte v) => DivisionRankChanged.InvokeAsync(v))"
-                                                 Label="Rank" Min="1" Max="20" Variant="Variant.Outlined" Margin="Margin.Dense" Style="max-width:140px" />
-                                <MudButton Color="Color.Primary" Variant="Variant.Filled" Size="Size.Small"
-                                           Disabled="@string.IsNullOrWhiteSpace(DivisionName)"
-                                           OnClick="@(() => OnSaveDivision.InvokeAsync())">Save</MudButton>
-                                <MudButton Variant="Variant.Text" Size="Size.Small"
-                                           OnClick="@(() => OnCancelInlineEditDivision.InvokeAsync())">Cancel</MudButton>
+                                <MudCheckBox T="bool" Value="DivisionUseSharedWindows"
+                                             ValueChanged="@((bool v) => DivisionUseSharedWindowsChanged.InvokeAsync(v))"
+                                             Label="Use the competition's shared match windows"
+                                             Color="Color.Primary" />
                             }
-                            else
+                            else if (!d.UseSharedMatchWindows && divWindows.Count == 0)
                             {
-                                <MudText Typo="Typo.body2" Style="flex:1">
-                                    <b>Rank @d.Rank</b> - @d.Name
-                                </MudText>
-                                <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="Size.Small"
-                                               OnClick="@(() => OnStartInlineEditDivision.InvokeAsync(d))" />
-                                <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small" Color="Color.Error"
-                                               OnClick="@(() => OnDeleteDivision.InvokeAsync(d))" />
+                                <MudAlert Severity="Severity.Warning" Variant="Variant.Outlined" Dense="true">
+                                    This division has opted out of the shared windows but doesn't have any windows of its own — add one in the Match Windows section below, or edit the division and tick "Use shared windows".
+                                </MudAlert>
                             }
                         </MudStack>
                     </MudPaper>
@@ -355,6 +389,9 @@
 
     [Parameter] public byte DivisionRank { get; set; } = 1;
     [Parameter] public EventCallback<byte> DivisionRankChanged { get; set; }
+
+    [Parameter] public bool DivisionUseSharedWindows { get; set; } = true;
+    [Parameter] public EventCallback<bool> DivisionUseSharedWindowsChanged { get; set; }
 
     [Parameter] public bool ShowSeedDivisionsDialog { get; set; }
     [Parameter] public EventCallback<bool> ShowSeedDivisionsDialogChanged { get; set; }

--- a/DropShot.UI/Components/Pages/CompetitionPage.razor
+++ b/DropShot.UI/Components/Pages/CompetitionPage.razor
@@ -564,6 +564,8 @@ else
                     DivisionNameChanged="@(v => _divisionName = v)"
                     DivisionRank="_divisionRank"
                     DivisionRankChanged="@(v => _divisionRank = v)"
+                    DivisionUseSharedWindows="_divisionUseSharedWindows"
+                    DivisionUseSharedWindowsChanged="@(v => _divisionUseSharedWindows = v)"
                     ShowSeedDivisionsDialog="_showSeedDivisionsDialog"
                     ShowSeedDivisionsDialogChanged="@(v => _showSeedDivisionsDialog = v)"
                     SeedSourceCompetitionId="_seedSourceCompetitionId"
@@ -2046,6 +2048,7 @@ else
     private CompetitionDivisionDto? _editingDivision;
     private string _divisionName = "";
     private byte _divisionRank = 1;
+    private bool _divisionUseSharedWindows = true;
     private bool _addingDivision;
     private int? _inlineEditDivisionId;
 
@@ -3470,6 +3473,7 @@ else
         _inlineEditDivisionId = null;
         _divisionName = "";
         _divisionRank = (byte)(_divisions.Count == 0 ? 1 : _divisions.Max(d => d.Rank) + 1);
+        _divisionUseSharedWindows = true;
         _addingDivision = true;
     }
 
@@ -3486,6 +3490,7 @@ else
         _inlineEditDivisionId = d.CompetitionDivisionId;
         _divisionName = d.Name;
         _divisionRank = d.Rank;
+        _divisionUseSharedWindows = d.UseSharedMatchWindows;
     }
 
     private void CancelInlineEditDivision()
@@ -3501,7 +3506,7 @@ else
         try
         {
             await Admin.SaveDivisionAsync(Id, _editingDivision?.CompetitionDivisionId,
-                new SaveDivisionRequest(_divisionName.Trim(), _divisionRank));
+                new SaveDivisionRequest(_divisionName.Trim(), _divisionRank, _divisionUseSharedWindows));
         }
         catch (InvalidOperationException ex)
         {

--- a/DropShot/Data/Migrations/20260517212913_AddDivisionUseSharedWindows.Designer.cs
+++ b/DropShot/Data/Migrations/20260517212913_AddDivisionUseSharedWindows.Designer.cs
@@ -4,16 +4,19 @@ using DropShot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace DropShot.Migrations
+namespace DropShot.Data.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260517212913_AddDivisionUseSharedWindows")]
+    partial class AddDivisionUseSharedWindows
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DropShot/Data/Migrations/20260517212913_AddDivisionUseSharedWindows.cs
+++ b/DropShot/Data/Migrations/20260517212913_AddDivisionUseSharedWindows.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropShot.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDivisionUseSharedWindows : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Existing divisions get UseSharedMatchWindows = true so we don't
+            // suddenly start treating them as misconfigured: that matches
+            // pre-migration behaviour (a division with no per-division windows
+            // implicitly falls back to the competition's shared windows).
+            migrationBuilder.AddColumn<bool>(
+                name: "UseSharedMatchWindows",
+                table: "CompetitionDivisions",
+                type: "bit",
+                nullable: false,
+                defaultValue: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "UseSharedMatchWindows",
+                table: "CompetitionDivisions");
+        }
+    }
+}

--- a/DropShot/Models/CompetitionDivision.cs
+++ b/DropShot/Models/CompetitionDivision.cs
@@ -7,6 +7,14 @@ public class CompetitionDivision
     public byte Rank { get; set; } // 1 = top division
     public string Name { get; set; } = "";
 
+    /// <summary>
+    /// When true, this division uses the competition's shared
+    /// (CompetitionDivisionId-null) match windows for auto-scheduling. When
+    /// false, the user is expected to define division-scoped windows; if none
+    /// exist, the setup page warns and the scheduler skips the division.
+    /// </summary>
+    public bool UseSharedMatchWindows { get; set; } = true;
+
     public Competition Competition { get; set; } = null!;
     public ICollection<CompetitionParticipant> Participants { get; set; } = [];
     public ICollection<CompetitionTeam> Teams { get; set; } = [];

--- a/DropShot/Services/WebCompetitionAdminService.cs
+++ b/DropShot/Services/WebCompetitionAdminService.cs
@@ -850,7 +850,7 @@ public sealed class WebCompetitionAdminService(
     }
 
     private static CompetitionDivisionDto ToDivisionDto(CompetitionDivision d) =>
-        new(d.CompetitionDivisionId, d.CompetitionId, d.Rank, d.Name);
+        new(d.CompetitionDivisionId, d.CompetitionId, d.Rank, d.Name, d.UseSharedMatchWindows);
 
     private static CompetitionTeamDto ToTeamDto(CompetitionTeam t) =>
         new(t.CompetitionTeamId, t.CompetitionId, t.Name,
@@ -1282,9 +1282,10 @@ public sealed class WebCompetitionAdminService(
                 throw new InvalidOperationException($"Division rank {request.Rank} already exists.");
             var div = new CompetitionDivision
             {
-                CompetitionId = competitionId,
-                Name          = request.Name.Trim(),
-                Rank          = request.Rank,
+                CompetitionId          = competitionId,
+                Name                   = request.Name.Trim(),
+                Rank                   = request.Rank,
+                UseSharedMatchWindows  = request.UseSharedMatchWindows,
             };
             db.CompetitionDivisions.Add(div);
             if (!comp.HasDivisions) comp.HasDivisions = true;
@@ -1302,8 +1303,9 @@ public sealed class WebCompetitionAdminService(
                     x => x.CompetitionId == competitionId && x.Rank == request.Rank
                          && x.CompetitionDivisionId != row.CompetitionDivisionId, ct))
                 throw new InvalidOperationException($"Division rank {request.Rank} already exists.");
-            row.Name = request.Name.Trim();
-            row.Rank = request.Rank;
+            row.Name                  = request.Name.Trim();
+            row.Rank                  = request.Rank;
+            row.UseSharedMatchWindows = request.UseSharedMatchWindows;
             await db.SaveChangesAsync(ct);
             return row.CompetitionDivisionId;
         }


### PR DESCRIPTION
## Summary
Adds an explicit choice — when adding (or editing) a division, the user picks **between using the competition's shared match windows or providing division-specific ones**.

The choice persists on `CompetitionDivision.UseSharedMatchWindows` (bit, default `true`), so the setup page can warn when a division has opted out of shared windows but has no windows of its own — exactly the misconfiguration the user wanted to catch.

## Changes
- **DB**: new `CompetitionDivisions.UseSharedMatchWindows` column + migration `AddDivisionUseSharedWindows` (default `true`, so existing divisions backfill to the safe "share competition windows" state).
- **DTOs**: `CompetitionDivisionDto` and `SaveDivisionRequest` carry the flag.
- **Server**: `WebCompetitionAdminService.SaveDivisionAsync` persists the flag on create + update.
- **UI**: `DivisionsSection`
  - Add Division inline form gains a `Use the competition's shared match windows` checkbox (default ticked) + a one-line caption explaining the choice.
  - Inline edit form mirrors the checkbox so users can flip the choice later.
  - Each division's header now shows either a `Uses shared windows` outlined chip or, when opted out **and** no per-division windows are defined, a yellow `No windows defined` chip + a warning alert telling the user what to do.

The fixture scheduler is not touched in this PR — `UseSharedMatchWindows` tracks intent. The follow-up "schedule for this division" step can now read the flag if you want it to refuse to run when the division is misconfigured.

## Test plan
- [ ] On an existing competition with divisions, open the setup page → each division shows the `Uses shared windows` chip (because the migration backfilled to true). No warnings.
- [ ] Click **Add Division** → form shows the new checkbox ticked by default with the caption.
- [ ] Add a division with the box ticked → division appears with the `Uses shared windows` chip.
- [ ] Add a division with the box **un**ticked and **no** per-division windows → division appears with the yellow `No windows defined` chip and a warning alert in its panel.
- [ ] Add at least one match window to that division → warning + chip both disappear.
- [ ] Edit an existing division and toggle the checkbox → state changes round-trip via Save.
- [ ] Migration `dotnet ef database update` adds the column with default `true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
