### PR TITLE
Singles Elo Ladder competition format

### DIFF
--- a/DropShot.Maui/Services/HttpMatchScoringService.cs
+++ b/DropShot.Maui/Services/HttpMatchScoringService.cs
@@ -99,4 +99,13 @@ public sealed class HttpMatchScoringService(HttpClient http) : IMatchScoringServ
         var resp = await http.DeleteAsync($"api/match-scoring/live-match/{savedMatchId}{qs}", ct);
         resp.EnsureSuccessStatusCode();
     }
+
+    public async Task<int> CreateLadderFixtureAsync(
+        CreateLadderFixtureRequest request, CancellationToken ct = default)
+    {
+        var resp = await http.PostAsJsonAsync("api/match-scoring/ladder-fixture", request, ct);
+        resp.EnsureSuccessStatusCode();
+        var body = await resp.Content.ReadFromJsonAsync<CreateLadderFixtureResponse>(cancellationToken: ct);
+        return body?.FixtureId ?? 0;
+    }
 }

--- a/DropShot.Shared/Dtos/CompetitionAdminDtos.cs
+++ b/DropShot.Shared/Dtos/CompetitionAdminDtos.cs
@@ -202,7 +202,11 @@ public record SaveCompetitionEditRequest(
     int? SeededFromCompetitionId,
     bool IsRestricted = false,
     IReadOnlyList<int>? AllowedPlayerIds = null,
-    string? Description = null);
+    string? Description = null,
+    double LadderKFactor = 20.0,
+    double LadderStartingRating = 1000.0,
+    int LadderProvisionalMatches = 10,
+    bool LadderUseMarginOfVictory = true);
 
 public record ApplyStageFollowUpRequest(IReadOnlyList<StageType> StageTypes);
 

--- a/DropShot.Shared/Dtos/CompetitionDtos.cs
+++ b/DropShot.Shared/Dtos/CompetitionDtos.cs
@@ -52,7 +52,11 @@ public record CompetitionDetailDto(
     List<CourtPairDto>? CourtPairs = null,
     LeagueScoringMode LeagueScoring = LeagueScoringMode.WinPoints,
     int? MyPlayerId = null,
-    string? Description = null);
+    string? Description = null,
+    double LadderKFactor = 20.0,
+    double LadderStartingRating = 1000.0,
+    int LadderProvisionalMatches = 10,
+    bool LadderUseMarginOfVictory = true);
 
 public record CompetitionStageDto(
     int CompetitionStageId,
@@ -74,7 +78,11 @@ public record CompetitionParticipantDto(
     string? DivisionName = null,
     PlayerRatingDto? Rating = null,
     PlayerRatingSuggestionDto? RatingSuggestion = null,
-    PlacementSuggestionDto? PlacementSuggestion = null);
+    PlacementSuggestionDto? PlacementSuggestion = null,
+    double LadderEloRating = 1000.0,
+    int LadderMatchesPlayed = 0,
+    bool LadderIsProvisional = true,
+    DateTime? LadderLastMatchAt = null);
 
 public record PlayerRatingDto(double CurrentRating, bool IsProvisional);
 
@@ -121,7 +129,11 @@ public record CompetitionFixtureDto(
     DateTime? CompletedAt = null,
     string? OriginalResultSummary = null,
     bool ResultModifiedByAdmin = false,
-    string? CompetitionName = null);
+    string? CompetitionName = null,
+    double? Player1RatingBefore = null,
+    double? Player1RatingAfter = null,
+    double? Player2RatingBefore = null,
+    double? Player2RatingAfter = null);
 
 public record CompetitionTeamDto(
     int CompetitionTeamId,
@@ -166,7 +178,11 @@ public record SaveCompetitionRequest(
     bool IsRestricted = false,
     List<int>? AllowedPlayerIds = null,
     bool HasDivisions = false,
-    int? SeededFromCompetitionId = null);
+    int? SeededFromCompetitionId = null,
+    double LadderKFactor = 20.0,
+    double LadderStartingRating = 1000.0,
+    int LadderProvisionalMatches = 10,
+    bool LadderUseMarginOfVictory = true);
 
 public record AddStageRequest(StageType StageType, string? Name = null, int? StageOrder = null);
 

--- a/DropShot.Shared/Dtos/MatchDtos.cs
+++ b/DropShot.Shared/Dtos/MatchDtos.cs
@@ -175,6 +175,15 @@ public record FinaliseLiveFixtureRequest(
     int HomeGamesTotal,
     int AwayGamesTotal);
 
+/// <summary>
+/// Request to create an ad-hoc fixture in a Singles Ladder competition. The
+/// caller is Player1 (resolved from the JWT-linked Player); <paramref name="OpponentPlayerId"/>
+/// becomes Player2. Both must be FullPlayer participants in the competition.
+/// </summary>
+public record CreateLadderFixtureRequest(int CompetitionId, int OpponentPlayerId);
+
+public record CreateLadderFixtureResponse(int FixtureId);
+
 // ── Phase 7 PR 7e: IMatchSetupService surface (MatchSetupWizard move) ──
 
 /// <summary>

--- a/DropShot.Shared/Enums.cs
+++ b/DropShot.Shared/Enums.cs
@@ -6,7 +6,8 @@ public enum CompetitionFormat : byte
     Doubles = 2,
     Team = 3,
     MixedDoubles = 4,
-    TeamMatch = 5
+    TeamMatch = 5,
+    SinglesLadder = 6
 }
 
 public enum PlayerSex : byte

