### PR TITLE
Singles Ladder: inactivity decay with warning emails

### DIFF
--- a/DropShot.Shared/Dtos/CompetitionDtos.cs
+++ b/DropShot.Shared/Dtos/CompetitionDtos.cs
@@ -56,7 +56,16 @@ public record CompetitionDetailDto(
     double LadderKFactor = 20.0,
     double LadderStartingRating = 1000.0,
     int LadderProvisionalMatches = 10,
-    bool LadderUseMarginOfVictory = true);
+    bool LadderUseMarginOfVictory = true,
+    List<LadderInactivityDecayDto>? LadderDecayEvents = null);
+
+public record LadderInactivityDecayDto(
+    int PlayerId,
+    string PlayerName,
+    DateTime AppliedAt,
+    double RatingBefore,
+    double RatingAfter,
+    int DaysInactive);
 
 public record CompetitionStageDto(
     int CompetitionStageId,

--- a/DropShot.Tests/Helpers/LadderInactivityServiceTests.cs
+++ b/DropShot.Tests/Helpers/LadderInactivityServiceTests.cs
@@ -1,0 +1,262 @@
+using DropShot.Models;
+using DropShot.Services;
+using DropShot.Shared;
+using Xunit;
+using DecayRunResult = DropShot.Services.LadderInactivityService.DecayRunResult;
+
+namespace DropShot.Tests.Helpers;
+
+public class LadderInactivityServiceTests
+{
+    private const int CompId = 700;
+    private const int PlayerAId = 11;
+    private const int PlayerBId = 22;
+    private static readonly DateTime BaseDate = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    private static async Task SeedAsync(
+        TestDbContextFactory factory,
+        DateTime registeredAt,
+        DateTime? lastMatchAt,
+        double rating = 1100,
+        DateTime? lastDecayAt = null,
+        DateTime? lastWarnAt = null,
+        CompetitionFormat format = CompetitionFormat.SinglesLadder,
+        bool isStarted = true,
+        bool isArchived = false,
+        double startingRating = 1000,
+        int playerId = PlayerAId,
+        string email = "p@example.com")
+    {
+        using var db = factory.CreateDbContext();
+        if (!db.Players.Any(p => p.PlayerId == playerId))
+        {
+            db.Players.Add(new Player
+            {
+                PlayerId = playerId,
+                DisplayName = $"P{playerId}",
+                Email = email,
+            });
+        }
+        if (!db.Competition.Any(c => c.CompetitionID == CompId))
+        {
+            db.Competition.Add(new Competition
+            {
+                CompetitionID = CompId,
+                CompetitionName = "Ladder",
+                CompetitionFormat = format,
+                IsStarted = isStarted,
+                IsArchived = isArchived,
+                LadderStartingRating = startingRating,
+            });
+        }
+        db.CompetitionParticipants.Add(new CompetitionParticipant
+        {
+            CompetitionId = CompId,
+            PlayerId = playerId,
+            Status = ParticipantStatus.FullPlayer,
+            RegisteredAt = registeredAt,
+            LastMatchAt = lastMatchAt,
+            LastDecayAppliedAt = lastDecayAt,
+            LastInactivityWarningAt = lastWarnAt,
+            EloRating = rating,
+        });
+        await db.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task InsideGracePeriod_NoDecayNoWarning()
+    {
+        var factory = new TestDbContextFactory();
+        await SeedAsync(factory, registeredAt: BaseDate, lastMatchAt: BaseDate.AddDays(-10));
+
+        DecayRunResult result;
+        using (var db = factory.CreateDbContext())
+            result = await Run(db, BaseDate.AddDays(5)); // 15 days since last match
+
+        Assert.Equal(0, result.DecayEventsApplied);
+        Assert.Equal(0, result.WarningsSent);
+
+        using var verify = factory.CreateDbContext();
+        var p = verify.CompetitionParticipants.Single(x => x.PlayerId == PlayerAId);
+        Assert.Equal(1100, p.EloRating);
+        Assert.Null(p.LastDecayAppliedAt);
+        Assert.Null(p.LastInactivityWarningAt);
+    }
+
+    [Fact]
+    public async Task ThreeDaysBeforeGraceEnd_SendsWarning_NoDecay()
+    {
+        var factory = new TestDbContextFactory();
+        // 18 days idle => 3 days remaining in grace
+        await SeedAsync(factory, registeredAt: BaseDate.AddDays(-30), lastMatchAt: BaseDate.AddDays(-18));
+
+        DecayRunResult result;
+        using (var db = factory.CreateDbContext())
+            result = await Run(db, BaseDate);
+
+        Assert.Equal(0, result.DecayEventsApplied);
+        Assert.Equal(1, result.WarningsSent);
+
+        using var verify = factory.CreateDbContext();
+        var p = verify.CompetitionParticipants.Single(x => x.PlayerId == PlayerAId);
+        Assert.NotNull(p.LastInactivityWarningAt);
+        Assert.Null(p.LastDecayAppliedAt);
+    }
+
+    [Fact]
+    public async Task SecondSweepWithinGrace_DoesNotResendWarning()
+    {
+        var factory = new TestDbContextFactory();
+        await SeedAsync(factory,
+            registeredAt: BaseDate.AddDays(-30),
+            lastMatchAt: BaseDate.AddDays(-18),
+            lastWarnAt: BaseDate.AddHours(-2));
+
+        DecayRunResult result;
+        using (var db = factory.CreateDbContext())
+            result = await Run(db, BaseDate);
+
+        Assert.Equal(0, result.WarningsSent);
+    }
+
+    [Fact]
+    public async Task PastGrace_AppliesOneDecayStep()
+    {
+        var factory = new TestDbContextFactory();
+        await SeedAsync(factory, registeredAt: BaseDate.AddDays(-40), lastMatchAt: BaseDate.AddDays(-25));
+
+        DecayRunResult result;
+        using (var db = factory.CreateDbContext())
+            result = await Run(db, BaseDate); // 25 days idle, 4 days post-grace
+
+        Assert.Equal(1, result.DecayEventsApplied);
+
+        using var verify = factory.CreateDbContext();
+        var p = verify.CompetitionParticipants.Single(x => x.PlayerId == PlayerAId);
+        Assert.Equal(1090, p.EloRating, 1);
+        Assert.NotNull(p.LastDecayAppliedAt);
+
+        var decay = verify.LadderInactivityDecays.Single();
+        Assert.Equal(1100, decay.RatingBefore, 1);
+        Assert.Equal(1090, decay.RatingAfter, 1);
+        Assert.Equal(25, decay.DaysInactive);
+    }
+
+    [Fact]
+    public async Task SameDayRerun_IsIdempotent()
+    {
+        var factory = new TestDbContextFactory();
+        await SeedAsync(factory, registeredAt: BaseDate.AddDays(-40), lastMatchAt: BaseDate.AddDays(-25));
+
+        using (var db = factory.CreateDbContext())
+            await Run(db, BaseDate);
+        using (var db = factory.CreateDbContext())
+            await Run(db, BaseDate.AddHours(2)); // same day, slightly later
+
+        using var verify = factory.CreateDbContext();
+        var p = verify.CompetitionParticipants.Single(x => x.PlayerId == PlayerAId);
+        // Only one decay step in total.
+        Assert.Equal(1090, p.EloRating, 1);
+        Assert.Single(verify.LadderInactivityDecays);
+    }
+
+    [Fact]
+    public async Task SevenDaysAfterPriorDecay_AppliesAnother()
+    {
+        var factory = new TestDbContextFactory();
+        var sweepDay1 = BaseDate;
+        var sweepDay2 = BaseDate.AddDays(7);
+        await SeedAsync(factory, registeredAt: BaseDate.AddDays(-40), lastMatchAt: BaseDate.AddDays(-25));
+
+        using (var db = factory.CreateDbContext())
+            await Run(db, sweepDay1);
+        using (var db = factory.CreateDbContext())
+            await Run(db, sweepDay2);
+
+        using var verify = factory.CreateDbContext();
+        var p = verify.CompetitionParticipants.Single(x => x.PlayerId == PlayerAId);
+        Assert.Equal(1080, p.EloRating, 1);
+        Assert.Equal(2, verify.LadderInactivityDecays.Count());
+    }
+
+    [Fact]
+    public async Task DecayFlooredAtStartingRating()
+    {
+        var factory = new TestDbContextFactory();
+        // Rating already 1003 — only 3 points of headroom above the 1000 floor.
+        await SeedAsync(factory,
+            registeredAt: BaseDate.AddDays(-60),
+            lastMatchAt: BaseDate.AddDays(-30),
+            rating: 1003);
+
+        DecayRunResult result;
+        using (var db = factory.CreateDbContext())
+            result = await Run(db, BaseDate);
+
+        Assert.Equal(1, result.DecayEventsApplied);
+
+        using var verify = factory.CreateDbContext();
+        var p = verify.CompetitionParticipants.Single(x => x.PlayerId == PlayerAId);
+        Assert.Equal(1000, p.EloRating, 1);
+
+        // Another week later: at floor; no audit row but anchor still advances
+        // so we don't recompute every day.
+        using (var db = factory.CreateDbContext())
+            result = await Run(db, BaseDate.AddDays(7));
+        Assert.Equal(0, result.DecayEventsApplied);
+        using var v2 = factory.CreateDbContext();
+        Assert.Single(v2.LadderInactivityDecays);
+    }
+
+    [Fact]
+    public async Task NonSinglesLadderFormat_NotTouched()
+    {
+        var factory = new TestDbContextFactory();
+        await SeedAsync(factory,
+            registeredAt: BaseDate.AddDays(-60),
+            lastMatchAt: BaseDate.AddDays(-40),
+            format: CompetitionFormat.Singles);
+
+        DecayRunResult result;
+        using (var db = factory.CreateDbContext())
+            result = await Run(db, BaseDate);
+
+        Assert.Equal(0, result.DecayEventsApplied);
+        Assert.Equal(0, result.WarningsSent);
+        using var verify = factory.CreateDbContext();
+        Assert.Equal(1100, verify.CompetitionParticipants.Single().EloRating);
+    }
+
+    [Fact]
+    public async Task ArchivedCompetition_NotTouched()
+    {
+        var factory = new TestDbContextFactory();
+        await SeedAsync(factory,
+            registeredAt: BaseDate.AddDays(-60),
+            lastMatchAt: BaseDate.AddDays(-40),
+            isArchived: true);
+
+        DecayRunResult result;
+        using (var db = factory.CreateDbContext())
+            result = await Run(db, BaseDate);
+
+        Assert.Equal(0, result.DecayEventsApplied);
+    }
+
+    [Fact]
+    public async Task PlayerWithNoLastMatch_UsesRegisteredAt()
+    {
+        var factory = new TestDbContextFactory();
+        // 25 days since registration, never played
+        await SeedAsync(factory, registeredAt: BaseDate.AddDays(-25), lastMatchAt: null);
+
+        DecayRunResult result;
+        using (var db = factory.CreateDbContext())
+            result = await Run(db, BaseDate);
+
+        Assert.Equal(1, result.DecayEventsApplied);
+    }
+
+    private static Task<DecayRunResult> Run(DropShot.Data.MyDbContext db, DateTime now) =>
+        LadderInactivityService.RunSweepAsync(db, now, email: null);
+}

--- a/DropShot.UI/Components/Pages/ViewCompetition.razor
+++ b/DropShot.UI/Components/Pages/ViewCompetition.razor
@@ -393,6 +393,10 @@ else
                     <MudTh>W</MudTh>
                     <MudTh>L</MudTh>
                     <MudTh>@pointsHeader</MudTh>
+                    @if (isLadder)
+                    {
+                        <MudTh>Last played</MudTh>
+                    }
                 </HeaderContent>
                 <RowTemplate>
                     <MudTd DataLabel="Pos">@(_leagueTable.IndexOf(context) + 1)</MudTd>
@@ -407,6 +411,49 @@ else
                     <MudTd DataLabel="W">@context.Won</MudTd>
                     <MudTd DataLabel="L">@context.Lost</MudTd>
                     <MudTd DataLabel="@pointsHeader" Style="font-weight:bold">@context.Points</MudTd>
+                    @if (isLadder)
+                    {
+                        <MudTd DataLabel="Last played">@LastPlayedLabel(context.PlayerId)</MudTd>
+                    }
+                </RowTemplate>
+            </MudTable>
+        </MudExpansionPanel>
+    }
+
+    @* Recent activity feed for SinglesLadder — completed fixtures and decay
+       events merged chronologically. Only renders when there's something to
+       show; non-ladder formats fall through to the existing fixtures panels. *@
+    @if (_competition.CompetitionFormat == CompetitionFormat.SinglesLadder && _ladderActivity.Count > 0)
+    {
+        <MudExpansionPanel Class="mb-2" Text="Recent activity">
+            <MudTable Items="@_ladderActivity" Dense="true" Hover="true" Breakpoint="Breakpoint.Sm" Class="mb-4 mobile-stack-table" Style="max-width:700px">
+                <HeaderContent>
+                    <MudTh>When</MudTh>
+                    <MudTh>Event</MudTh>
+                    <MudTh>Detail</MudTh>
+                    <MudTh Style="text-align:right">Δ Rating</MudTh>
+                </HeaderContent>
+                <RowTemplate>
+                    <MudTd DataLabel="When">@context.At.ToLocalTime().ToString("dd MMM HH:mm")</MudTd>
+                    <MudTd DataLabel="Event">
+                        @if (context.Kind == "Decay")
+                        {
+                            <MudChip T="string" Size="Size.Small" Color="Color.Warning" Variant="Variant.Outlined">Inactivity</MudChip>
+                        }
+                        else
+                        {
+                            <MudChip T="string" Size="Size.Small" Color="Color.Success" Variant="Variant.Outlined">Match</MudChip>
+                        }
+                    </MudTd>
+                    <MudTd DataLabel="Detail">@context.Description</MudTd>
+                    <MudTd DataLabel="Δ Rating" Style="text-align:right; font-variant-numeric:tabular-nums">
+                        @if (context.Delta.HasValue)
+                        {
+                            var d = context.Delta.Value;
+                            var color = d >= 0 ? Color.Success : Color.Error;
+                            <MudText Inline="true" Color="@color">@(d >= 0 ? "+" : "")@d.ToString("0")</MudText>
+                        }
+                    </MudTd>
                 </RowTemplate>
             </MudTable>
         </MudExpansionPanel>
@@ -581,6 +628,19 @@ else
 
     private record LeagueRow(int PlayerId, string PlayerName, int Played, int Won, int Lost, int Points);
     private List<LeagueRow> _leagueTable = [];
+
+    // Recent-activity row for SinglesLadder — completed fixture results and
+    // inactivity-decay events merged into one chronological feed.
+    private record ActivityRow(DateTime At, string Kind, string Description, double? Delta);
+    private List<ActivityRow> _ladderActivity = [];
+
+    private string LastPlayedLabel(int playerId)
+    {
+        var p = _participants.FirstOrDefault(x => x.PlayerId == playerId);
+        if (p?.LadderLastMatchAt is not DateTime when) return "—";
+        var days = (int)(DateTime.UtcNow - when).TotalDays;
+        return days <= 0 ? "today" : $"{days}d ago";
+    }
 
     private record TeamLeagueRow(int TeamId, string TeamName, string? CaptainName, int Played, int Won, int Drawn, int Lost, int ScoringFor, int ScoringAgainst, int Points);
     private List<TeamLeagueRow> _teamLeagueTable = [];
@@ -817,6 +877,44 @@ else
                     .OrderByDescending(r => r.Points)
                     .ThenByDescending(r => r.Won)
                     .ThenBy(r => r.PlayerName)
+                    .ToList();
+
+                // Recent-activity feed: union of completed fixtures and decay
+                // events, sorted newest-first, capped to 25 rows.
+                var nameById = _participants.ToDictionary(p => p.PlayerId, p => p.DisplayName);
+                var fixtureRows = _fixtures
+                    .Where(f => f.Status == FixtureStatus.Completed
+                                && f.CompletedAt.HasValue
+                                && f.Player1Id.HasValue && f.Player2Id.HasValue)
+                    .Select(f =>
+                    {
+                        var p1 = nameById.GetValueOrDefault(f.Player1Id!.Value, "?");
+                        var p2 = nameById.GetValueOrDefault(f.Player2Id!.Value, "?");
+                        var winner = f.WinnerPlayerId == f.Player1Id ? p1
+                                   : f.WinnerPlayerId == f.Player2Id ? p2 : "—";
+                        var score = string.IsNullOrEmpty(f.ResultSummary)
+                            ? $"{p1} vs {p2}"
+                            : $"{p1} vs {p2} ({f.ResultSummary})";
+                        double? delta = null;
+                        if (f.Player1RatingBefore.HasValue && f.Player1RatingAfter.HasValue)
+                            delta = f.Player1RatingAfter.Value - f.Player1RatingBefore.Value;
+                        return new ActivityRow(
+                            f.CompletedAt!.Value,
+                            "Match",
+                            $"{winner} beat {(winner == p1 ? p2 : p1)} — {score}",
+                            delta);
+                    });
+
+                var decayRows = (_competition.LadderDecayEvents ?? new())
+                    .Select(d => new ActivityRow(
+                        d.AppliedAt,
+                        "Decay",
+                        $"{d.PlayerName} — {d.DaysInactive}d inactive",
+                        d.RatingAfter - d.RatingBefore));
+
+                _ladderActivity = fixtureRows.Concat(decayRows)
+                    .OrderByDescending(r => r.At)
+                    .Take(25)
                     .ToList();
             }
 

--- a/DropShot/Data/Migrations/20260517225602_AddLadderInactivityDecay.Designer.cs
+++ b/DropShot/Data/Migrations/20260517225602_AddLadderInactivityDecay.Designer.cs
@@ -4,16 +4,19 @@ using DropShot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace DropShot.Migrations
+namespace DropShot.Data.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260517225602_AddLadderInactivityDecay")]
+    partial class AddLadderInactivityDecay
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DropShot/Data/Migrations/20260517225602_AddLadderInactivityDecay.cs
+++ b/DropShot/Data/Migrations/20260517225602_AddLadderInactivityDecay.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropShot.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLadderInactivityDecay : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LastDecayAppliedAt",
+                table: "CompetitionParticipants",
+                type: "datetime2",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LastInactivityWarningAt",
+                table: "CompetitionParticipants",
+                type: "datetime2",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "LadderInactivityDecays",
+                columns: table => new
+                {
+                    LadderInactivityDecayId = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    CompetitionId = table.Column<int>(type: "int", nullable: false),
+                    PlayerId = table.Column<int>(type: "int", nullable: false),
+                    AppliedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    RatingBefore = table.Column<double>(type: "float", nullable: false),
+                    RatingAfter = table.Column<double>(type: "float", nullable: false),
+                    DaysInactive = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LadderInactivityDecays", x => x.LadderInactivityDecayId);
+                    table.ForeignKey(
+                        name: "FK_LadderInactivityDecays_Competition_CompetitionId",
+                        column: x => x.CompetitionId,
+                        principalTable: "Competition",
+                        principalColumn: "CompetitionID",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_LadderInactivityDecays_Players_PlayerId",
+                        column: x => x.PlayerId,
+                        principalTable: "Players",
+                        principalColumn: "PlayerId",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LadderInactivityDecays_CompetitionId_AppliedAt",
+                table: "LadderInactivityDecays",
+                columns: new[] { "CompetitionId", "AppliedAt" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LadderInactivityDecays_PlayerId",
+                table: "LadderInactivityDecays",
+                column: "PlayerId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "LadderInactivityDecays");
+
+            migrationBuilder.DropColumn(
+                name: "LastDecayAppliedAt",
+                table: "CompetitionParticipants");
+
+            migrationBuilder.DropColumn(
+                name: "LastInactivityWarningAt",
+                table: "CompetitionParticipants");
+        }
+    }
+}

--- a/DropShot/Data/MyDbContext.cs
+++ b/DropShot/Data/MyDbContext.cs
@@ -45,6 +45,7 @@ namespace DropShot.Data
         public DbSet<ClubLinkRequest> ClubLinkRequests { get; set; }
         public DbSet<CompetitionAllowedPlayer> CompetitionAllowedPlayers { get; set; }
         public DbSet<PlayerRatingSnapshot> PlayerRatingSnapshots { get; set; }
+        public DbSet<LadderInactivityDecay> LadderInactivityDecays { get; set; }
 
         protected override void OnModelCreating(ModelBuilder builder)
         {
@@ -671,6 +672,23 @@ namespace DropShot.Data
                       .WithMany()
                       .HasForeignKey(s => s.CompetitionId)
                       .OnDelete(DeleteBehavior.NoAction);
+            });
+
+            // ── LadderInactivityDecay ───────────────────────────────────────────
+            builder.Entity<LadderInactivityDecay>(entity =>
+            {
+                entity.HasIndex(d => new { d.CompetitionId, d.AppliedAt });
+                entity.HasIndex(d => d.PlayerId);
+
+                entity.HasOne(d => d.Player)
+                      .WithMany()
+                      .HasForeignKey(d => d.PlayerId)
+                      .OnDelete(DeleteBehavior.Restrict);
+
+                entity.HasOne(d => d.Competition)
+                      .WithMany()
+                      .HasForeignKey(d => d.CompetitionId)
+                      .OnDelete(DeleteBehavior.Cascade);
             });
 
             // ── RoleSwitchLog ───────────────────────────────────────────────────

