### PR TITLE
SubmitScorePage: per-set validation, MudMenu dropdown, viewport scroll fix

### DIFF
--- a/DropShot.UI/Components/Pages/SubmitScorePage.razor
+++ b/DropShot.UI/Components/Pages/SubmitScorePage.razor
@@ -44,6 +44,7 @@
                 {
                     int idx = i;
                     <div class="set-row">
+                        <div></div>
                         <button type="button"
                                 class="@CellClass(idx, side1: true)"
                                 @onclick="@(() => SetActive(idx, true))">
@@ -55,6 +56,13 @@
                                 @onclick="@(() => SetActive(idx, false))">
                             @(_score2[idx]?.ToString() ?? "0")
                         </button>
+                        <div class="set-status">
+                            @if (IsSetInvalid(idx))
+                            {
+                                <MudIcon Icon="@Icons.Material.Filled.Close"
+                                         Color="Color.Error" Size="Size.Small" />
+                            }
+                        </div>
                     </div>
                 }
             </MudPaper>
@@ -71,10 +79,25 @@
                         <MudIcon Icon="@Icons.Material.Filled.ArrowBack" Size="Size.Medium" />
                     </button>
                     <button type="button" class="keypad-key" @onclick="@(() => PressDigit(0))">0</button>
-                    <button type="button" class="keypad-key keypad-tb"
-                            @onclick="OpenTieBreak" aria-label="Tie break — pick a number">
-                        Tie Break +
-                    </button>
+                    <MudMenu Class="keypad-tb-menu"
+                             AnchorOrigin="Origin.TopRight"
+                             TransformOrigin="Origin.BottomRight"
+                             MaxHeight="320"
+                             Dense="true">
+                        <ActivatorContent>
+                            <button type="button" class="keypad-key keypad-tb"
+                                    aria-label="Tie break — pick a number">
+                                Tie Break +
+                            </button>
+                        </ActivatorContent>
+                        <ChildContent>
+                            @for (int n = 7; n <= 99; n++)
+                            {
+                                int val = n;
+                                <MudMenuItem OnClick="@(() => PickTieBreak(val))">@val</MudMenuItem>
+                            }
+                        </ChildContent>
+                    </MudMenu>
                 </div>
             </MudPaper>
 
@@ -86,11 +109,14 @@
                         @(_winnerName ?? "—")
                     </MudText>
                     <div class="winner-tick-cell">
-                        <button type="button" class="winner-tick"
-                                @onclick="SubmitAsync" disabled="@_saving"
-                                aria-label="Submit score">
-                            <MudIcon Icon="@Icons.Material.Filled.Check" Size="Size.Medium" />
-                        </button>
+                        @if (CanSubmit)
+                        {
+                            <button type="button" class="winner-tick"
+                                    @onclick="SubmitAsync" disabled="@_saving"
+                                    aria-label="Submit score">
+                                <MudIcon Icon="@Icons.Material.Filled.Check" Size="Size.Medium" />
+                            </button>
+                        }
                     </div>
                 </div>
             </MudPaper>
@@ -104,25 +130,6 @@
                 Cancel
             </MudButton>
         </MudStack>
-
-        @* Tie-break picker overlay: numbers 7–99 in a grid. *@
-        @if (_tbOpen)
-        {
-            <MudOverlay Visible="true" DarkBackground="true" OnClick="CloseTieBreak" ZIndex="1300" />
-            <div class="tb-picker">
-                <div class="tb-picker-header">
-                    <MudText Typo="Typo.subtitle1">Tie break score</MudText>
-                    <MudIconButton Icon="@Icons.Material.Filled.Close" Size="Size.Small" OnClick="CloseTieBreak" />
-                </div>
-                <div class="tb-grid">
-                    @for (int n = 7; n <= 99; n++)
-                    {
-                        int val = n;
-                        <button type="button" class="tb-key" @onclick="@(() => PickTieBreak(val))">@val</button>
-                    }
-                </div>
-            </div>
-        }
     }
 </MudContainer>
 
@@ -132,11 +139,12 @@
 
     .set-row {
         display: grid;
-        grid-template-columns: 1fr auto 1fr;
+        grid-template-columns: 28px 1fr auto 1fr 28px;
         align-items: center;
-        gap: 12px;
+        gap: 8px;
         padding: 6px 0;
     }
+    .set-status { display: flex; align-items: center; justify-content: center; }
     .set-row + .set-row { border-top: 1px solid rgba(255,255,255,0.06); }
     [data-theme="light"] .set-row + .set-row { border-top-color: rgba(0,0,0,0.08); }
 