--- a/DropShot.Tests/Helpers/LadderRatingServiceTests.cs
+++ b/DropShot.Tests/Helpers/LadderRatingServiceTests.cs
@@ -1,0 +1,160 @@
+using DropShot.Models;
+using DropShot.Services;
+using DropShot.Shared;
+using Xunit;
+
+namespace DropShot.Tests.Helpers;
+
+public class LadderRatingServiceTests
+{
+    private const int CompId = 500;
+    private const int FxId = 9000;
+    private const int PlayerAId = 11;
+    private const int PlayerBId = 22;
+
+    private static async Task SeedAsync(
+        TestDbContextFactory factory,
+        double ratingA = 1000, int matchesA = 0,
+        double ratingB = 1000, int matchesB = 0,
+        CompetitionFormat format = CompetitionFormat.SinglesLadder,
+        double kFactor = 20, int provisional = 10,
+        bool useMov = false,
+        int? winnerPlayerId = PlayerAId,
+        int homeGames = 12, int awayGames = 8)
+    {
+        using var db = factory.CreateDbContext();
+        db.Players.Add(new Player { PlayerId = PlayerAId, DisplayName = "A" });
+        db.Players.Add(new Player { PlayerId = PlayerBId, DisplayName = "B" });
+        db.Competition.Add(new Competition
+        {
+            CompetitionID = CompId,
+            CompetitionName = "Ladder",
+            CompetitionFormat = format,
+            LadderKFactor = kFactor,
+            LadderStartingRating = 1000,
+            LadderProvisionalMatches = provisional,
+            LadderUseMarginOfVictory = useMov,
+        });
+        db.CompetitionParticipants.Add(new CompetitionParticipant
+        {
+            CompetitionId = CompId, PlayerId = PlayerAId,
+            Status = ParticipantStatus.FullPlayer,
+            EloRating = ratingA, MatchesPlayed = matchesA,
+            IsProvisional = matchesA < provisional,
+        });
+        db.CompetitionParticipants.Add(new CompetitionParticipant
+        {
+            CompetitionId = CompId, PlayerId = PlayerBId,
+            Status = ParticipantStatus.FullPlayer,
+            EloRating = ratingB, MatchesPlayed = matchesB,
+            IsProvisional = matchesB < provisional,
+        });
+        db.CompetitionFixtures.Add(new CompetitionFixture
+        {
+            CompetitionFixtureId = FxId,
+            CompetitionId = CompId,
+            Player1Id = PlayerAId,
+            Player2Id = PlayerBId,
+            WinnerPlayerId = winnerPlayerId,
+            HomeGamesTotal = homeGames,
+            AwayGamesTotal = awayGames,
+            Status = FixtureStatus.Completed,
+        });
+        await db.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task EqualRatedFirstWin_MovesByExpectedDelta()
+    {
+        var factory = new TestDbContextFactory();
+        await SeedAsync(factory);
+
+        using (var db = factory.CreateDbContext())
+            await LadderRatingService.ApplyForFinalisedFixtureAsync(db, FxId);
+
+        using var verify = factory.CreateDbContext();
+        var pa = verify.CompetitionParticipants.Single(p => p.PlayerId == PlayerAId);
+        var pb = verify.CompetitionParticipants.Single(p => p.PlayerId == PlayerBId);
+
+        // Provisional => K=40. Expected score for equal ratings = 0.5.
+        // Delta = 40 * (1 - 0.5) = 20.
+        Assert.Equal(1020, pa.EloRating, 1);
+        Assert.Equal(980, pb.EloRating, 1);
+        Assert.Equal(1, pa.MatchesPlayed);
+        Assert.Equal(1, pb.MatchesPlayed);
+        Assert.True(pa.IsProvisional);
+        Assert.True(pb.IsProvisional);
+    }
+
+    [Fact]
+    public async Task NonLadderFormat_NoOp()
+    {
+        var factory = new TestDbContextFactory();
+        await SeedAsync(factory, format: CompetitionFormat.Singles);
+
+        using (var db = factory.CreateDbContext())
+            await LadderRatingService.ApplyForFinalisedFixtureAsync(db, FxId);
+
+        using var verify = factory.CreateDbContext();
+        var pa = verify.CompetitionParticipants.Single(p => p.PlayerId == PlayerAId);
+        Assert.Equal(1000, pa.EloRating);
+        Assert.Equal(0, pa.MatchesPlayed);
+    }
+
+    [Fact]
+    public async Task EleventhMatch_FlipsOutOfProvisional_AndUsesBaseK()
+    {
+        var factory = new TestDbContextFactory();
+        await SeedAsync(factory, matchesA: 10, matchesB: 10);
+
+        using (var db = factory.CreateDbContext())
+            await LadderRatingService.ApplyForFinalisedFixtureAsync(db, FxId);
+
+        using var verify = factory.CreateDbContext();
+        var pa = verify.CompetitionParticipants.Single(p => p.PlayerId == PlayerAId);
+        var pb = verify.CompetitionParticipants.Single(p => p.PlayerId == PlayerBId);
+
+        // K=20 (post-provisional). Delta = 20 * 0.5 = 10.
+        Assert.Equal(1010, pa.EloRating, 1);
+        Assert.Equal(990, pb.EloRating, 1);
+        Assert.False(pa.IsProvisional);
+        Assert.False(pb.IsProvisional);
+    }
+
+    [Fact]
+    public async Task FixtureAlreadyApplied_Idempotent()
+    {
+        var factory = new TestDbContextFactory();
+        await SeedAsync(factory);
+
+        using (var db = factory.CreateDbContext())
+            await LadderRatingService.ApplyForFinalisedFixtureAsync(db, FxId);
+        using (var db = factory.CreateDbContext())
+            await LadderRatingService.ApplyForFinalisedFixtureAsync(db, FxId);
+
+        using var verify = factory.CreateDbContext();
+        var pa = verify.CompetitionParticipants.Single(p => p.PlayerId == PlayerAId);
+        // Should only have moved once.
+        Assert.Equal(1020, pa.EloRating, 1);
+        Assert.Equal(1, pa.MatchesPlayed);
+    }
+
+    [Fact]
+    public async Task StoresBeforeAndAfterOnFixture()
+    {
+        var factory = new TestDbContextFactory();
+        await SeedAsync(factory, ratingA: 1100, ratingB: 900);
+
+        using (var db = factory.CreateDbContext())
+            await LadderRatingService.ApplyForFinalisedFixtureAsync(db, FxId);
+
+        using var verify = factory.CreateDbContext();
+        var fx = verify.CompetitionFixtures.Single(f => f.CompetitionFixtureId == FxId);
+        Assert.Equal(1100, fx.Player1RatingBefore);
+        Assert.Equal(900, fx.Player2RatingBefore);
+        Assert.NotNull(fx.Player1RatingAfter);
+        Assert.NotNull(fx.Player2RatingAfter);
+        Assert.True(fx.Player1RatingAfter! > fx.Player1RatingBefore);
+        Assert.True(fx.Player2RatingAfter! < fx.Player2RatingBefore);
+    }
+}

--- a/DropShot.UI/Components/Competitions/CompetitionFormModel.cs
+++ b/DropShot.UI/Components/Competitions/CompetitionFormModel.cs
@@ -32,27 +32,34 @@ public sealed class CompetitionFormModel
     public bool HasDivisions { get; set; }
     public int? SeededFromCompetitionId { get; set; }
     public string? Description { get; set; }
+
+    // SinglesLadder config (only meaningful when Format == SinglesLadder).
+    public double LadderKFactor { get; set; } = 20.0;
+    public double LadderStartingRating { get; set; } = 1000.0;
+    public int LadderProvisionalMatches { get; set; } = 10;
+    public bool LadderUseMarginOfVictory { get; set; } = true;
 }
 
 // UI-only enums that separate category (Male/Female/Mixed) from the format shown in the