--- a/DropShot/Models/CompetitionParticipant.cs
+++ b/DropShot/Models/CompetitionParticipant.cs
@@ -21,6 +21,14 @@ public class CompetitionParticipant
     public bool IsProvisional { get; set; } = true;
     public DateTime? LastMatchAt { get; set; }
 
+    // ── Inactivity-decay bookkeeping (LadderInactivityHostedService) ────────
+    // LastInactivityWarningAt: timestamp of the most recent "your rating will
+    // start decaying soon" warning email so the sweep doesn't spam.
+    // LastDecayAppliedAt: anchor for the next weekly decay step; reset
+    // implicitly by LastMatchAt overriding it via the reference-date max.
+    public DateTime? LastInactivityWarningAt { get; set; }
+    public DateTime? LastDecayAppliedAt { get; set; }
+
     public Competition Competition { get; set; } = null!;
     public Player Player { get; set; } = null!;
     public CompetitionTeam? Team { get; set; }

--- a/DropShot/Models/LadderInactivityDecay.cs
+++ b/DropShot/Models/LadderInactivityDecay.cs
@@ -1,0 +1,21 @@
+namespace DropShot.Models;
+
+/// <summary>
+/// Audit row written by <c>LadderInactivityService</c> whenever a SinglesLadder
+/// participant's rating is decayed for inactivity. One row per weekly decay
+/// step; lets the recent-activity feed render the decay event alongside
+/// completed fixtures.
+/// </summary>
+public class LadderInactivityDecay
+{
+    public int LadderInactivityDecayId { get; set; }
+    public int CompetitionId { get; set; }
+    public int PlayerId { get; set; }
+    public DateTime AppliedAt { get; set; } = DateTime.UtcNow;
+    public double RatingBefore { get; set; }
+    public double RatingAfter { get; set; }
+    public int DaysInactive { get; set; }
+
+    public Competition Competition { get; set; } = null!;
+    public Player Player { get; set; } = null!;
+}

