### PR TITLE
Singles Ladder: keep open for entry after start

### DIFF
--- a/DropShot/Services/WebCompetitionService.cs
+++ b/DropShot/Services/WebCompetitionService.cs
@@ -689,12 +689,19 @@ public sealed class WebCompetitionService(
             .ToListAsync(ct);
 
         var today = DateTime.UtcNow.Date;
+        // SinglesLadder is a continuous format — players can register at any
+        // point in the ladder's lifetime, so the IsStarted flag and the
+        // start-date-in-the-past check (both "registration closed" gates for
+        // bracket/league formats) don't apply. RegisterByDate still does:
+        // admins keep the option of a hard registration cutoff.
         var candidates = await db.Competition
             .Include(c => c.HostClub)
             .Include(c => c.Event)
             .Include(c => c.AllowedPlayers)
-            .Where(c => !enteredIds.Contains(c.CompetitionID) && !c.IsArchived && !c.IsStarted)
-            .Where(c => !c.StartDate.HasValue || c.StartDate.Value >= today)
+            .Where(c => !enteredIds.Contains(c.CompetitionID) && !c.IsArchived
+                        && (c.CompetitionFormat == CompetitionFormat.SinglesLadder || !c.IsStarted))
+            .Where(c => c.CompetitionFormat == CompetitionFormat.SinglesLadder
+                        || !c.StartDate.HasValue || c.StartDate.Value >= today)
             .Where(c => !c.RegisterByDate.HasValue || c.RegisterByDate.Value >= today)
             .OrderBy(c => c.StartDate).ThenBy(c => c.CompetitionName)
             .ToListAsync(ct);
@@ -873,9 +880,11 @@ public sealed class WebCompetitionService(
             ?? throw new KeyNotFoundException($"Competition {competitionId} not found.");
 
         var today = DateTime.UtcNow.Date;
-        if (comp.IsStarted)
-            throw new InvalidOperationException("This competition has already started.");
-        if (comp.StartDate.HasValue && comp.StartDate.Value < today)
+        // SinglesLadder is continuous — players can join at any point, so
+        // the "already started" gate (both the explicit IsStarted flag and
+        // a past StartDate) doesn't apply. RegisterByDate still does.
+        var isLadder = comp.CompetitionFormat == CompetitionFormat.SinglesLadder;
+        if (!isLadder && (comp.IsStarted || (comp.StartDate.HasValue && comp.StartDate.Value < today)))
             throw new InvalidOperationException("This competition has already started.");
         if (comp.RegisterByDate.HasValue && comp.RegisterByDate.Value < today)
             throw new InvalidOperationException("Registration for this competition has closed.");


### PR DESCRIPTION
## Summary
- A SinglesLadder is continuous — players should be able to register at any point in the ladder's lifetime, even after the admin marks it Started. The existing entry gates (designed for bracket/league formats) treated `IsStarted` and `StartDate < today` as a registration cutoff, so started ladders silently vanished from users' "Available to Enter" list and entry attempts threw "This competition has already started".
- Exempt `CompetitionFormat.SinglesLadder` from those two gates in both `GetMyCompetitionsViewAsync` (listing) and `EnterCompetitionAsync` (entry action). `IsArchived`, `RegisterByDate`, eligibility, `MaxParticipants`, and already-entered checks still apply uniformly.
- Consolidated the two duplicate "already started" throws in `EnterCompetitionAsync` while I was there.

## Test plan
- [x] `dotnet build` — clean
- [x] `dotnet test` non-page suites — 35/35 pass (17 page-test failures are pre-existing baseline, unrelated `PersistentComponentState` DI registration missing in the bunit harness)
- [ ] Manual end-to-end: as admin, create a Men's Singles Ladder, toggle Start; as a male standard user, visit `/competitions` → ladder appears in "Available to Enter"; click Enter → registration succeeds
- [ ] Regression: a started bracket Singles competition is still excluded and still rejects entry with "already started"
- [ ] Regression: a ladder with `RegisterByDate` in the past is still excluded and still rejects entry with "Registration ... has closed"
- [ ] Regression: an archived ladder is still excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)