### PR TITLE
Respect active role on Edit + Simulate buttons

### DIFF
--- a/DropShot.Maui/Services/MauiCurrentUser.cs
+++ b/DropShot.Maui/Services/MauiCurrentUser.cs
@@ -60,6 +60,8 @@ public sealed class MauiCurrentUser : ICurrentUser, IDisposable
     public bool IsAuthenticated => _auth.Session is not null;
     public bool IsAdmin => _auth.IsAdmin;
     public bool IsClubAdmin => _auth.IsClubAdmin;
+    public bool IsSuperAdmin =>
+        string.Equals(_auth.ActiveRole, "SuperAdmin", StringComparison.OrdinalIgnoreCase);
 
     // The login DTO doesn't carry the subscription bit yet, so on MAUI we
     // conservatively report false. The "user competition" creation path is a

--- a/DropShot.UI/Components/Pages/ViewCompetition.razor
+++ b/DropShot.UI/Components/Pages/ViewCompetition.razor
@@ -115,7 +115,7 @@ else
     </MudGrid>
 
     @if (_competition.CompetitionFormat == CompetitionFormat.SinglesLadder
-         && CurrentUser.HasRole("SuperAdmin"))
+         && CurrentUser.IsSuperAdmin)
     {
         <MudPaper Class="pa-3 mb-4" Elevation="0" Style="background: rgba(255,193,7,0.10); border: 1px dashed rgba(255,193,7,0.4);">
             <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Wrap="Wrap.Wrap">

--- a/DropShot.UI/Services/Auth/ICurrentUser.cs
+++ b/DropShot.UI/Services/Auth/ICurrentUser.cs
@@ -25,6 +25,13 @@ public interface ICurrentUser
     bool IsAdmin { get; }
     bool IsClubAdmin { get; }
     bool IsSubscribed { get; }
+    /// <summary>
+    /// True when the user's <em>active</em> role is SuperAdmin. Distinct from
+    /// <c>HasRole("SuperAdmin")</c>, which would also return true for a
+    /// SuperAdmin who has switched to a lower-privilege role for browsing
+    /// purposes.
+    /// </summary>
+    bool IsSuperAdmin { get; }
     bool HasRole(string role);
     bool CanEditClub(int clubId);
     bool CanEditCompetition(int? hostClubId);

--- a/DropShot/Services/WebCurrentUser.cs
+++ b/DropShot/Services/WebCurrentUser.cs
@@ -224,16 +224,20 @@ public sealed class WebCurrentUser : ICurrentUser, IDisposable
     public bool IsAuthenticated => ApiPrincipal is not null || _isAuthenticated;
     public bool IsAdmin => _activeRole is "Admin" or "SuperAdmin";
     public bool IsClubAdmin => _activeRole == "ClubAdmin";
+    public bool IsSuperAdmin => _activeRole == "SuperAdmin";
     public bool IsSubscribed => _isSubscribed;
 
     public bool HasRole(string role) =>
         _grantedRoles.Contains(role, StringComparer.OrdinalIgnoreCase);
 
     public bool CanEditClub(int clubId) =>
-        IsAdmin || _adminClubIds.Contains(clubId);
+        IsAdmin || (IsClubAdmin && _adminClubIds.Contains(clubId));
 
+    // Must be acting as Admin/SuperAdmin OR acting as ClubAdmin of the host
+    // club. ClubAdmin memberships on _adminClubIds alone aren't enough — a
+    // ClubAdmin who's role-switched to User shouldn't see edit affordances.
     public bool CanEditCompetition(int? hostClubId) =>
-        IsAdmin || (hostClubId.HasValue && _adminClubIds.Contains(hostClubId.Value));
+        IsAdmin || (IsClubAdmin && hostClubId.HasValue && _adminClubIds.Contains(hostClubId.Value));
 
     public bool CanCreateUserCompetition
     {


### PR DESCRIPTION
Two role-switch bugs reported on the competition view.

## Bug 1: Simulate button visible when browsing as a user
The button used `CurrentUser.HasRole("SuperAdmin")`, which checks the *granted* role list. That returns true even after a SuperAdmin switches to User mode for browsing.

**Fix:** Added `IsSuperAdmin` to `ICurrentUser` — reads the active role. Switched the button gate to use it.

## Bug 2: Edit competition button visible when ClubAdmin is browsing as a user
`WebCurrentUser.CanEditCompetition(hostClubId)` returned true whenever the user's `_adminClubIds` list contained the host club, irrespective of active role. A ClubAdmin who'd toggled to User mode still saw the Edit button (and got redirected away on click).

**Fix:** Tightened to require the active role be Admin/SuperAdmin, or ClubAdmin *of the host club*. User-mode hides the affordance entirely. `CanEditClub` got the same treatment for consistency.

```csharp
// before
public bool CanEditCompetition(int? hostClubId) =>
    IsAdmin || (hostClubId.HasValue && _adminClubIds.Contains(hostClubId.Value));

// after
public bool CanEditCompetition(int? hostClubId) =>
    IsAdmin || (IsClubAdmin && hostClubId.HasValue && _adminClubIds.Contains(hostClubId.Value));
```

## Test plan
- [x] dotnet build clean
- [x] All ladder/view tests pass (17/17)
- [ ] Manual: as SuperAdmin who's switched to User mode, navigate to a SinglesLadder — Simulate button hidden, Edit button hidden, can still record a match as a participant
- [ ] Manual: as ClubAdmin who's switched to User mode, view a competition in their own host club — Edit button hidden
- [ ] Manual: as plain ClubAdmin (no switching), view their host-club competition — Edit button shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)