### PR TITLE
SubmitScorePage: add 7 key, relocate tick, defer cross until both sides entered

### DIFF
--- a/DropShot.UI/Components/Pages/SubmitScorePage.razor
+++ b/DropShot.UI/Components/Pages/SubmitScorePage.razor
@@ -69,16 +69,19 @@
 
             <MudPaper Class="frosted-card pa-3 score-section" Elevation="0">
                 <div class="keypad">
+                    @* Rows 1–2: digits 1–6 *@
                     @for (int n = 1; n <= 6; n++)
                     {
                         int digit = n;
                         <button type="button" class="keypad-key" @onclick="@(() => PressDigit(digit))">@digit</button>
                     }
+
+                    @* Row 3: back, 7, Tie Break + *@
                     <button type="button" class="keypad-key keypad-control"
                             @onclick="PressBack" aria-label="Previous field">
                         <MudIcon Icon="@Icons.Material.Filled.ArrowBack" Size="Size.Medium" />
                     </button>
-                    <button type="button" class="keypad-key" @onclick="@(() => PressDigit(0))">0</button>
+                    <button type="button" class="keypad-key" @onclick="@(() => PressDigit(7))">7</button>
                     <MudMenu Class="keypad-tb-menu"
                              AnchorOrigin="Origin.TopRight"
                              TransformOrigin="Origin.BottomRight"
@@ -91,34 +94,33 @@
                             </button>
                         </ActivatorContent>
                         <ChildContent>
-                            @for (int n = 7; n <= 99; n++)
+                            @for (int n = 8; n <= 99; n++)
                             {
                                 int val = n;
                                 <MudMenuItem OnClick="@(() => PickTieBreak(val))">@val</MudMenuItem>
                             }
                         </ChildContent>
                     </MudMenu>
+
+                    @* Row 4: empty spacer, 0, submit tick *@
+                    <div></div>
+                    <button type="button" class="keypad-key" @onclick="@(() => PressDigit(0))">0</button>
+                    @if (CanSubmit)
+                    {
+                        <button type="button" class="keypad-key keypad-submit"
+                                @onclick="SubmitAsync" disabled="@_saving"
+                                aria-label="Submit score">
+                            <MudIcon Icon="@Icons.Material.Filled.Check" Size="Size.Medium" />
+                        </button>
+                    }
                 </div>
             </MudPaper>
 
             <MudPaper Class="frosted-card pa-3 score-section" Elevation="0">
                 <MudText Typo="Typo.caption" Color="Color.Secondary" Align="Align.Center" Class="d-block">Winner</MudText>
-                <div class="winner-row">
-                    <div></div>
-                    <MudText Typo="Typo.body1" Align="Align.Center" Class="mt-1" Style="font-weight:600;">
-                        @(_winnerName ?? "—")
-                    </MudText>
-                    <div class="winner-tick-cell">
-                        @if (CanSubmit)
-                        {
-                            <button type="button" class="winner-tick"
-                                    @onclick="SubmitAsync" disabled="@_saving"
-                                    aria-label="Submit score">
-                                <MudIcon Icon="@Icons.Material.Filled.Check" Size="Size.Medium" />
-                            </button>
-                        }
-                    </div>
-                </div>
+                <MudText Typo="Typo.body1" Align="Align.Center" Class="mt-1" Style="font-weight:600;">
+                    @(_winnerName ?? "—")
+                </MudText>
             </MudPaper>
 
             @if (!string.IsNullOrEmpty(_error))
@@ -203,28 +205,12 @@
     .keypad-key:active { transform: scale(0.97); }
     .keypad-key:disabled { opacity: 0.5; cursor: not-allowed; }
     .keypad-tb { font-size: 0.85rem; letter-spacing: 0.2px; }
