### PR TITLE
Slim main toolbar to Competitions, My Players, and (paid) Match

### DIFF
--- a/DropShot.Maui/Components/Layout/NavMenu.razor
+++ b/DropShot.Maui/Components/Layout/NavMenu.razor
@@ -30,10 +30,11 @@
         Home
     </MudNavLink>
 
-    @* Primary nav links live in DropShot.UI.Services.Navigation.NavCatalog
-       so the web and MAUI menus stay in sync — adding a link in the catalog
-       lights it up in both hosts automatically. *@
-    @foreach (var link in DropShot.UI.Services.Navigation.NavCatalog.Primary)
+    @* Nav links live in DropShot.UI.Services.Navigation.NavCatalog so the web
+       and MAUI menus stay in sync. MAUI flattens Primary + Secondary into the
+       drawer; the web routes Secondary into its account dropdown instead. *@
+    @foreach (var link in DropShot.UI.Services.Navigation.NavCatalog.Primary
+        .Concat(DropShot.UI.Services.Navigation.NavCatalog.Secondary))
     {
         @* Subscription gate is layered on top of role auth — skip entries that
            require a subscription when the active user can't score. *@

--- a/DropShot.UI/Components/Shared/CurrentUserBadge.razor
+++ b/DropShot.UI/Components/Shared/CurrentUserBadge.razor
@@ -3,13 +3,7 @@
 
 @if (CurrentUser.IsAuthenticated)
 {
-    <span class="current-user-badge" style="display:inline-flex;align-items:center;gap:0.5rem;">
-        <span>@CurrentUser.UserName</span>
-        @if (!string.IsNullOrEmpty(CurrentUser.ActiveRole))
-        {
-            <MudChip T="string" Size="Size.Small" Color="Color.Default" Class="ma-0">@CurrentUser.ActiveRole</MudChip>
-        }
-    </span>
+    <span class="current-user-badge">@CurrentUser.UserName</span>
 }
 
 @code {

--- a/DropShot.UI/Services/Navigation/NavCatalog.cs
+++ b/DropShot.UI/Services/Navigation/NavCatalog.cs
@@ -31,11 +31,18 @@ public sealed record NavLinkEntry(
     bool RequiresSubscription = false);
 
 /// <summary>
-/// Single source of truth for the primary navigation links shown in the
-/// web's top-row navbar and the MAUI drawer. Host-specific entries (web's
-/// My-Players-vs-Club-Players toggle, MAUI's Home shortcut, account /
-/// admin / theme sections) stay in their respective <c>NavMenu.razor</c>
-/// because they need bespoke rendering.
+/// Single source of truth for the navigation links shown in the web's
+/// top-row navbar and the MAUI drawer.
+///
+/// <para><see cref="Primary"/> entries surface in the web's main toolbar
+/// (Match for subscribers, Competitions for everyone). <see cref="Secondary"/>
+/// entries are tucked into the web's right-hand account dropdown (Clubs,
+/// Rules Sets, Players). MAUI flattens both lists into its drawer since the
+/// drawer has no equivalent toolbar/dropdown split.</para>
+///
+/// Host-specific entries (web's My-Players-vs-Club-Players toggle, MAUI's
+/// Home shortcut, account / admin / theme sections) stay in their respective
+/// <c>NavMenu.razor</c> because they need bespoke rendering.
 /// </summary>
 public static class NavCatalog
 {
@@ -50,7 +57,10 @@ public static class NavCatalog
         new("competitions", "Competitions",
             Icons.Material.Filled.EmojiEvents,
             "Browse and manage events"),
+    ];
 
+    public static readonly IReadOnlyList<NavLinkEntry> Secondary =
+    [
         new("clubs", "Clubs",
             Icons.Material.Filled.Business,
             "Browse tennis clubs"),

--- a/DropShot/Components/Layout/NavMenu.razor
+++ b/DropShot/Components/Layout/NavMenu.razor
@@ -107,25 +107,6 @@
 
         <div class="nav-utils">
             <AuthorizeView>
-                <Authorized Context="themeCtx">
-                    <div class="nav-item">
-                        <button class="theme-toggle-btn" onclick="event.stopPropagation(); toggleDropShotTheme()">
-                            <svg class="nav-icon theme-toggle-icon theme-icon-light" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="currentColor">
-                                <path d="M12 7c-2.76 0-5 2.24-5 5s2.24 5 5 5 5-2.24 5-5-2.24-5-5-5zM2 13h2c.55 0 1-.45 1-1s-.45-1-1-1H2c-.55 0-1 .45-1 1s.45 1 1 1zm18 0h2c.55 0 1-.45 1-1s-.45-1-1-1h-2c-.55 0-1 .45-1 1s.45 1 1 1zM11 2v2c0 .55.45 1 1 1s1-.45 1-1V2c0-.55-.45-1-1-1s-1 .45-1 1zm0 18v2c0 .55.45 1 1 1s1-.45 1-1v-2c0-.55-.45-1-1-1s-1 .45-1 1zM5.99 4.58a.996.996 0 00-1.41 0 .996.996 0 000 1.41l1.06 1.06c.39.39 1.03.39 1.41 0s.39-1.03 0-1.41L5.99 4.58zm12.37 12.37a.996.996 0 00-1.41 0 .996.996 0 000 1.41l1.06 1.06c.39.39 1.03.39 1.41 0a.996.996 0 000-1.41l-1.06-1.06zm1.06-10.96a.996.996 0 000-1.41.996.996 0 00-1.41 0l-1.06 1.06c-.39.39-.39 1.03 0 1.41s1.03.39 1.41 0l1.06-1.06zM7.05 18.36a.996.996 0 000-1.41.996.996 0 00-1.41 0l-1.06 1.06c-.39.39-.39 1.03 0 1.41s1.03.39 1.41 0l1.06-1.06z"/>
-                            </svg>
-                            <svg class="nav-icon theme-toggle-icon theme-icon-dark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="currentColor">
-                                <path d="M12 3a9 9 0 109 9c0-.46-.04-.92-.1-1.36a5.389 5.389 0 01-4.4 2.26 5.403 5.403 0 01-3.14-9.8c-.44-.06-.9-.1-1.36-.1z"/>
-                            </svg>
-                            <span class="nav-label-group theme-toggle-label">
-                                <span class="nav-label">Light Mode</span>
-                                <span class="nav-sublabel">Switch theme</span>
-                            </span>
-                        </button>
-                    </div>
-                </Authorized>
-            </AuthorizeView>
-
-            <AuthorizeView>
                 <Authorized>
                     <div class="nav-item nav-dropdown nav-dropdown-right">
                         <button class="nav-link nav-dropdown-trigger" onclick="event.stopPropagation()">
@@ -146,6 +127,49 @@
                             </span>
                         </button>
                         <div class="nav-dropdown-menu">
+                            @* Secondary nav links (Clubs, Rules Sets, Players)
+                               live inside the account dropdown rather than the
+                               main toolbar — same role / subscription gating as
+                               the Primary list above. *@
+                            @foreach (var link in NavCatalog.Secondary)
+                            {
+                                if (link.RequiresSubscription && !CurrentUser.CanScoreMatch)
+                                {
+                                    continue;
+                                }
+
+                                if (!string.IsNullOrEmpty(link.RequiredRoles))
+                                {
+                                    <AuthorizeView Roles="@link.RequiredRoles" Context="secCtx">
+                                        <NavLink class="nav-link" href="@link.Href">
+                                            <MudIcon Icon="@link.Icon" Class="nav-icon" />
+                                            <span class="nav-label-group">
+                                                <span class="nav-label">@link.Label</span>
+                                                @if (!string.IsNullOrEmpty(link.Sublabel))
+                                                {
+                                                    <span class="nav-sublabel">@link.Sublabel</span>
+                                                }
+                                            </span>
+                                        </NavLink>
+                                    </AuthorizeView>
+                                }
+                                else
+                                {
+                                    <NavLink class="nav-link" href="@link.Href">
+                                        <MudIcon Icon="@link.Icon" Class="nav-icon" />
+                                        <span class="nav-label-group">
+                                            <span class="nav-label">@link.Label</span>
+                                            @if (!string.IsNullOrEmpty(link.Sublabel))
+                                            {
+                                                <span class="nav-sublabel">@link.Sublabel</span>
+                                            }
+                                        </span>
+                                    </NavLink>
+                                }
+                            }
+
+                            <hr class="nav-dropdown-divider" />
+
                             @* TODO: re-enable upgrade nav item when Premium ships.
                             <NavLink class="nav-link" href="upgrade">
                                 <MudIcon Icon="@Icons.Material.Filled.Star" Class="nav-icon" />
@@ -203,8 +227,25 @@
                                         <span class="nav-sublabel">Approve player links</span>
                                     </span>
                                 </NavLink>
-                                <hr class="nav-dropdown-divider" />
                             </AuthorizeView>
+
+                            <hr class="nav-dropdown-divider" />
+
+                            <div class="nav-dropdown-item">
+                                <button type="button" class="nav-link theme-toggle-btn" onclick="event.stopPropagation(); toggleDropShotTheme()">
+                                    <svg class="nav-icon theme-toggle-icon theme-icon-light" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="currentColor">
+                                        <path d="M12 7c-2.76 0-5 2.24-5 5s2.24 5 5 5 5-2.24 5-5-2.24-5-5-5zM2 13h2c.55 0 1-.45 1-1s-.45-1-1-1H2c-.55 0-1 .45-1 1s.45 1 1 1zm18 0h2c.55 0 1-.45 1-1s-.45-1-1-1h-2c-.55 0-1 .45-1 1s.45 1 1 1zM11 2v2c0 .55.45 1 1 1s1-.45 1-1V2c0-.55-.45-1-1-1s-1 .45-1 1zm0 18v2c0 .55.45 1 1 1s1-.45 1-1v-2c0-.55-.45-1-1-1s-1 .45-1 1zM5.99 4.58a.996.996 0 00-1.41 0 .996.996 0 000 1.41l1.06 1.06c.39.39 1.03.39 1.41 0s.39-1.03 0-1.41L5.99 4.58zm12.37 12.37a.996.996 0 00-1.41 0 .996.996 0 000 1.41l1.06 1.06c.39.39 1.03.39 1.41 0a.996.996 0 000-1.41l-1.06-1.06zm1.06-10.96a.996.996 0 000-1.41.996.996 0 00-1.41 0l-1.06 1.06c-.39.39-.39 1.03 0 1.41s1.03.39 1.41 0l1.06-1.06zM7.05 18.36a.996.996 0 000-1.41.996.996 0 00-1.41 0l-1.06 1.06c-.39.39-.39 1.03 0 1.41s1.03.39 1.41 0l1.06-1.06z"/>
+                                    </svg>
+                                    <svg class="nav-icon theme-toggle-icon theme-icon-dark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="currentColor">
+                                        <path d="M12 3a9 9 0 109 9c0-.46-.04-.92-.1-1.36a5.389 5.389 0 01-4.4 2.26 5.403 5.403 0 01-3.14-9.8c-.44-.06-.9-.1-1.36-.1z"/>
+                                    </svg>
+                                    <span class="nav-label-group">
+                                        <span class="nav-label theme-label-light">Light Mode</span>
+                                        <span class="nav-label theme-label-dark">Dark Mode</span>
+                                        <span class="nav-sublabel">Switch theme</span>
+                                    </span>
+                                </button>
+                            </div>
 
                             <div class="nav-dropdown-item">
                                 <form action="Account/Logout" method="post">

--- a/DropShot/Components/Layout/NavMenu.razor.css
+++ b/DropShot/Components/Layout/NavMenu.razor.css
@@ -208,27 +208,17 @@
 }
 
 /* ── Theme toggle ──────────────────────────────────────────────────── */
+/* The button lives inside .nav-dropdown-item and carries the .nav-link
+   class, so .nav-dropdown-menu .nav-link picks up padding / gap / colour.
+   These rules just unset the user-agent <button> defaults so it blends
+   in with the surrounding <a> / NavLink rows. */
 .theme-toggle-btn {
     background: none;
     border: none;
     cursor: pointer;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0 0.75rem;
-    border-radius: 4px;
-    font-size: 0.9rem;
-    color: #d7d7d7;
-    height: 3.5rem;
-}
-
-.theme-toggle-btn:hover {
-    background-color: rgba(255,255,255,0.1);
-    color: white;
-}
-
-.theme-toggle-label {
-    display: none;
+    width: 100%;
+    text-align: left;
+    font: inherit;
 }
 
 /* ── Hamburger toggle ──────────────────────────────────────────────── */
@@ -424,10 +414,6 @@
         align-items: center;
     }
 
-    .theme-toggle-label {
-        display: inline-flex;
-    }
-
     /* Show the descriptive second line for each menu item on mobile. */
     .nav-sublabel {
         display: block;
@@ -437,18 +423,6 @@
        take the remaining width so the chevron stays right-aligned. */
     .nav-dropdown-trigger .nav-label-group {
         flex: 1;
-    }
-
-    .theme-toggle-btn {
-        min-height: 3rem;
-        height: auto;
-        padding: 0.5rem 1.25rem;
-        width: 100%;
-        align-items: center;
-    }
-
-    .theme-toggle-btn:hover {
-        background-color: rgba(0, 137, 123, 0.15);
     }
 
     .nav-label {

--- a/DropShot/wwwroot/css/theme-light.css
+++ b/DropShot/wwwroot/css/theme-light.css
@@ -249,6 +249,21 @@
     display: inline-block;
 }
 
+/* Label mirrors the icon — "Light Mode" (the destination) shows while the
+   page is in dark theme, "Dark Mode" shows while in light theme. */
+.theme-label-dark {
+    display: none;
+}
+.theme-label-light {
+    display: inline;
+}
+[data-theme="light"] .theme-label-light {
+    display: none;
+}
+[data-theme="light"] .theme-label-dark {
+    display: inline;
+}
+
 /* ── Footer ─────────────────────────────────────────────────────────── */
 [data-theme="light"] .site-footer {
     background: #ffffff !important;


### PR DESCRIPTION
## Summary
- Main toolbar now only renders Competitions, the role-aware My Players / Club Players slot, and Match (paid-tier users only).
- Clubs, Rules Sets (admin/club-admin), and Players (SuperAdmin) moved into the right-hand account dropdown for all users.
- Light / Dark mode toggle moved into the dropdown above Logout; its label flips with the theme.
- Dropped the role chip beside the username in the account-dropdown trigger.
- MAUI drawer is unchanged for users — it now flattens `NavCatalog.Primary` + `Secondary` so every entry still appears.

## Why
The top bar had grown busy with role-gated and one-off links. Pushing the secondary nav, admin shortcuts, and theme toggle into a single dropdown keeps the toolbar focused on the everyday actions (browse competitions, manage your players, score a match if you're paid) while still surfacing everything else one click away.

## Files
- `DropShot.UI/Services/Navigation/NavCatalog.cs` — split `Primary` (toolbar) from `Secondary` (dropdown / MAUI drawer).
- `DropShot/Components/Layout/NavMenu.razor` + `.razor.css` — render Secondary inside the dropdown, host the theme toggle there, drop the standalone toggle and its now-unused CSS.
- `DropShot/wwwroot/css/theme-light.css` — added `.theme-label-light` / `.theme-label-dark` rules mirroring the existing icon toggle.
- `DropShot.Maui/Components/Layout/NavMenu.razor` — drawer iterates `Primary.Concat(Secondary)`.
- `DropShot.UI/Components/Shared/CurrentUserBadge.razor` — removed the `MudChip` showing `ActiveRole`.

## Test plan
- [ ] Logged-out: toolbar shows nothing extra; Register / Login on the right; no dropdown visible.
- [ ] Plain authenticated user: toolbar shows Competitions + My Players; dropdown shows Clubs, Account, Theme toggle, Logout. No Match button.
- [ ] Paid (subscribed) user: same as above, plus Match in the toolbar.
- [ ] ClubAdmin (acting): toolbar swaps My Players → Club Players; dropdown adds Rules Sets, Scoreboard View, Display Control, Link Requests.
- [ ] Admin / SuperAdmin: dropdown shows Users + Site Settings + (SuperAdmin) Players.
- [ ] Theme toggle in the dropdown switches the page and the label flips between "Light Mode" and "Dark Mode".
- [ ] No role chip next to the username in the dropdown trigger.
- [ ] MAUI drawer still shows Clubs / Rules Sets / Players where appropriate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)