### PR TITLE
Singles Ladder: fix edit-page format display, hide irrelevant sections

### DIFF
--- a/DropShot.UI/Components/Pages/CompetitionPage.razor
+++ b/DropShot.UI/Components/Pages/CompetitionPage.razor
@@ -211,7 +211,7 @@ else
                                ValueChanged="@(v => { Model.Format = v; AutoGenerateName(); })">
                         @foreach (var f in AllowedFormats(Model.Category))
                         {
-                            <MudSelectItem T="CompetitionFormatUi?" Value="@((CompetitionFormatUi?)f)">@f.ToString()</MudSelectItem>
+                            <MudSelectItem T="CompetitionFormatUi?" Value="@((CompetitionFormatUi?)f)">@FormatLabel(f)</MudSelectItem>
                         }
                     </MudSelect>
 
@@ -396,15 +396,18 @@ else
 
                     <MudCheckBox @bind-Value="Model.RequireVerification" Label="Require admin verification of results" Class="mt-2" />
 
-                    <MudCheckBox @bind-Value="Model.HasDivisions"
-                                 Label="Split this competition into ranked divisions"
-                                 Class="mt-1" />
-                    @if (Model.HasDivisions)
+                    @if (EffectivePersistedFormat() != CompetitionFormat.SinglesLadder)
                     {
-                        <MudText Typo="Typo.caption" Class="mb-2" Style="opacity:0.75">
-                            Teams will only play others in their own division and league tables render per-division.
-                            Manage each division (plus its teams, match windows and fixtures) in the <b>Divisions</b> section further down this page.
-                        </MudText>
+                        <MudCheckBox @bind-Value="Model.HasDivisions"
+                                     Label="Split this competition into ranked divisions"
+                                     Class="mt-1" />
+                        @if (Model.HasDivisions)
+                        {
+                            <MudText Typo="Typo.caption" Class="mb-2" Style="opacity:0.75">
+                                Teams will only play others in their own division and league tables render per-division.
+                                Manage each division (plus its teams, match windows and fixtures) in the <b>Divisions</b> section further down this page.
+                            </MudText>
+                        }
                     }
                 </MudStack>
 
@@ -460,8 +463,8 @@ else
                 OnRemoveAdmin="RemoveCompetitionAdmin" />
         }
 
-        @* ── Stages ─────────────────────────────────────────── *@
-        @if (IsEdit)
+        @* ── Stages (skip for SinglesLadder — ad-hoc, no fixed stages) ── *@
+        @if (IsEdit && EffectivePersistedFormat() != CompetitionFormat.SinglesLadder)
         {
             <StagesSection
                 Stages="_stages"
@@ -1164,7 +1167,7 @@ else
 }
 
 <div id="nav-anchor-fixtures" class="section-anchor"></div>