-// dropdown (Singles/Doubles/Team). The persisted CompetitionFormat + EligibleSex pair is
-// derived from these two on save.
+// dropdown (Singles/Doubles/Team/SinglesLadder). The persisted CompetitionFormat +
+// EligibleSex pair is derived from these two on save.
 public enum CompetitionCategoryUi { Male, Female, Mixed }
-public enum CompetitionFormatUi { Singles, Doubles, Team }
+public enum CompetitionFormatUi { Singles, Doubles, Team, SinglesLadder }
 
 public static class CompetitionFormHelpers
 {
     public static IEnumerable<CompetitionFormatUi> AllowedFormats(CompetitionCategoryUi? category) =>
-        new[] { CompetitionFormatUi.Singles, CompetitionFormatUi.Doubles, CompetitionFormatUi.Team };
+        new[] { CompetitionFormatUi.Singles, CompetitionFormatUi.Doubles, CompetitionFormatUi.Team, CompetitionFormatUi.SinglesLadder };
 
     public static CompetitionFormat? EffectivePersistedFormat(CompetitionCategoryUi? category, CompetitionFormatUi? format) =>
         (category, format) switch
         {
             (CompetitionCategoryUi.Mixed, CompetitionFormatUi.Doubles) => CompetitionFormat.MixedDoubles,
             (CompetitionCategoryUi.Mixed, CompetitionFormatUi.Team)    => CompetitionFormat.TeamMatch,
-            (_, CompetitionFormatUi.Singles) => CompetitionFormat.Singles,
-            (_, CompetitionFormatUi.Doubles) => CompetitionFormat.Doubles,
-            (_, CompetitionFormatUi.Team)    => CompetitionFormat.Team,
+            (_, CompetitionFormatUi.Singles)       => CompetitionFormat.Singles,
+            (_, CompetitionFormatUi.Doubles)       => CompetitionFormat.Doubles,
+            (_, CompetitionFormatUi.Team)          => CompetitionFormat.Team,
+            (_, CompetitionFormatUi.SinglesLadder) => CompetitionFormat.SinglesLadder,
             _ => null
         };
 

--- a/DropShot.UI/Components/Pages/CompetitionWizardPage.razor
+++ b/DropShot.UI/Components/Pages/CompetitionWizardPage.razor
@@ -114,6 +114,30 @@ else
                             Team: squads play head-to-head fixtures made up of several rubbers. Rubber roles and scoring are configured later via the rubber template.
                         </MudText>
                     }
+                    else if (Model.Format == CompetitionFormatUi.SinglesLadder)
+                    {
+                        <MudText Typo="Typo.caption" Class="mt-2" Style="opacity:0.75">
+                            Singles Ladder: a continuous 1-vs-1 ladder ranked by live Elo rating. Players register, then record ad-hoc matches against any other participant — ratings update on every result.
+                        </MudText>
+
+                        <MudStack Spacing="3" Class="mt-4">
+                            <MudNumericField T="double" @bind-Value="Model.LadderKFactor"
+                                             Label="K-factor"
+                                             HelperText="How much each match moves a rating. 20 is a sensible default; raise for faster-moving ladders, lower for stability."
+                                             Min="1" Max="100" Step="1" Variant="Variant.Outlined" />
+                            <MudNumericField T="double" @bind-Value="Model.LadderStartingRating"
+                                             Label="Starting rating"
+                                             HelperText="Rating assigned when a player first joins the ladder. 1000 is standard."
+                                             Min="0" Max="5000" Step="50" Variant="Variant.Outlined" />
+                            <MudNumericField T="int" @bind-Value="Model.LadderProvisionalMatches"
+                                             Label="Provisional matches"
+                                             HelperText="Number of matches before a player's rating stabilises. K is doubled while provisional, so early matches swing more."
+                                             Min="0" Max="100" Variant="Variant.Outlined" />
+                            <MudSwitch T="bool" @bind-Value="Model.LadderUseMarginOfVictory"
+                                       Label="Apply margin-of-victory multiplier"
+                                       Color="Color.Primary" />
+                        </MudStack>
+                    }
 
                     @StepActions(canBack: true, advance: TryAdvanceFromFormat)
                 </MudPaper>
@@ -863,7 +887,12 @@ else
                 HasDivisions: Model.HasDivisions,
                 SeededFromCompetitionId: null,
                 IsRestricted: false,
-                AllowedPlayerIds: null);
+                AllowedPlayerIds: null,
+                Description: Model.Description,
+                LadderKFactor: Model.LadderKFactor,
+                LadderStartingRating: Model.LadderStartingRating,
+                LadderProvisionalMatches: Model.LadderProvisionalMatches,
+                LadderUseMarginOfVictory: Model.LadderUseMarginOfVictory);
 
             var savedId = await Admin.SaveCompetitionAsync(null, request);
             _savedCompetitionId = savedId;
@@ -953,9 +982,10 @@ else
 
     private static string FormatLabel(CompetitionFormatUi format) => format switch
     {
-        CompetitionFormatUi.Singles => "Singles (1 vs 1)",
-        CompetitionFormatUi.Doubles => "Doubles (2 vs 2 fixed pairs)",
-        CompetitionFormatUi.Team    => "Team (squad-vs-squad with rubbers)",
+        CompetitionFormatUi.Singles       => "Singles (1 vs 1)",
+        CompetitionFormatUi.Doubles       => "Doubles (2 vs 2 fixed pairs)",
+        CompetitionFormatUi.Team          => "Team (squad-vs-squad with rubbers)",
+        CompetitionFormatUi.SinglesLadder => "Singles Ladder (continuous Elo ranking)",
         _ => format.ToString()
     };
 