-
-    .winner-row {
-        display: grid;
-        grid-template-columns: 1fr auto 1fr;
-        align-items: center;
-        gap: 8px;
-    }
-    .winner-tick-cell { display: flex; justify-content: flex-end; }
-    .winner-tick {
-        height: 44px;
-        width: 44px;
+    .keypad-submit {
         background: var(--mud-palette-primary);
         color: var(--mud-palette-primary-text);
-        border: 1px solid var(--mud-palette-primary);
-        border-radius: 10px;
-        cursor: pointer;
-        display: flex;
-        align-items: center;
-        justify-content: center;
+        border-color: var(--mud-palette-primary);
     }
-    .winner-tick:hover { background: var(--mud-palette-primary-darken); }
-    .winner-tick:disabled { opacity: 0.5; cursor: not-allowed; }
+    .keypad-submit:hover { background: var(--mud-palette-primary-darken); }
 
     /* Make the MudMenu wrapper fill its keypad grid cell so the inner
        Tie Break + button matches the surrounding digit keys. */
@@ -257,16 +243,14 @@
 
     private bool _isLastCell => _activeSet == _bestOf - 1 && !_activeIsSide1;
 
-    // A set is "invalid" when it's partially entered (one side missing) or
-    // when its score breaks the competition's scoring rules. Sets with both
-    // sides null are considered "not entered" — neither invalid nor valid.
+    // A set is "invalid" — and shows a red cross — only once both sides have
+    // been entered and the resulting score breaks the competition's scoring
+    // rules. Partially entered sets are mid-entry and don't show the cross;
+    // CanSubmit still blocks on them separately.
     private bool IsSetInvalid(int idx)
     {
         if (_context is null) return false;
-        bool hasA = _score1[idx].HasValue;
-        bool hasB = _score2[idx].HasValue;
-        if (!hasA && !hasB) return false;
-        if (!hasA || !hasB) return true;
+        if (!_score1[idx].HasValue || !_score2[idx].HasValue) return false;
 
         int a = _score1[idx]!.Value, b = _score2[idx]!.Value;
         if (a == b) return true;
@@ -307,7 +291,11 @@
             bool anyEntered = false;
             for (int i = 0; i < _bestOf; i++)
             {
-                if (_score1[i].HasValue || _score2[i].HasValue) anyEntered = true;
+                bool hasA = _score1[i].HasValue;
+                bool hasB = _score2[i].HasValue;
+                if (hasA || hasB) anyEntered = true;
+                // Partial entry is silent (no cross) but blocks submit.
+                if (hasA != hasB) return false;
                 if (IsSetInvalid(i)) return false;
             }
             if (!anyEntered) return false;


### PR DESCRIPTION
## Summary

Keypad layout grows from 3x3 to 4x3:

```
1 2 3
4 5 6
← 7 [Tie Break +]
·  0 ✓
```

- **New `7` key** in the middle column of row 3 — common winning scores (6 and 7) can now both be tapped directly without opening the dropdown.
- **Back arrow (`←`)** sits to the immediate left of `7`.
- **`Tie Break +`** stays on the right of row 3 but its dropdown range is tightened to `8`–`99` (7 is no longer needed in the menu).
- **Submit tick (`✓`)** moves back into the keypad in the bottom-right cell, next to `0`, using the existing `keypad-submit` styling. The Winner card is now just the centred winner name — no embedded button.

## Cross-display rule

A set's red ✗ now only appears once both sides of that set have a value entered. While the user is mid-entry (one side filled, the other still defaulting to `0`), no cross shows. `CanSubmit` still blocks on partial-entry sets independently, so a half-filled match can't be submitted.

## Why

The previous 3-row keypad meant any set won 7-x (a common tie-break score) required popping the Tie Break + dropdown — a heavy interaction for a routine score. The cross also appeared the moment you tapped a digit on the first side, which felt like an error during normal entry rather than after-the-fact validation.

## Test plan

- [ ] Build `dotnet build DropShot/DropShot.csproj` succeeds.
- [ ] Open `/match/submit/{fixtureId}`. Keypad shows 4 rows; `7` is tappable.
- [ ] Tap a digit on side 1 of set 1 — no cross appears on the row.
- [ ] Tap another digit on side 2 with an invalid score (e.g. tied) — red ✗ appears.
- [ ] Adjust to a valid score — cross clears.
- [ ] Submit tick in the bottom-right of the keypad renders only when every entered set is valid and a winner is determined.
- [ ] Tie Break + dropdown lists 8–99 (no 7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)