### PR TITLE
GDPR-compliant phone-number sharing in competitions

### DIFF
--- a/DropShot.Maui/Services/HttpCompetitionService.cs
+++ b/DropShot.Maui/Services/HttpCompetitionService.cs
@@ -18,19 +18,21 @@ public sealed class HttpCompetitionService(HttpClient http) : ICompetitionServic
     public Task<CompetitionDetailDto?> GetCompetitionAsync(int id, CancellationToken ct = default) =>
         http.GetFromJsonAsync<CompetitionDetailDto>($"api/competitions/{id}", ct);
 
-    public async Task SelfRegisterAsync(int competitionId, ParticipantStatus status, CancellationToken ct = default)
+    public async Task SelfRegisterAsync(
+        int competitionId, ParticipantStatus status, PhoneShareConsent consent, CancellationToken ct = default)
     {
         var resp = await http.PostAsJsonAsync(
             $"api/competitions/{competitionId}/self-register",
-            new UpdateParticipantStatusRequest(status), ct);
+            new SelfRegisterRequest(status, consent), ct);
         resp.EnsureSuccessStatusCode();
     }
 
-    public async Task ConfirmParticipationAsync(int competitionId, ParticipantStatus status, CancellationToken ct = default)
+    public async Task ConfirmParticipationAsync(
+        int competitionId, ParticipantStatus status, PhoneShareConsent consent, CancellationToken ct = default)
     {
         var resp = await http.PostAsJsonAsync(
             $"api/competitions/{competitionId}/confirm-participation",
-            new UpdateParticipantStatusRequest(status), ct);
+            new SelfRegisterRequest(status, consent), ct);
         resp.EnsureSuccessStatusCode();
     }
 
@@ -86,13 +88,26 @@ public sealed class HttpCompetitionService(HttpClient http) : ICompetitionServic
         resp.EnsureSuccessStatusCode();
     }
 
-    public async Task EnterCompetitionAsync(int competitionId, CancellationToken ct = default)
+    public async Task EnterCompetitionAsync(
+        int competitionId, PhoneShareConsent consent, CancellationToken ct = default)
     {
-        var resp = await http.PostAsync($"api/competitions/{competitionId}/enter", null, ct);
+        var resp = await http.PostAsJsonAsync(
+            $"api/competitions/{competitionId}/enter",
+            new EnterCompetitionRequest(consent), ct);
         if (!resp.IsSuccessStatusCode)
         {
             var body = await resp.Content.ReadAsStringAsync(ct);
             throw new InvalidOperationException(string.IsNullOrEmpty(body) ? resp.ReasonPhrase ?? "Failed to enter." : body);
+        }
+    }
+
+    public async Task LeaveCompetitionAsync(int competitionId, CancellationToken ct = default)
+    {
+        var resp = await http.PostAsync($"api/competitions/{competitionId}/leave", null, ct);
+        if (!resp.IsSuccessStatusCode)
+        {
+            var body = await resp.Content.ReadAsStringAsync(ct);
+            throw new InvalidOperationException(string.IsNullOrEmpty(body) ? resp.ReasonPhrase ?? "Failed to leave." : body);
         }
     }
 

--- a/DropShot.Shared/Dtos/CompetitionAdminDtos.cs
+++ b/DropShot.Shared/Dtos/CompetitionAdminDtos.cs
@@ -305,7 +305,11 @@ public record SearchPlayersForAddRequest(
 /// </summary>
 public record BulkAddParticipantsRequest(
     IReadOnlyList<int> PlayerIds,
-    ParticipantStatus Status = ParticipantStatus.Registered);
+    ParticipantStatus Status = ParticipantStatus.Registered,
+    // Single attestation covers every player in the batch — the admin is
+    // asserting they have consent from all of them under the same Source.
+    // Null = no peer-share consent (e.g. simulated-roster test data).
+    AdminRecordedPhoneShareConsent? AttestedConsent = null);
 
 public record BulkAddParticipantsResultDto(int Added, int Skipped);
 