--- a/DropShot/Program.cs
+++ b/DropShot/Program.cs
@@ -152,6 +152,7 @@ builder.Services.AddScoped<FixtureSimulationService>();
 builder.Services.AddScoped<CompetitionSchedulerService>();
 builder.Services.AddSingleton<QrLoginService>();
 builder.Services.AddHostedService<QrSessionCleanupService>();
+builder.Services.AddHostedService<LadderInactivityHostedService>();
 builder.Services.AddMudServices();
 builder.Services.AddScoped<ISiteAlertService, SiteAlertService>();
 

--- a/DropShot/Services/AdminEmailService.cs
+++ b/DropShot/Services/AdminEmailService.cs
@@ -38,6 +38,28 @@ public class AdminEmailService(
     }
 
     /// <summary>
+    /// Warns a SinglesLadder participant that their rating will start decaying
+    /// in <paramref name="daysUntilDecay"/> days unless they play a match.
+    /// Sent by <see cref="LadderInactivityService"/> from the daily sweep.
+    /// </summary>
+    public async Task SendLadderInactivityWarningAsync(
+        Player player, Competition competition, int daysUntilDecay, CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(player.Email)) return;
+
+        var link = $"{BaseUrl}/competition/{competition.CompetitionID}/view";
+        var subject = $"Play a match in {competition.CompetitionName} to keep your rating";
+        var bodyText =
+            $"Hi {player.DisplayName},\n\n" +
+            $"Your rating in **{competition.CompetitionName}** will start decaying in {daysUntilDecay} day{(daysUntilDecay == 1 ? "" : "s")} unless you record a match.\n\n" +
+            $"After the {LadderInactivityService.GraceDays}-day grace period, the ladder loses {LadderInactivityService.DecayPointsPerWeek:0} points per week of inactivity — recoverable as soon as you play again.\n\n" +
+            $"[Record a match]({link})";
+
+        var html = emailTemplateService.AdminCustomEmail(bodyText);
+        await SendSafe(player.Email!, subject, html, "ladder inactivity warning", isHtml: true);
+    }
+
+    /// <summary>
     /// Sends an email to all competition participants who have an email address.
     /// </summary>
     public async Task SendCompetitionEmailAsync(

--- a/DropShot/Services/LadderInactivityHostedService.cs
+++ b/DropShot/Services/LadderInactivityHostedService.cs
@@ -1,0 +1,57 @@
+using DropShot.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace DropShot.Services;
+
+/// <summary>
+/// Runs the SinglesLadder inactivity sweep every 24 hours: decays idle
+/// participants by <see cref="LadderInactivityService.DecayPointsPerWeek"/>
+/// points per week past the grace window, and emails a warning to players
+/// approaching it. Errors are logged but never crash the loop.
+/// </summary>
+public class LadderInactivityHostedService(
+    IServiceProvider services,
+    ILogger<LadderInactivityHostedService> logger) : BackgroundService
+{
+    private static readonly TimeSpan StartupDelay = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan SweepInterval = TimeSpan.FromHours(24);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        // Let app startup / DI / EF model warm up before the first sweep.
+        try { await Task.Delay(StartupDelay, stoppingToken); }
+        catch (OperationCanceledException) { return; }
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                using var scope = services.CreateScope();
+                var dbFactory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<MyDbContext>>();
+                var email = scope.ServiceProvider.GetRequiredService<AdminEmailService>();
+
+                await using var db = await dbFactory.CreateDbContextAsync(stoppingToken);
+                var result = await LadderInactivityService.RunSweepAsync(
+                    db, DateTime.UtcNow, email, stoppingToken);
+
+                if (result.DecayEventsApplied > 0 || result.WarningsSent > 0)
+                {
+                    logger.LogInformation(
+                        "Ladder inactivity sweep: {Decays} decays applied, {Warnings} warnings sent.",
+                        result.DecayEventsApplied, result.WarningsSent);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Ladder inactivity sweep failed; will retry next interval.");
+            }
+
+            try { await Task.Delay(SweepInterval, stoppingToken); }
+            catch (OperationCanceledException) { return; }
+        }
+    }
+}