--- a/DropShot.UI/Components/Pages/ViewCompetition.razor
+++ b/DropShot.UI/Components/Pages/ViewCompetition.razor
@@ -1,9 +1,13 @@
 @inject ICompetitionService CompetitionService
 @inject IRulesSetService RulesSetService
+@inject IMatchScoringService MatchScoring
 @inject ICurrentUser CurrentUser
 @inject NavigationManager Nav
+@inject ISnackbar Snackbar
 @using DropShot.Shared.Extensions
 @using DropShot.Shared.Helpers
+@using DropShot.Shared.Dtos
+@using DropShot.UI.Services
 
 @* Routing + auth + MudProviders supplied by host shims. *@
 
@@ -109,6 +113,38 @@ else
             </MudItem>
         }
     </MudGrid>
+
+    @if (_competition.CompetitionFormat == CompetitionFormat.SinglesLadder
+         && _myParticipant?.Status == ParticipantStatus.FullPlayer)
+    {
+        <MudPaper Class="pa-3 mb-4" Elevation="0" Style="background: rgba(0,180,216,0.08);">
+            <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Wrap="Wrap.Wrap">
+                <MudIcon Icon="@Icons.Material.Filled.SportsTennis" Color="Color.Info" />
+                <MudText Typo="Typo.body2" Style="flex:1 1 auto;">
+                    Record a singles match against another participant — ratings update on the spot.
+                </MudText>
+                <MudSelect T="int?" @bind-Value="_ladderOpponentId" Variant="Variant.Outlined"
+                           Dense="true" Label="Opponent" Style="min-width:220px;">
+                    @foreach (var opp in _participants
+                                 .Where(p => p.Status == ParticipantStatus.FullPlayer
+                                             && p.PlayerId != _myParticipant.PlayerId)
+                                 .OrderBy(p => p.DisplayName))
+                    {
+                        <MudSelectItem T="int?" Value="@((int?)opp.PlayerId)">@opp.DisplayName</MudSelectItem>
+                    }
+                </MudSelect>
+                <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                           Disabled="@(!_ladderOpponentId.HasValue || _ladderCreating)"
+                           OnClick="StartLadderMatchAsync">
+                    Record match
+                </MudButton>
+            </MudStack>
+            @if (!string.IsNullOrEmpty(_ladderError))
+            {
+                <MudAlert Severity="Severity.Error" Dense="true" Class="mt-2">@_ladderError</MudAlert>
+            }
+        </MudPaper>
+    }
 
     @if (!_canEdit && _myParticipant?.Status == ParticipantStatus.Registered)
     {
@@ -341,7 +377,10 @@ else
     }
     else if (_leagueTable.Any())
     {
-        <MudExpansionPanel Class="mb-2" Text="League Table">
+        var isLadder = _competition.CompetitionFormat == CompetitionFormat.SinglesLadder;
+        var pointsHeader = isLadder ? "Rating" : "Pts";
+        var panelTitle = isLadder ? "Ladder Standings" : "League Table";
+        <MudExpansionPanel Class="mb-2" Text="@panelTitle">
             <MudTable Items="@_leagueTable" Dense="true" Hover="true" Breakpoint="Breakpoint.Sm" Class="mb-4 mobile-stack-table" Style="max-width:600px">
                 <HeaderContent>
                     <MudTh>Pos</MudTh>
@@ -349,15 +388,21 @@ else
                     <MudTh>P</MudTh>
                     <MudTh>W</MudTh>
                     <MudTh>L</MudTh>
-                    <MudTh>Pts</MudTh>
+                    <MudTh>@pointsHeader</MudTh>
                 </HeaderContent>
                 <RowTemplate>
                     <MudTd DataLabel="Pos">@(_leagueTable.IndexOf(context) + 1)</MudTd>
-                    <MudTd DataLabel="Player" Style="font-weight:500">@context.PlayerName</MudTd>
+                    <MudTd DataLabel="Player" Style="font-weight:500">
+                        @context.PlayerName
+                        @if (isLadder && _participants.FirstOrDefault(p => p.PlayerId == context.PlayerId)?.LadderIsProvisional == true)
+                        {
+                            <MudChip T="string" Size="Size.Small" Color="Color.Info" Variant="Variant.Outlined" Class="ml-2">prov</MudChip>
+                        }
+                    </MudTd>
                     <MudTd DataLabel="P">@context.Played</MudTd>
                     <MudTd DataLabel="W">@context.Won</MudTd>
                     <MudTd DataLabel="L">@context.Lost</MudTd>
-                    <MudTd DataLabel="Pts" Style="font-weight:bold">@context.Points</MudTd>
+                    <MudTd DataLabel="@pointsHeader" Style="font-weight:bold">@context.Points</MudTd>
                 </RowTemplate>
             </MudTable>
         </MudExpansionPanel>
@@ -551,6 +596,34 @@ else
     private bool _selfRegisterSaving;
     private string? _selfRegisterError;
 
+    private int? _ladderOpponentId;
+    private bool _ladderCreating;
+    private string? _ladderError;
+
+    private async Task StartLadderMatchAsync()
+    {
+        if (_competition is null || _myParticipant is null) return;
+        if (_ladderOpponentId is not int opp) return;
+
+        _ladderCreating = true;
+        _ladderError = null;
+        try
+        {
+            var fxId = await MatchScoring.CreateLadderFixtureAsync(
+                new CreateLadderFixtureRequest(_competition.CompetitionId, opp));
+            Nav.NavigateTo($"/tennisscore?fixtureId={fxId}");
+        }
+        catch (Exception ex)
+        {
+            _ladderError = ex.Message;
+            Snackbar.Add("Could not start the match.", Severity.Error);
+        }
+        finally
+        {
+            _ladderCreating = false;
+        }
+    }
+
     protected override async Task OnParametersSetAsync()
     {
         _loading = true;
@@ -704,6 +777,43 @@ else
             {
                 _fixturesByDivision = [new DivisionFixtureGroup(null, BuildStageGroups(_fixtures))];
                 _teamsByDivision = [(null, _teams)];
+            }
+
+            // SinglesLadder: standings come from the live per-participant Elo
+            // rating; played/won/lost rolled up from completed ad-hoc fixtures.
+            if (_competition.CompetitionFormat == CompetitionFormat.SinglesLadder)
+            {
+                var played = _participants.ToDictionary(p => p.PlayerId, _ => 0);
+                var won = _participants.ToDictionary(p => p.PlayerId, _ => 0);
+                var lost = _participants.ToDictionary(p => p.PlayerId, _ => 0);
+
+                foreach (var f in _fixtures.Where(f =>
+                    f.Status == FixtureStatus.Completed && f.WinnerPlayerId.HasValue))
+                {
+                    if (f.Player1Id is int p1 && played.ContainsKey(p1))
+                    {
+                        played[p1]++;
+                        if (f.WinnerPlayerId == p1) won[p1]++; else lost[p1]++;
+                    }
+                    if (f.Player2Id is int p2 && played.ContainsKey(p2))
+                    {
+                        played[p2]++;
+                        if (f.WinnerPlayerId == p2) won[p2]++; else lost[p2]++;
+                    }
+                }
+
+                _leagueTable = _participants
+                    .Select(p => new LeagueRow(
+                        p.PlayerId,
+                        p.DisplayName,
+                        played[p.PlayerId],
+                        won[p.PlayerId],
+                        lost[p.PlayerId],
+                        (int)Math.Round(p.LadderEloRating)))
+                    .OrderByDescending(r => r.Points)
+                    .ThenByDescending(r => r.Won)
+                    .ThenBy(r => r.PlayerName)
+                    .ToList();
             }
 
             var rrStageIds = _competition.Stages

--- a/DropShot.UI/Services/IMatchScoringService.cs
+++ b/DropShot.UI/Services/IMatchScoringService.cs
@@ -102,4 +102,15 @@ public interface IMatchScoringService
     /// <c>DeviceToken</c> matches the row's.
     /// </summary>
     Task DiscardLiveMatchAsync(int savedMatchId, string? deviceToken, CancellationToken ct = default);
+
+    /// <summary>
+    /// Ad-hoc fixture creation for a Singles Ladder competition. Resolves the
+    /// caller's Player from JWT, validates both caller and opponent are
+    /// FullPlayer participants in the competition, creates a Scheduled
+    /// fixture (Player1 = caller, Player2 = opponent), and returns its id so
+    /// the caller can navigate to <c>/tennisscore?fixtureId=…</c>. Throws
+    /// <see cref="UnauthorizedAccessException"/> when caller has no linked
+    /// Player or when either side isn't a FullPlayer participant.
+    /// </summary>
+    Task<int> CreateLadderFixtureAsync(CreateLadderFixtureRequest request, CancellationToken ct = default);
 }

--- a/DropShot/Controllers/CompetitionsController.cs
+++ b/DropShot/Controllers/CompetitionsController.cs
@@ -1148,6 +1148,55 @@ public class CompetitionsController(
             .FirstOrDefaultAsync(c => c.CompetitionID == id);
         if (comp is null) return NotFound();
 
+        // SinglesLadder: standings are the live Elo rating order. Played/Won/Lost
+        // counted directly from completed ad-hoc fixtures; "Points" carries the
+        // Elo rating (rounded) so the standard table renderer can show it.
+        if (comp.CompetitionFormat == CompetitionFormat.SinglesLadder)
+        {
+            var ladderParticipants = await db.CompetitionParticipants
+                .Where(cp => cp.CompetitionId == id)
+                .Include(cp => cp.Player)
+                .ToListAsync();
+
+            var ladderFixtures = await db.CompetitionFixtures
+                .Where(f => f.CompetitionId == id
+                            && f.Status == FixtureStatus.Completed
+                            && f.WinnerPlayerId != null)
+                .Select(f => new { f.Player1Id, f.Player2Id, f.WinnerPlayerId })
+                .ToListAsync();
+
+            var ladderPlayed = ladderParticipants.ToDictionary(cp => cp.PlayerId, _ => 0);
+            var ladderWon = ladderParticipants.ToDictionary(cp => cp.PlayerId, _ => 0);
+            var ladderLost = ladderParticipants.ToDictionary(cp => cp.PlayerId, _ => 0);
+            foreach (var f in ladderFixtures)
+            {
+                if (f.Player1Id is int p1 && ladderPlayed.ContainsKey(p1))
+                {
+                    ladderPlayed[p1]++;
+                    if (f.WinnerPlayerId == p1) ladderWon[p1]++; else ladderLost[p1]++;
+                }
+                if (f.Player2Id is int p2 && ladderPlayed.ContainsKey(p2))
+                {
+                    ladderPlayed[p2]++;
+                    if (f.WinnerPlayerId == p2) ladderWon[p2]++; else ladderLost[p2]++;
+                }
+            }
+
+            var ladderEntries = ladderParticipants
+                .Select(cp => new LeagueTableEntryDto(
+                    cp.PlayerId,
+                    cp.Player?.DisplayName ?? "",
+                    ladderPlayed[cp.PlayerId],
+                    ladderWon[cp.PlayerId],
+                    ladderLost[cp.PlayerId],
+                    (int)Math.Round(cp.EloRating)))
+                .OrderByDescending(e => e.Points)
+                .ThenByDescending(e => e.Won)
+                .ThenBy(e => e.PlayerName)
+                .ToList();
+            return Ok(ladderEntries);
+        }
+
         // Find round-robin stage IDs for this competition
         var rrStageIds = await db.CompetitionStages
             .Where(s => s.CompetitionId == id && s.StageType == StageType.RoundRobin)

--- a/DropShot/Controllers/MatchScoringController.cs
+++ b/DropShot/Controllers/MatchScoringController.cs
@@ -101,6 +101,20 @@ public class MatchScoringController(IMatchScoringService scoring) : ControllerBa
         return NoContent();
     }
 
+    [Authorize(AuthenticationSchemes = "Bearer")]
+    [HttpPost("ladder-fixture")]
+    public async Task<ActionResult<CreateLadderFixtureResponse>> CreateLadderFixture(
+        [FromBody] CreateLadderFixtureRequest req, CancellationToken ct)
+    {
+        try
+        {
+            var id = await scoring.CreateLadderFixtureAsync(req, ct);
+            return new CreateLadderFixtureResponse(id);
+        }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (InvalidOperationException ex) { return BadRequest(ex.Message); }
+    }
+
     [AllowAnonymous]
     [HttpDelete("live-match/{savedMatchId:int}")]
     public async Task<IActionResult> DiscardLiveMatch(

--- a/DropShot/Data/Migrations/20260517214409_AddSinglesLadderSupport.Designer.cs
+++ b/DropShot/Data/Migrations/20260517214409_AddSinglesLadderSupport.Designer.cs
@@ -4,16 +4,19 @@ using DropShot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace DropShot.Migrations
+namespace DropShot.Data.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260517214409_AddSinglesLadderSupport")]
+    partial class AddSinglesLadderSupport
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DropShot/Data/Migrations/20260517214409_AddSinglesLadderSupport.cs
+++ b/DropShot/Data/Migrations/20260517214409_AddSinglesLadderSupport.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropShot.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSinglesLadderSupport : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<double>(
+                name: "EloRating",
+                table: "CompetitionParticipants",
+                type: "float",
+                nullable: false,
+                defaultValue: 0.0);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsProvisional",
+                table: "CompetitionParticipants",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LastMatchAt",
+                table: "CompetitionParticipants",
+                type: "datetime2",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "MatchesPlayed",
+                table: "CompetitionParticipants",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<double>(
+                name: "Player1RatingAfter",
+                table: "CompetitionFixtures",
+                type: "float",
+                nullable: true);
+
+            migrationBuilder.AddColumn<double>(
+                name: "Player1RatingBefore",
+                table: "CompetitionFixtures",
+                type: "float",
+                nullable: true);
+
+            migrationBuilder.AddColumn<double>(
+                name: "Player2RatingAfter",
+                table: "CompetitionFixtures",
+                type: "float",
+                nullable: true);
+
+            migrationBuilder.AddColumn<double>(
+                name: "Player2RatingBefore",
+                table: "CompetitionFixtures",
+                type: "float",
+                nullable: true);
+
+            migrationBuilder.AddColumn<double>(
+                name: "LadderKFactor",
+                table: "Competition",
+                type: "float",
+                nullable: false,
+                defaultValue: 0.0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "LadderProvisionalMatches",
+                table: "Competition",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<double>(
+                name: "LadderStartingRating",
+                table: "Competition",
+                type: "float",
+                nullable: false,
+                defaultValue: 0.0);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "LadderUseMarginOfVictory",
+                table: "Competition",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "EloRating",
+                table: "CompetitionParticipants");
+
+            migrationBuilder.DropColumn(
+                name: "IsProvisional",
+                table: "CompetitionParticipants");
+
+            migrationBuilder.DropColumn(
+                name: "LastMatchAt",
+                table: "CompetitionParticipants");
+
+            migrationBuilder.DropColumn(
+                name: "MatchesPlayed",
+                table: "CompetitionParticipants");
+
+            migrationBuilder.DropColumn(
+                name: "Player1RatingAfter",
+                table: "CompetitionFixtures");
+
+            migrationBuilder.DropColumn(
+                name: "Player1RatingBefore",
+                table: "CompetitionFixtures");
+
+            migrationBuilder.DropColumn(
+                name: "Player2RatingAfter",
+                table: "CompetitionFixtures");
+
+            migrationBuilder.DropColumn(
+                name: "Player2RatingBefore",
+                table: "CompetitionFixtures");
+
+            migrationBuilder.DropColumn(
+                name: "LadderKFactor",
+                table: "Competition");
+
+            migrationBuilder.DropColumn(
+                name: "LadderProvisionalMatches",
+                table: "Competition");
+
+            migrationBuilder.DropColumn(
+                name: "LadderStartingRating",
+                table: "Competition");
+
+            migrationBuilder.DropColumn(
+                name: "LadderUseMarginOfVictory",
+                table: "Competition");
+        }
+    }
+}

