### PR TITLE
Ladder simulator: give idle players a rating head-start

### DIFF
--- a/DropShot/Services/LadderSimulationService.cs
+++ b/DropShot/Services/LadderSimulationService.cs
@@ -73,9 +73,21 @@ public static class LadderSimulationService
         var now = DateTime.UtcNow;
         var simStart = now.AddDays(-weeks * 7);
 
-        // Idle players "last played" two weeks before the sim started — gives
-        // their decay clock something to chew on while sweeps run.
-        foreach (var p in idle) p.LastMatchAt = simStart.AddDays(-14);
+        // Idle players: backdate "last played" so the decay clock is well past
+        // grace when the first sweep fires, and give them a rating head-start
+        // above LadderStartingRating so decay has room to operate (the
+        // production floor clamps at starting rating, so an idle player sitting
+        // at exactly the starting rating would never produce a visible decay
+        // event). Mark them out-of-provisional too so the "prov" chip doesn't
+        // appear on what's meant to look like a long-time member.
+        const double IdleHeadStart = 200.0;
+        foreach (var p in idle)
+        {
+            p.EloRating = comp.LadderStartingRating + IdleHeadStart;
+            p.MatchesPlayed = Math.Max(1, comp.LadderProvisionalMatches);
+            p.IsProvisional = false;
+            p.LastMatchAt = simStart.AddDays(-14);
+        }
 
         // ── Generate match fixtures across the window ──────────────────────
         // Aim for roughly 1.5 matches per active player per week.


### PR DESCRIPTION
Quick fix to PR [#671](https://github.com/kingbeazer/DropShot/pull/671) reported in testing: \"Generated 183 fixtures and 0 decay events across 26 week(s) for 7 active + 2 idle players.\"

## What was wrong
The simulator reset every participant's rating to `LadderStartingRating` and then marked some as idle. But the production decay floor is `LadderStartingRating` — idle players sitting at exactly the floor have zero decay headroom, so the sweep ran fine but every step clamped to a 0-point delta and skipped writing an audit row.

## Fix
After the reset, bump idle participants to `LadderStartingRating + 200`, mark them out-of-provisional, and backdate their LastMatchAt. Now the decay sweep finds real headroom and produces visible weekly decay events across the simulation window.

Production behaviour is unchanged — this is purely the simulator setting up an idle player who has \"earned\" some rating before going quiet, instead of one sitting at the floor from the start.

## Test plan
- [x] dotnet build clean
- [ ] Manual: run the simulator on the same 7+2 ladder — expect ~20 decay events across the 26-week window (each idle player decays from 1200 down toward 1000 over ~20 weekly steps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)