### PR TITLE
Hide upgrade promo and disable /upgrade route

### DIFF
--- a/DropShot.Maui/Components/Layout/NavMenu.razor
+++ b/DropShot.Maui/Components/Layout/NavMenu.razor
@@ -77,6 +77,7 @@
         </MudNavLink>
     </AuthorizeView>
 
+    @* TODO: re-enable upgrade nav item when Premium ships.
     <AuthorizeView>
         <Authorized Context="upgradeCtx">
             <MudDivider Class="my-2" />
@@ -85,6 +86,7 @@
             </MudNavLink>
         </Authorized>
     </AuthorizeView>
+    *@
 
     <MudDivider Class="my-2" />
     <MudNavLink Icon="@(Theme.IsDarkMode ? Icons.Material.Filled.LightMode : Icons.Material.Filled.DarkMode)"

--- a/DropShot.Maui/Components/Pages/Upgrade.razor
+++ b/DropShot.Maui/Components/Pages/Upgrade.razor
@@ -1,4 +1,4 @@
-@page "/upgrade"
+@* TODO: re-enable when Premium ships — @page "/upgrade" *@
 
 <DropShot.UI.Components.Pages.Upgrade>
     <CheckoutControls>

--- a/DropShot.UI/Components/Pages/Features.razor
+++ b/DropShot.UI/Components/Pages/Features.razor
@@ -338,10 +338,12 @@
                    Href="/Account/Register" Class="mr-2">
             Sign Up Free
         </MudButton>
+        @* TODO: re-enable View Plans button when Premium ships.
         <MudButton Variant="Variant.Outlined" Style="color: white; border-color: white;"
                    Size="Size.Large" Href="/upgrade">
             View Plans
         </MudButton>
+        *@
     </MudPaper>
 
 </MudContainer>

--- a/DropShot.UI/Components/Pages/Home.razor
+++ b/DropShot.UI/Components/Pages/Home.razor
@@ -12,6 +12,7 @@
    the web shim passes it via the AnonymousQrPanel render fragment; MAUI
    doesn't have a QR-login flow and omits the slot. *@
 
+@* TODO: re-enable upgrade promo banner when Premium ships.
 @if (_showUpgradeBanner)
 {
     <MudAlert Severity="Severity.Info" Variant="Variant.Filled" Class="mb-4"
@@ -28,6 +29,7 @@
         </MudStack>
     </MudAlert>
 }
+*@
 
 @if (LinkedPlayer)
 {

--- a/DropShot/Components/Layout/NavMenu.razor
+++ b/DropShot/Components/Layout/NavMenu.razor
@@ -135,6 +135,7 @@
                             </span>
                         </button>
                         <div class="nav-dropdown-menu">
+                            @* TODO: re-enable upgrade nav item when Premium ships.
                             <NavLink class="nav-link" href="upgrade">
                                 <MudIcon Icon="@Icons.Material.Filled.Star" Class="nav-icon" />
                                 <span class="nav-label-group">
@@ -142,6 +143,7 @@
                                     <span class="nav-sublabel">Unlock more features</span>
                                 </span>
                             </NavLink>
+                            *@
                             <a class="nav-link" href="Account/Manage" data-enhance-nav="false">
                                 <MudIcon Icon="@Icons.Material.Filled.Person" Class="nav-icon" />
                                 <span class="nav-label-group">

--- a/DropShot/Components/Pages/Upgrade.razor
+++ b/DropShot/Components/Pages/Upgrade.razor
@@ -1,4 +1,4 @@
-@page "/upgrade"
+@* TODO: re-enable when Premium ships — @page "/upgrade" *@
 @rendermode InteractiveServer
 @inject IConfiguration Configuration
 @inject IJSRuntime JS


### PR DESCRIPTION
## Summary
- Comment out the Home page "Go Premium" banner, the web/MAUI nav "Upgrade" entries, and the Features page "View Plans" CTA.
- Comment out `@page "/upgrade"` on both host shims so the route is no longer reachable; the shared `DropShot.UI/Components/Pages/Upgrade.razor` view and `IPaymentService` backend are untouched.
- All disabled blocks are wrapped in `@* TODO: re-enable when Premium ships ... *@` markers — restoration is a six-spot uncomment.

## Test plan
- [ ] `dotnet build` for `DropShot` and `DropShot.UI` (verified clean locally — one expected `CS0414` warning on `_showUpgradeBanner` since the field's reader is now commented out; left in place for easy restore).
- [ ] Web: sign in as non-subscribed user — Home banner gone, nav dropdown no longer shows Upgrade, `/upgrade` 404s, Features page "View Plans" gone.
- [ ] MAUI: sign in — no Upgrade nav entry, `/upgrade` not routable.