-@if (IsEdit)
+@if (IsEdit && EffectivePersistedFormat() != CompetitionFormat.SinglesLadder)
 {
             @if (!Model.HasDivisions)
             {
@@ -2205,22 +2208,30 @@ else
     }
 
     // UI-only enums that separate category (Male/Female/Mixed) from the format shown in the
-    // dropdown (Singles/Doubles/Team). The persisted CompetitionFormat + EligibleSex pair is
-    // derived from these two on save; see EffectivePersistedFormat / EffectiveEligibleSex.
+    // dropdown (Singles/Doubles/Team/SinglesLadder). The persisted CompetitionFormat +
+    // EligibleSex pair is derived from these two on save; see EffectivePersistedFormat /
+    // EffectiveEligibleSex.
     public enum CompetitionCategoryUi { Male, Female, Mixed }
-    public enum CompetitionFormatUi { Singles, Doubles, Team }
+    public enum CompetitionFormatUi { Singles, Doubles, Team, SinglesLadder }
 
     private static IEnumerable<CompetitionFormatUi> AllowedFormats(CompetitionCategoryUi? category) =>
-        new[] { CompetitionFormatUi.Singles, CompetitionFormatUi.Doubles, CompetitionFormatUi.Team };
+        new[] { CompetitionFormatUi.Singles, CompetitionFormatUi.Doubles, CompetitionFormatUi.Team, CompetitionFormatUi.SinglesLadder };
+
+    private static string FormatLabel(CompetitionFormatUi format) => format switch
+    {
+        CompetitionFormatUi.SinglesLadder => "Singles Ladder",
+        _ => format.ToString()
+    };
 
     private CompetitionFormat? EffectivePersistedFormat() =>
         (Model.Category, Model.Format) switch
         {
             (CompetitionCategoryUi.Mixed, CompetitionFormatUi.Doubles) => CompetitionFormat.MixedDoubles,
             (CompetitionCategoryUi.Mixed, CompetitionFormatUi.Team)    => CompetitionFormat.TeamMatch,
-            (_, CompetitionFormatUi.Singles) => CompetitionFormat.Singles,
-            (_, CompetitionFormatUi.Doubles) => CompetitionFormat.Doubles,
-            (_, CompetitionFormatUi.Team)    => CompetitionFormat.Team,
+            (_, CompetitionFormatUi.Singles)       => CompetitionFormat.Singles,
+            (_, CompetitionFormatUi.Doubles)       => CompetitionFormat.Doubles,
+            (_, CompetitionFormatUi.Team)          => CompetitionFormat.Team,
+            (_, CompetitionFormatUi.SinglesLadder) => CompetitionFormat.SinglesLadder,
             _ => (CompetitionFormat?)null
         };
 
@@ -2689,8 +2700,9 @@ else
             },
             persisted switch
             {
-                CompetitionFormat.Doubles => CompetitionFormatUi.Doubles,
-                CompetitionFormat.Team    => CompetitionFormatUi.Team,
+                CompetitionFormat.Doubles       => CompetitionFormatUi.Doubles,
+                CompetitionFormat.Team          => CompetitionFormatUi.Team,
+                CompetitionFormat.SinglesLadder => CompetitionFormatUi.SinglesLadder,
                 _ => CompetitionFormatUi.Singles
             })
     };

--- a/DropShot.UI/Components/Pages/CompetitionWizardPage.razor
+++ b/DropShot.UI/Components/Pages/CompetitionWizardPage.razor
@@ -88,7 +88,7 @@ else
                     <MudSelect T="CompetitionFormatUi?" Label="Format" Variant="Variant.Outlined"
                                Required="true" RequiredError="Please pick a format."
                                Value="Model.Format"
-                               ValueChanged="@(v => Model.Format = v)"
+                               ValueChanged="OnFormatChanged"
                                Class="mt-3">
                         @foreach (var f in CompetitionFormHelpers.AllowedFormats(Model.Category))
                         {
@@ -262,8 +262,12 @@ else
                 </MudPaper>
             }
 
-            @* ── Step 5: Divisions ─────────────────────────── *@
-            @if (_currentStep > 5)
+            @* ── Step 5: Divisions (N/A for SinglesLadder) ─────────────────────────── *@
+            @{
+                var _persistedFmt = CompetitionFormHelpers.EffectivePersistedFormat(Model.Category, Model.Format);
+                var _isLadder = _persistedFmt == CompetitionFormat.SinglesLadder;
+            }
+            @if (_currentStep > 5 && !_isLadder)
             {
                 <StepSummary Label="Divisions"
                              Icon="@Icons.Material.Filled.AccountTree"
@@ -271,7 +275,7 @@ else
                              Summary="@(Model.HasDivisions ? "Split into ranked divisions" : "Single field, no divisions")"
                              OnEdit="@(() => GoToStep(5))" />
             }
