### PR TITLE
Gate match scoring behind paid tier

### DIFF
--- a/DropShot.Maui/Components/Layout/NavMenu.razor
+++ b/DropShot.Maui/Components/Layout/NavMenu.razor
@@ -35,6 +35,13 @@
        lights it up in both hosts automatically. *@
     @foreach (var link in DropShot.UI.Services.Navigation.NavCatalog.Primary)
     {
+        @* Subscription gate is layered on top of role auth — skip entries that
+           require a subscription when the active user can't score. *@
+        if (link.RequiresSubscription && !CurrentUser.CanScoreMatch)
+        {
+            continue;
+        }
+
         if (!string.IsNullOrEmpty(link.RequiredRoles))
         {
             <AuthorizeView Roles="@link.RequiredRoles">

--- a/DropShot.Maui/Services/AuthService.cs
+++ b/DropShot.Maui/Services/AuthService.cs
@@ -22,6 +22,7 @@ public class AuthService : AuthenticationStateProvider
     public List<string> GrantedRoles => _session?.GrantedRoles ?? [];
     public bool IsAdmin => _session?.ActiveRole is "Admin" or "SuperAdmin";
     public bool IsClubAdmin => _session?.ActiveRole == "ClubAdmin";
+    public bool IsSubscribed => _session?.IsSubscribed ?? false;
     public List<int> AdminClubIds => _session?.AdminClubIds ?? [];
 
     public bool CanEditClub(int clubId) =>
@@ -96,7 +97,7 @@ public class AuthService : AuthenticationStateProvider
             var info = await _http.GetFromJsonAsync<UserInfoDto>("api/auth/me");
             if (info is null) { await LogoutAsync(); return; }
 
-            _session = new LoginResponse(token, info.UserName, info.Email, info.Roles, info.AdminClubIds, info.ActiveRole, info.GrantedRoles);
+            _session = new LoginResponse(token, info.UserName, info.Email, info.Roles, info.AdminClubIds, info.ActiveRole, info.GrantedRoles, info.IsSubscribed);
             NotifyAuthenticationStateChanged(GetAuthenticationStateAsync());
         }
         catch

--- a/DropShot.Maui/Services/MauiCurrentUser.cs
+++ b/DropShot.Maui/Services/MauiCurrentUser.cs
@@ -63,10 +63,11 @@ public sealed class MauiCurrentUser : ICurrentUser, IDisposable
     public bool IsSuperAdmin =>
         string.Equals(_auth.ActiveRole, "SuperAdmin", StringComparison.OrdinalIgnoreCase);
 
-    // The login DTO doesn't carry the subscription bit yet, so on MAUI we
-    // conservatively report false. The "user competition" creation path is a
-    // web-only feature until that plumbing lands.
-    public bool IsSubscribed => false;
+    public bool IsSubscribed => _auth.IsSubscribed;
+
+    // Mirrors WebCurrentUser: admin acting roles bypass subscription so they
+    // can score on behalf of others; everyone else needs an active sub.
+    public bool CanScoreMatch => IsAdmin || IsClubAdmin || IsSubscribed;
 
     public bool HasRole(string role) =>
         _auth.GrantedRoles.Contains(role, StringComparer.OrdinalIgnoreCase);

--- a/DropShot.Shared/Dtos/AuthDtos.cs
+++ b/DropShot.Shared/Dtos/AuthDtos.cs
@@ -9,7 +9,8 @@ public record LoginResponse(
     List<string> Roles,
     List<int> AdminClubIds,
     string ActiveRole,
-    List<string> GrantedRoles);
+    List<string> GrantedRoles,
+    bool IsSubscribed);
 
 public record UserInfoDto(
     string UserId,
@@ -18,7 +19,8 @@ public record UserInfoDto(
     List<string> Roles,
     List<int> AdminClubIds,
     string ActiveRole,
-    List<string> GrantedRoles);
+    List<string> GrantedRoles,
+    bool IsSubscribed);
 
 public record SwitchRoleRequest(string Role);
 

--- a/DropShot.Tests/Helpers/DropShotTestContext.cs
+++ b/DropShot.Tests/Helpers/DropShotTestContext.cs
@@ -26,7 +26,8 @@ public class DropShotTestContext : BunitContext
         bool authenticated = true,
         string userId = "test-user-id",
         string userName = "test@example.com",