--- a/DropShot/Services/LadderInactivityService.cs
+++ b/DropShot/Services/LadderInactivityService.cs
@@ -1,0 +1,120 @@
+using DropShot.Data;
+using DropShot.Models;
+using DropShot.Shared;
+using Microsoft.EntityFrameworkCore;
+
+namespace DropShot.Services;
+
+/// <summary>
+/// Daily sweep that decays inactive SinglesLadder participants' Elo ratings
+/// and sends warning emails when a player is about to enter the decay window.
+/// Idempotent: re-running the sweep within the same week is a no-op per player.
+///
+/// Designed for testability — pass <paramref name="now"/> explicitly so unit
+/// tests can simulate days passing without touching wall-clock time.
+/// </summary>
+public static class LadderInactivityService
+{
+    /// <summary>How long after a player's last activity before decay begins.</summary>
+    public const int GraceDays = 21;
+
+    /// <summary>Rating points removed per fully-elapsed week of post-grace inactivity.</summary>
+    public const double DecayPointsPerWeek = 10.0;
+
+    /// <summary>Send a warning email this many days before decay starts.</summary>
+    public const int WarnDaysBefore = 3;
+
+    public sealed record DecayRunResult(int DecayEventsApplied, int WarningsSent);
+
+    public static async Task<DecayRunResult> RunSweepAsync(
+        MyDbContext db,
+        DateTime now,
+        AdminEmailService? email,
+        CancellationToken ct = default)
+    {
+        // Pull every active SinglesLadder FullPlayer participant in one query.
+        // Small enough for clubs of any realistic size; ladders rarely exceed
+        // a few hundred participants.
+        var rows = await db.CompetitionParticipants
+            .Where(p => p.Status == ParticipantStatus.FullPlayer
+                        && p.Competition.CompetitionFormat == CompetitionFormat.SinglesLadder
+                        && p.Competition.IsStarted
+                        && !p.Competition.IsArchived)
+            .Include(p => p.Competition)
+            .Include(p => p.Player)
+            .ToListAsync(ct);
+
+        int decayCount = 0;
+        int warnCount = 0;
+
+        foreach (var p in rows)
+        {
+            // Activity anchor is the most recent of last match / registration —
+            // i.e. when the player was last "active" in the ladder. LastDecay
+            // is gated separately so weekly steps continue accruing while the
+            // player stays idle.
+            DateTime anchor = p.LastMatchAt ?? p.RegisteredAt;
+            int daysIdle = Math.Max(0, (int)Math.Floor((now - anchor).TotalDays));
+            int graceRemaining = GraceDays - daysIdle;
+
+            // ── Warning pass ────────────────────────────────────────────────
+            // Fires when we're inside [1, WarnDaysBefore] days from decay
+            // starting, and we haven't already warned about the current idle
+            // stretch (player hasn't played since the last warning, and the
+            // warning isn't stale beyond a full grace cycle).
+            if (graceRemaining > 0 && graceRemaining <= WarnDaysBefore)
+            {
+                bool alreadyWarned = p.LastInactivityWarningAt is DateTime w
+                    && (p.LastMatchAt is null || p.LastMatchAt <= w)
+                    && (now - w).TotalDays < GraceDays;
+
+                if (!alreadyWarned)
+                {
+                    if (email is not null && !string.IsNullOrEmpty(p.Player.Email))
+                    {
+                        await email.SendLadderInactivityWarningAsync(p.Player, p.Competition, graceRemaining, ct);
+                    }
+                    p.LastInactivityWarningAt = now;
+                    warnCount++;
+                }
+            }
+
+            // ── Decay pass ──────────────────────────────────────────────────
+            // Past grace, and either no prior decay or the prior decay is at
+            // least a week old. One step per sweep — re-running today is a
+            // no-op for the same player.
+            bool pastGrace = daysIdle >= GraceDays;
+            bool weekSinceLastDecay = p.LastDecayAppliedAt is not DateTime ld
+                                       || (now - ld).TotalDays >= 7;
+
+            if (pastGrace && weekSinceLastDecay)
+            {
+                double floor = p.Competition.LadderStartingRating;
+                double currentRating = p.EloRating;
+                double delta = Math.Min(DecayPointsPerWeek, Math.Max(0, currentRating - floor));
+
+                // Always advance the anchor so the next-step gate ticks forward,
+                // even when there's no room left to decay further.
+                p.LastDecayAppliedAt = now;
+
+                if (delta > 0)
+                {
+                    p.EloRating = currentRating - delta;
+                    db.LadderInactivityDecays.Add(new LadderInactivityDecay
+                    {
+                        CompetitionId = p.CompetitionId,
+                        PlayerId = p.PlayerId,
+                        AppliedAt = now,
+                        RatingBefore = currentRating,
+                        RatingAfter = p.EloRating,
+                        DaysInactive = daysIdle,
+                    });
+                    decayCount++;
+                }
+            }
+        }
+
+        await db.SaveChangesAsync(ct);
+        return new DecayRunResult(decayCount, warnCount);
+    }
+}