@@ -218,47 +226,11 @@
     .winner-tick:hover { background: var(--mud-palette-primary-darken); }
     .winner-tick:disabled { opacity: 0.5; cursor: not-allowed; }
 
-    .tb-picker {
-        position: fixed;
-        top: 50%;
-        left: 50%;
-        transform: translate(-50%, -50%);
-        z-index: 1400;
-        background: var(--mud-palette-surface);
-        color: var(--mud-palette-text-primary);
-        border-radius: 12px;
-        padding: 12px;
-        max-width: calc(100vw - 32px);
-        width: 360px;
-        box-shadow: 0 12px 40px rgba(0,0,0,0.4);
-    }
-    .tb-picker-header {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        padding: 0 4px 8px;
-    }
-    .tb-grid {
-        display: grid;
-        grid-template-columns: repeat(5, 1fr);
-        gap: 6px;
-        max-height: 50vh;
-        overflow-y: auto;
-    }
-    .tb-key {
-        height: 44px;
-        font: 600 1rem/1 inherit;
-        background: rgba(255,255,255,0.08);
-        border: 1px solid rgba(255,255,255,0.12);
-        color: inherit;
-        border-radius: 8px;
-        cursor: pointer;
-    }
-    [data-theme="light"] .tb-key {
-        background: rgba(255,255,255,0.6);
-        border-color: rgba(0,0,0,0.1);
-    }
-    .tb-key:hover { background: rgba(var(--mud-palette-primary-rgb, 25, 118, 210), 0.2); }
+    /* Make the MudMenu wrapper fill its keypad grid cell so the inner
+       Tie Break + button matches the surrounding digit keys. */
+    .keypad-tb-menu { width: 100%; height: 100%; }
+    .keypad-tb-menu > .mud-menu-activator,
+    .keypad-tb-menu > .mud-menu-activator > button { width: 100%; height: 100%; }
 </style>
 
 @code {
@@ -281,10 +253,79 @@
     private bool _adminRequested;
     private bool _adminOverrideActive;
     private bool _saving;
-    private bool _tbOpen;
     private string? _error;
 
     private bool _isLastCell => _activeSet == _bestOf - 1 && !_activeIsSide1;
+
+    // A set is "invalid" when it's partially entered (one side missing) or
+    // when its score breaks the competition's scoring rules. Sets with both
+    // sides null are considered "not entered" — neither invalid nor valid.
+    private bool IsSetInvalid(int idx)
+    {
+        if (_context is null) return false;
+        bool hasA = _score1[idx].HasValue;
+        bool hasB = _score2[idx].HasValue;
+        if (!hasA && !hasB) return false;
+        if (!hasA || !hasB) return true;
+
+        int a = _score1[idx]!.Value, b = _score2[idx]!.Value;
+        if (a == b) return true;
+
+        int gps = _context.GamesPerSet;
+        int winner = Math.Max(a, b), loser = Math.Min(a, b);
+
+        if (_context.SetWinMode == SetWinMode.FirstTo)
+        {
+            if (winner != gps) return true;
+            if (loser >= gps) return true;
+        }
+        else
+        {
+            if (winner < gps) return true;
+            if (winner == gps && loser > gps - 2) return true;
+            if (winner > gps && Math.Abs(a - b) != 1 && Math.Abs(a - b) != 2) return true;
+        }
+        return false;
+    }
+
+    // Show the submit tick only when every entered set passes validation,
+    // at least one set has been entered, and the match has a resolvable
+    // outcome (a clear winner, or a fixed-set draw). Admin override
+    // bypasses these — admins can always submit.
+    private bool CanSubmit
+    {
+        get
+        {
+            if (_context is null || _saving) return false;
+            if (_adminOverrideActive)
+            {
+                for (int i = 0; i < _bestOf; i++)
+                    if (_score1[i].HasValue || _score2[i].HasValue) return true;
+                return false;
+            }
+
+            bool anyEntered = false;
+            for (int i = 0; i < _bestOf; i++)
+            {
+                if (_score1[i].HasValue || _score2[i].HasValue) anyEntered = true;
+                if (IsSetInvalid(i)) return false;
+            }
+            if (!anyEntered) return false;
+
+            int s1 = 0, s2 = 0;
+            for (int i = 0; i < _bestOf; i++)
+            {
+                if (_score1[i].HasValue && _score2[i].HasValue)
+                {
+                    if (_score1[i] > _score2[i]) s1++;
+                    else if (_score2[i] > _score1[i]) s2++;
+                }
+            }
+            bool tied = s1 == s2;
+            bool isFixed = _context.MatchFormat == MatchFormatType.FixedSets;
+            return !tied || isFixed;
+        }
+    }
 
     private int? _winnerPlayerId
     {
@@ -418,14 +459,7 @@
         }
     }
 
