### PR TITLE
Surface real error detail when competition delete fails

### DIFF
--- a/DropShot.UI/Components/Pages/Competitions.razor
+++ b/DropShot.UI/Components/Pages/Competitions.razor
@@ -841,9 +841,9 @@ else
         {
             await CompetitionService.DeleteCompetitionAsync(comp.CompetitionId);
         }
-        catch (Exception)
+        catch (Exception ex)
         {
-            SiteAlerts.Add("Failed to delete. Please try again.", Severity.Error);
+            SiteAlerts.Add($"Couldn't delete '{comp.CompetitionName}': {ex.Message}", Severity.Error);
             return;
         }
 

--- a/DropShot/Services/WebCompetitionService.cs
+++ b/DropShot/Services/WebCompetitionService.cs
@@ -26,7 +26,8 @@ public sealed class WebCompetitionService(
     BackgroundTaskQueue backgroundTasks,
     RubberResolutionService rubberResolver,
     PlayerRatingService ratings,
-    IPhoneVisibilityService phoneVisibility) : ICompetitionService
+    IPhoneVisibilityService phoneVisibility,
+    ILogger<WebCompetitionService> logger) : ICompetitionService
 {
     /// <summary>
     /// Best-available principal: HttpContext.User on prerender, controllers,
@@ -963,7 +964,26 @@ public sealed class WebCompetitionService(
         db.CompetitionFixtures.RemoveRange(fixtures);
 
         db.Competition.Remove(entity);
-        await db.SaveChangesAsync(ct);
+        try
+        {
+            await db.SaveChangesAsync(ct);
+        }
+        catch (DbUpdateException ex)
+        {
+            logger.LogError(ex, "Failed to delete competition {CompetitionId}", competitionId);
+            // The outer DbUpdateException message is the generic EF wrapper
+            // ("An error occurred while saving the entity changes…"); the
+            // inner SqlException carries the actual FK constraint name. Rethrow
+            // as InvalidOperationException so the UI can surface ex.Message
+            // without needing an EF Core reference.
+            var detail = ex.InnerException?.Message ?? ex.Message;
+            throw new InvalidOperationException(detail, ex);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to delete competition {CompetitionId}", competitionId);
+            throw;
+        }
     }
 
     public async Task EnterCompetitionAsync(


### PR DESCRIPTION
## Summary
- Replaces the generic `"Failed to delete. Please try again."` toast on the competitions page with `Couldn't delete '<name>': <reason>`, surfacing the underlying exception message.
- `WebCompetitionService.DeleteCompetitionAsync` now logs `SaveChangesAsync` failures with the `CompetitionId` scope and unwraps `DbUpdateException` so the inner `SqlException` message (the actual FK constraint name) reaches the UI — rethrown as `InvalidOperationException` to keep EF Core out of `DropShot.UI`'s reference graph.

## Test plan
- [ ] Archive a competition that has data blocking deletion (e.g. `PlayerRatingSnapshot` rows from `OnDelete(NoAction)`), click Delete: toast names the failing constraint instead of "Please try again."
- [ ] Archive and delete a competition with no blocking related data: existing `'X' deleted.` success toast still appears.
- [ ] Force a failure and check server logs: one `LogError` entry with `CompetitionId` scope and full stack trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)