--- a/DropShot/Models/Competition.cs
+++ b/DropShot/Models/Competition.cs
@@ -87,6 +87,16 @@ namespace DropShot.Models
         /// </summary>
         public int? SeededFromCompetitionId { get; set; }
 
+        // ── Singles Elo Ladder config ───────────────────────────────────────
+        // Only meaningful when CompetitionFormat == SinglesLadder. Defaults
+        // are inert for other formats. K is doubled while a participant's
+        // MatchesPlayed < LadderProvisionalMatches (mirrors PlayerRatingService
+        // 40/20 convention).
+        public double LadderKFactor { get; set; } = 20.0;
+        public double LadderStartingRating { get; set; } = 1000.0;
+        public int LadderProvisionalMatches { get; set; } = 10;
+        public bool LadderUseMarginOfVictory { get; set; } = true;
+
         public RulesSet? Rules { get; set; }
         public Club? HostClub { get; set; }
         public Event? Event { get; set; }

--- a/DropShot/Models/CompetitionFixture.cs
+++ b/DropShot/Models/CompetitionFixture.cs
@@ -47,6 +47,15 @@ public class CompetitionFixture
     public int? HomeGamesTotal { get; set; }
     public int? AwayGamesTotal { get; set; }
 
+    // Per-fixture Elo deltas for SinglesLadder competitions. Captured by
+    // LadderRatingService on finalisation so the recent-matches feed can
+    // render "+12 / −12" without recomputing. Null for non-ladder fixtures
+    // and for ladder fixtures that completed before this column existed.
+    public double? Player1RatingBefore { get; set; }
+    public double? Player1RatingAfter { get; set; }
+    public double? Player2RatingBefore { get; set; }
+    public double? Player2RatingAfter { get; set; }
+
     public Competition Competition { get; set; } = null!;
     public CompetitionStage? Stage { get; set; }
     public Court? Court { get; set; }