-        string[]? roles = null)
+        string[]? roles = null,
+        bool subscribed = false)
     {
         // Allow all JS interop calls (MudBlazor uses JS heavily)
         JSInterop.Mode = JSRuntimeMode.Loose;
@@ -71,6 +72,15 @@ public class DropShotTestContext : BunitContext
         var userManager = Substitute.For<UserManager<ApplicationUser>>(
             userStore,
             null!, null!, null!, null!, null!, null!, null!, null!);
+        // WebCurrentUser reads ApplicationUser.IsSubscribed via FindByIdAsync to
+        // populate _isSubscribed, which feeds CanScoreMatch — the gate behind
+        // /match, /tennisscore and /team-match. Tests that render scoring
+        // pages should pass subscribed:true to cross the gate.
+        if (authenticated)
+        {
+            userManager.FindByIdAsync(userId)
+                .Returns(new ApplicationUser { Id = userId, IsSubscribed = subscribed });
+        }
         Services.AddSingleton(userManager);
 
         var contextAccessor = Substitute.For<Microsoft.AspNetCore.Http.IHttpContextAccessor>();
@@ -157,6 +167,15 @@ public class DropShotTestContext : BunitContext
         Services.AddScoped<IUserService, WebUserService>();
         Services.AddScoped<IScoreboardHubFactory, WebScoreboardHubFactory>();
         Services.AddScoped<IPaymentService, WebPaymentService>();
+        // MudProviders.razor injects SiteAlertHost into every interactive page,
+        // and SiteAlertHost @injects ISiteAlertService — without this binding
+        // every bUnit page render that pulls in MudProviders throws at component
+        // instantiation.
+        Services.AddScoped<ISiteAlertService, SiteAlertService>();
+        // WebCompetitionService takes IPhoneVisibilityService — added with the
+        // GDPR phone-sharing work and not yet wired into the test container.
+        // Tests don't exercise the consent paths, so a substitute is enough.
+        Services.AddScoped(_ => Substitute.For<IPhoneVisibilityService>());
 
         // Logging
         Services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));

--- a/DropShot.Tests/Pages/MatchListTests.cs
+++ b/DropShot.Tests/Pages/MatchListTests.cs
@@ -1,6 +1,8 @@
 using Bunit;
 using DropShot.Components.Pages;
 using DropShot.Tests.Helpers;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace DropShot.Tests.Pages;
@@ -8,11 +10,31 @@ namespace DropShot.Tests.Pages;
 public class MatchListTests
 {
     [Fact]
-    public async Task Match_Renders_Without_Exception()
+    public async Task Match_Renders_Without_Exception_For_Subscriber()
     {
-        await using var ctx = new DropShotTestContext(authenticated: false);
+        await using var ctx = new DropShotTestContext(authenticated: true, subscribed: true);
         var cut = ctx.Render<Match>();
 
         Assert.NotEmpty(cut.Markup);
+    }
+
+    [Fact]
+    public async Task Match_Redirects_Home_For_Anonymous_User()
+    {
+        await using var ctx = new DropShotTestContext(authenticated: false);
+        ctx.Render<Match>();
+
+        var nav = ctx.Services.GetRequiredService<NavigationManager>();
+        Assert.EndsWith("/", nav.Uri);
+    }
+
+    [Fact]
+    public async Task Match_Redirects_Home_For_Unsubscribed_User()
+    {
+        await using var ctx = new DropShotTestContext(authenticated: true, subscribed: false);
+        ctx.Render<Match>();
+
+        var nav = ctx.Services.GetRequiredService<NavigationManager>();
+        Assert.EndsWith("/", nav.Uri);
     }
 }

--- a/DropShot.Tests/Pages/TennisScoreTests.cs
+++ b/DropShot.Tests/Pages/TennisScoreTests.cs
@@ -2,6 +2,8 @@ using Bunit;
 using DropShot.Components.Pages;
 using DropShot.Models;
 using DropShot.Tests.Helpers;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace DropShot.Tests.Pages;
