### PR TITLE
Redesign SubmitScorePage with numeric keypad and read-only winner

### DIFF
--- a/DropShot.UI/Components/Pages/SubmitScorePage.razor
+++ b/DropShot.UI/Components/Pages/SubmitScorePage.razor
@@ -2,231 +2,202 @@
 @inject NavigationManager Navigation
 @inject ISiteAlertService SiteAlerts
 
-@{
-    RenderFragment<(string Name, int? Current, bool IsSide1)> sideRow = ctx =>
-        @<MudStack Spacing="1">
-            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
-                <MudText Typo="Typo.body2" Style="flex:1 1 auto; font-weight:600;">@ctx.Name</MudText>
-                <MudText Typo="Typo.h6" Color="Color.Primary" Style="min-width:32px; text-align:right;">
-                    @(ctx.Current?.ToString() ?? "–")
-                </MudText>
-            </MudStack>
-            <div class="score-chip-row">
-                @for (int n = 0; n <= LowChipMax; n++)
-                {
-                    int value = n;
-                    bool selected = ctx.Current == value;
-                    bool isSide1 = ctx.IsSide1;
-                    <MudButton Variant="@(selected ? Variant.Filled : Variant.Outlined)"
-                               Color="@(selected ? Color.Primary : Color.Default)"
-                               Class="score-chip"
-                               OnClick="@(() => PickScore(isSide1, value))">
-                        @value
-                    </MudButton>
-                }
-                <MudMenu Icon="@Icons.Material.Filled.Add"
-                         Class="score-chip score-chip-more"
-                         AriaLabel="More scores">
-                    @for (int n = LowChipMax + 1; n <= HighChipMax; n++)
-                    {
-                        int value = n;
-                        bool isSide1 = ctx.IsSide1;
-                        <MudMenuItem OnClick="@(() => PickScore(isSide1, value))">@value</MudMenuItem>
-                    }
-                </MudMenu>
-                @if (ctx.Current.HasValue)
-                {
-                    bool isSide1 = ctx.IsSide1;
-                    <MudButton Variant="Variant.Text"
-                               Class="score-chip"
-                               OnClick="@(() => ClearScore(isSide1))">
-                        Clear
-                    </MudButton>
-                }
-            </div>
-        </MudStack>;
-}
-
-<MudContainer MaxWidth="MaxWidth.Small" Class="py-4 submit-score-page">
+<MudContainer MaxWidth="MaxWidth.ExtraSmall" Class="py-4 submit-score-page">
     @if (!_loaded)
     {
-        <MudProgressCircular Indeterminate="true" />
+        <div class="centered">
+            <MudProgressCircular Indeterminate="true" />
+        </div>
     }
     else if (_context is null)
     {
         <MudAlert Severity="Severity.Error">This fixture is not available.</MudAlert>
-        <MudButton Class="mt-3" OnClick="Cancel">Back</MudButton>
+        <div class="centered mt-3">
+            <MudButton OnClick="Cancel">Back</MudButton>
+        </div>
     }
     else
     {
-        <MudStack Spacing="3">
-            <div>
-                <MudText Typo="Typo.h5">Submit Score</MudText>
-                <MudText Typo="Typo.body1" Class="mt-1">
+        <MudStack Spacing="3" AlignItems="AlignItems.Center" Class="submit-score-stack">
+
+            <MudPaper Class="frosted-card pa-4 score-section header-section" Elevation="0">
+                <MudText Typo="Typo.h5" Align="Align.Center">Submit Score</MudText>
+                <MudText Typo="Typo.body1" Align="Align.Center" Class="mt-1">
                     <strong>@_side1</strong> vs <strong>@_side2</strong>
                 </MudText>
                 @if (!string.IsNullOrEmpty(_context.Fixture.CompetitionName))
                 {
-                    <MudText Typo="Typo.caption" Color="Color.Secondary">
+                    <MudText Typo="Typo.caption" Color="Color.Secondary" Align="Align.Center" Class="d-block mt-1">
                         @_context.Fixture.CompetitionName@(_context.Fixture.FixtureLabel != null ? $" — {_context.Fixture.FixtureLabel}" : "")
                         &nbsp;·&nbsp;@(_context.MatchFormat == MatchFormatType.FixedSets ? $"{_bestOf} sets" : $"Best of {_bestOf}")
                         &nbsp;·&nbsp;@_context.GamesPerSet games/set
                         &nbsp;·&nbsp;@(_context.SetWinMode == SetWinMode.WinBy2 ? "Win by 2" : "First to")
                     </MudText>
                 }
-            </div>
+            </MudPaper>
 
             @if (_adminOverrideActive)
             {
-                <MudAlert Severity="Severity.Warning" Dense="true">
+                <MudAlert Severity="Severity.Warning" Dense="true" Class="frosted-card score-section">
                     Override Result — score validation is bypassed.
                 </MudAlert>
             }
 
-            @* Set strip — overview of all sets, tap to edit any. *@
-            @if (_bestOf > 1)
-            {
-                <div class="set-strip">
-                    @for (int i = 0; i < _bestOf; i++)
-                    {
-                        int idx = i;
-                        bool isActive = idx == _activeSet;
-                        bool hasEntry = _score1[idx].HasValue || _score2[idx].HasValue;
-                        <MudButton Variant="@(isActive ? Variant.Filled : Variant.Outlined)"
-                                   Color="@(isActive ? Color.Primary : Color.Default)"
-                                   Size="Size.Small"
-                                   OnClick="@(() => SelectActiveSet(idx))"
-                                   Class="set-strip-chip">
-                            <span class="set-strip-label">Set @(idx + 1)</span>
-                            <span class="set-strip-score">
-                                @if (hasEntry)
-                                {
-                                    @((_score1[idx]?.ToString() ?? "?") + "–" + (_score2[idx]?.ToString() ?? "?"))
-                                }
-                                else
-                                {
-                                    @("–")
-                                }
-                            </span>
-                        </MudButton>
-                    }
-                </div>
-            }
-
-            @* Active set editor — two rows of chips, one per side. *@
-            <MudPaper Class="active-set-card pa-3" Elevation="2">
-                <MudText Typo="Typo.subtitle1" Class="mb-2">Set @(_activeSet + 1)</MudText>
-
-                @sideRow((_side1, _score1[_activeSet], true))
-                <MudDivider Class="my-2" />
-                @sideRow((_side2, _score2[_activeSet], false))
+            @* Set rows: {Score A}  Set X  {Score B} *@
+            <MudPaper Class="frosted-card pa-4 score-section sets-section" Elevation="0">
+                @for (int i = 0; i < _bestOf; i++)
+                {
+                    int idx = i;
+                    <div class="set-row">
+                        <button type="button"
+                                class="@CellClass(idx, side1: true)"
+                                @onclick="@(() => SetActive(idx, true))">
+                            @(_score1[idx]?.ToString() ?? "0")
+                        </button>
+                        <span class="set-label">Set @(idx + 1)</span>
+                        <button type="button"
+                                class="@CellClass(idx, side1: false)"
+                                @onclick="@(() => SetActive(idx, false))">
+                            @(_score2[idx]?.ToString() ?? "0")
+                        </button>
+                    </div>
+                }
             </MudPaper>
 
-            @if (_showWinnerPicker)
-            {
-                <MudPaper Class="pa-3" Elevation="0" Outlined="true">
-                    <MudText Typo="Typo.subtitle2" Class="mb-2">Winner</MudText>
-                    <MudStack Row="true" Spacing="2" Class="winner-picker">
-                        @if (_context.Fixture.Player1Id.HasValue)
-                        {
-                            <MudButton Variant="@(_winnerPlayerId == _context.Fixture.Player1Id ? Variant.Filled : Variant.Outlined)"
-                                       Color="Color.Primary"
-                                       OnClick="@(() => _winnerPlayerId = _context.Fixture.Player1Id)">
-                                @_side1
-                            </MudButton>
-                        }
-                        @if (_context.Fixture.Player2Id.HasValue)
-                        {
-                            <MudButton Variant="@(_winnerPlayerId == _context.Fixture.Player2Id ? Variant.Filled : Variant.Outlined)"
-                                       Color="Color.Primary"
-                                       OnClick="@(() => _winnerPlayerId = _context.Fixture.Player2Id)">
-                                @_side2
-                            </MudButton>
-                        }
-                    </MudStack>
-                </MudPaper>
-            }
+            @* Numeric pad — phone layout, ← 0 → on the bottom row. *@
+            <MudPaper Class="frosted-card pa-3 score-section keypad-section" Elevation="0">
+                <div class="keypad">
+                    @for (int n = 1; n <= 9; n++)
+                    {
+                        int digit = n;
+                        <button type="button" class="keypad-key" @onclick="@(() => PressDigit(digit))">@digit</button>
+                    }
+                    <button type="button" class="keypad-key keypad-control"
+                            @onclick="PressBackspace"
+                            aria-label="Backspace">
+                        <MudIcon Icon="@Icons.Material.Filled.Backspace" Size="Size.Medium" />
+                    </button>
+                    <button type="button" class="keypad-key" @onclick="@(() => PressDigit(0))">0</button>
+                    @if (_isLastCell)
+                    {
+                        <button type="button" class="keypad-key keypad-control keypad-submit"
+                                @onclick="SubmitAsync"
+                                disabled="@_saving"
+                                aria-label="Submit score">
+                            <MudIcon Icon="@Icons.Material.Filled.Check" Size="Size.Medium" />
+                        </button>
+                    }
+                    else
+                    {
+                        <button type="button" class="keypad-key keypad-control"
+                                @onclick="PressForward"
+                                aria-label="Next field">
+                            <MudIcon Icon="@Icons.Material.Filled.ArrowForward" Size="Size.Medium" />
+                        </button>
+                    }
+                </div>
+            </MudPaper>
+
+            <MudPaper Class="frosted-card pa-3 score-section winner-section" Elevation="0">
+                <MudText Typo="Typo.caption" Color="Color.Secondary" Align="Align.Center" Class="d-block">Winner</MudText>
+                <MudText Typo="Typo.body1" Align="Align.Center" Class="mt-1" Style="font-weight:600;">
+                    @(_winnerName ?? "—")
+                </MudText>
+            </MudPaper>
 
             @if (!string.IsNullOrEmpty(_error))
             {
-                <MudAlert Severity="Severity.Error">@_error</MudAlert>
+                <MudAlert Severity="Severity.Error" Class="frosted-card score-section">@_error</MudAlert>
             }
-        </MudStack>
 
-        @* Sticky action bar — Cancel / Prev / Next-or-Submit. *@
-        <div class="submit-score-actions">
-            <MudButton OnClick="Cancel" Disabled="_saving">Cancel</MudButton>
-            <MudButton OnClick="PrevSet" Disabled="_activeSet == 0 || _saving">Previous set</MudButton>
-            @if (_isLastSet)
-            {
-                <MudButton Color="Color.Primary" Variant="Variant.Filled"
-                           OnClick="SubmitAsync" Disabled="_saving">
-                    Submit
-                </MudButton>
-            }
-            else
-            {
-                <MudButton Color="Color.Primary" Variant="Variant.Filled"
-                           OnClick="NextSet" Disabled="!_currentSetFilled || _saving">
-                    Next set
-                </MudButton>
-            }
-        </div>
+            <MudButton Variant="Variant.Text" OnClick="Cancel" Disabled="_saving" Class="mt-2">
+                Cancel
+            </MudButton>
+        </MudStack>
     }
 </MudContainer>
 
 <style>