-    private void OpenTieBreak() => _tbOpen = true;
-    private void CloseTieBreak() => _tbOpen = false;
-
-    private void PickTieBreak(int value)
-    {
-        _tbOpen = false;
-        WriteAndAdvance(value);
-    }
+    private void PickTieBreak(int value) => WriteAndAdvance(value);
 
     private void Cancel() => Navigation.NavigateTo(_returnUrl);
 

--- a/DropShot/Components/App.razor
+++ b/DropShot/Components/App.razor
@@ -53,9 +53,17 @@
 
     protected override void OnInitialized()
     {
+        // Apply the immersive scoring lock only for the live tennis-scoring
+        // page (`/match/{matchId:int}` or `/tennisscore`). Other `/match/...`
+        // routes — e.g. `/match/submit/{fixtureId}` — should keep normal
+        // document scroll.
         var path = HttpContext?.Request.Path.Value ?? "";
-        if (path.StartsWith("/match/", StringComparison.OrdinalIgnoreCase)
-            || path.Equals("/tennisscore", StringComparison.OrdinalIgnoreCase))
+        const string MatchPrefix = "/match/";
+        bool isLiveScoring =
+            path.Equals("/tennisscore", StringComparison.OrdinalIgnoreCase)
+            || (path.StartsWith(MatchPrefix, StringComparison.OrdinalIgnoreCase)
+                && int.TryParse(path.AsSpan(MatchPrefix.Length), out _));
+        if (isLiveScoring)
         {
             _bodyClass = "scoring-active";
         }


### PR DESCRIPTION
## Summary

Three follow-ups to the `/match/submit/{fixtureId}` page after #684 was merged.

### 1. Per-set validation indicator
A red `×` icon appears next to any entered set whose score breaks the competition's actual scoring rules (the same rules the server-side `SubmitAsync` validation enforces). Empty sets show nothing — only entered ones are evaluated.

The set row grid grew from `1fr auto 1fr` to `28px 1fr auto 1fr 28px`, with symmetric spacers, so the score cells and "Set N" label remain centred regardless of whether a cross is showing on the right.

Invalid criteria:
- one side filled but not the other
- both sides equal (tied set)
- **First-To** mode: winner ≠ `GamesPerSet`, or loser ≥ `GamesPerSet`
- **Win-by-2** mode: winner < `GamesPerSet`; at `gps` exactly, loser must be ≤ `gps-2`; above `gps`, margin must be 1 (tie-break) or 2 (extended)

### 2. Submit-tick gating
The tick in the Winner card now only renders when `CanSubmit` is true: every entered set is valid, at least one set has been entered, and the match has a resolvable outcome (clear winner OR `FixedSets` with a tied set count). Admin override skips per-set validation but still needs an entered set.

### 3. Custom tie-break overlay → MudMenu dropdown
Replaced the custom centred overlay+grid with a standard `MudMenu` dropdown of `MudMenuItem`s `7`–`99` anchored to the "Tie Break +" button. Removed all the overlay markup, the `_tbOpen` state, open/close helpers, and the `.tb-picker` / `.tb-grid` / `.tb-key` CSS.

### 4. Viewport scroll fix (the actual root cause)
The submit page wasn't scrolling on overflow because [App.razor](DropShot/Components/App.razor) was applying `body.scoring-active` (which sets `overflow: hidden !important`) to **any** path starting with `/match/` — including `/match/submit/{fixtureId}`. That class is only meant for the live tennis-scoring page (`/match/{matchId:int}` and `/tennisscore`).

Tightened the predicate so the immersive lock only triggers when the path matches `/tennisscore` or `/match/{integer}`. `int.TryParse(path.AsSpan("/match/".Length), out _)` returns false for `"submit/5"`, so the submit page passes through to normal scrollable document flow.

## Test plan

- [ ] Build (`dotnet build DropShot/DropShot.csproj`) succeeds.
- [ ] Open the submit page on a fixture from a competition with `Win-by-2 / 6 games`. Enter `6-2` on set 1 → no cross. Change to `5-2` → red cross appears. Restore to `6-3` → cross clears.
- [ ] Tap the "Tie Break +" key → a vertical MudMenu drops down with `7`-`99`. Tapping `10` writes the cell and auto-advances.
- [ ] The submit tick in the Winner card only renders when scores are valid and a winner is determined. Hidden while a cross is showing or while there's no clear outcome.
- [ ] On the live scoring page (`/match/{matchId}`) the immersive viewport lock still works (no scroll, header hidden). On the submit page (`/match/submit/{fixtureId}`) the page scrolls when content overflows the viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)