### PR TITLE
Singles Ladder: drop Fixtures panel, add simulator + Elo explainer

### DIFF
--- a/DropShot.Maui/Services/HttpCompetitionService.cs
+++ b/DropShot.Maui/Services/HttpCompetitionService.cs
@@ -41,6 +41,16 @@ public sealed class HttpCompetitionService(HttpClient http) : ICompetitionServic
         resp.EnsureSuccessStatusCode();
     }
 
+    public async Task<LadderSimulationResultDto> SimulateLadderAsync(
+        int competitionId, int weeks, int? seed = null, CancellationToken ct = default)
+    {
+        var qs = seed.HasValue ? $"?weeks={weeks}&seed={seed}" : $"?weeks={weeks}";
+        var resp = await http.PostAsync($"api/competitions/{competitionId}/ladder/simulate{qs}", content: null, ct);
+        resp.EnsureSuccessStatusCode();
+        return await resp.Content.ReadFromJsonAsync<LadderSimulationResultDto>(cancellationToken: ct)
+            ?? throw new InvalidOperationException("Empty simulation response.");
+    }
+
     public async Task SubmitFixtureScoreAsync(int fixtureId, SubmitFixtureScoreRequest request, CancellationToken ct = default)
     {
         var resp = await http.PostAsJsonAsync(

--- a/DropShot.Shared/Dtos/CompetitionDtos.cs
+++ b/DropShot.Shared/Dtos/CompetitionDtos.cs
@@ -67,6 +67,17 @@ public record LadderInactivityDecayDto(
     double RatingAfter,
     int DaysInactive);
 
+/// <summary>
+/// Result of the SuperAdmin "simulate N weeks" tool — counts of synthetic
+/// fixtures and decay events produced.
+/// </summary>
+public record LadderSimulationResultDto(
+    int Participants,
+    int ActivePlayers,
+    int IdlePlayers,
+    int FixturesGenerated,
+    int DecayEventsGenerated);
+
 public record CompetitionStageDto(
     int CompetitionStageId,
     string Name,
@@ -142,7 +153,9 @@ public record CompetitionFixtureDto(
     double? Player1RatingBefore = null,
     double? Player1RatingAfter = null,
     double? Player2RatingBefore = null,
-    double? Player2RatingAfter = null);
+    double? Player2RatingAfter = null,
+    int? HomeGamesTotal = null,
+    int? AwayGamesTotal = null);
 
 public record CompetitionTeamDto(
     int CompetitionTeamId,

--- a/DropShot.UI/Components/Pages/ViewCompetition.razor
+++ b/DropShot.UI/Components/Pages/ViewCompetition.razor
@@ -115,6 +115,53 @@ else
     </MudGrid>
 
     @if (_competition.CompetitionFormat == CompetitionFormat.SinglesLadder
+         && CurrentUser.HasRole("SuperAdmin"))
+    {
+        <MudPaper Class="pa-3 mb-4" Elevation="0" Style="background: rgba(255,193,7,0.10); border: 1px dashed rgba(255,193,7,0.4);">
+            <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Wrap="Wrap.Wrap">
+                <MudIcon Icon="@Icons.Material.Filled.Science" Color="Color.Warning" />
+                <MudStack Spacing="0" Style="flex:1 1 auto;">
+                    <MudText Typo="Typo.body2"><b>SuperAdmin: simulate ladder activity</b></MudText>
+                    <MudText Typo="Typo.caption" Style="opacity:0.85">
+                        Replaces all fixtures and resets every participant's rating, then generates synthetic matches across the chosen window. Some players are designated idle so the inactivity decay fires too.
+                    </MudText>
+                </MudStack>
+                <MudNumericField T="int" @bind-Value="_simulateWeeks"
+                                 Label="Weeks" Min="1" Max="26"
+                                 Style="max-width:90px;" Margin="Margin.Dense" />
+                <MudButton Variant="Variant.Filled" Color="Color.Warning"
+                           Disabled="@_simulating"
+                           OnClick="@(() => _showSimulateConfirmDialog = true)">
+                    Simulate
+                </MudButton>
+            </MudStack>
+            @if (!string.IsNullOrEmpty(_simulateMessage))
+            {
+                <MudAlert Severity="Severity.Info" Dense="true" Class="mt-2">@_simulateMessage</MudAlert>
+            }
+        </MudPaper>
+
+        <MudDialog @bind-Visible="_showSimulateConfirmDialog"
+                   Options="@(new DialogOptions { CloseOnEscapeKey = true, MaxWidth = MaxWidth.Small, FullWidth = true })">
+            <TitleContent>Simulate @_simulateWeeks week(s) of activity?</TitleContent>
+            <DialogContent>
+                <MudText Typo="Typo.body2">
+                    This will <b>delete all existing fixtures</b> and <b>reset every participant's rating</b>
+                    for this ladder before generating synthetic activity. Continue?
+                </MudText>
+            </DialogContent>
+            <DialogActions>
+                <MudButton OnClick="@(() => _showSimulateConfirmDialog = false)">Cancel</MudButton>
+                <MudButton Color="Color.Warning" Variant="Variant.Filled"
+                           Disabled="@_simulating"
+                           OnClick="RunLadderSimulationAsync">
+                    Yes, simulate
+                </MudButton>
+            </DialogActions>
+        </MudDialog>
+    }
+
+    @if (_competition.CompetitionFormat == CompetitionFormat.SinglesLadder
          && _myParticipant?.Status == ParticipantStatus.FullPlayer)
     {
         <MudPaper Class="pa-3 mb-4" Elevation="0" Style="background: rgba(0,180,216,0.08);">
@@ -348,9 +395,11 @@ else
             </MudExpansionPanel>
         }
     }
-    else
+    else if (_competition.CompetitionFormat != CompetitionFormat.SinglesLadder)
     {
-        @* Non-divisional competitions keep the flat Fixtures + Teams panels. *@
+        @* Non-divisional competitions keep the flat Fixtures + Teams panels.
+           SinglesLadder uses the Recent Activity feed instead — fixture rows
+           are ad-hoc and already rendered there alongside decay events. *@
         <MudExpansionPanel Class="mb-2" Text="Fixtures">
         @if (!_fixtures.Any())
         {
@@ -426,12 +475,13 @@ else
     @if (_competition.CompetitionFormat == CompetitionFormat.SinglesLadder && _ladderActivity.Count > 0)
     {
         <MudExpansionPanel Class="mb-2" Text="Recent activity">
-            <MudTable Items="@_ladderActivity" Dense="true" Hover="true" Breakpoint="Breakpoint.Sm" Class="mb-4 mobile-stack-table" Style="max-width:700px">
+            <MudTable Items="@_ladderActivity" Dense="true" Hover="true" Breakpoint="Breakpoint.Sm" Class="mb-4 mobile-stack-table" Style="max-width:760px">
                 <HeaderContent>
                     <MudTh>When</MudTh>
                     <MudTh>Event</MudTh>
                     <MudTh>Detail</MudTh>
                     <MudTh Style="text-align:right">Δ Rating</MudTh>
+                    <MudTh Style="width:40px"></MudTh>
                 </HeaderContent>
                 <RowTemplate>
                     <MudTd DataLabel="When">@context.At.ToLocalTime().ToString("dd MMM HH:mm")</MudTd>
@@ -454,9 +504,49 @@ else
                             <MudText Inline="true" Color="@color">@(d >= 0 ? "+" : "")@d.ToString("0")</MudText>
                         }
                     </MudTd>
+                    <MudTd>
+                        @if (context.Detail is not null)
+                        {
+                            <MudTooltip Text="Explain this rating change">
+                                <MudIconButton Icon="@Icons.Material.Filled.Info"
+                                               Size="Size.Small"
+                                               OnClick="@(() => OpenExplanation(context.Detail))" />
+                            </MudTooltip>
+                        }
+                    </MudTd>
                 </RowTemplate>
             </MudTable>
         </MudExpansionPanel>
+
+        <MudDialog @bind-Visible="_showExplanationDialog"
+                   Options="@(new DialogOptions { CloseOnEscapeKey = true, MaxWidth = MaxWidth.Small, FullWidth = true })">
+            <TitleContent>Rating change explained</TitleContent>
+            <DialogContent>
+                @if (_selectedExplanation is { } x)
+                {
+                    var (line1, line2, blocks) = BuildExplanation(x);
+                    <MudText Typo="Typo.body2"><b>@line1</b></MudText>
+                    <MudText Typo="Typo.caption" Class="mb-3" Style="opacity:0.85">@line2</MudText>
+                    <MudSimpleTable Dense="true" Hover="false" Elevation="0">
+                        <tbody>
+                            @foreach (var (label, value) in blocks)
+                            {
+                                <tr>
+                                    <td style="opacity:0.75; padding:4px 8px;">@label</td>
+                                    <td style="font-variant-numeric:tabular-nums; padding:4px 8px;">@value</td>
+                                </tr>
+                            }
+                        </tbody>
+                    </MudSimpleTable>
+                    <MudText Typo="Typo.caption" Class="mt-3" Style="opacity:0.75">
+                        Elo math: <em>delta = K × MoV × (score − expected)</em>. Score is 1 for a win, 0 for a loss. Expected is the chance of winning given the rating gap. K is the base K-factor (doubled while a player is provisional). MoV is the optional margin-of-victory multiplier.
+                    </MudText>
+                }
+            </DialogContent>
+            <DialogActions>
+                <MudButton OnClick="@(() => _showExplanationDialog = false)">Close</MudButton>
+            </DialogActions>
+        </MudDialog>
     }
 
     @* Non-divisional: keep the flat Teams / Competitors panel below the
@@ -630,9 +720,81 @@ else
     private List<LeagueRow> _leagueTable = [];
 
     // Recent-activity row for SinglesLadder — completed fixture results and
-    // inactivity-decay events merged into one chronological feed.
-    private record ActivityRow(DateTime At, string Kind, string Description, double? Delta);
+    // inactivity-decay events merged into one chronological feed. Match rows
+    // carry enough of the raw fixture data to reconstruct the Elo math on
+    // demand (expected score, K·MoV multiplier, deltas) for the explanation
+    // dialog.
+    private record MatchEloDetail(
+        string Player1Name, double Player1Before, double Player1After,
+        string Player2Name, double Player2Before, double Player2After,
+        int? HomeGames, int? AwayGames, bool Player1Won, string ScoreSummary,
+        double LadderKFactor, int LadderProvisionalMatches, bool UseMov);
+    private record ActivityRow(DateTime At, string Kind, string Description, double? Delta, MatchEloDetail? Detail);
     private List<ActivityRow> _ladderActivity = [];
+
+    private MatchEloDetail? _selectedExplanation;
+    private bool _showExplanationDialog;
+
+    private void OpenExplanation(MatchEloDetail detail)
+    {
+        _selectedExplanation = detail;
+        _showExplanationDialog = true;
+    }
+
+    // Reconstructs the Elo math from the values stored on the fixture so the
+    // dialog can show the user *why* the rating moved the way it did. Returns
+    // a short header line, a sub-line summarising the result, and a list of
+    // labelled value rows.
+    private static (string Line1, string Line2, List<(string Label, string Value)> Blocks)
+        BuildExplanation(MatchEloDetail x)
+    {
+        // Expected scores from pre-match ratings (standard 400-scale).
+        double expected1 = 1.0 / (1.0 + Math.Pow(10, (x.Player2Before - x.Player1Before) / 400.0));
+        double expected2 = 1.0 - expected1;
+
+        double delta1 = x.Player1After - x.Player1Before;
+        double delta2 = x.Player2After - x.Player2Before;
+
+        double score1 = x.Player1Won ? 1.0 : 0.0;
+        double score2 = 1.0 - score1;
+
+        // The fixture stores the *result* of K × MoV × (score − expected). We
+        // invert to recover the effective multiplier (K × MoV combined).
+        double divisor1 = score1 - expected1;
+        double effective1 = Math.Abs(divisor1) > 0.0001 ? delta1 / divisor1 : 0.0;
+
+        // MoV is recomputable from games (we know the formula). K is then
+        // effective / mov when MoV is enabled, else effective on its own.
+        double? mov = null;
+        if (x.UseMov && x.HomeGames.HasValue && x.AwayGames.HasValue
+            && x.HomeGames.Value != x.AwayGames.Value)
+        {
+            double pd = Math.Abs(x.HomeGames.Value - x.AwayGames.Value);
+            double rd = Math.Abs(x.Player1Before - x.Player2Before);
+            double factor = 2.2 / (rd * 0.001 + 2.2);
+            mov = Math.Log(pd + 1) * factor;
+        }
+        double kEstimate = mov is double m && m > 0.01 ? effective1 / m : effective1;
+
+        var line1 = $"{x.Player1Name} ({x.Player1Before:0}) vs {x.Player2Name} ({x.Player2Before:0})";
+        var line2 = x.Player1Won
+            ? $"{x.Player1Name} won  {x.ScoreSummary}"
+            : $"{x.Player2Name} won  {x.ScoreSummary}";
+
+        var blocks = new List<(string, string)>
+        {
+            ($"Expected {x.Player1Name}",  $"{expected1 * 100:0}% chance of winning"),
+            ($"Expected {x.Player2Name}",  $"{expected2 * 100:0}% chance of winning"),
+            ($"Result",                    x.Player1Won ? $"{x.Player1Name} +1, {x.Player2Name} 0" : $"{x.Player1Name} 0, {x.Player2Name} +1"),
+            ($"K-factor (effective)",      $"{kEstimate:0.0}"),
+        };
+        if (mov is double mv) blocks.Add(("Margin-of-victory ×", $"{mv:0.00}"));
+
+        blocks.Add(($"Δ {x.Player1Name}", $"{(delta1 >= 0 ? "+" : "")}{delta1:0.0}  →  {x.Player1After:0}"));
+        blocks.Add(($"Δ {x.Player2Name}", $"{(delta2 >= 0 ? "+" : "")}{delta2:0.0}  →  {x.Player2After:0}"));
+
+        return (line1, line2, blocks);
+    }
 
     private string LastPlayedLabel(int playerId)
     {
@@ -663,6 +825,38 @@ else
     private int? _ladderOpponentId;
     private bool _ladderCreating;
     private string? _ladderError;
+
+    private int _simulateWeeks = 8;
+    private bool _simulating;
+    private bool _showSimulateConfirmDialog;
+    private string? _simulateMessage;
+
+    private async Task RunLadderSimulationAsync()
+    {
+        if (_competition is null) return;
+        _showSimulateConfirmDialog = false;
+        _simulating = true;
+        _simulateMessage = null;
+        try
+        {
+            var result = await CompetitionService.SimulateLadderAsync(_competition.CompetitionId, _simulateWeeks);
+            _simulateMessage =
+                $"Generated {result.FixturesGenerated} fixtures and {result.DecayEventsGenerated} decay events " +
+                $"across {_simulateWeeks} week(s) for {result.ActivePlayers} active + {result.IdlePlayers} idle players.";
+            Snackbar.Add("Ladder simulation complete.", Severity.Success);
+            // Reload competition data so the standings / activity panels refresh.
+            await OnParametersSetAsync();
+        }
+        catch (Exception ex)
+        {
+            _simulateMessage = ex.Message;
+            Snackbar.Add("Simulation failed.", Severity.Error);
+        }
+        finally
+        {
+            _simulating = false;
+        }
+    }
 
     private async Task StartLadderMatchAsync()
     {
@@ -896,13 +1090,27 @@ else
                             ? $"{p1} vs {p2}"
                             : $"{p1} vs {p2} ({f.ResultSummary})";
                         double? delta = null;
-                        if (f.Player1RatingBefore.HasValue && f.Player1RatingAfter.HasValue)
+                        MatchEloDetail? detail = null;
+                        if (f.Player1RatingBefore.HasValue && f.Player1RatingAfter.HasValue
+                            && f.Player2RatingBefore.HasValue && f.Player2RatingAfter.HasValue)
+                        {
                             delta = f.Player1RatingAfter.Value - f.Player1RatingBefore.Value;
+                            detail = new MatchEloDetail(
+                                p1, f.Player1RatingBefore.Value, f.Player1RatingAfter.Value,
+                                p2, f.Player2RatingBefore.Value, f.Player2RatingAfter.Value,
+                                f.HomeGamesTotal, f.AwayGamesTotal,
+                                f.WinnerPlayerId == f.Player1Id,
+                                f.ResultSummary ?? "",
+                                _competition.LadderKFactor,
+                                _competition.LadderProvisionalMatches,
+                                _competition.LadderUseMarginOfVictory);
+                        }
                         return new ActivityRow(
                             f.CompletedAt!.Value,
                             "Match",
                             $"{winner} beat {(winner == p1 ? p2 : p1)} — {score}",
-                            delta);
+                            delta,
+                            detail);
                     });
 
                 var decayRows = (_competition.LadderDecayEvents ?? new())
@@ -910,7 +1118,8 @@ else
                         d.AppliedAt,
                         "Decay",
                         $"{d.PlayerName} — {d.DaysInactive}d inactive",
-                        d.RatingAfter - d.RatingBefore));
+                        d.RatingAfter - d.RatingBefore,
+                        null));
 
                 _ladderActivity = fixtureRows.Concat(decayRows)
                     .OrderByDescending(r => r.At)