-    .submit-score-page { padding-bottom: 96px; }
-    .set-strip {
-        display: flex;
-        flex-wrap: wrap;
+    .submit-score-page { display: flex; justify-content: center; }
+    .submit-score-stack { width: 100%; max-width: 360px; }
+    .score-section { width: 100%; }
+    .centered { display: flex; justify-content: center; }
+
+    .set-row {
+        display: grid;
+        grid-template-columns: 1fr auto 1fr;
+        align-items: center;
+        gap: 12px;
+        padding: 6px 0;
+    }
+    .set-row + .set-row { border-top: 1px solid rgba(255,255,255,0.06); }
+    [data-theme="light"] .set-row + .set-row { border-top-color: rgba(0,0,0,0.08); }
+
+    .score-cell {
+        font: 600 1.8rem/1 inherit;
+        background: transparent;
+        border: 1px solid rgba(255,255,255,0.18);
+        color: inherit;
+        border-radius: 10px;
+        padding: 10px 0;
+        min-height: 56px;
+        cursor: pointer;
+        transition: background 120ms, border-color 120ms;
+    }
+    .score-cell.side-left { justify-self: end; width: 100%; max-width: 90px; }
+    .score-cell.side-right { justify-self: start; width: 100%; max-width: 90px; }
+    [data-theme="light"] .score-cell { border-color: rgba(0,0,0,0.18); }
+    .score-cell.active {
+        border-color: var(--mud-palette-primary);
+        background: rgba(var(--mud-palette-primary-rgb, 25, 118, 210), 0.15);
+        color: var(--mud-palette-primary);
+    }
+
+    .set-label {
+        font-size: 0.95rem;
+        color: var(--mud-palette-text-secondary);
+        white-space: nowrap;
+        padding: 0 4px;
+    }
+
+    .keypad {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
         gap: 8px;
     }
-    .set-strip-chip {
-        min-width: 84px;
-        display: inline-flex;
-        flex-direction: column;
-        padding: 6px 10px;
-        line-height: 1.1;
-    }
-    .set-strip-label { font-size: 0.7rem; opacity: 0.7; }
-    .set-strip-score { font-weight: 600; font-size: 0.95rem; }
-    .score-chip-row {
+    .keypad-key {
+        height: 56px;
+        font: 600 1.4rem/1 inherit;
+        background: rgba(255,255,255,0.08);
+        border: 1px solid rgba(255,255,255,0.12);
+        color: inherit;
+        border-radius: 10px;
+        cursor: pointer;
         display: flex;
-        flex-wrap: wrap;
-        gap: 6px;
-        margin-top: 6px;
+        align-items: center;
+        justify-content: center;
+        transition: background 120ms;
     }
-    .score-chip {
-        min-width: 44px;
-        height: 44px;
-        padding: 0 8px;
-        font-weight: 600;
+    [data-theme="light"] .keypad-key {
+        background: rgba(255,255,255,0.55);
+        border-color: rgba(0,0,0,0.1);
     }
-    .score-chip-more { padding: 0 4px; }
-    .winner-picker .mud-button { flex: 1 1 auto; }
-    .submit-score-actions {
-        position: sticky;
-        bottom: 0;
-        display: flex;
-        gap: 8px;
-        justify-content: flex-end;
-        padding: 12px 0;
-        margin-top: 16px;
-        background: var(--mud-palette-background);
-        border-top: 1px solid var(--mud-palette-divider);
+    .keypad-key:hover { background: rgba(255,255,255,0.16); }
+    [data-theme="light"] .keypad-key:hover { background: rgba(255,255,255,0.85); }
+    .keypad-key:active { transform: scale(0.97); }
+    .keypad-key:disabled { opacity: 0.5; cursor: not-allowed; }
+    .keypad-submit {
+        background: var(--mud-palette-primary);
+        color: var(--mud-palette-primary-text);
+        border-color: var(--mud-palette-primary);
     }
-    .submit-score-actions .mud-button { flex: 1 1 auto; }
-    @@media (min-width: 600px) {
-        .submit-score-actions .mud-button { flex: 0 0 auto; }
-    }
+    .keypad-submit:hover { background: var(--mud-palette-primary-darken); }
 </style>
 
 @code {
     [Parameter, EditorRequired] public int FixtureId { get; set; }
 
-    private const int LowChipMax = 7;     // inline chips: 0..7
-    private const int HighChipMax = 12;   // tie-break / extended via "+" menu
+    private const int MaxCellValue = 99;
 
     private bool _loaded;
     private FixtureScoreContextDto? _context;
@@ -237,22 +208,23 @@
     private int _bestOf = 3;
     private int?[] _score1 = [];
     private int?[] _score2 = [];
-    private int? _winnerPlayerId;
+
+    // Active cell — the one the keypad writes to. Tap any cell to change it.
     private int _activeSet;
+    private bool _activeIsSide1 = true;
+
     private string _returnUrl = "/";
     private bool _adminRequested;
     private bool _adminOverrideActive;
     private bool _saving;
     private string? _error;
 
-    private bool _isLastSet => _activeSet == _bestOf - 1;
-    private bool _currentSetFilled => _score1[_activeSet].HasValue && _score2[_activeSet].HasValue;
+    private bool _isLastCell => _activeSet == _bestOf - 1 && !_activeIsSide1;
 
-    private bool _showWinnerPicker
+    private int? _winnerPlayerId
     {
         get
         {
-            if (_context is null) return false;
             int s1 = 0, s2 = 0;
             for (int i = 0; i < _bestOf; i++)
             {
@@ -262,11 +234,20 @@
                     else if (_score2[i] > _score1[i]) s2++;
                 }
             }
-            bool isFixedSets = _context.MatchFormat == MatchFormatType.FixedSets;
-            // Show when admin override is active so they can correct a winner,
-            // or when set counts are tied (but not when a fixed-set match is
-            // a draw — that leaves WinnerPlayerId = null intentionally).
-            return _adminOverrideActive || (s1 == s2 && !(isFixedSets && s1 + s2 > 0));
+            if (s1 > s2) return Fixture.Player1Id;
+            if (s2 > s1) return Fixture.Player2Id;
+            return null;
+        }
+    }
+
+    private string? _winnerName
+    {
+        get
+        {
+            var id = _winnerPlayerId;
+            if (id == Fixture.Player1Id) return _side1;
+            if (id == Fixture.Player2Id) return _side2;
+            return null;
         }
     }
 
@@ -292,13 +273,8 @@
             return;
         }
 
-        if (_context is null)
-        {
-            _loaded = true;
-            return;
-        }
+        if (_context is null) { _loaded = true; return; }
 
-        // Team-match fixtures are scored on the dedicated team-match page.
         if (Fixture.HomeTeamId.HasValue || Fixture.AwayTeamId.HasValue)
         {
             Navigation.NavigateTo($"/team-match/{Fixture.CompetitionFixtureId}");
@@ -321,79 +297,58 @@
 
         _adminOverrideActive = _adminRequested && _context.CanAdminOverride;
         _activeSet = 0;
-        _winnerPlayerId = null;
+        _activeIsSide1 = true;
         _loaded = true;
     }
 
-    private void PickScore(bool isSide1, int value)
+    private string CellClass(int setIdx, bool side1)
     {
-        int idx = _activeSet;
-        int?[] mine = isSide1 ? _score1 : _score2;
-        int?[] theirs = isSide1 ? _score2 : _score1;
-
-        mine[idx] = value;
-
-        // Auto-fill opposing score using existing competition rules.
-        if (!theirs[idx].HasValue)
-        {
-            int gps = _context!.GamesPerSet;
-            if (_context.SetWinMode == SetWinMode.FirstTo)
-            {
-                if (value < gps) theirs[idx] = gps;
-            }
-            else
-            {
-                if (value < gps - 1) theirs[idx] = gps;
-                else if (value == gps - 1) theirs[idx] = gps + 1;
-                else if (value >= gps) theirs[idx] = value + 1;
-            }
-        }
-
-        AutoDetectWinner();
-
-        // Advance once both scores are in.
-        if (_currentSetFilled && _activeSet < _bestOf - 1)
-            _activeSet++;
+        bool isActive = setIdx == _activeSet && side1 == _activeIsSide1;
+        return $"score-cell {(side1 ? "side-left" : "side-right")}{(isActive ? " active" : "")}";
     }
 
-    private void ClearScore(bool isSide1)
+    private void SetActive(int setIdx, bool side1)
     {
-        int idx = _activeSet;
-        if (isSide1) _score1[idx] = null; else _score2[idx] = null;
-        AutoDetectWinner();
+        _activeSet = setIdx;
+        _activeIsSide1 = side1;
+        _error = null;
     }
 
-    private void AutoDetectWinner()
-    {
-        int s1 = 0, s2 = 0;
-        for (int i = 0; i < _bestOf; i++)
-        {
-            if (_score1[i].HasValue && _score2[i].HasValue)
-            {
-                if (_score1[i] > _score2[i]) s1++;
-                else if (_score2[i] > _score1[i]) s2++;
-            }
-        }
+    private int?[] ActiveArray => _activeIsSide1 ? _score1 : _score2;
 
-        if (s1 > s2 && Fixture.Player1Id.HasValue)
-            _winnerPlayerId = Fixture.Player1Id;
-        else if (s2 > s1 && Fixture.Player2Id.HasValue)
-            _winnerPlayerId = Fixture.Player2Id;
+    private void PressDigit(int digit)
+    {
+        _error = null;
+        var arr = ActiveArray;
+        int? current = arr[_activeSet];
+        int next = current.HasValue ? current.Value * 10 + digit : digit;
+        if (next > MaxCellValue) next = digit; // overflow → restart
+        arr[_activeSet] = next;
+    }
+
+    private void PressBackspace()
+    {
+        _error = null;
+        var arr = ActiveArray;
+        int? current = arr[_activeSet];
+        if (!current.HasValue) return;
+        int reduced = current.Value / 10;
+        arr[_activeSet] = reduced == 0 && current.Value < 10 ? null : reduced;
+    }
+
+    private void PressForward()
+    {
+        if (_isLastCell) return;
+        if (_activeIsSide1)
+        {
+            _activeIsSide1 = false;
+        }
         else
-            _winnerPlayerId = null;
+        {
+            _activeSet++;
+            _activeIsSide1 = true;
+        }
     }
-
-    private void NextSet()
-    {
-        if (_activeSet < _bestOf - 1) _activeSet++;
-    }
-
-    private void PrevSet()
-    {
-        if (_activeSet > 0) _activeSet--;
-    }
-
-    private void SelectActiveSet(int idx) => _activeSet = idx;
 
     private void Cancel() => Navigation.NavigateTo(_returnUrl);
 
@@ -402,23 +357,31 @@
         _error = null;
         if (_context is null) return;
 
-        var enteredSets = Enumerable.Range(0, _bestOf)
+        // Include only sets where at least one side has actually been entered.
+        var enteredIndices = Enumerable.Range(0, _bestOf)
             .Where(i => _score1[i].HasValue || _score2[i].HasValue)
-            .Select(i => $"{_score1[i] ?? 0}–{_score2[i] ?? 0}")
             .ToList();
 
-        if (enteredSets.Count == 0)
+        if (enteredIndices.Count == 0)
         {
             _error = "Please enter at least one set score.";
             return;
         }
 
+        var enteredSets = enteredIndices
+            .Select(i => $"{_score1[i] ?? 0}–{_score2[i] ?? 0}")
+            .ToList();
+
         if (!_adminOverrideActive)
         {
             int gps = _context.GamesPerSet;
-            for (int i = 0; i < _bestOf; i++)
+            foreach (int i in enteredIndices)
             {
-                if (!_score1[i].HasValue || !_score2[i].HasValue) continue;
+                if (!_score1[i].HasValue || !_score2[i].HasValue)
+                {
+                    _error = $"Set {i + 1}: please enter both scores.";
+                    return;
+                }
                 int a = _score1[i]!.Value, b = _score2[i]!.Value;
 
                 if (a == b)
@@ -434,7 +397,7 @@
                 {
                     if (winner != gps)
                     {
-                        _error = $"Set {i + 1}: winner must reach exactly {gps} games (First to mode).";
+                        _error = $"Set {i + 1}: winner must reach exactly {gps} games (First to).";
                         return;
                     }
                     if (loser >= gps)
@@ -476,13 +439,13 @@
         }
         bool matchIsTied = side1Sets == side2Sets;
 
-        if (_winnerPlayerId == null && !(isFixedSets && matchIsTied))
+        int? winnerForSubmit = _winnerPlayerId;
+        if (winnerForSubmit is null && !(isFixedSets && matchIsTied))
         {
-            _error = "Please select a winner.";
+            _error = "No clear winner — please review the scores.";
             return;
         }
-        if (isFixedSets && matchIsTied)
-            _winnerPlayerId = null;
+        if (isFixedSets && matchIsTied) winnerForSubmit = null;
 
         _saving = true;
         try
@@ -494,7 +457,7 @@
             await CompetitionService.SubmitFixtureScoreAsync(
                 Fixture.CompetitionFixtureId,
                 new SubmitFixtureScoreRequest(
-                    resultSummary, _winnerPlayerId,
+                    resultSummary, winnerForSubmit,
                     side1Sets, side2Sets, homeGames, awayGames,
                     _adminOverrideActive));
 


### PR DESCRIPTION
## Summary

Follow-up to #681 — the user wanted a different feel for the submit-score page. This PR replaces the chip-row layout with a numeric keypad and removes all auto-anything.

- **All sets shown stacked**, each rendered as `{Score A}  Set X  {Score B}` and defaulting to `0  Set X  0` until edited.
- **Standard numeric keypad** (phone layout, 1-2-3 on top). Digits *append* to the active cell so `1` then `0` enters `10`. Bottom row is `⌫  0  →`. The `→` becomes a `✓` tick when the active cell is the last one (set N, side 2) — pressing the tick submits.
- **No auto-fill, no auto-advance.** Tapping a digit only writes to the currently active cell; the user explicitly taps a score to make it active and explicitly presses → to move to the next field. The previous behaviour was confusing.
- **Frosted-card** styling applied to every section (header, set list, keypad, winner) using the existing `.frosted-card` class.
- **Winner is read-only** — derived from set counts (no picker). Shows `—` when no clear winner.
- **Centred layout** — 360px-max column centred on the page.

The server-side endpoint, route, call sites, and DTOs added in #681 are unchanged.

## Test plan

- [ ] Build (`dotnet build DropShot/DropShot.csproj`) succeeds.
- [ ] Open a pending review from Home → page renders three rows of `0 Set X 0` with frosted cards.
- [ ] Tap a score cell → it gets the primary-coloured border.
- [ ] Type `6` → cell shows `6`. Tap → → next cell active. Type `2` → cell shows `2`. Continue to enter `6-3` and `6-4` for sets 2 and 3.
- [ ] Type two digits in a row (e.g. `1` then `0`) → cell shows `10` (for tie-break scores).
- [ ] Press ⌫ → last digit removed; pressing on an empty cell does nothing.
- [ ] On the last cell, → becomes a ✓; pressing ✓ submits and returns to `returnUrl`.
- [ ] Admin override via `?admin=1` still shows the warning banner and skips validation.
- [ ] Winner field auto-updates as set counts change; reads `—` when tied or undetermined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)