--- a/DropShot/Services/LadderRatingService.cs
+++ b/DropShot/Services/LadderRatingService.cs
@@ -83,11 +83,16 @@ public static class LadderRatingService
         pa.MatchesPlayed += 1;
         pa.LastMatchAt = now;
         pa.IsProvisional = pa.MatchesPlayed < comp.LadderProvisionalMatches;
+        // Playing resets the inactivity-decay clock for the next idle stretch.
+        pa.LastDecayAppliedAt = null;
+        pa.LastInactivityWarningAt = null;
 
         pb.EloRating = newB;
         pb.MatchesPlayed += 1;
         pb.LastMatchAt = now;
         pb.IsProvisional = pb.MatchesPlayed < comp.LadderProvisionalMatches;
+        pb.LastDecayAppliedAt = null;
+        pb.LastInactivityWarningAt = null;
 
         await db.SaveChangesAsync(ct);
     }

--- a/DropShot/Services/WebCompetitionService.cs
+++ b/DropShot/Services/WebCompetitionService.cs
@@ -135,6 +135,26 @@ public sealed class WebCompetitionService(
         var rolePlacements = (await ratings.SuggestRolePlacementsAsync(id, ct))
             .ToDictionary(p => p.PlayerId);
 
+        // Decay-event feed for SinglesLadder. Null for other formats so the UI
+        // doesn't accidentally render an "activity" panel where none belongs.
+        List<LadderInactivityDecayDto>? decayEvents = null;
+        if (c.CompetitionFormat == CompetitionFormat.SinglesLadder)
+        {
+            decayEvents = await db.LadderInactivityDecays
+                .Where(d => d.CompetitionId == id)
+                .Include(d => d.Player)
+                .OrderByDescending(d => d.AppliedAt)
+                .Take(50)
+                .Select(d => new LadderInactivityDecayDto(
+                    d.PlayerId,
+                    d.Player.DisplayName,
+                    d.AppliedAt,
+                    d.RatingBefore,
+                    d.RatingAfter,
+                    d.DaysInactive))
+                .ToListAsync(ct);
+        }
+
         return new CompetitionDetailDto(
             c.CompetitionID, c.CompetitionName,
             c.CompetitionFormat,
@@ -195,7 +215,8 @@ public sealed class WebCompetitionService(
             c.LadderKFactor,
             c.LadderStartingRating,
             c.LadderProvisionalMatches,
-            c.LadderUseMarginOfVictory);
+            c.LadderUseMarginOfVictory,
+            decayEvents);
     }
 
     private static PlacementSuggestionDto? BuildPlacementSuggestion(


### PR DESCRIPTION
Follow-up to [#665](https://github.com/kingbeazer/DropShot/pull/665) + [#666](https://github.com/kingbeazer/DropShot/pull/666).

## Summary
- **Daily background sweep** ([LadderInactivityHostedService](DropShot/Services/LadderInactivityHostedService.cs)) decays SinglesLadder participants who don't play. Mirrors the existing [QrSessionCleanupService](DropShot/Services/QrSessionCleanupService.cs) BackgroundService pattern; errors logged, never crashes the loop.
- **Gentle defaults** baked into [LadderInactivityService](DropShot/Services/LadderInactivityService.cs) as constants for v1: 21-day grace period, 10 pts/week, floored at the competition's LadderStartingRating. Hardcoded rather than per-ladder columns to keep schema/wizard clean — easy to promote to admin-tunable fields later.
- **Warning email 3 days before decay starts** via a new AdminEmailService.SendLadderInactivityWarningAsync method (reuses the existing Azure ACS pipeline; console-fallback when unconfigured).
- **Decay clock resets on match completion.** [LadderRatingService](DropShot/Services/LadderRatingService.cs) now clears LastDecayAppliedAt / LastInactivityWarningAt on a finalised fixture, so playing again wipes the slate.
- **Recent activity feed** on ViewCompetition for SinglesLadder — completed fixtures (with Elo deltas) and decay events merged chronologically. Standings gains a "Last played Nd ago" column.

## Data model
- Two columns on CompetitionParticipant: LastInactivityWarningAt, LastDecayAppliedAt.
- New LadderInactivityDecays table (one row per weekly decay step) with indexes on (CompetitionId, AppliedAt) and PlayerId.

## Test plan
- [x] dotnet build clean across DropShot, DropShot.UI, DropShot.Shared, DropShot.Tests
- [x] LadderInactivityServiceTests — 10/10 pass: inside-grace no-op, 3-day-before-grace warning, no-resend-within-grace, past-grace one step, same-day idempotency, weekly cadence, floor clamping, archived/non-ladder skip, no-LastMatchAt-uses-RegisteredAt
- [x] LadderRatingServiceTests — 5/5 still pass (no regression in match-completion path)
- [x] PlayerRatingServiceTests — 24/24 still pass
- [x] ViewCompetitionTests — 2/2 still pass
- [ ] Manual end-to-end: register a player with LastMatchAt 19d ago, wait for sweep (or run manually) — expect warning email + LastInactivityWarningAt set; nudge LastMatchAt to 25d ago — expect one LadderInactivityDecay row, rating drops 10, Recent activity panel shows the decay entry; play a match — clock resets.

## Out of scope
- Per-ladder tunable parameters (promote constants to Competition columns + wizard inputs when an admin asks).
- Skip-decay-while-provisional exception.
- Notification channels beyond email.

🤖 Generated with [Claude Code](https://claude.com/claude-code)