@@ -9,9 +11,9 @@ namespace DropShot.Tests.Pages;
 public class TennisScoreTests
 {
     [Fact]
-    public async Task TennisScore_Renders_Without_Exception()
+    public async Task TennisScore_Renders_Without_Exception_For_Subscriber()
     {
-        await using var ctx = new DropShotTestContext(authenticated: false);
+        await using var ctx = new DropShotTestContext(authenticated: true, subscribed: true);
 
         using (var db = ctx.SeedDatabase())
         {
@@ -22,5 +24,39 @@ public class TennisScoreTests
         var cut = ctx.Render<TennisScore>(p => p.Add(x => x.MatchId, 1));
 
         Assert.NotEmpty(cut.Markup);
+    }
+
+    [Fact]
+    public async Task TennisScore_Redirects_Home_For_Anonymous_User()
+    {
+        await using var ctx = new DropShotTestContext(authenticated: false);
+
+        using (var db = ctx.SeedDatabase())
+        {
+            db.SavedMatch.Add(new SavedMatch { SavedMatchId = 1 });
+            db.SaveChanges();
+        }
+
+        ctx.Render<TennisScore>(p => p.Add(x => x.MatchId, 1));
+
+        var nav = ctx.Services.GetRequiredService<NavigationManager>();
+        Assert.EndsWith("/", nav.Uri);
+    }
+
+    [Fact]
+    public async Task TennisScore_Redirects_Home_For_Unsubscribed_User()
+    {
+        await using var ctx = new DropShotTestContext(authenticated: true, subscribed: false);
+
+        using (var db = ctx.SeedDatabase())
+        {
+            db.SavedMatch.Add(new SavedMatch { SavedMatchId = 1 });
+            db.SaveChanges();
+        }
+
+        ctx.Render<TennisScore>(p => p.Add(x => x.MatchId, 1));
+
+        var nav = ctx.Services.GetRequiredService<NavigationManager>();
+        Assert.EndsWith("/", nav.Uri);
     }
 }

--- a/DropShot.UI/Components/Competitions/Setup/FixturesSection.razor
+++ b/DropShot.UI/Components/Competitions/Setup/FixturesSection.razor
@@ -1,5 +1,7 @@
 @using DropShot.Shared
 @using DropShot.Shared.Dtos
+@using DropShot.UI.Services.Auth
+@inject ICurrentUser CurrentUser
 
 <MudPaper id="section-fixtures" Class="pa-4 setup-section frosted-card" Elevation="0"
      Style="color: white;">
@@ -133,7 +135,8 @@
             </MudTd>
             <MudTd>
                 @if (context.HomeTeamId.HasValue && context.AwayTeamId.HasValue
-                     && context.Status is not (FixtureStatus.Completed or FixtureStatus.Cancelled or FixtureStatus.Walkover or FixtureStatus.AwaitingVerification))
+                     && context.Status is not (FixtureStatus.Completed or FixtureStatus.Cancelled or FixtureStatus.Walkover or FixtureStatus.AwaitingVerification)
+                     && CurrentUser.CanScoreMatch)
                 {
                     <MudIconButton Icon="@Icons.Material.Filled.SportsTennis" Size="Size.Small"
                                    Color="Color.Success" aria-label="Play Team Match"

--- a/DropShot.UI/Components/Pages/CompetitionPage.razor
+++ b/DropShot.UI/Components/Pages/CompetitionPage.razor
@@ -1382,7 +1382,8 @@ else
                                                         </td>
                                                         <td>
                                                             @if (f.HomeTeamId.HasValue && f.AwayTeamId.HasValue
-                                                                 && f.Status is not (FixtureStatus.Completed or FixtureStatus.Cancelled or FixtureStatus.Walkover or FixtureStatus.AwaitingVerification))
+                                                                 && f.Status is not (FixtureStatus.Completed or FixtureStatus.Cancelled or FixtureStatus.Walkover or FixtureStatus.AwaitingVerification)
+                                                                 && CurrentUser.CanScoreMatch)
                                                             {
                                                                 <MudIconButton Icon="@Icons.Material.Filled.SportsTennis" Size="Size.Small"
                                                                                Color="Color.Success" aria-label="Play Team Match"

--- a/DropShot.UI/Components/Pages/Home.razor
+++ b/DropShot.UI/Components/Pages/Home.razor
@@ -162,7 +162,7 @@
     </MudCardContent>
 </MudCard>
 
-@if (_isAuthenticated)
+@if (_isAuthenticated && CurrentUser.CanScoreMatch)
 {
     <MudPaper Class="mt-4 pa-5" Elevation="0"
               Style="background: linear-gradient(135deg, #004d40 0%, #00897b 60%, #4db6ac 100%); border-radius: 16px; text-align: center;">
@@ -218,11 +218,14 @@
                                 </MudTd>
                                 <MudTd>
                                     <MudStack Row="true" Spacing="2">
-                                        <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary"
-                                                   StartIcon="@Icons.Material.Filled.PlayArrow"
-                                                   OnClick="@(() => StartFixtureMatchAsync(context))">
-                                            Play
-                                        </MudButton>
+                                        @if (CurrentUser.CanScoreMatch)
+                                        {
+                                            <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary"
+                                                       StartIcon="@Icons.Material.Filled.PlayArrow"
+                                                       OnClick="@(() => StartFixtureMatchAsync(context))">
+                                                Play
+                                            </MudButton>
+                                        }
                                         <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Secondary"
                                                    StartIcon="@Icons.Material.Filled.Edit"
                                                    OnClick="@(() => OpenSubmitScoreAsync(context))">

--- a/DropShot.UI/Components/Pages/Match.razor
+++ b/DropShot.UI/Components/Pages/Match.razor
@@ -49,6 +49,19 @@
     {
         if (firstRender)
         {
+            // Match scoring sits behind the subscription gate. Anyone who can't
+            // score (anonymous, signed-in-but-unsubscribed, role-switched into
+            // plain User without a sub) gets redirected home so the URL can't
+            // be entered directly. Admins/club-admins acting in their admin
+            // role bypass the gate via CanScoreMatch.
+            await CurrentUser.EnsureLoadedAsync();
+            if (!CurrentUser.CanScoreMatch)
+            {
+                _redirecting = true;
+                Navigation.NavigateTo("/", replace: true);
+                return;
+            }
+
             string? deviceToken = null;
             if (!CurrentUser.IsAuthenticated)
             {

--- a/DropShot.UI/Components/Pages/TeamMatchScoring.razor
+++ b/DropShot.UI/Components/Pages/TeamMatchScoring.razor
@@ -130,7 +130,22 @@ else
 
     private bool CanEditCompletedRubber => _isCompetitionAdmin && EditMode == 1;
 
-    protected override async Task OnInitializedAsync() => await LoadAsync();
+    protected override async Task OnInitializedAsync()
+    {
+        // Team-match scoring is gated by subscription. Anyone who can't score
+        // (anonymous, non-subscriber acting as plain User) is redirected home
+        // so the URL can't be entered directly. Admins/club-admins acting in
+        // their admin role bypass via CanScoreMatch — they may need to
+        // record results on behalf of teams.
+        await CurrentUser.EnsureLoadedAsync();
+        if (!CurrentUser.CanScoreMatch)
+        {
+            Navigation.NavigateTo("/", replace: true);
+            return;
+        }
+
+        await LoadAsync();
+    }
 
     private async Task LoadAsync()
     {

--- a/DropShot.UI/Components/Pages/TennisScore.razor
+++ b/DropShot.UI/Components/Pages/TennisScore.razor
@@ -860,8 +860,23 @@
     }
 
 
+    private bool _gateRedirect;
+
     protected override async Task OnInitializedAsync()
     {
+        // Live match scoring is gated by subscription. Anyone who can't score
+        // (anonymous, non-subscriber acting as plain User) is redirected home
+        // so the scoring URL — including /tennisscore, /match/0 and
+        // /match/{id} — can't be entered directly. Admins/club-admins acting
+        // in their admin role bypass via CanScoreMatch.
+        await CurrentUser.EnsureLoadedAsync();
+        if (!CurrentUser.CanScoreMatch)
+        {
+            _gateRedirect = true;
+            Navigation.NavigateTo("/", replace: true);
+            return;
+        }
+
         _currentUserId = CurrentUser.UserId;
 
         var bootstrap = await Scoring.GetBootstrapAsync();
@@ -1014,6 +1029,11 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+        // Skip hub setup and device-token bookkeeping if we already kicked off
+        // a redirect from OnInitializedAsync — the user can't score and the
+        // page is just waiting for navigation to take effect.
+        if (_gateRedirect) return;
+
         if (firstRender)
         {
             if (_currentUserId == null)

--- a/DropShot.UI/Components/Pages/ViewCompetition.razor
+++ b/DropShot.UI/Components/Pages/ViewCompetition.razor
@@ -164,7 +164,8 @@ else
     }
 
     @if (_competition.CompetitionFormat == CompetitionFormat.SinglesLadder
-         && _myParticipant?.Status == ParticipantStatus.FullPlayer)
+         && _myParticipant?.Status == ParticipantStatus.FullPlayer
+         && CurrentUser.CanScoreMatch)
     {
         <MudPaper Class="pa-3 mb-4" Elevation="0" Style="background: rgba(0,180,216,0.08);">
             <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Wrap="Wrap.Wrap">

--- a/DropShot.UI/Services/Auth/ICurrentUser.cs
+++ b/DropShot.UI/Services/Auth/ICurrentUser.cs
@@ -44,6 +44,18 @@ public interface ICurrentUser
     /// </summary>
     bool CanCreateUserCompetition { get; }
 
+    /// <summary>
+    /// Whether the user can access the live match-scoring screens
+    /// (<c>/match</c>, <c>/match/{id}</c>, <c>/team-match/{id}</c>,
+    /// <c>/tennisscore</c>). Admin/ClubAdmin acting in their admin role
+    /// bypass the gate; otherwise the user must have an active subscription.
+    /// Buttons that lead into scoring (NavMenu Match link, fixture Play
+    /// buttons, ladder Record-match) and the scoring pages themselves all
+    /// gate on this property — the pages additionally redirect to home when
+    /// it's false so the URL can't be entered directly.
+    /// </summary>
+    bool CanScoreMatch { get; }
+
     /// <summary>Raised after the underlying auth state changes (login, logout, role switch, session restore).</summary>
     event Action? Changed;
 

--- a/DropShot.UI/Services/Navigation/NavCatalog.cs
+++ b/DropShot.UI/Services/Navigation/NavCatalog.cs
@@ -18,12 +18,17 @@ namespace DropShot.UI.Services.Navigation;
 /// <param name="RequiredRoles">Optional comma-separated roles. When
 /// <c>null</c> the link is rendered for any authenticated user. When
 /// empty the link is rendered for everyone (including anonymous).</param>
+/// <param name="RequiresSubscription">When true the link is only shown to
+/// users for whom <c>ICurrentUser.CanScoreMatch</c> is true — i.e. an
+/// active subscriber or an admin/club-admin acting in their admin role.
+/// Layered on top of <paramref name="RequiredRoles"/>: both must pass.</param>
 public sealed record NavLinkEntry(
     string Href,
     string Label,
     string Icon,
     string? Sublabel = null,
-    string? RequiredRoles = null);
+    string? RequiredRoles = null,
+    bool RequiresSubscription = false);
 
 /// <summary>
 /// Single source of truth for the primary navigation links shown in the
@@ -39,7 +44,8 @@ public static class NavCatalog
         new("match", "Match",
             Icons.Material.Filled.SportsTennis,
             "Score or join a match",
-            RequiredRoles: "User"),
+            RequiredRoles: "User",
+            RequiresSubscription: true),
 
         new("competitions", "Competitions",
             Icons.Material.Filled.EmojiEvents,

--- a/DropShot/Components/Layout/NavMenu.razor
+++ b/DropShot/Components/Layout/NavMenu.razor
@@ -4,10 +4,12 @@
 @using Microsoft.AspNetCore.Identity
 @using Microsoft.EntityFrameworkCore
 @using DropShot.Data
+@using DropShot.UI.Services.Auth
 @using DropShot.UI.Services.Navigation
 
 @inject NavigationManager NavigationManager
 @inject IDbContextFactory<MyDbContext> DbFactory
+@inject ICurrentUser CurrentUser
 
 <div class="top-row navbar navbar-dark">
     <a class="navbar-brand" href="">
@@ -25,6 +27,15 @@
                account/admin/utility dropdown) stay in this file. *@
             @foreach (var link in NavCatalog.Primary)
             {
+                @* Subscription gate is layered on top of the auth/role gate:
+                   skip the entry entirely when it requires a subscription and
+                   the current user can't score. CurrentUser is read at render
+                   time and re-evaluates on every StateHasChanged. *@
+                if (link.RequiresSubscription && !CurrentUser.CanScoreMatch)
+                {
+                    continue;
+                }
+
                 if (!string.IsNullOrEmpty(link.RequiredRoles))
                 {
                     <AuthorizeView Roles="@link.RequiredRoles">
@@ -248,6 +259,10 @@
     {
         currentUrl = NavigationManager.ToBaseRelativePath(NavigationManager.Uri);
         NavigationManager.LocationChanged += OnLocationChanged;
+        // The subscription gate on the Match link reads from CurrentUser; rerender
+        // when the auth/role snapshot updates so the link appears/disappears on
+        // login, role-switch, or subscription change without a full page reload.
+        CurrentUser.Changed += OnCurrentUserChanged;
 
         if (HttpContext?.User.Identity?.IsAuthenticated == true)
         {
@@ -273,8 +288,11 @@
         StateHasChanged();
     }
 
+    private void OnCurrentUserChanged() => InvokeAsync(StateHasChanged);
+
     public void Dispose()
     {
         NavigationManager.LocationChanged -= OnLocationChanged;
+        CurrentUser.Changed -= OnCurrentUserChanged;
     }
 }

--- a/DropShot/Controllers/AuthController.cs
+++ b/DropShot/Controllers/AuthController.cs
@@ -41,7 +41,7 @@ public class AuthController(
             .Select(ca => ca.ClubId)
             .ToListAsync();
 
-        return Ok(new LoginResponse(token, user.UserName!, user.Email!, roles, adminClubIds, activeRole, roles));
+        return Ok(new LoginResponse(token, user.UserName!, user.Email!, roles, adminClubIds, activeRole, roles, user.IsSubscribed));
     }
 
     [HttpGet("me")]
@@ -63,7 +63,7 @@ public class AuthController(
             .Select(ca => ca.ClubId)
             .ToListAsync();
 
-        return Ok(new UserInfoDto(user.Id, user.UserName!, user.Email!, grantedRoles, adminClubIds, activeRole, grantedRoles));
+        return Ok(new UserInfoDto(user.Id, user.UserName!, user.Email!, grantedRoles, adminClubIds, activeRole, grantedRoles, user.IsSubscribed));
     }
 
     [HttpPost("switch-role")]
@@ -153,6 +153,6 @@ public class AuthController(
             .Select(ca => ca.ClubId)
             .ToListAsync();
 
-        return Ok(new LoginResponse(token, user.UserName!, user.Email!, roles, adminClubIds, activeRole, roles));
+        return Ok(new LoginResponse(token, user.UserName!, user.Email!, roles, adminClubIds, activeRole, roles, user.IsSubscribed));
     }
 }

--- a/DropShot/Services/WebCurrentUser.cs
+++ b/DropShot/Services/WebCurrentUser.cs
@@ -227,6 +227,12 @@ public sealed class WebCurrentUser : ICurrentUser, IDisposable
     public bool IsSuperAdmin => _activeRole == "SuperAdmin";
     public bool IsSubscribed => _isSubscribed;
 
+    // Admin/ClubAdmin acting in their admin role bypass the subscription
+    // requirement so they can still score for administration purposes. A
+    // SuperAdmin role-switched to "User" intentionally loses the bypass —
+    // same shape as CanCreateUserCompetition.
+    public bool CanScoreMatch => IsAdmin || IsClubAdmin || _isSubscribed;
+
     public bool HasRole(string role) =>
         _grantedRoles.Contains(role, StringComparer.OrdinalIgnoreCase);
 


### PR DESCRIPTION
## Summary
- Adds `ICurrentUser.CanScoreMatch` (subscriber OR admin/club-admin acting in their admin role) and gates the Match nav link, Home page "Start a Match" + fixture "Play" buttons, fixture "Play Team Match" icon buttons (FixturesSection + CompetitionPage), and the ladder "Record match" button on it.
- `/match`, `/match/{id}`, `/tennisscore` and `/team-match/{id}` now redirect to `/` when `CanScoreMatch` is false so the URLs can't be entered directly. Admins/club-admins bypass per the agreed scope.
- Plumbs `IsSubscribed` through `LoginResponse` / `UserInfoDto` so MAUI subscribers also clear the gate — `MauiCurrentUser` previously hard-coded `IsSubscribed = false`, which would otherwise have locked every non-admin MAUI user out of scoring entirely.

## Test plan
- [x] `dotnet test DropShot.Tests` — added redirect-vs-render coverage for Match and TennisScore (subscriber, anonymous, signed-in unsubscribed). 69/71 pass; the 2 `CompetitionsTests` failures reproduce on `main` and are unrelated.
- [ ] Manual: sign in as a non-subscriber → Match link absent from nav; navigating to `/match`, `/match/1`, `/tennisscore`, `/team-match/1` redirects to `/`; Home shows no "Start a Match" tile and fixture rows show "Submit Score" but no "Play".
- [ ] Manual: sign in as a subscriber and as an admin → all of the above remain available.
- [ ] Manual: QR code embedded in fixture invites still points at `/match/0?fixtureId=...` ([CompetitionPage.razor:4037](DropShot.UI/Components/Pages/CompetitionPage.razor#L4037)) — unsubscribed scanners now redirect home. Worth a separate look at the QR flow if that UX matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)