-            else if (_currentStep == 5)
+            else if (_currentStep == 5 && !_isLadder)
             {
                 <MudPaper Class="pa-4 wizard-step" Elevation="0">
                     <MudText Typo="Typo.h6" Class="mb-2">Split into divisions?</MudText>
@@ -755,13 +759,47 @@ else
 
     private void GoBack()
     {
-        if (_currentStep > 0) _currentStep--;
+        if (_currentStep <= 0) { _serverError = null; return; }
+        _currentStep--;
+        while (_currentStep > 0 && !StepApplies(_currentStep))
+            _currentStep--;
         _serverError = null;
     }
 
     private void TryAdvance()
     {
-        if (_currentStep < TotalSteps - 1) _currentStep++;
+        if (_currentStep >= TotalSteps - 1) return;
+        _currentStep++;
+        while (_currentStep < TotalSteps - 1 && !StepApplies(_currentStep))
+            _currentStep++;
+    }
+
+    // Returns false for steps that should be skipped given the current Model.
+    // - HasDivisions question (step 5) and the post-save divisions list (StepDivs)
+    //   are skipped for SinglesLadder, which never uses divisions.
+    // - StepStages is skipped for SinglesLadder (ad-hoc matches, no fixed stages).
+    // - StepRubber is skipped for any non-TeamMatch format (rubber templates don't apply).
+    // - The post-save divisions list (StepDivs) is also skipped when HasDivisions is false.
+    private bool StepApplies(int step)
+    {
+        var persisted = CompetitionFormHelpers.EffectivePersistedFormat(Model.Category, Model.Format);
+        var isLadder = persisted == CompetitionFormat.SinglesLadder;
+
+        if (step == 5 && isLadder) return false;
+        if (step == StepStages && isLadder) return false;
+        if (step == StepRubber && persisted != CompetitionFormat.TeamMatch) return false;
+        if (step == StepDivs && (isLadder || !Model.HasDivisions)) return false;
+        return true;
+    }
+
+    private void OnFormatChanged(CompetitionFormatUi? format)
+    {
+        Model.Format = format;
+        // Divisions don't apply to a SinglesLadder. Clear the toggle so the
+        // wizard's Divisions question (and subsequent divisions-list step) is
+        // skipped via StepApplies.
+        if (CompetitionFormHelpers.EffectivePersistedFormat(Model.Category, format) == CompetitionFormat.SinglesLadder)
+            Model.HasDivisions = false;
     }
 
     private void TryAdvanceFromCategory()


### PR DESCRIPTION
Follow-up to [#665](https://github.com/kingbeazer/DropShot/pull/665).

## Summary
- **Bug fix**: `CompetitionPage.razor` had its own local `CompetitionFormatUi` enum that didn't know about `SinglesLadder`, so editing a ladder showed "Singles" in the format dropdown. The local enum + `EffectivePersistedFormat` / `SplitPersistedFormat` round-trippers now know about the new value. Dropdown labels go through a `FormatLabel` helper so the chip reads "Singles Ladder" instead of the raw enum name.
- **Hide irrelevant sections on the edit page** when format is `SinglesLadder`: Stages, Match Windows, Rubber Template, Templates, Fixtures — none of these apply to an ad-hoc Elo ladder. Also hides the "Split into divisions" checkbox.
- **Wizard skips inapplicable steps** instead of showing dead "this step doesn't apply" placeholder content. New `StepApplies` helper consulted from `TryAdvance` and `GoBack`:
  - Divisions question (step 5) and divisions list (step 12) — skipped for `SinglesLadder`
  - Stages (step 10) — skipped for `SinglesLadder`
  - Rubber template (step 11) — skipped for any non-`TeamMatch` format (this also kills the "rubber templates only apply to Team competitions" message that used to appear for plain Singles/Doubles)
  - Divisions list (step 12) — also skipped when `HasDivisions` is false
- Forcing `HasDivisions = false` on format → `SinglesLadder` so the divisions toggle can't survive a format change.

## Test plan
- [x] `dotnet build` clean across DropShot, DropShot.UI, DropShot.Shared, DropShot.Tests
- [ ] Edit existing ladder → "Singles Ladder" shown in format chip
- [ ] Wizard with Singles Ladder selected → skips Divisions question, Stages, Rubber, and Divisions list steps; lands on Finish after Misc/Save
- [ ] Wizard with Singles selected → still skips Rubber step (used to show a "doesn't apply" placeholder)
- [ ] Wizard with TeamMatch + HasDivisions=true → all steps still reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)