--- a/DropShot.Shared/Dtos/CompetitionDtos.cs
+++ b/DropShot.Shared/Dtos/CompetitionDtos.cs
@@ -57,7 +57,13 @@ public record CompetitionDetailDto(
     double LadderStartingRating = 1000.0,
     int LadderProvisionalMatches = 10,
     bool LadderUseMarginOfVictory = true,
-    List<LadderInactivityDecayDto>? LadderDecayEvents = null);
+    List<LadderInactivityDecayDto>? LadderDecayEvents = null,
+    // The current user's own MobileNumber (or null if they have no Player
+    // record / no number on file). Used by the entry consent dialog to
+    // render the masked number and decide whether to block entry until a
+    // number is added. Always populated for the caller themselves regardless
+    // of peer visibility — viewing your own number doesn't require consent.
+    string? MyMobileNumber = null);
 
 public record LadderInactivityDecayDto(
     int PlayerId,
@@ -183,7 +189,11 @@ public record LeagueTableEntryDto(
 public record MyCompetitionsViewDto(
     bool HasPlayer,
     List<CompetitionDto> Entered,
-    List<CompetitionDto> Available);
+    List<CompetitionDto> Available,
+    // Caller's own MobileNumber (null when no Player record / no number on
+    // file). Used by the per-competition entry consent dialog to render the
+    // masked number and to gate the Enter button until a number is added.
+    string? MyMobileNumber = null);
 
 public record SaveCompetitionRequest(
     string CompetitionName,
@@ -208,7 +218,27 @@ public record SaveCompetitionRequest(
 
 public record AddStageRequest(StageType StageType, string? Name = null, int? StageOrder = null);
 
-public record AddParticipantRequest(int PlayerId, bool Force = false);
+/// <summary>
+/// Admin attestation that the data subject (the player being added) has
+/// consented to their mobile number being shared with other competitors —
+/// typically because they emailed the admin asking to enter. Materially
+/// weaker than self-asserted consent (the player didn't click anything
+/// themselves), so the recorded ConsentVersion is distinct ("v1-2026-05-admin")
+/// and <see cref="Source"/> captures the admin's evidence (subject line,
+/// date, channel) for audit. Players retain self-service withdrawal via
+/// Leave competition.
+/// </summary>
+public record AdminRecordedPhoneShareConsent(
+    bool Attested,
+    string Source);
+
+public record AddParticipantRequest(
+    int PlayerId,
+    bool Force = false,
+    // Null = no peer-share consent recorded (e.g. test data, simulated
+    // rosters). Server will not throw — the visibility service simply
+    // keeps the number hidden from peers until the player self-consents.
+    AdminRecordedPhoneShareConsent? AttestedConsent = null);
 
 /// <summary>
 /// Approve an awaiting-verification fixture result, optionally overriding the
@@ -255,6 +285,33 @@ public record EligibilityWarning(string Code, string Message);
 public record EligibilityWarningsResponse(string Message, List<EligibilityWarning> Warnings);
 
 public record UpdateParticipantStatusRequest(ParticipantStatus Status);
+
+/// <summary>
+/// Per-competition consent payload submitted when a player enters a competition.
+/// <c>WordingShown</c> is the exact text the user saw (so it can be recorded
+/// verbatim for audit) and <c>Version</c> matches the server's
+/// <c>PhoneVisibilityService.CurrentConsentVersion</c> — mismatches are
+/// rejected so a stale client reloads.
+/// </summary>
+public record PhoneShareConsent(
+    bool Granted,
+    string WordingShown,
+    string Version);
+
+/// <summary>
+/// Self-register / confirm-participation request body. Carries the chosen
+/// participation status plus the per-competition phone-share consent the user
+/// gave in the dialog.
+/// </summary>
+public record SelfRegisterRequest(
+    ParticipantStatus Status,
+    PhoneShareConsent Consent);
+
+/// <summary>
+/// Enter-competition request body. No status field (the server picks
+/// Registered) — only the per-competition phone-share consent.
+/// </summary>
+public record EnterCompetitionRequest(PhoneShareConsent Consent);
 
 public record SaveFixtureRequest(
     int? CompetitionStageId,

--- a/DropShot.Shared/Helpers/PhoneMasker.cs
+++ b/DropShot.Shared/Helpers/PhoneMasker.cs
@@ -1,0 +1,20 @@
+namespace DropShot.Shared.Helpers;
+
+public static class PhoneMasker
+{
+    public static string Mask(string? phone)
+    {
+        if (string.IsNullOrWhiteSpace(phone)) return "";
+
+        var digits = new string(phone.Where(char.IsDigit).ToArray());
+        if (digits.Length <= 5)
+        {
+            return new string('*', digits.Length);
+        }
+
+        var prefix = digits[..2];
+        var suffix = digits[^3..];
+        var stars = new string('*', digits.Length - 5);
+        return $"{prefix}{stars}{suffix}";
+    }
+}

--- a/DropShot.UI/Components/Pages/CompetitionPage.razor
+++ b/DropShot.UI/Components/Pages/CompetitionPage.razor
@@ -658,6 +658,32 @@ else
                                        OnClick="OpenNewPlayerDialog">Add new</MudButton>
                         </MudTooltip>
                     }
+
+                    @* Admin-attested consent: ticking this records the player's
+                       consent on their behalf so other competitors in the
+                       division can see their mobile number. Untick to enrol
+                       a player without sharing their number (e.g. test data,
+                       or you haven't actually got their consent yet — they
+                       can self-consent on their own login). *@
+                    <MudPaper Class="pa-3 mt-1" Elevation="0"
+                              Style="background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.10);">
+                        <MudStack Spacing="2">
+                            <MudCheckBox @bind-Value="_addAttestConsent" Color="Color.Primary" Dense="true">
+                                Record phone-share consent on this player's behalf (I have evidence
+                                they've consented, e.g. email asking to enter)
+                            </MudCheckBox>
+                            <MudTextField @bind-Value="_addAttestSource"
+                                          Label="Source of consent"
+                                          Placeholder="e.g. Email 14 May, subject 'Yes please add me'"
+                                          Variant="Variant.Outlined" Margin="Margin.Dense"
+                                          Disabled="@(!_addAttestConsent)"
+                                          HelperText="Recorded in the audit trail. Required when the checkbox is ticked." />
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">
+                                When unticked, players are added without sharing their number with peers — they can
+                                consent themselves the next time they log in.
+                            </MudText>
+                        </MudStack>
+                    </MudPaper>
                 </MudStack>
 
                 @if (_showDeleteAllParticipantsConfirm)
@@ -2059,6 +2085,15 @@ else
     // populated roster is immediately eligible for team generation.
     private ParticipantStatus _addParticipantStatus = ParticipantStatus.FullPlayer;
 
+    // Admin-attested phone-share consent for the players I'm adding (e.g.
+    // "Alice emailed asking to be entered and is happy to share her number
+    // with the division"). Applies to subsequent single-adds via the
+    // autocomplete and to the bulk-add submission. When unticked, players
+    // are added without a consent row — their numbers stay peer-hidden
+    // until they self-consent via Leave/Enter on their own login.
+    private bool _addAttestConsent;
+    private string _addAttestSource = "";
+
     // Clone competition dialog state
     private bool _showCloneDialog;
     private string _cloneName = "";
@@ -2914,12 +2949,22 @@ else
     private async Task ConfirmBulkAddAsync()
     {
         if (_bulkAddSelected.Count == 0) return;
+
+        var attestation = BuildAttestationOrNull();
+        if (_addAttestConsent && attestation is null)
+        {
+            SiteAlerts.Add(
+                "Source of consent is required when the attestation checkbox is ticked.",
+                Severity.Warning);
+            return;
+        }
+
         _bulkAddSubmitting = true;
         try
         {
             var playerIds = _bulkAddSelected.Select(p => p.PlayerId).ToList();
             var result = await Admin.BulkAddParticipantsAsync(Id,
-                new BulkAddParticipantsRequest(playerIds, _bulkAddStatus));
+                new BulkAddParticipantsRequest(playerIds, _bulkAddStatus, AttestedConsent: attestation));
             _showBulkAddDialog = false;
             await ReloadAfterServerMutationAsync();
             var msg = result.Skipped > 0
@@ -2990,6 +3035,17 @@ else
         SiteAlerts.Add($"{_newPlayerForm.DisplayName} added to club and competition.", Severity.Success);
     }
 
+    // Returns an AdminRecordedPhoneShareConsent payload if the admin has
+    // ticked the attestation checkbox AND provided a Source; null otherwise
+    // (which the server treats as "no consent recorded" — number stays
+    // peer-hidden until the player self-consents).
+    private AdminRecordedPhoneShareConsent? BuildAttestationOrNull()
+    {
+        if (!_addAttestConsent) return null;
+        if (string.IsNullOrWhiteSpace(_addAttestSource)) return null;
+        return new AdminRecordedPhoneShareConsent(true, _addAttestSource.Trim());
+    }
+
     private async Task AddParticipant(PlayerSearchResultDto? player)
     {
         if (player == null || _participants.Any(p => p.PlayerId == player.PlayerId)) return;
@@ -3002,9 +3058,19 @@ else
             return;
         }
 
+        var attestation = BuildAttestationOrNull();
+        if (_addAttestConsent && attestation is null)
+        {
+            SiteAlerts.Add(
+                "Source of consent is required when the attestation checkbox is ticked.",
+                Severity.Warning);
+            return;
+        }
+
         try
         {
-            await Admin.AddParticipantAsync(Id, new AddParticipantRequest(player.PlayerId, Force: false));
+            await Admin.AddParticipantAsync(Id,
+                new AddParticipantRequest(player.PlayerId, Force: false, AttestedConsent: attestation));
         }
         catch (InvalidOperationException ex)
         {
@@ -3025,7 +3091,8 @@ else
             Logger.LogWarning(
                 "Admin override: player {PlayerId} added to competition {CompetitionId} despite eligibility violation(s).",
                 player.PlayerId, Id);
-            await Admin.AddParticipantAsync(Id, new AddParticipantRequest(player.PlayerId, Force: true));
+            await Admin.AddParticipantAsync(Id,
+                new AddParticipantRequest(player.PlayerId, Force: true, AttestedConsent: attestation));
         }
 
         await Admin.UpdateParticipantStatusAsync(Id, player.PlayerId,

--- a/DropShot.UI/Components/Pages/Competitions.razor
+++ b/DropShot.UI/Components/Pages/Competitions.razor
@@ -460,6 +460,7 @@ else
     // Standard-user view
     private bool _isUserView;
     private bool _hasPlayer;
+    private string? _myMobileNumber;
     private List<CompetitionDto> _myEnteredComps = [];
     private List<CompetitionDto> _availableComps = [];
 
@@ -489,7 +490,8 @@ else
         Dictionary<int, List<CompetitionDto>> CompsByEventId,
         List<CompetitionDto> MyEnteredComps,
         List<CompetitionDto> AvailableComps,
-        List<CompetitionFixtureDto> PendingFixtures);
+        List<CompetitionFixtureDto> PendingFixtures,
+        string? MyMobileNumber);
 
     private PersistingComponentStateSubscription _persistSubscription;
 
@@ -538,6 +540,7 @@ else
         _myEnteredComps = snap.MyEnteredComps;
         _availableComps = snap.AvailableComps;
         _pendingFixtures = snap.PendingFixtures;
+        _myMobileNumber = snap.MyMobileNumber;
         _events = snap.EventGroups
             .Select(e => new EventGroup
             {
@@ -560,7 +563,8 @@ else
             _events.ToDictionary(g => g.Event.EventId, g => g.Competitions),
             _myEnteredComps,
             _availableComps,
-            _pendingFixtures);
+            _pendingFixtures,
+            _myMobileNumber);
         AppState.PersistAsJson(nameof(Competitions), snap);
         return Task.CompletedTask;
     }
@@ -602,6 +606,7 @@ else
             _hasPlayer = view.HasPlayer;
             _myEnteredComps = view.Entered;
             _availableComps = view.Available;
+            _myMobileNumber = view.MyMobileNumber;
             return;
         }
 