--- a/DropShot.UI/Services/ICompetitionService.cs
+++ b/DropShot.UI/Services/ICompetitionService.cs
@@ -36,6 +36,14 @@ public interface ICompetitionService
     Task ApproveFixtureResultAsync(int fixtureId, ApproveFixtureResultRequest request, CancellationToken ct = default);
 
     /// <summary>
+    /// SuperAdmin-only: generate synthetic activity for a SinglesLadder
+    /// competition. Destructive — wipes prior fixtures + decay events and
+    /// resets every participant before simulating. See
+    /// <c>LadderSimulationService</c> for behaviour.
+    /// </summary>
+    Task<LadderSimulationResultDto> SimulateLadderAsync(int competitionId, int weeks, int? seed = null, CancellationToken ct = default);
+
+    /// <summary>
     /// Submit a fixture score for the first time (or override an existing one
     /// when the caller is an admin). Server enforces RequireVerification
     /// (sets Status = AwaitingVerification + a VerificationToken when needed)

--- a/DropShot/Controllers/CompetitionsController.cs
+++ b/DropShot/Controllers/CompetitionsController.cs
@@ -1122,6 +1122,30 @@ public class CompetitionsController(
         return Ok();
     }
 
+    /// <summary>
+    /// Generate synthetic activity for a SinglesLadder competition so an admin
+    /// can see ratings, decay events, and the activity feed in action without
+    /// waiting for real play. Destructive — wipes all fixtures + decay events
+    /// and resets every participant's rating bookkeeping before simulating.
+    /// SuperAdmin only.
+    /// </summary>
+    [HttpPost("{id:int}/ladder/simulate")]
+    [Authorize(Roles = "SuperAdmin")]
+    public async Task<ActionResult<LadderSimulationResultDto>> SimulateLadder(
+        int id, [FromQuery] int weeks = 8, [FromQuery] int? seed = null, CancellationToken ct = default)
+    {
+        await using var db = dbFactory.CreateDbContext();
+        try
+        {
+            var r = await LadderSimulationService.SimulateAsync(db, id, weeks, seed, ct);
+            return Ok(new LadderSimulationResultDto(
+                r.Participants, r.ActivePlayers, r.IdlePlayers,
+                r.FixturesGenerated, r.DecayEventsGenerated));
+        }
+        catch (InvalidOperationException ex) { return BadRequest(ex.Message); }
+        catch (ArgumentOutOfRangeException ex) { return BadRequest(ex.Message); }
+    }
+
     [HttpPost("{id:int}/fixtures/schedule")]
     public async Task<IActionResult> ScheduleFixtures(int id)
     {

--- a/DropShot/Services/LadderSimulationService.cs
+++ b/DropShot/Services/LadderSimulationService.cs
@@ -1,0 +1,199 @@
+using DropShot.Data;
+using DropShot.Models;
+using DropShot.Shared;
+using Microsoft.EntityFrameworkCore;
+
+namespace DropShot.Services;
+
+/// <summary>
+/// Admin-only test fixture: generates synthetic SinglesLadder activity so an
+/// admin can see ratings, decay, and the activity feed in action without
+/// waiting weeks of real play.
+///
+/// Destructive — wipes all fixtures and decay events for the target ladder
+/// and resets every participant's rating bookkeeping to the competition's
+/// starting state before simulating. The endpoint that calls this is gated
+/// to SuperAdmin only.
+/// </summary>
+public static class LadderSimulationService
+{
+    public sealed record SimulationResult(
+        int Participants, int ActivePlayers, int IdlePlayers,
+        int FixturesGenerated, int DecayEventsGenerated);
+
+    public static async Task<SimulationResult> SimulateAsync(
+        MyDbContext db, int competitionId, int weeks, int? seed, CancellationToken ct = default)
+    {
+        if (weeks < 1 || weeks > 26)
+            throw new ArgumentOutOfRangeException(nameof(weeks), "weeks must be 1..26");
+
+        var comp = await db.Competition.FirstOrDefaultAsync(c => c.CompetitionID == competitionId, ct)
+            ?? throw new InvalidOperationException("Competition not found.");
+        if (comp.CompetitionFormat != CompetitionFormat.SinglesLadder)
+            throw new InvalidOperationException("Simulation is only valid for SinglesLadder competitions.");
+
+        var participants = await db.CompetitionParticipants
+            .Where(p => p.CompetitionId == competitionId && p.Status == ParticipantStatus.FullPlayer)
+            .Include(p => p.Player)
+            .ToListAsync(ct);
+        if (participants.Count < 4)
+            throw new InvalidOperationException("Need at least 4 FullPlayer participants to simulate.");
+
+        var rnd = seed.HasValue ? new Random(seed.Value) : new Random();
+
+        // ── Wipe any prior fixtures + decay events for this ladder ─────────
+        var existingFixtures = await db.CompetitionFixtures
+            .Where(f => f.CompetitionId == competitionId)
+            .ToListAsync(ct);
+        db.CompetitionFixtures.RemoveRange(existingFixtures);
+
+        var existingDecays = await db.LadderInactivityDecays
+            .Where(d => d.CompetitionId == competitionId)
+            .ToListAsync(ct);
+        db.LadderInactivityDecays.RemoveRange(existingDecays);
+
+        // Reset participant state to the starting line.
+        foreach (var p in participants)
+        {
+            p.EloRating = comp.LadderStartingRating;
+            p.MatchesPlayed = 0;
+            p.IsProvisional = true;
+            p.LastMatchAt = null;
+            p.LastDecayAppliedAt = null;
+            p.LastInactivityWarningAt = null;
+        }
+        await db.SaveChangesAsync(ct);
+
+        // ── Pick active vs idle (deterministic via seed) ───────────────────
+        var shuffled = participants.OrderBy(_ => rnd.Next()).ToList();
+        int idleCount = Math.Max(1, shuffled.Count * 3 / 10);   // ~30 % idle
+        var idle = shuffled.Take(idleCount).ToList();
+        var active = shuffled.Skip(idleCount).ToList();
+
+        var now = DateTime.UtcNow;
+        var simStart = now.AddDays(-weeks * 7);
+
+        // Idle players "last played" two weeks before the sim started — gives
+        // their decay clock something to chew on while sweeps run.
+        foreach (var p in idle) p.LastMatchAt = simStart.AddDays(-14);
+
+        // ── Generate match fixtures across the window ──────────────────────
+        // Aim for roughly 1.5 matches per active player per week.
+        int matchesAdded = 0;
+        for (int day = 0; day < weeks * 7; day++)
+        {
+            var dayStart = simStart.AddDays(day);
+
+            int target = (active.Count * 3) / 14;             // ~1.5/wk per player ÷ 2 (each match = 2 players)
+            int matchesToday = Math.Max(0, target + rnd.Next(-1, 2));
+
+            for (int i = 0; i < matchesToday; i++)
+            {
+                var p1 = active[rnd.Next(active.Count)];
+                var p2 = active[rnd.Next(active.Count)];
+                int tries = 0;
+                while (p2.PlayerId == p1.PlayerId && tries++ < 5)
+                    p2 = active[rnd.Next(active.Count)];
+                if (p2.PlayerId == p1.PlayerId) continue;
+
+                double expA = EloCalculator.ExpectedScore(p1.EloRating, p2.EloRating);
+                bool p1Wins = rnd.NextDouble() < expA;
+
+                int wSets = 2;
+                int lSets = rnd.Next(0, 2); // 0 or 1
+                int wGames = wSets * 6 + rnd.Next(0, 4);
+                int lGames = lSets * 6 + rnd.Next(0, 7);
+
+                int homeSets = p1Wins ? wSets : lSets;
+                int awaySets = p1Wins ? lSets : wSets;
+                int homeGames = p1Wins ? wGames : lGames;
+                int awayGames = p1Wins ? lGames : wGames;
+
+                double? mov = comp.LadderUseMarginOfVictory && homeGames != awayGames
+                    ? EloCalculator.MarginOfVictoryMultiplier(homeGames, awayGames, p1.EloRating, p2.EloRating)
+                    : null;
+
+                double kA = p1.MatchesPlayed < comp.LadderProvisionalMatches
+                    ? comp.LadderKFactor * 2 : comp.LadderKFactor;
+                double kB = p2.MatchesPlayed < comp.LadderProvisionalMatches
+                    ? comp.LadderKFactor * 2 : comp.LadderKFactor;
+
+                double scoreA = p1Wins ? 1.0 : 0.0;
+                double newA = EloCalculator.UpdateRating(p1.EloRating, expA, scoreA, kA, mov);
+                double newB = EloCalculator.UpdateRating(p2.EloRating, 1.0 - expA, 1.0 - scoreA, kB, mov);
+
+                var fx = new CompetitionFixture
+                {
+                    CompetitionId = competitionId,
+                    Player1Id = p1.PlayerId,
+                    Player2Id = p2.PlayerId,
+                    Status = FixtureStatus.Completed,
+                    ScheduledAt = dayStart,
+                    CompletedAt = dayStart.AddHours(1),
+                    WinnerPlayerId = p1Wins ? p1.PlayerId : p2.PlayerId,
+                    HomeSetsWon = homeSets,
+                    AwaySetsWon = awaySets,
+                    HomeGamesTotal = homeGames,
+                    AwayGamesTotal = awayGames,
+                    ResultSummary = $"[sim] {homeSets}-{awaySets} ({homeGames}-{awayGames} games)",
+                    Player1RatingBefore = p1.EloRating,
+                    Player1RatingAfter = newA,
+                    Player2RatingBefore = p2.EloRating,
+                    Player2RatingAfter = newB,
+                };
+                db.CompetitionFixtures.Add(fx);
+
+                p1.EloRating = newA;
+                p1.MatchesPlayed++;
+                p1.LastMatchAt = fx.CompletedAt;
+                p1.IsProvisional = p1.MatchesPlayed < comp.LadderProvisionalMatches;
+
+                p2.EloRating = newB;
+                p2.MatchesPlayed++;
+                p2.LastMatchAt = fx.CompletedAt;
+                p2.IsProvisional = p2.MatchesPlayed < comp.LadderProvisionalMatches;
+
+                matchesAdded++;
+            }
+        }
+        await db.SaveChangesAsync(ct);
+
+        // ── Run weekly inactivity sweeps over the simulated window ─────────
+        // RunSweepAsync gates on Competition.IsStarted; flip it on if the
+        // admin hasn't pressed Start yet, otherwise the sweep is a no-op.
+        bool flippedStarted = false;
+        if (!comp.IsStarted)
+        {
+            comp.IsStarted = true;
+            flippedStarted = true;
+            await db.SaveChangesAsync(ct);
+        }
+
+        int decayCount = 0;
+        for (var sweep = simStart.AddDays(7); sweep <= now; sweep = sweep.AddDays(7))
+        {
+            var r = await LadderInactivityService.RunSweepAsync(db, sweep, null, ct);
+            decayCount += r.DecayEventsApplied;
+        }
+        // One more sweep at "now" to catch any decay events that fall between
+        // the last 7-day boundary and the simulation end.
+        if (now > simStart.AddDays(((weeks * 7) / 7) * 7))
+        {
+            var r = await LadderInactivityService.RunSweepAsync(db, now, null, ct);
+            decayCount += r.DecayEventsApplied;
+        }
+
+        if (flippedStarted)
+        {
+            // Leave IsStarted true — simulation is meaningless otherwise, and
+            // any subsequent real play needs it on too.
+        }
+
+        return new SimulationResult(
+            Participants: participants.Count,
+            ActivePlayers: active.Count,
+            IdlePlayers: idle.Count,
+            FixturesGenerated: matchesAdded,
+            DecayEventsGenerated: decayCount);
+    }
+}

--- a/DropShot/Services/WebCompetitionService.cs
+++ b/DropShot/Services/WebCompetitionService.cs
@@ -266,7 +266,9 @@ public sealed class WebCompetitionService(
         Player1RatingBefore: f.Player1RatingBefore,
         Player1RatingAfter: f.Player1RatingAfter,
         Player2RatingBefore: f.Player2RatingBefore,
-        Player2RatingAfter: f.Player2RatingAfter);
+        Player2RatingAfter: f.Player2RatingAfter,
+        HomeGamesTotal: f.HomeGamesTotal,
+        AwayGamesTotal: f.AwayGamesTotal);
 
     public async Task SelfRegisterAsync(int competitionId, DropShot.Shared.ParticipantStatus status, CancellationToken ct = default)
     {
@@ -305,6 +307,16 @@ public sealed class WebCompetitionService(
 
         participant.Status = status;
         await db.SaveChangesAsync(ct);
+    }
+
+    public async Task<LadderSimulationResultDto> SimulateLadderAsync(
+        int competitionId, int weeks, int? seed = null, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var r = await LadderSimulationService.SimulateAsync(db, competitionId, weeks, seed, ct);
+        return new LadderSimulationResultDto(
+            r.Participants, r.ActivePlayers, r.IdlePlayers,
+            r.FixturesGenerated, r.DecayEventsGenerated);
     }
 
     public async Task ApproveFixtureResultAsync(


### PR DESCRIPTION
Follow-up to [#665](https://github.com/kingbeazer/DropShot/pull/665) / [#666](https://github.com/kingbeazer/DropShot/pull/666) / [#668](https://github.com/kingbeazer/DropShot/pull/668).

## Summary
- **Hide the standalone Fixtures expansion panel** on ViewCompetition for SinglesLadder. The Recent Activity feed already shows completed matches alongside decay events, so the Fixtures panel was redundant duplication.
- **Super-admin "Simulate N weeks" tool** ([LadderSimulationService](DropShot/Services/LadderSimulationService.cs), [POST /api/competitions/{id}/ladder/simulate](DropShot/Controllers/CompetitionsController.cs)). Wipes fixtures + decay events for the ladder, resets every participant's rating bookkeeping, then generates synthetic match results across the chosen window (~1.5 matches/week per active player). ~30% of participants are designated idle so the production inactivity sweep fires real decay events too. Uses the production EloCalculator + LadderInactivityService so what you see is what real play would produce. SuperAdmin-only, behind a confirm dialog because it's destructive.
- **Per-match Elo explanation**: info icon on each match row in the Recent Activity feed pops a dialog reconstructing the math from the stored before/after ratings — expected scores, effective K, MoV multiplier, per-player deltas. Built from the values already on CompetitionFixture; added HomeGamesTotal/AwayGamesTotal to the fixture DTO so MoV can be shown.

## Test plan
- [x] dotnet build clean across DropShot, DropShot.UI, DropShot.Shared, DropShot.Tests
- [x] All ladder/elo test suites green (LadderRatingService 5/5, LadderInactivityService 10/10, PlayerRatingService 24/24, ViewCompetition 2/2 = 41/41)
- [ ] Manual: as SuperAdmin, register ≥4 players in a SinglesLadder, click Simulate (8 weeks) — expect ~70-ish fixtures, decay events on the idle 30%, standings reordered by rating, info icon on each match opens the explanation
- [ ] Manual: as non-SuperAdmin, simulate button is hidden
- [ ] Manual: non-ladder competitions render Fixtures panel unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)