### PR TITLE
Use MudBlazor date picker for DOB on Register and Profile pages

### DIFF
--- a/DropShot/Components/Account/Pages/Manage/Index.razor
+++ b/DropShot/Components/Account/Pages/Manage/Index.razor
@@ -5,6 +5,7 @@
 @using DropShot.Data
 @using DropShot.Models
 @using DropShot.Shared
+@using DropShot.Components.Account.Shared
 @using Microsoft.EntityFrameworkCore
 
 @inject UserManager<ApplicationUser> UserManager
@@ -74,9 +75,8 @@
                     </InputRadioGroup>
                     <ValidationMessage For="() => Input.CompetitionCategory" class="text-danger" />
                 </fieldset>
-                <div class="form-floating mb-3">
-                    <InputDate @bind-Value="Input.DateOfBirth" class="form-control" placeholder="Date of Birth" />
-                    <label for="date-of-birth" class="form-label">Date of birth</label>
+                <div class="mb-3">
+                    <DateOfBirthIsland Name="Input.DateOfBirth" InitialValue="@Input.DateOfBirth" Label="Date of birth" />
                     <ValidationMessage For="() => Input.DateOfBirth" class="text-danger" />
                 </div>
             }

--- a/DropShot/Components/Account/Pages/Register.razor
+++ b/DropShot/Components/Account/Pages/Register.razor
@@ -9,6 +9,7 @@
 @using DropShot.Data
 @using DropShot.Models
 @using DropShot.Shared
+@using DropShot.Components.Account.Shared
 @using Microsoft.EntityFrameworkCore
 
 @inject UserManager<ApplicationUser> UserManager
@@ -54,9 +55,8 @@
                 <label for="confirm-password">Confirm Password</label>
                 <ValidationMessage For="() => Input.ConfirmPassword" class="text-danger" />
             </div>
-            <div class="form-floating mb-3">
-                <InputDate @bind-Value="Input.DateOfBirth" class="form-control" aria-required="true" placeholder="Date of Birth" />
-                <label for="date-of-birth">Date of Birth</label>
+            <div class="mb-3">
+                <DateOfBirthIsland Name="Input.DateOfBirth" InitialValue="@Input.DateOfBirth" Label="Date of Birth" />
                 <ValidationMessage For="() => Input.DateOfBirth" class="text-danger" />
             </div>
             <fieldset class="mb-3">

--- a/DropShot/Components/Account/Shared/DateOfBirthIsland.razor
+++ b/DropShot/Components/Account/Shared/DateOfBirthIsland.razor
@@ -1,0 +1,22 @@
+@* Interactive island that renders a MudBlazor date picker inside a static SSR
+   form. The island carries the value back to the SSR form via a hidden <input>
+   named after the form field — Account pages stay SSR (so SignInManager cookie
+   writes still work) while users get the MudBlazor calendar UX. *@
+@rendermode InteractiveServer
+@using MudBlazor
+
+<MudPopoverProvider />
+<MudDatePicker @bind-Date="_date" Label="@Label" Variant="Variant.Outlined"
+               DateFormat="dd/MM/yyyy" Editable="true" MaxDate="DateTime.Today" />
+<input type="hidden" name="@Name" value="@_dateString" />
+
+@code {
+    [Parameter, EditorRequired] public string Name { get; set; } = default!;
+    [Parameter] public DateTime? InitialValue { get; set; }
+    [Parameter] public string? Label { get; set; } = "Date of birth";
+
+    private DateTime? _date;
+    private string _dateString => _date?.ToString("yyyy-MM-dd") ?? "";
+
+    protected override void OnInitialized() => _date = InitialValue;
+}


### PR DESCRIPTION
## Summary
- The Register page and the Profile page (`/Account/Manage`) used Blazor's stock `InputDate`, which renders a plain HTML5 `<input type="date">`. The rest of the app uses `MudDatePicker`.
- These two pages have to stay static SSR — `AccountLayout` (lines 63–72) explicitly redirects back to SSR if it detects interactive mode, because Identity actions (`SignInManager.SignInAsync`, `RefreshSignInAsync`) need to write the auth cookie to the HTTP response. That rules out making the whole page `InteractiveServer`.
- Instead this adds a small interactive island component (`DateOfBirthIsland`) that renders `MudDatePicker` inside `@rendermode InteractiveServer`, and writes the chosen date back to the SSR form via a hidden `<input name="…">` matching the form field path (e.g. `Input.DateOfBirth`). The pattern mirrors `QrLoginPanel.razor`, the existing interactive island used on the Login page.

## Test plan
- [ ] `/Account/Register` — DOB field now shows a MudBlazor calendar popup with `dd/MM/yyyy` formatting; picking a valid adult date and registering succeeds end-to-end
- [ ] `/Account/Register` — submitting with no DOB still shows the "Please enter your date of birth." validation message
- [ ] `/Account/Register` — picking a DOB under 18 still triggers the existing "You can only register if you are over 18…" identity error
- [ ] `/Account/Manage` — DOB picker pre-fills from the user's existing value, picking a new value and saving persists it
- [ ] `/Account/Manage` — picking a DOB under 18 still shows the "you must be at least 18" error and does not persist
- [ ] No regressions to the rest of the Profile form (display name, competition category, phone number, avatar upload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)