@@ -637,9 +642,29 @@ else
 
     private async Task EnterCompetitionAsync(CompetitionDto comp)
     {
+        if (string.IsNullOrWhiteSpace(_myMobileNumber))
+        {
+            SiteAlerts.Add(
+                "Add a mobile number to your profile before entering competitions — " +
+                "head to My Players.",
+                Severity.Warning);
+            return;
+        }
+
+        var parameters = new DialogParameters
+        {
+            [nameof(DropShot.UI.Components.Shared.EnterCompetitionConsentDialog.CompetitionName)] = comp.CompetitionName,
+            [nameof(DropShot.UI.Components.Shared.EnterCompetitionConsentDialog.MobileNumber)] = _myMobileNumber,
+        };
+        var dialog = await DialogService.ShowAsync<DropShot.UI.Components.Shared.EnterCompetitionConsentDialog>(
+            "Share your mobile number with competitors", parameters);
+        var result = await dialog.Result;
+        if (result is null || result.Canceled) return;
+        if (result.Data is not PhoneShareConsent consent) return;
+
         try
         {
-            await CompetitionService.EnterCompetitionAsync(comp.CompetitionId);
+            await CompetitionService.EnterCompetitionAsync(comp.CompetitionId, consent);
         }
         catch (InvalidOperationException ex)
         {

--- a/DropShot.UI/Components/Pages/MyPlayers.razor
+++ b/DropShot.UI/Components/Pages/MyPlayers.razor
@@ -114,6 +114,11 @@
             <MudItem xs="12">
                 <MudTextField @bind-Value="_form.MobileNumber" Label="Mobile number" Variant="Variant.Outlined"
                               InputType="InputType.Telephone" />
+                <MudText Typo="Typo.caption" Color="Color.Secondary">
+                    Required to enter competitions. When you enter a competition, this number
+                    will be visible to other competitors in that competition (with your consent
+                    each time). You can leave the competition at any time to remove it.
+                </MudText>
             </MudItem>
             <MudItem xs="12">
                 <MudText Typo="Typo.body2" Class="mb-1">Competition category</MudText>

--- a/DropShot.UI/Components/Pages/Players.razor
+++ b/DropShot.UI/Components/Pages/Players.razor
@@ -97,8 +97,12 @@
                               InputType="InputType.Email" />
             </MudItem>
             <MudItem xs="6">
-                <MudTextField @bind-Value="_form.MobileNumber" Label="Mobile Number (optional)" Variant="Variant.Outlined"
+                <MudTextField @bind-Value="_form.MobileNumber" Label="Mobile Number" Variant="Variant.Outlined"
                               InputType="InputType.Telephone" />
+                <MudText Typo="Typo.caption" Color="Color.Secondary">
+                    Required to enter competitions. When entering, this number will be visible to
+                    other competitors in that competition (with consent each time).
+                </MudText>
             </MudItem>
             <MudItem xs="6">
                 <MudDatePicker @bind-Date="_form.DateOfBirthDt" Label="Date of Birth" Variant="Variant.Outlined"
@@ -144,8 +148,12 @@
                               InputType="InputType.Email" />
             </MudItem>
             <MudItem xs="6">
-                <MudTextField @bind-Value="_form.MobileNumber" Label="Mobile Number (optional)" Variant="Variant.Outlined"
+                <MudTextField @bind-Value="_form.MobileNumber" Label="Mobile Number" Variant="Variant.Outlined"
                               InputType="InputType.Telephone" />
+                <MudText Typo="Typo.caption" Color="Color.Secondary">
+                    Required to enter competitions. When entering, this number will be visible to
+                    other competitors in that competition (with consent each time).
+                </MudText>
             </MudItem>
             <MudItem xs="6">
                 <MudDatePicker @bind-Date="_form.DateOfBirthDt" Label="Date of Birth" Variant="Variant.Outlined"

--- a/DropShot.UI/Components/Pages/Privacy.razor
+++ b/DropShot.UI/Components/Pages/Privacy.razor
@@ -5,7 +5,7 @@
 <MudContainer MaxWidth="MaxWidth.Medium" Class="mt-8 mb-8">
     <MudText Typo="Typo.h4" Align="Align.Center" GutterBottom="true">Privacy Policy</MudText>
     <MudText Typo="Typo.caption" Align="Align.Center" Color="Color.Secondary" Class="mb-6">
-        Last updated: 28 April 2026
+        Last updated: 18 May 2026
     </MudText>
 
     <MudText Typo="Typo.body1" Class="mb-4">
@@ -60,11 +60,27 @@
     <MudText Typo="Typo.body2" Class="mb-2">We share personal data only with:</MudText>
     <ul class="mud-typography mud-typography-body2" style="padding-left:1.5rem;">
         <li><strong>Service providers</strong> who help us operate the Service, including Microsoft Azure (hosting), Azure Communication Services (transactional email), Google AdSense (advertising), and PayPal (payments);</li>
-        <li><strong>Other users of the Service</strong>, where you have chosen to participate in a public competition, club, or team — your display name, results, and profile photo may be visible to those users;</li>
+        <li><strong>Other users of the Service</strong>, where you have chosen to participate in a public competition, club, or team — your display name, results, and profile photo may be visible to those users. Your mobile number may additionally be visible to other competitors <em>within a competition you have entered</em>, but only after you give explicit consent at the point of entry, and only to administrators and players in the same division;</li>
         <li><strong>Legal authorities</strong> where we are required by law to do so.</li>
     </ul>
     <MudText Typo="Typo.body2" Class="mb-4">
         We do not sell your personal data.
+    </MudText>
+
+    <MudText Typo="Typo.h5" Class="mt-6 mb-2">5a. Mobile Numbers and Competition Entry</MudText>
+    <MudText Typo="Typo.body2" Class="mb-2">
+        Mobile numbers are collected so that competitors can coordinate matches between themselves.
+        They are handled as follows:
+    </MudText>
+    <ul class="mud-typography mud-typography-body2" style="padding-left:1.5rem;">
+        <li><strong>Explicit per-competition consent.</strong> When you enter a competition, you are shown a notice with your masked number and must actively tick a consent checkbox before entry is confirmed. The exact wording you saw is recorded for audit.</li>
+        <li><strong>Limited audience.</strong> Your number is shown only to other active participants in the same division of that competition, and to administrators of the competition or its host club (the latter under a legitimate-interest basis for running the event).</li>
+        <li><strong>Instant withdrawal.</strong> A single "Leave competition" action withdraws you from the competition and immediately removes your number from other competitors' views.</li>
+        <li><strong>Under-13 protection.</strong> Mobile numbers belonging to players under 13 are never shared with other competitors, regardless of consent.</li>
+    </ul>
+    <MudText Typo="Typo.body2" Class="mb-4">
+        Our lawful basis for sharing mobile numbers with other competitors is your consent under
+        UK GDPR Article 6(1)(a), which you may withdraw at any time via the Leave competition action.
     </MudText>
 
     <MudText Typo="Typo.h5" Class="mt-6 mb-2">6. International Transfers</MudText>

--- a/DropShot.UI/Components/Pages/ViewCompetition.razor
+++ b/DropShot.UI/Components/Pages/ViewCompetition.razor
@@ -4,9 +4,11 @@
 @inject ICurrentUser CurrentUser
 @inject NavigationManager Nav
 @inject ISnackbar Snackbar
+@inject IDialogService DialogService
 @using DropShot.Shared.Extensions
 @using DropShot.Shared.Helpers
 @using DropShot.Shared.Dtos
+@using DropShot.UI.Components.Shared
 @using DropShot.UI.Services
 
 @* Routing + auth + MudProviders supplied by host shims. *@
@@ -219,6 +221,26 @@ else
                 </MudStack>
             </MudStack>
         </MudAlert>
+    }
+
+    @* "Leave competition" — visible to any active participant of the
+       competition. One-click action (no extra confirmation) so withdrawing
+       consent is as easy as giving it, per GDPR. Sets ParticipantStatus to
+       Withdrawn and stamps the active CompetitionEntryConsent row's
+       WithdrawnUtc — peer views drop the number on reload. *@
+    @if (!_canEdit
+         && _myParticipant is not null
+         && _myParticipant.Status != ParticipantStatus.Withdrawn
+         && _myParticipant.Status != ParticipantStatus.Disqualified)
+    {
+        <MudStack Row="true" Class="mb-4">
+            <MudButton Variant="Variant.Outlined" Color="Color.Warning"
+                       StartIcon="@Icons.Material.Filled.ExitToApp"
+                       Disabled="_leaveSaving"
+                       OnClick="LeaveCompetitionAsync">
+                Leave competition
+            </MudButton>
+        </MudStack>
     }
 
     <MudDivider Class="mb-4" />
@@ -1516,12 +1538,16 @@ else
     private async Task SelfRegisterAsync(ParticipantStatus status)
     {
         if (_competition is null) return;
+
+        var consent = await TryGetEntryConsentAsync();
+        if (consent is null) return;
+
         _selfRegisterSaving = true;
         _selfRegisterError = null;
         StateHasChanged();
         try
         {
-            await CompetitionService.SelfRegisterAsync(_competition.CompetitionId, status);
+            await CompetitionService.SelfRegisterAsync(_competition.CompetitionId, status, consent);
             Nav.NavigateTo(Nav.Uri, forceLoad: true);
         }
         catch (Exception ex)
@@ -1538,12 +1564,16 @@ else
     private async Task ConfirmParticipationAsync(ParticipantStatus status)
     {
         if (_competition is null) return;
+
+        var consent = await TryGetEntryConsentAsync();
+        if (consent is null) return;
+
         _selfRegisterSaving = true;
         _selfRegisterError = null;
         StateHasChanged();
         try
         {
-            await CompetitionService.ConfirmParticipationAsync(_competition.CompetitionId, status);
+            await CompetitionService.ConfirmParticipationAsync(_competition.CompetitionId, status, consent);
             await OnParametersSetAsync();
         }
         catch (Exception ex)
@@ -1553,6 +1583,59 @@ else
         finally
         {
             _selfRegisterSaving = false;
+            StateHasChanged();
+        }
+    }
+
+    /// Open the EnterCompetitionConsentDialog and return the user's consent.
+    /// Returns null if they cancelled, OR if their profile has no mobile
+    /// number (in which case the inline alert prompts them to add one
+    /// before retrying — server-side guard would reject anyway).
+    private async Task<PhoneShareConsent?> TryGetEntryConsentAsync()
+    {
+        if (_competition is null) return null;
+
+        if (string.IsNullOrWhiteSpace(_competition.MyMobileNumber))
+        {
+            _selfRegisterError =
+                "Add a mobile number to your profile before entering competitions. " +
+                "It will be visible to other competitors so you can coordinate matches.";
+            StateHasChanged();
+            return null;
+        }
+
+        var parameters = new DialogParameters
+        {
+            [nameof(EnterCompetitionConsentDialog.CompetitionName)] = _competition.CompetitionName,
+            [nameof(EnterCompetitionConsentDialog.MobileNumber)] = _competition.MyMobileNumber,
+        };
+        var dialog = await DialogService.ShowAsync<EnterCompetitionConsentDialog>(
+            "Share your mobile number with competitors", parameters);
+        var result = await dialog.Result;
+        if (result is null || result.Canceled) return null;
+        return result.Data as PhoneShareConsent;
+    }
+
+    private bool _leaveSaving;
+
+    private async Task LeaveCompetitionAsync()
+    {
+        if (_competition is null) return;
+        _leaveSaving = true;
+        StateHasChanged();
+        try
+        {
+            await CompetitionService.LeaveCompetitionAsync(_competition.CompetitionId);
+            Snackbar.Add("You have left the competition. Your mobile number is no longer shared.", Severity.Info);
+            Nav.NavigateTo(Nav.Uri, forceLoad: true);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Failed to leave: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _leaveSaving = false;
             StateHasChanged();
         }
     }

--- a/DropShot.UI/Components/Shared/EnterCompetitionConsentDialog.razor
+++ b/DropShot.UI/Components/Shared/EnterCompetitionConsentDialog.razor
@@ -1,0 +1,62 @@
+@using DropShot.Shared.Dtos
+@using DropShot.Shared.Helpers
+
+@* Shared dialog for the three entry paths (SelfRegister, ConfirmParticipation,
+   EnterCompetition). Renders the per-competition phone-share consent wording
+   with a masked version of the player's mobile, requires the user to actively
+   tick the checkbox, and returns the exact rendered text + version so the
+   server records it verbatim. *@
+
+<MudDialog>
+    <TitleContent>
+        <MudText Typo="Typo.h6">Share your mobile number with competitors</MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudStack Spacing="3" Class="pa-2">
+            <MudText Typo="Typo.body2">@_wording</MudText>
+            <MudCheckBox @bind-Value="_consentGiven" Color="Color.Primary" Dense="true">
+                I agree to share my mobile number with other competitors in this competition.
+            </MudCheckBox>
+            <MudText Typo="Typo.caption" Color="Color.Secondary">
+                You can leave the competition at any time to remove your number from other
+                competitors' views.
+            </MudText>
+        </MudStack>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel">Cancel</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                   Disabled="@(!_consentGiven)" OnClick="Confirm">
+            Confirm entry
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    public const string ConsentVersion = "v1-2026-05";
+
+    [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = default!;
+
+    [Parameter, EditorRequired] public string CompetitionName { get; set; } = "";
+    [Parameter, EditorRequired] public string? MobileNumber { get; set; }
+
+    private bool _consentGiven;
+    private string _wording = "";
+
+    protected override void OnParametersSet()
+    {
+        var masked = PhoneMasker.Mask(MobileNumber);
+        _wording =
+            $"By entering {CompetitionName}, your mobile number ({masked}) will be visible " +
+            "to other competitors in this competition so you can coordinate matches. " +
+            "You can leave the competition at any time to remove it.";
+    }
+
+    private void Confirm() =>
+        MudDialog.Close(DialogResult.Ok(new PhoneShareConsent(
+            Granted: true,
+            WordingShown: _wording,
+            Version: ConsentVersion)));
+
+    private void Cancel() => MudDialog.Cancel();
+}

--- a/DropShot.UI/Services/ICompetitionService.cs
+++ b/DropShot.UI/Services/ICompetitionService.cs
@@ -17,15 +17,21 @@ public interface ICompetitionService
     /// Register the authenticated user as a participant in the competition.
     /// Server resolves the player from the authenticated user's <c>UserId</c>;
     /// returns a 400-equivalent on web (KeyNotFoundException) when no player
-    /// record exists for the user, or already-registered.
+    /// record exists for the user, or already-registered. The <paramref name="consent"/>
+    /// payload carries the per-competition phone-share consent collected in
+    /// the EnterCompetitionConsentDialog and is recorded against the player.
     /// </summary>
-    Task SelfRegisterAsync(int competitionId, ParticipantStatus status, CancellationToken ct = default);
+    Task SelfRegisterAsync(
+        int competitionId, ParticipantStatus status, PhoneShareConsent consent, CancellationToken ct = default);
 
     /// <summary>
     /// Upgrade the authenticated user's participation status (typically from
-    /// Registered → FullPlayer or Substitute).
+    /// Registered → FullPlayer or Substitute). Requires a fresh consent
+    /// payload — the user re-acknowledges phone-share visibility each time
+    /// they (re-)commit to participating.
     /// </summary>
-    Task ConfirmParticipationAsync(int competitionId, ParticipantStatus status, CancellationToken ct = default);
+    Task ConfirmParticipationAsync(
+        int competitionId, ParticipantStatus status, PhoneShareConsent consent, CancellationToken ct = default);
 
     /// <summary>
     /// Approve a fixture's awaiting-verification result. Without
@@ -102,9 +108,21 @@ public interface ICompetitionService
     /// Self-enter the authenticated user's player into the competition.
     /// Server enforces date/eligibility/capacity/duplicate-entry guards and
     /// throws <see cref="InvalidOperationException"/> with a user-facing
-    /// message when any of them fail.
+    /// message when any of them fail. The <paramref name="consent"/> payload
+    /// is recorded against the player at the same time the participant row
+    /// is created (single transaction).
     /// </summary>
-    Task EnterCompetitionAsync(int competitionId, CancellationToken ct = default);
+    Task EnterCompetitionAsync(
+        int competitionId, PhoneShareConsent consent, CancellationToken ct = default);
+
+    /// <summary>
+    /// Leave a competition. Sets the participant's status to
+    /// <see cref="ParticipantStatus.Withdrawn"/> and stamps the active
+    /// CompetitionEntryConsent row's WithdrawnUtc, dropping the player's
+    /// number from peer views. One-click action — matches the GDPR
+    /// principle that withdrawal must be as easy as consent.
+    /// </summary>
+    Task LeaveCompetitionAsync(int competitionId, CancellationToken ct = default);
 
     /// <summary>
     /// Loads the rubber-scoring context for a team-match fixture: per-rubber

--- a/DropShot/Controllers/CompetitionsController.cs
+++ b/DropShot/Controllers/CompetitionsController.cs
@@ -406,11 +406,11 @@ public class CompetitionsController(
     /// </summary>
     [HttpPost("{id:int}/self-register")]
     public async Task<IActionResult> SelfRegister(
-        int id, [FromBody] UpdateParticipantStatusRequest req, CancellationToken ct)
+        int id, [FromBody] SelfRegisterRequest req, CancellationToken ct)
     {
         try
         {
-            await competitionService.SelfRegisterAsync(id, req.Status, ct);
+            await competitionService.SelfRegisterAsync(id, req.Status, req.Consent, ct);
             return NoContent();
         }
         catch (KeyNotFoundException ex) { return BadRequest(new { message = ex.Message }); }
@@ -423,11 +423,11 @@ public class CompetitionsController(
     /// </summary>
     [HttpPost("{id:int}/confirm-participation")]
     public async Task<IActionResult> ConfirmParticipation(
-        int id, [FromBody] UpdateParticipantStatusRequest req, CancellationToken ct)
+        int id, [FromBody] SelfRegisterRequest req, CancellationToken ct)
     {
         try
         {
-            await competitionService.ConfirmParticipationAsync(id, req.Status, ct);
+            await competitionService.ConfirmParticipationAsync(id, req.Status, req.Consent, ct);
             return NoContent();
         }
         catch (KeyNotFoundException ex) { return NotFound(new { message = ex.Message }); }
@@ -630,11 +630,24 @@ public class CompetitionsController(
     }
 
     [HttpPost("{id:int}/enter")]
-    public async Task<IActionResult> EnterCompetition(int id, CancellationToken ct)
+    public async Task<IActionResult> EnterCompetition(
+        int id, [FromBody] EnterCompetitionRequest req, CancellationToken ct)
     {
         try
         {
-            await competitionService.EnterCompetitionAsync(id, ct);
+            await competitionService.EnterCompetitionAsync(id, req.Consent, ct);
+            return NoContent();
+        }
+        catch (KeyNotFoundException ex) { return NotFound(new { message = ex.Message }); }
+        catch (InvalidOperationException ex) { return BadRequest(new { message = ex.Message }); }
+    }
+
+    [HttpPost("{id:int}/leave")]
+    public async Task<IActionResult> LeaveCompetition(int id, CancellationToken ct)
+    {
+        try
+        {
+            await competitionService.LeaveCompetitionAsync(id, ct);
             return NoContent();
         }
         catch (KeyNotFoundException ex) { return NotFound(new { message = ex.Message }); }

--- a/DropShot/Data/Migrations/20260518000931_AddCompetitionEntryConsent.Designer.cs
+++ b/DropShot/Data/Migrations/20260518000931_AddCompetitionEntryConsent.Designer.cs
@@ -4,16 +4,19 @@ using DropShot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace DropShot.Migrations
+namespace DropShot.Data.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260518000931_AddCompetitionEntryConsent")]
+    partial class AddCompetitionEntryConsent
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DropShot/Data/Migrations/20260518000931_AddCompetitionEntryConsent.cs
+++ b/DropShot/Data/Migrations/20260518000931_AddCompetitionEntryConsent.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropShot.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCompetitionEntryConsent : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LastDecayAppliedAt",
+                table: "CompetitionParticipants",
+                type: "datetime2",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LastInactivityWarningAt",
+                table: "CompetitionParticipants",
+                type: "datetime2",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "LadderInactivityDecays",
+                columns: table => new
+                {
+                    LadderInactivityDecayId = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    CompetitionId = table.Column<int>(type: "int", nullable: false),
+                    PlayerId = table.Column<int>(type: "int", nullable: false),
+                    AppliedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    RatingBefore = table.Column<double>(type: "float", nullable: false),
+                    RatingAfter = table.Column<double>(type: "float", nullable: false),
+                    DaysInactive = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LadderInactivityDecays", x => x.LadderInactivityDecayId);
+                    table.ForeignKey(
+                        name: "FK_LadderInactivityDecays_Competition_CompetitionId",
+                        column: x => x.CompetitionId,
+                        principalTable: "Competition",
+                        principalColumn: "CompetitionID",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_LadderInactivityDecays_Players_PlayerId",
+                        column: x => x.PlayerId,
+                        principalTable: "Players",
+                        principalColumn: "PlayerId",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LadderInactivityDecays_CompetitionId_AppliedAt",
+                table: "LadderInactivityDecays",
+                columns: new[] { "CompetitionId", "AppliedAt" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LadderInactivityDecays_PlayerId",
+                table: "LadderInactivityDecays",
+                column: "PlayerId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "LadderInactivityDecays");
+
+            migrationBuilder.DropColumn(
+                name: "LastDecayAppliedAt",
+                table: "CompetitionParticipants");
+
+            migrationBuilder.DropColumn(
+                name: "LastInactivityWarningAt",
+                table: "CompetitionParticipants");
+        }
+    }
+}

--- a/DropShot/Data/MyDbContext.cs
+++ b/DropShot/Data/MyDbContext.cs
@@ -46,6 +46,7 @@ namespace DropShot.Data
         public DbSet<CompetitionAllowedPlayer> CompetitionAllowedPlayers { get; set; }
         public DbSet<PlayerRatingSnapshot> PlayerRatingSnapshots { get; set; }
         public DbSet<LadderInactivityDecay> LadderInactivityDecays { get; set; }
+        public DbSet<CompetitionEntryConsent> CompetitionEntryConsents { get; set; }
 
         protected override void OnModelCreating(ModelBuilder builder)
         {
@@ -689,6 +690,31 @@ namespace DropShot.Data
                       .WithMany()
                       .HasForeignKey(d => d.CompetitionId)
                       .OnDelete(DeleteBehavior.Cascade);
+            });
+
+            // ── CompetitionEntryConsent ─────────────────────────────────────────
+            // Append-only consent log for the GDPR phone-share-with-competitors
+            // flow. One row per (player, competition) entry; withdrawal sets
+            // WithdrawnUtc on the most-recent row. Re-entry creates a new row.
+            builder.Entity<CompetitionEntryConsent>(entity =>
+            {
+                entity.Property(c => c.ConsentWordingShown).HasColumnType("nvarchar(max)").IsRequired();
+                entity.Property(c => c.ConsentVersion).HasMaxLength(32).IsRequired();
+
+                entity.HasOne(c => c.Competition)
+                      .WithMany()
+                      .HasForeignKey(c => c.CompetitionId)
+                      .OnDelete(DeleteBehavior.Cascade);
+
+                // Restrict on Player FK matches the convention used by other
+                // Player references in this DbContext (avoids multi-cascade-path).
+                entity.HasOne(c => c.Player)
+                      .WithMany()
+                      .HasForeignKey(c => c.PlayerId)
+                      .OnDelete(DeleteBehavior.Restrict);
+
+                // Hot path: "any active consent row for (competition, player)?"
+                entity.HasIndex(c => new { c.CompetitionId, c.PlayerId, c.WithdrawnUtc });
             });
 
             // ── RoleSwitchLog ───────────────────────────────────────────────────

--- a/DropShot/Models/CompetitionEntryConsent.cs
+++ b/DropShot/Models/CompetitionEntryConsent.cs
@@ -1,0 +1,15 @@
+namespace DropShot.Models;
+
+public class CompetitionEntryConsent
+{
+    public int CompetitionEntryConsentId { get; set; }
+    public int CompetitionId { get; set; }
+    public int PlayerId { get; set; }
+    public DateTime ConsentGivenUtc { get; set; }
+    public string ConsentWordingShown { get; set; } = "";
+    public string ConsentVersion { get; set; } = "";
+    public DateTime? WithdrawnUtc { get; set; }
+
+    public Competition Competition { get; set; } = null!;
+    public Player Player { get; set; } = null!;
+}

--- a/DropShot/Program.cs
+++ b/DropShot/Program.cs
@@ -127,6 +127,7 @@ builder.Services.AddScoped<IEmailService, WebEmailService>();
 builder.Services.AddScoped<IPlayerService, WebPlayerService>();
 builder.Services.AddScoped<IClubService, WebClubService>();
 builder.Services.AddScoped<IEventService, WebEventService>();
+builder.Services.AddScoped<IPhoneVisibilityService, PhoneVisibilityService>();
 builder.Services.AddScoped<ICompetitionService, WebCompetitionService>();
 builder.Services.AddScoped<ICompetitionAdminService, WebCompetitionAdminService>();
 builder.Services.AddScoped<IRulesSetService, WebRulesSetService>();

--- a/DropShot/Services/EligibilityEvaluator.cs
+++ b/DropShot/Services/EligibilityEvaluator.cs
@@ -66,7 +66,7 @@ public static class EligibilityEvaluator
         return violations;
     }
 
-    private static int AgeOn(DateOnly on, DateOnly dob)
+    public static int AgeOn(DateOnly on, DateOnly dob)
     {
         int age = on.Year - dob.Year;
         if (dob > on.AddYears(-age)) age--;

--- a/DropShot/Services/PhoneVisibilityService.cs
+++ b/DropShot/Services/PhoneVisibilityService.cs
@@ -1,0 +1,248 @@
+using DropShot.Data;
+using DropShot.Models;
+using DropShot.Shared;
+using Microsoft.EntityFrameworkCore;
+
+namespace DropShot.Services;
+
+/// <summary>
+/// Single source of truth for whether one player's mobile number is allowed
+/// to be shown to another in the context of a competition. Encapsulates the
+/// per-competition consent record (CompetitionEntryConsent), the under-13
+/// hard block, and the same-division peer scope. Admin bypass is delegated
+/// to the caller via the <c>viewerIsCompetitionAdmin</c> flag — admins
+/// retain visibility under a legitimate-interest basis, distinct from the
+/// peer-consent flow this service governs.
+/// </summary>
+// TODO(privacy): In-app messaging that brokers contact without revealing
+// numbers is the longer-term goal. Once that lands, CanViewPhoneNumber should
+// default to false for peers and we'd surface a "message via app" action
+// instead of returning the number.
+public interface IPhoneVisibilityService
+{
+    /// <summary>
+    /// True iff the viewer is allowed to see <paramref name="targetPlayerId"/>'s
+    /// mobile number in the context of <paramref name="competitionId"/>.
+    /// </summary>
+    Task<bool> CanViewPhoneNumberAsync(
+        string viewerUserId,
+        int targetPlayerId,
+        int competitionId,
+        bool viewerIsCompetitionAdmin,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Bulk variant for list rendering. Returns the subset of
+    /// <paramref name="candidatePlayerIds"/> whose mobile numbers the viewer
+    /// is allowed to see.
+    /// </summary>
+    Task<HashSet<int>> VisiblePhoneNumberPlayerIdsAsync(
+        string viewerUserId,
+        int competitionId,
+        IReadOnlyCollection<int> candidatePlayerIds,
+        bool viewerIsCompetitionAdmin,
+        CancellationToken ct = default);
+}
+
+public sealed class PhoneVisibilityService(
+    IDbContextFactory<MyDbContext> dbFactory) : IPhoneVisibilityService
+{
+    /// <summary>
+    /// Bumped whenever the consent dialog template wording changes. The
+    /// consent record stores both the version and the rendered text (the
+    /// version makes bulk reporting easy; the rendered text is the legal
+    /// audit trail). Server rejects entry requests whose Version doesn't
+    /// match — that forces a stale client to reload before continuing.
+    /// </summary>
+    public const string CurrentConsentVersion = "v1-2026-05";
+
+    /// <summary>
+    /// Consent version stamped on rows the admin attests to on behalf of
+    /// the player (the email-asked-to-enter path). Distinct from
+    /// <see cref="CurrentConsentVersion"/> so audits can filter
+    /// admin-attested vs self-asserted consents — the former are materially
+    /// weaker (no direct data-subject click) and rely on the
+    /// <c>ConsentWordingShown</c> field capturing the admin's evidence.
+    /// </summary>
+    public const string AdminRecordedConsentVersion = "v1-2026-05-admin";
+
+    /// <summary>
+    /// Hard age limit, in years. Players under this age never have their
+    /// mobile number shared with peers, regardless of consent. Matches the
+    /// "Children" clause in Privacy.razor §9 and DropShot's stance of not
+    /// being directed at under-13s.
+    /// </summary>
+    public const int MinimumAgeForPhoneSharing = 13;
+
+    public async Task<bool> CanViewPhoneNumberAsync(
+        string viewerUserId,
+        int targetPlayerId,
+        int competitionId,
+        bool viewerIsCompetitionAdmin,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(viewerUserId)) return false;
+
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+
+        var target = await db.Players
+            .AsNoTracking()
+            .Where(p => p.PlayerId == targetPlayerId)
+            .Select(p => new { p.PlayerId, p.UserId, p.DateOfBirth })
+            .FirstOrDefaultAsync(ct);
+        if (target is null) return false;
+
+        // 1. Self — always visible.
+        if (!string.IsNullOrEmpty(target.UserId) && target.UserId == viewerUserId)
+            return true;
+
+        // 2. Under-13 block. A null DateOfBirth is "unknown" rather than
+        //    "minor": the block requires a positive signal. Future parental-
+        //    consent flow will plug in here.
+        if (target.DateOfBirth is { } dob)
+        {
+            var today = DateOnly.FromDateTime(DateTime.UtcNow);
+            if (EligibilityEvaluator.AgeOn(today, dob) < MinimumAgeForPhoneSharing)
+                return false;
+        }
+
+        // 3. Admin bypass — distinct from peer consent. See class comment.
+        if (viewerIsCompetitionAdmin) return true;
+
+        // 4. Both must be active (non-withdrawn, non-disqualified) participants
+        //    in the same competition.
+        var participants = await db.CompetitionParticipants
+            .AsNoTracking()
+            .Where(cp => cp.CompetitionId == competitionId
+                         && (cp.Player!.UserId == viewerUserId || cp.PlayerId == targetPlayerId))
+            .Select(cp => new
+            {
+                cp.PlayerId,
+                cp.Status,
+                cp.CompetitionDivisionId,
+                ViewerMatch = cp.Player!.UserId == viewerUserId
+            })
+            .ToListAsync(ct);
+
+        var viewerRow = participants.FirstOrDefault(p => p.ViewerMatch);
+        var targetRow = participants.FirstOrDefault(p => p.PlayerId == targetPlayerId);
+        if (viewerRow is null || targetRow is null) return false;
+        if (!IsActiveParticipant(viewerRow.Status) || !IsActiveParticipant(targetRow.Status))
+            return false;
+
+        // 5. Same-division check (mirrors CanSeeContactForDivision in
+        //    ViewCompetition.razor). When the competition has no divisions
+        //    both rows have a null CompetitionDivisionId and they match.
+        if (viewerRow.CompetitionDivisionId != targetRow.CompetitionDivisionId)
+            return false;
+
+        // 6. Most-recent CompetitionEntryConsent row for the target must be
+        //    active (WithdrawnUtc IS NULL).
+        var latestConsent = await db.CompetitionEntryConsents
+            .AsNoTracking()
+            .Where(c => c.CompetitionId == competitionId && c.PlayerId == targetPlayerId)
+            .OrderByDescending(c => c.ConsentGivenUtc)
+            .Select(c => new { c.WithdrawnUtc })
+            .FirstOrDefaultAsync(ct);
+        return latestConsent is { WithdrawnUtc: null };
+    }
+
+    public async Task<HashSet<int>> VisiblePhoneNumberPlayerIdsAsync(
+        string viewerUserId,
+        int competitionId,
+        IReadOnlyCollection<int> candidatePlayerIds,
+        bool viewerIsCompetitionAdmin,
+        CancellationToken ct = default)
+    {
+        if (candidatePlayerIds.Count == 0 || string.IsNullOrEmpty(viewerUserId))
+            return [];
+
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+
+        var candidateIds = candidatePlayerIds.ToHashSet();
+
+        var viewerPlayer = await db.Players
+            .AsNoTracking()
+            .Where(p => p.UserId == viewerUserId)
+            .Select(p => new { p.PlayerId })
+            .FirstOrDefaultAsync(ct);
+
+        var candidates = await db.Players
+            .AsNoTracking()
+            .Where(p => candidateIds.Contains(p.PlayerId))
+            .Select(p => new { p.PlayerId, p.UserId, p.DateOfBirth })
+            .ToListAsync(ct);
+
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var visible = new HashSet<int>();
+
+        // Self is always visible — and rules 1+2 apply even when the viewer
+        // isn't a participant of this competition (their own profile page).
+        foreach (var c in candidates)
+        {
+            if (!string.IsNullOrEmpty(c.UserId) && c.UserId == viewerUserId)
+                visible.Add(c.PlayerId);
+        }
+
+        // Under-13s drop out unconditionally for the remainder.
+        var eligibleByAge = candidates
+            .Where(c => c.DateOfBirth is null
+                        || EligibilityEvaluator.AgeOn(today, c.DateOfBirth.Value) >= MinimumAgeForPhoneSharing)
+            .Select(c => c.PlayerId)
+            .ToHashSet();
+
+        if (viewerIsCompetitionAdmin)
+        {
+            foreach (var id in eligibleByAge) visible.Add(id);
+            return visible;
+        }
+
+        if (viewerPlayer is null) return visible;
+
+        var participantRows = await db.CompetitionParticipants
+            .AsNoTracking()
+            .Where(cp => cp.CompetitionId == competitionId
+                         && (cp.PlayerId == viewerPlayer.PlayerId || candidateIds.Contains(cp.PlayerId)))
+            .Select(cp => new { cp.PlayerId, cp.Status, cp.CompetitionDivisionId })
+            .ToListAsync(ct);
+
+        var viewerRow = participantRows.FirstOrDefault(p => p.PlayerId == viewerPlayer.PlayerId);
+        if (viewerRow is null || !IsActiveParticipant(viewerRow.Status))
+            return visible;
+
+        var sameDivisionPeerIds = participantRows
+            .Where(p => p.PlayerId != viewerPlayer.PlayerId
+                        && IsActiveParticipant(p.Status)
+                        && p.CompetitionDivisionId == viewerRow.CompetitionDivisionId
+                        && eligibleByAge.Contains(p.PlayerId))
+            .Select(p => p.PlayerId)
+            .ToHashSet();
+
+        if (sameDivisionPeerIds.Count == 0) return visible;
+
+        // For each same-division peer, take the latest consent row.
+        var latestConsents = await db.CompetitionEntryConsents
+            .AsNoTracking()
+            .Where(c => c.CompetitionId == competitionId && sameDivisionPeerIds.Contains(c.PlayerId))
+            .GroupBy(c => c.PlayerId)
+            .Select(g => new
+            {
+                PlayerId = g.Key,
+                Latest = g.OrderByDescending(c => c.ConsentGivenUtc)
+                    .Select(c => new { c.WithdrawnUtc })
+                    .First()
+            })
+            .ToListAsync(ct);
+
+        foreach (var row in latestConsents)
+        {
+            if (row.Latest.WithdrawnUtc is null)
+                visible.Add(row.PlayerId);
+        }
+
+        return visible;
+    }
+
+    private static bool IsActiveParticipant(ParticipantStatus status) =>
+        status != ParticipantStatus.Withdrawn && status != ParticipantStatus.Disqualified;
+}

--- a/DropShot/Services/WebCompetitionAdminService.cs
+++ b/DropShot/Services/WebCompetitionAdminService.cs
@@ -1018,7 +1018,8 @@ public sealed class WebCompetitionAdminService(
             .Include(c => c.Participants)
             .FirstOrDefaultAsync(c => c.CompetitionID == competitionId, ct)
             ?? throw new KeyNotFoundException("Competition not found.");
-        if (!await authzService.CanEditCompetitionAsync(await GetCurrentPrincipalAsync(), comp.HostClubId, competitionId))
+        var principal = await GetCurrentPrincipalAsync();
+        if (!await authzService.CanEditCompetitionAsync(principal, comp.HostClubId, competitionId))
             throw new UnauthorizedAccessException("You can't edit this competition.");
 
         if (comp.Participants.Any(p => p.PlayerId == request.PlayerId))
@@ -1040,7 +1041,40 @@ public sealed class WebCompetitionAdminService(
             RegisteredAt  = DateTime.UtcNow,
             Status        = ParticipantStatus.Registered,
         });
+
+        if (request.AttestedConsent is { } att)
+            db.CompetitionEntryConsents.Add(BuildAdminAttestedConsent(competitionId, request.PlayerId, att, principal));
+
         await db.SaveChangesAsync(ct);
+    }
+
+    /// <summary>
+    /// Build a CompetitionEntryConsent row from an admin's attestation. The
+    /// version is distinct from the self-asserted version, and the wording
+    /// captures who attested, when, and the admin-supplied evidence source —
+    /// so audits can trace any peer-visible number back to its lawful basis.
+    /// </summary>
+    private static CompetitionEntryConsent BuildAdminAttestedConsent(
+        int competitionId, int playerId, AdminRecordedPhoneShareConsent att, ClaimsPrincipal principal)
+    {
+        if (!att.Attested)
+            throw new InvalidOperationException(
+                "Admin attestation checkbox must be ticked to record consent on the player's behalf.");
+        if (string.IsNullOrWhiteSpace(att.Source))
+            throw new InvalidOperationException(
+                "Source of consent (e.g. email subject and date) is required when recording consent on the player's behalf.");
+
+        var adminLabel = principal.Identity?.Name ?? "unknown-admin";
+        return new CompetitionEntryConsent
+        {
+            CompetitionId = competitionId,
+            PlayerId = playerId,
+            ConsentGivenUtc = DateTime.UtcNow,
+            ConsentVersion = PhoneVisibilityService.AdminRecordedConsentVersion,
+            ConsentWordingShown =
+                $"Admin-recorded consent by {adminLabel} on {DateTime.UtcNow:yyyy-MM-dd HH:mm} UTC. " +
+                $"Source: {att.Source.Trim()}",
+        };
     }
 
     public async Task<BulkAddParticipantsResultDto> BulkAddParticipantsAsync(
@@ -1051,7 +1085,8 @@ public sealed class WebCompetitionAdminService(
             .Include(c => c.Participants)
             .FirstOrDefaultAsync(c => c.CompetitionID == competitionId, ct)
             ?? throw new KeyNotFoundException("Competition not found.");
-        if (!await authzService.CanEditCompetitionAsync(await GetCurrentPrincipalAsync(), comp.HostClubId, competitionId))
+        var principal = await GetCurrentPrincipalAsync();
+        if (!await authzService.CanEditCompetitionAsync(principal, comp.HostClubId, competitionId))
             throw new UnauthorizedAccessException("You can't edit this competition.");
 
         if (request.PlayerIds.Count == 0)
@@ -1077,6 +1112,8 @@ public sealed class WebCompetitionAdminService(
                 RegisteredAt  = now,
                 Status        = request.Status,
             });
+            if (request.AttestedConsent is { } att)
+                db.CompetitionEntryConsents.Add(BuildAdminAttestedConsent(competitionId, playerId, att, principal));
             added++;
         }
         if (added > 0) await db.SaveChangesAsync(ct);

--- a/DropShot/Services/WebCompetitionService.cs
+++ b/DropShot/Services/WebCompetitionService.cs
@@ -25,7 +25,8 @@ public sealed class WebCompetitionService(
     ICurrentUser currentUser,
     BackgroundTaskQueue backgroundTasks,
     RubberResolutionService rubberResolver,
-    PlayerRatingService ratings) : ICompetitionService
+    PlayerRatingService ratings,
+    IPhoneVisibilityService phoneVisibility) : ICompetitionService
 {
     /// <summary>
     /// Best-available principal: HttpContext.User on prerender, controllers,
@@ -121,10 +122,21 @@ public sealed class WebCompetitionService(
             .ToListAsync(ct);
 
         int? myPlayerId = null;
+        string? myMobileNumber = null;
         if (!string.IsNullOrEmpty(currentUser.UserId))
         {
             myPlayerId = c.Participants
                 .FirstOrDefault(p => p.Player?.UserId == currentUser.UserId)?.PlayerId;
+
+            // The caller's own number — separate from the participants
+            // projection because the entry-consent dialog needs it before
+            // the caller is in the participants list. Always populated for
+            // the caller themselves (rule #1 in PhoneVisibilityService).
+            myMobileNumber = await db.Players
+                .AsNoTracking()
+                .Where(p => p.UserId == currentUser.UserId)
+                .Select(p => p.MobileNumber)
+                .FirstOrDefaultAsync(ct);
         }
 
         var ratingsByPlayer = await ratings.GetRosterRatingsAsync(id, ct);
@@ -155,6 +167,17 @@ public sealed class WebCompetitionService(
                 .ToListAsync(ct);
         }
 
+        // Strip MobileNumber from the wire payload for players the viewer
+        // isn't allowed to see. Server-side gating — hiding it client-side
+        // would still leak the value in the JSON response.
+        var canEditThisCompetition = await authzService.CanEditCompetitionAsync(user, c.HostClubId, id);
+        var visiblePhonePlayerIds = await phoneVisibility.VisiblePhoneNumberPlayerIdsAsync(
+            currentUser.UserId ?? "",
+            id,
+            c.Participants.Select(p => p.PlayerId).ToList(),
+            canEditThisCompetition,
+            ct);
+
         return new CompetitionDetailDto(
             c.CompetitionID, c.CompetitionName,
             c.CompetitionFormat,
@@ -169,7 +192,7 @@ public sealed class WebCompetitionService(
                 p.PlayerId, p.Player?.DisplayName ?? "",
                 p.Status,
                 p.RegisteredAt, p.TeamId, p.Team?.Name,
-                p.Player?.MobileNumber,
+                visiblePhonePlayerIds.Contains(p.PlayerId) ? p.Player?.MobileNumber : null,
                 p.Role,
                 p.Player?.Sex,
                 p.CompetitionDivisionId,
@@ -216,7 +239,8 @@ public sealed class WebCompetitionService(
             c.LadderStartingRating,
             c.LadderProvisionalMatches,
             c.LadderUseMarginOfVictory,
-            decayEvents);
+            decayEvents,
+            myMobileNumber);
     }
 
     private static PlacementSuggestionDto? BuildPlacementSuggestion(
@@ -270,7 +294,11 @@ public sealed class WebCompetitionService(
         HomeGamesTotal: f.HomeGamesTotal,
         AwayGamesTotal: f.AwayGamesTotal);
 
-    public async Task SelfRegisterAsync(int competitionId, DropShot.Shared.ParticipantStatus status, CancellationToken ct = default)
+    public async Task SelfRegisterAsync(
+        int competitionId,
+        DropShot.Shared.ParticipantStatus status,
+        PhoneShareConsent consent,
+        CancellationToken ct = default)
     {
         if (string.IsNullOrEmpty(currentUser.UserId))
             throw new InvalidOperationException("Not authenticated.");
@@ -278,6 +306,8 @@ public sealed class WebCompetitionService(
         await using var db = await dbFactory.CreateDbContextAsync(ct);
         var player = await db.Players.FirstOrDefaultAsync(p => p.UserId == currentUser.UserId, ct)
             ?? throw new KeyNotFoundException("Could not find your player record.");
+
+        RequirePhoneAndConsent(player, consent);
 
         var existing = await db.CompetitionParticipants
             .AnyAsync(cp => cp.CompetitionId == competitionId && cp.PlayerId == player.PlayerId, ct);
@@ -291,21 +321,30 @@ public sealed class WebCompetitionService(
             Status = status,
             RegisteredAt = DateTime.UtcNow
         });
+        db.CompetitionEntryConsents.Add(BuildConsentRow(competitionId, player.PlayerId, consent));
         await db.SaveChangesAsync(ct);
     }
 
-    public async Task ConfirmParticipationAsync(int competitionId, DropShot.Shared.ParticipantStatus status, CancellationToken ct = default)
+    public async Task ConfirmParticipationAsync(
+        int competitionId,
+        DropShot.Shared.ParticipantStatus status,
+        PhoneShareConsent consent,
+        CancellationToken ct = default)
     {
         if (string.IsNullOrEmpty(currentUser.UserId))
             throw new InvalidOperationException("Not authenticated.");
 
         await using var db = await dbFactory.CreateDbContextAsync(ct);
         var participant = await db.CompetitionParticipants
+            .Include(cp => cp.Player)
             .FirstOrDefaultAsync(cp => cp.CompetitionId == competitionId
                 && cp.Player!.UserId == currentUser.UserId, ct)
             ?? throw new KeyNotFoundException("Could not find your participant record.");
 
+        RequirePhoneAndConsent(participant.Player!, consent);
+
         participant.Status = status;
+        db.CompetitionEntryConsents.Add(BuildConsentRow(competitionId, participant.PlayerId, consent));
         await db.SaveChangesAsync(ct);
     }
 
@@ -318,6 +357,32 @@ public sealed class WebCompetitionService(
             r.Participants, r.ActivePlayers, r.IdlePlayers,
             r.FixturesGenerated, r.DecayEventsGenerated);
     }
+
+    private static void RequirePhoneAndConsent(Player player, PhoneShareConsent consent)
+    {
+        if (string.IsNullOrWhiteSpace(player.MobileNumber))
+            throw new InvalidOperationException(
+                "Add a mobile number to your profile before entering competitions.");
+        if (!consent.Granted)
+            throw new InvalidOperationException(
+                "Consent required to share your mobile number with other competitors.");
+        if (string.IsNullOrWhiteSpace(consent.WordingShown))
+            throw new InvalidOperationException("Consent wording is required.");
+        if (consent.Version != PhoneVisibilityService.CurrentConsentVersion)
+            throw new InvalidOperationException(
+                "Consent form has been updated — please refresh the page and try again.");
+    }
+
+    private static CompetitionEntryConsent BuildConsentRow(
+        int competitionId, int playerId, PhoneShareConsent consent) => new()
+    {
+        CompetitionId = competitionId,
+        PlayerId = playerId,
+        ConsentGivenUtc = DateTime.UtcNow,
+        ConsentWordingShown = consent.WordingShown,
+        ConsentVersion = consent.Version,
+    };
+
 
     public async Task ApproveFixtureResultAsync(
         int fixtureId, ApproveFixtureResultRequest request, CancellationToken ct = default)
@@ -687,7 +752,7 @@ public sealed class WebCompetitionService(
     public async Task<MyCompetitionsViewDto> GetMyCompetitionsViewAsync(CancellationToken ct = default)
     {
         if (string.IsNullOrEmpty(currentUser.UserId))
-            return new MyCompetitionsViewDto(false, [], []);
+            return new MyCompetitionsViewDto(false, [], [], null);
 
         await using var db = await dbFactory.CreateDbContextAsync(ct);
 
@@ -704,7 +769,7 @@ public sealed class WebCompetitionService(
         var myPlayers = await db.Players
             .Where(p => p.UserId == currentUser.UserId)
             .ToListAsync(ct);
-        if (myPlayers.Count == 0) return new MyCompetitionsViewDto(false, [], []);
+        if (myPlayers.Count == 0) return new MyCompetitionsViewDto(false, [], [], null);
         var myPlayerIds = myPlayers.Select(p => p.PlayerId).ToList();
         var eligibilityPlayer = myPlayers.FirstOrDefault(p => !p.IsLight) ?? myPlayers[0];
 
@@ -742,7 +807,11 @@ public sealed class WebCompetitionService(
         var available = candidates
             .Where(c => EligibilityEvaluator.Evaluate(c, eligibilityPlayer).Count == 0)
             .Select(ToDto).ToList();
-        return new MyCompetitionsViewDto(true, enteredEntities.Select(ToDto).ToList(), available);
+        return new MyCompetitionsViewDto(
+            true,
+            enteredEntities.Select(ToDto).ToList(),
+            available,
+            eligibilityPlayer.MobileNumber);
     }
 
     public async Task<List<CompetitionFixtureDto>> GetPendingVerificationFixturesAsync(CancellationToken ct = default)
@@ -897,7 +966,8 @@ public sealed class WebCompetitionService(
         await db.SaveChangesAsync(ct);
     }
 
-    public async Task EnterCompetitionAsync(int competitionId, CancellationToken ct = default)
+    public async Task EnterCompetitionAsync(
+        int competitionId, PhoneShareConsent consent, CancellationToken ct = default)
     {
         if (string.IsNullOrEmpty(currentUser.UserId))
             throw new InvalidOperationException("Not authenticated.");
@@ -906,6 +976,8 @@ public sealed class WebCompetitionService(
         var player = await db.Players
             .FirstOrDefaultAsync(p => p.UserId == currentUser.UserId && !p.IsLight, ct)
             ?? throw new InvalidOperationException("You need a player profile before entering competitions.");
+
+        RequirePhoneAndConsent(player, consent);
 
         var comp = await db.Competition
             .Include(c => c.AllowedPlayers)
@@ -946,6 +1018,35 @@ public sealed class WebCompetitionService(
             RegisteredAt = DateTime.UtcNow,
             Status = ParticipantStatus.Registered
         });
+        db.CompetitionEntryConsents.Add(BuildConsentRow(competitionId, player.PlayerId, consent));
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task LeaveCompetitionAsync(int competitionId, CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(currentUser.UserId))
+            throw new InvalidOperationException("Not authenticated.");
+
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var participant = await db.CompetitionParticipants
+            .Include(cp => cp.Player)
+            .FirstOrDefaultAsync(cp => cp.CompetitionId == competitionId
+                && cp.Player!.UserId == currentUser.UserId, ct)
+            ?? throw new KeyNotFoundException("You are not entered in this competition.");
+
+        participant.Status = ParticipantStatus.Withdrawn;
+
+        // Stamp the latest active consent row (if any) as withdrawn so the
+        // visibility service drops this player's number from peer views.
+        var activeConsent = await db.CompetitionEntryConsents
+            .Where(c => c.CompetitionId == competitionId
+                        && c.PlayerId == participant.PlayerId
+                        && c.WithdrawnUtc == null)
+            .OrderByDescending(c => c.ConsentGivenUtc)
+            .FirstOrDefaultAsync(ct);
+        if (activeConsent is not null)
+            activeConsent.WithdrawnUtc = DateTime.UtcNow;
+
         await db.SaveChangesAsync(ct);
     }
 


### PR DESCRIPTION
## Summary

- Adds explicit, per-competition, audited consent before a player's mobile number is shown to other competitors in their division.
- New `CompetitionEntryConsent` table (append-only log) + EF migration; recorded inside the same transaction as the participant row.
- New `IPhoneVisibilityService` is the single source of truth for "can the viewer see this number?" — strips `MobileNumber` from DTOs server-side (no JSON leak), enforces an unconditional under-13 block, and respects an admin-bypass for legitimate-interest viewing.
- One-click "Leave competition" sets `ParticipantStatus.Withdrawn` AND stamps `WithdrawnUtc` on the active consent row, so withdrawal is as easy as consent.
- Admin "Add participant" / "Bulk add" can attest consent on the player's behalf (for the "Alice emailed asking to enter" case), with a distinct `ConsentVersion = "v1-2026-05-admin"` and the admin-supplied source captured in the audit trail. Unticked = player added with no consent row, number stays peer-hidden until they self-consent.
- Registration-level notice under the mobile field on Players / MyPlayers forms; Privacy policy §5 extended and new §5a covers the entry flow, under-13 protection, lawful basis, and one-click withdrawal.

## Test plan

- [ ] Run `dotnet ef database update --project DropShot` on a dev DB; confirm `CompetitionEntryConsents` table is created with the `(CompetitionId, PlayerId, WithdrawnUtc)` composite index.
- [ ] Without a mobile on file, click Enter on a competition → expect inline alert pointing to profile, no participant row created.
- [ ] With a mobile on file, click Enter → dialog shows masked number; Confirm disabled until checkbox ticked. Cancel = no rows. Confirm = participant row + consent row in one transaction.
- [ ] As a same-division peer, expect the entered player's number to appear in the Contact information panel.
- [ ] Click Leave competition → number disappears from peer views on reload; participant moves to Withdrawn; consent row has `WithdrawnUtc` set.
- [ ] As competition admin, repeat above and confirm numbers remain visible throughout (admin bypass).
- [ ] Set a test player's DoB to make them 12; insert a consent row manually; confirm peers still see "—" (defence in depth — minor block beats consent).
- [ ] Inspect participants JSON in devtools network tab — `MobileNumber` must be `null` for any player the viewer isn't allowed to see (don't trust the rendered table alone).
- [ ] Admin adds a player via autocomplete with attestation ticked + Source filled → consent row written with `ConsentVersion = "v1-2026-05-admin"` and the source captured in `ConsentWordingShown`. Unticked → no consent row, number stays peer-hidden.
- [ ] `/privacy` renders new wording and "Last updated: 18 May 2026".

🤖 Generated with [Claude Code](https://claude.com/claude-code)