--- a/DropShot/Models/CompetitionParticipant.cs
+++ b/DropShot/Models/CompetitionParticipant.cs
@@ -12,6 +12,15 @@ public class CompetitionParticipant
     public int? CompetitionDivisionId { get; set; }
     public string? Role { get; set; }
 
+    // ── Singles Elo Ladder per-player state ─────────────────────────────────
+    // Live rating maintained by LadderRatingService on fixture finalisation.
+    // Only meaningful when Competition.CompetitionFormat == SinglesLadder;
+    // defaults are inert for other formats.
+    public double EloRating { get; set; } = 1000.0;
+    public int MatchesPlayed { get; set; } = 0;
+    public bool IsProvisional { get; set; } = true;
+    public DateTime? LastMatchAt { get; set; }
+
     public Competition Competition { get; set; } = null!;
     public Player Player { get; set; } = null!;
     public CompetitionTeam? Team { get; set; }

--- a/DropShot/Services/LadderRatingService.cs
+++ b/DropShot/Services/LadderRatingService.cs
@@ -1,0 +1,94 @@
+using DropShot.Data;
+using DropShot.Models;
+using DropShot.Shared;
+using Microsoft.EntityFrameworkCore;
+
+namespace DropShot.Services;
+
+/// <summary>
+/// Applies Elo rating updates for singles-ladder competitions when a fixture
+/// is finalised. Called from <c>WebMatchScoringService.FinaliseLiveFixtureAsync</c>
+/// right after the fixture is saved as Completed.
+///
+/// No-ops for any competition whose format is not <see cref="CompetitionFormat.SinglesLadder"/>,
+/// so the call site can invoke it on every finalised fixture without branching.
+///
+/// Idempotent: if the fixture already has rating-after values set, the call
+/// is skipped — protects against duplicate finalise requests.
+/// </summary>
+public static class LadderRatingService
+{
+    public static async Task ApplyForFinalisedFixtureAsync(
+        MyDbContext db, int fixtureId, CancellationToken ct = default)
+    {
+        var fx = await db.CompetitionFixtures
+            .Include(f => f.Competition)
+            .FirstOrDefaultAsync(f => f.CompetitionFixtureId == fixtureId, ct);
+
+        if (fx is null) return;
+        if (fx.Competition.CompetitionFormat != CompetitionFormat.SinglesLadder) return;
+        if (fx.Player1RatingAfter.HasValue) return; // idempotency guard
+        if (fx.Player1Id is null || fx.Player2Id is null) return;
+        if (fx.WinnerPlayerId is null) return;
+
+        int competitionId = fx.CompetitionId;
+        int p1Id = fx.Player1Id.Value;
+        int p2Id = fx.Player2Id.Value;
+
+        var participants = await db.CompetitionParticipants
+            .Where(p => p.CompetitionId == competitionId
+                        && (p.PlayerId == p1Id || p.PlayerId == p2Id))
+            .ToListAsync(ct);
+
+        var pa = participants.FirstOrDefault(p => p.PlayerId == p1Id);
+        var pb = participants.FirstOrDefault(p => p.PlayerId == p2Id);
+        if (pa is null || pb is null) return;
+
+        var comp = fx.Competition;
+        double ratingA = pa.EloRating;
+        double ratingB = pb.EloRating;
+        double scoreA = fx.WinnerPlayerId == p1Id ? 1.0 : 0.0;
+        double scoreB = 1.0 - scoreA;
+
+        double kA = pa.MatchesPlayed < comp.LadderProvisionalMatches
+            ? comp.LadderKFactor * 2.0
+            : comp.LadderKFactor;
+        double kB = pb.MatchesPlayed < comp.LadderProvisionalMatches
+            ? comp.LadderKFactor * 2.0
+            : comp.LadderKFactor;
+
+        double expectedA = EloCalculator.ExpectedScore(ratingA, ratingB);
+        double expectedB = 1.0 - expectedA;
+
+        double? mov = null;
+        if (comp.LadderUseMarginOfVictory
+            && fx.HomeGamesTotal.HasValue
+            && fx.AwayGamesTotal.HasValue
+            && fx.HomeGamesTotal.Value != fx.AwayGamesTotal.Value)
+        {
+            mov = EloCalculator.MarginOfVictoryMultiplier(
+                fx.HomeGamesTotal.Value, fx.AwayGamesTotal.Value, ratingA, ratingB);
+        }
+
+        double newA = EloCalculator.UpdateRating(ratingA, expectedA, scoreA, kA, mov);
+        double newB = EloCalculator.UpdateRating(ratingB, expectedB, scoreB, kB, mov);
+
+        fx.Player1RatingBefore = ratingA;
+        fx.Player1RatingAfter = newA;
+        fx.Player2RatingBefore = ratingB;
+        fx.Player2RatingAfter = newB;
+
+        var now = DateTime.UtcNow;
+        pa.EloRating = newA;
+        pa.MatchesPlayed += 1;
+        pa.LastMatchAt = now;
+        pa.IsProvisional = pa.MatchesPlayed < comp.LadderProvisionalMatches;
+
+        pb.EloRating = newB;
+        pb.MatchesPlayed += 1;
+        pb.LastMatchAt = now;
+        pb.IsProvisional = pb.MatchesPlayed < comp.LadderProvisionalMatches;
+
+        await db.SaveChangesAsync(ct);
+    }
+}

