### PR TITLE
Delete rating snapshots when deleting a competition

### DIFF
--- a/DropShot.UI/Components/Pages/Competitions.razor
+++ b/DropShot.UI/Components/Pages/Competitions.razor
@@ -832,7 +832,7 @@ else
     {
         var confirm = await DialogService.ShowMessageBoxAsync(
             "Delete Competition",
-            $"Are you sure you want to permanently delete '{comp.CompetitionName}'? This will remove all participants, fixtures, stages, and teams. This action cannot be undone.",
+            $"Are you sure you want to permanently delete '{comp.CompetitionName}'? This will remove all participants, fixtures, stages, teams, and rating snapshots. This action cannot be undone.",
             yesText: "Delete", cancelText: "Cancel");
 
         if (confirm != true) return;

--- a/DropShot/Services/WebCompetitionService.cs
+++ b/DropShot/Services/WebCompetitionService.cs
@@ -963,6 +963,15 @@ public sealed class WebCompetitionService(
             .ToListAsync(ct);
         db.CompetitionFixtures.RemoveRange(fixtures);
 
+        // PlayerRatingSnapshot.CompetitionId uses OnDelete(NoAction) to keep
+        // the Elo audit trail intact under normal operation. When the user
+        // explicitly deletes an (archived) competition, drop them too — the
+        // alternative is the delete silently fails on a FK constraint.
+        var snapshots = await db.PlayerRatingSnapshots
+            .Where(s => s.CompetitionId == competitionId)
+            .ToListAsync(ct);
+        db.PlayerRatingSnapshots.RemoveRange(snapshots);
+
         db.Competition.Remove(entity);
         try
         {


### PR DESCRIPTION
## Summary
- `PlayerRatingSnapshot.CompetitionId` uses `OnDelete(NoAction)` to protect the Elo audit trail under normal operation, but that turns into an FK violation (`FK_PlayerRatingSnapshots_Competition_CompetitionId`) when a user explicitly deletes an archived competition.
- `WebCompetitionService.DeleteCompetitionAsync` now removes matching `PlayerRatingSnapshots` alongside the existing manual cleanup of Rubbers and Fixtures.
- Confirmation dialog updated to include "rating snapshots" in the list of what gets removed.

Follow-up to [#677](https://github.com/kingbeazer/DropShot/pull/677), which surfaced the FK error in the toast instead of hiding it behind a generic retry message.

## Test plan
- [ ] Delete an archived competition that has rating snapshots (a Singles Ladder with played fixtures): succeeds, snapshots gone from `PlayerRatingSnapshots`.
- [ ] Delete an archived competition with no snapshots: still works.
- [ ] Confirmation dialog text now mentions rating snapshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)