--- a/DropShot/Services/WebCompetitionAdminService.cs
+++ b/DropShot/Services/WebCompetitionAdminService.cs
@@ -416,6 +416,10 @@ public sealed class WebCompetitionAdminService(
         comp.SeededFromCompetitionId = req.SeededFromCompetitionId;
         comp.IsRestricted = req.IsRestricted;
         comp.Description = string.IsNullOrWhiteSpace(req.Description) ? null : req.Description;
+        comp.LadderKFactor = req.LadderKFactor;
+        comp.LadderStartingRating = req.LadderStartingRating;
+        comp.LadderProvisionalMatches = req.LadderProvisionalMatches;
+        comp.LadderUseMarginOfVictory = req.LadderUseMarginOfVictory;
     }
 
     public async Task<CloneCompetitionResultDto> CloneCompetitionAsync(

--- a/DropShot/Services/WebCompetitionService.cs
+++ b/DropShot/Services/WebCompetitionService.cs
@@ -160,7 +160,11 @@ public sealed class WebCompetitionService(
                 ratingSuggestions.TryGetValue(p.PlayerId, out var rs)
                     ? new PlayerRatingSuggestionDto(rs.PreviousRating, rs.SuggestedRating, rs.Delta, rs.RubbersPlayed)
                     : null,
-                BuildPlacementSuggestion(p.PlayerId, divisionPlacements, rolePlacements))).ToList(),
+                BuildPlacementSuggestion(p.PlayerId, divisionPlacements, rolePlacements),
+                p.EloRating,
+                p.MatchesPlayed,
+                p.IsProvisional,
+                p.LastMatchAt)).ToList(),
             c.IsArchived,
             c.IsStarted,
             c.CreatorUserId,
@@ -187,7 +191,11 @@ public sealed class WebCompetitionService(
                 cp.Name)).ToList(),
             c.LeagueScoring,
             myPlayerId,
-            c.Description);
+            c.Description,
+            c.LadderKFactor,
+            c.LadderStartingRating,
+            c.LadderProvisionalMatches,
+            c.LadderUseMarginOfVictory);
     }
 
     private static PlacementSuggestionDto? BuildPlacementSuggestion(
@@ -232,7 +240,12 @@ public sealed class WebCompetitionService(
                 r.HomeSetsWon, r.AwaySetsWon, r.HomeGamesTotal, r.AwayGamesTotal,
                 r.SetScores.Select(s => new RubberSetScoreDto(s.Home, s.Away)).ToList()))
             .ToList(),
-        f.CompletedAt, f.OriginalResultSummary, f.ResultModifiedByAdmin);
+        f.CompletedAt, f.OriginalResultSummary, f.ResultModifiedByAdmin,
+        CompetitionName: null,
+        Player1RatingBefore: f.Player1RatingBefore,
+        Player1RatingAfter: f.Player1RatingAfter,
+        Player2RatingBefore: f.Player2RatingBefore,
+        Player2RatingAfter: f.Player2RatingAfter);
 
     public async Task SelfRegisterAsync(int competitionId, DropShot.Shared.ParticipantStatus status, CancellationToken ct = default)
     {

--- a/DropShot/Services/WebMatchScoringService.cs
+++ b/DropShot/Services/WebMatchScoringService.cs
@@ -294,6 +294,7 @@ public sealed class WebMatchScoringService(
         fx.AwayGamesTotal = request.AwayGamesTotal;
 
         await db.SaveChangesAsync(ct);
+        await LadderRatingService.ApplyForFinalisedFixtureAsync(db, fx.CompetitionFixtureId, ct);
         await CompetitionProgressionService.TryAdvanceAsync(db, fx.CompetitionId, fx.CompetitionFixtureId);
     }
 
@@ -346,6 +347,55 @@ public sealed class WebMatchScoringService(
 
         db.SavedMatch.Remove(match);
         await db.SaveChangesAsync(ct);
+    }
+
+    public async Task<int> CreateLadderFixtureAsync(
+        CreateLadderFixtureRequest request, CancellationToken ct = default)
+    {
+        var userId = currentUser.UserId;
+        if (string.IsNullOrEmpty(userId))
+            throw new UnauthorizedAccessException("Sign-in required to record a ladder match.");
+
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+
+        var callerPlayerId = await db.Players
+            .Where(p => p.UserId == userId)
+            .Select(p => (int?)p.PlayerId)
+            .FirstOrDefaultAsync(ct);
+        if (callerPlayerId is null)
+            throw new UnauthorizedAccessException("No Player profile linked to the current user.");
+        if (callerPlayerId.Value == request.OpponentPlayerId)
+            throw new InvalidOperationException("Cannot record a match against yourself.");
+
+        var comp = await db.Competition
+            .FirstOrDefaultAsync(c => c.CompetitionID == request.CompetitionId, ct);
+        if (comp is null)
+            throw new InvalidOperationException("Competition not found.");
+        if (comp.CompetitionFormat != CompetitionFormat.SinglesLadder)
+            throw new InvalidOperationException("Ad-hoc fixture creation is only valid for SinglesLadder competitions.");
+
+        var enrolled = await db.CompetitionParticipants
+            .Where(p => p.CompetitionId == request.CompetitionId
+                        && p.Status == ParticipantStatus.FullPlayer
+                        && (p.PlayerId == callerPlayerId.Value || p.PlayerId == request.OpponentPlayerId))
+            .Select(p => p.PlayerId)
+            .ToListAsync(ct);
+        if (!enrolled.Contains(callerPlayerId.Value))
+            throw new UnauthorizedAccessException("You are not an active participant in this ladder.");
+        if (!enrolled.Contains(request.OpponentPlayerId))
+            throw new InvalidOperationException("Opponent is not an active participant in this ladder.");
+
+        var fx = new CompetitionFixture
+        {
+            CompetitionId = request.CompetitionId,
+            Player1Id = callerPlayerId.Value,
+            Player2Id = request.OpponentPlayerId,
+            ScheduledAt = DateTime.UtcNow,
+            Status = FixtureStatus.Scheduled,
+        };
+        db.CompetitionFixtures.Add(fx);
+        await db.SaveChangesAsync(ct);
+        return fx.CompetitionFixtureId;
     }
 
     private static TennisScoreFixtureContextDto ToFixtureContextDto(CompetitionFixture fx)


### PR DESCRIPTION
## Summary
- Adds a new `SinglesLadder` value to `CompetitionFormat`, surfaced as a 4th option in the existing competition wizard alongside Singles/Doubles/Team. Eligibility (gender, age range) flows through the existing wizard fields so a club can run multiple parallel ladders (mixed, men's only, women's only) without new infrastructure.
- Live per-participant Elo lives on `CompetitionParticipant` (`EloRating`, `MatchesPlayed`, `IsProvisional`, `LastMatchAt`); per-fixture before/after deltas live on `CompetitionFixture`. New `LadderRatingService.ApplyForFinalisedFixtureAsync` reuses the existing `EloCalculator` math and is called from `FinaliseLiveFixtureAsync` — no-ops for non-ladder formats so the call site stays uniform.
- Ad-hoc match creation via new `POST /api/match-scoring/ladder-fixture` — opponent picker on `ViewCompetition` creates a fixture and routes to the existing `TennisScore.razor` flow with `?fixtureId=…`. Ladder standings panel orders by rating with a "prov" chip while a player is provisional. The competitions listing chip works automatically via `ToDisplayName()`.

## Test plan
- [x] `dotnet build` — DropShot, DropShot.UI, DropShot.Shared, DropShot.Tests all clean
- [x] `dotnet test --filter LadderRatingServiceTests` — 5/5 pass (equal-rated win delta, no-op for non-ladder, provisional flip on 11th match, idempotency guard, before/after capture)
- [x] `dotnet test --filter PlayerRatingServiceTests` — 24/24 pass, no regression in existing Elo code
- [x] `dotnet test --filter ViewCompetitionTests` — 2/2 pass with new `IMatchScoringService` injection
- [ ] End-to-end: run wizard to create a mixed-singles ladder, register two players, click "Record a match", play through TennisScore, confirm both `EloRating` rows move + fixture stores before/after + standings reorder

## Deferred
- Inactivity rating decay
- Rating-tiered divisions (`HasDivisions` stays false for v1)
- Cross-ladder rating carryover via existing `PlayerRatingSnapshot` lineage

🤖 Generated with [Claude Code](https://claude.com/claude-code)