### PR TITLE
Fix Tie Break + dropdown: replace MudMenu with native <select>

### DIFF
--- a/DropShot.UI/Components/Pages/SubmitScorePage.razor
+++ b/DropShot.UI/Components/Pages/SubmitScorePage.razor
@@ -82,25 +82,16 @@
                         <MudIcon Icon="@Icons.Material.Filled.ArrowBack" Size="Size.Medium" />
                     </button>
                     <button type="button" class="keypad-key" @onclick="@(() => PressDigit(7))">7</button>
-                    <MudMenu Class="keypad-tb-menu"
-                             AnchorOrigin="Origin.TopRight"
-                             TransformOrigin="Origin.BottomRight"
-                             MaxHeight="320"
-                             Dense="true">
-                        <ActivatorContent>
-                            <button type="button" class="keypad-key keypad-tb"
-                                    aria-label="Tie break — pick a number">
-                                Tie Break +
-                            </button>
-                        </ActivatorContent>
-                        <ChildContent>
-                            @for (int n = 8; n <= 99; n++)
-                            {
-                                int val = n;
-                                <MudMenuItem OnClick="@(() => PickTieBreak(val))">@val</MudMenuItem>
-                            }
-                        </ChildContent>
-                    </MudMenu>
+                    <select class="keypad-key keypad-tb"
+                            value="@_tbSelectValue"
+                            @onchange="OnTieBreakChange"
+                            aria-label="Tie break — pick a number">
+                        <option value="" disabled selected>Tie Break +</option>
+                        @for (int n = 8; n <= 99; n++)
+                        {
+                            <option value="@n">@n</option>
+                        }
+                    </select>
 
                     @* Row 4: empty spacer, 0, submit tick *@
                     <div></div>
@@ -205,6 +196,22 @@
     .keypad-key:active { transform: scale(0.97); }
     .keypad-key:disabled { opacity: 0.5; cursor: not-allowed; }
     .keypad-tb { font-size: 0.85rem; letter-spacing: 0.2px; }
+    /* Native select element styled like a keypad key. */
+    select.keypad-tb {
+        appearance: none;
+        -webkit-appearance: none;
+        -moz-appearance: none;
+        text-align: center;
+        text-align-last: center;
+        background-image: linear-gradient(45deg, transparent 50%, currentColor 50%),
+                          linear-gradient(135deg, currentColor 50%, transparent 50%);
+        background-position: calc(100% - 14px) 50%, calc(100% - 9px) 50%;
+        background-size: 5px 5px, 5px 5px;
+        background-repeat: no-repeat;
+        padding-right: 22px;
+    }
+    select.keypad-tb option { background: var(--mud-palette-surface); color: var(--mud-palette-text-primary); }
+
     .keypad-submit {
         background: var(--mud-palette-primary);
         color: var(--mud-palette-primary-text);
@@ -212,11 +219,6 @@
     }
     .keypad-submit:hover { background: var(--mud-palette-primary-darken); }
 
-    /* Make the MudMenu wrapper fill its keypad grid cell so the inner
-       Tie Break + button matches the surrounding digit keys. */
-    .keypad-tb-menu { width: 100%; height: 100%; }
-    .keypad-tb-menu > .mud-menu-activator,
-    .keypad-tb-menu > .mud-menu-activator > button { width: 100%; height: 100%; }
 </style>
 
 @code {
@@ -240,6 +242,10 @@
     private bool _adminOverrideActive;
     private bool _saving;
     private string? _error;
+
+    // Held by the native <select>. We reset to "" after each pick so the
+    // placeholder option re-shows and the same number can be picked again.
+    private string _tbSelectValue = "";
 
     private bool _isLastCell => _activeSet == _bestOf - 1 && !_activeIsSide1;
 
@@ -448,6 +454,16 @@
     }
 
     private void PickTieBreak(int value) => WriteAndAdvance(value);
+
+    private void OnTieBreakChange(ChangeEventArgs e)
+    {
+        if (e.Value is string s && int.TryParse(s, out int val))
+        {
+            PickTieBreak(val);
+        }
+        // Reset so the placeholder "Tie Break +" shows again next time.
+        _tbSelectValue = "";
+    }
 
     private void Cancel() => Navigation.NavigateTo(_returnUrl);
 


### PR DESCRIPTION
## Summary

The Tie Break + button on the SubmitScorePage keypad was unresponsive — tapping it did nothing. Replace the MudMenu activator with a native HTML `<select>` element styled to match the surrounding keypad keys.

## What was wrong

Under MudBlazor 9.4, wrapping a custom HTML `<button>` inside `<MudMenu><ActivatorContent>...</ActivatorContent></MudMenu>` doesn't reliably forward the click to MudMenu's wrapper handler, so the popover never opens. (The same pattern works in some 6.x setups, hence the original implementation.)

## What changed

- Removed `MudMenu` + `ActivatorContent` + `MudMenuItem`s + the related `_tbOpen`-style plumbing (already historic) for the tie-break dropdown.
- Inserted a native `<select class="keypad-key keypad-tb">` with options `8`–`99`.
- Added `OnTieBreakChange` handler that calls the existing `PickTieBreak(value)` (writes the active cell + auto-advances) and resets the select back to its placeholder so the same number can be picked again.
- CSS strips the default browser chrome (`appearance: none`) and draws a small chevron via two CSS gradients so the cell still reads as a dropdown. Option styling forced to the surface palette for legibility in the dark theme.

## Why this is more robust

Native `<select>` needs no popover/JS infrastructure. On iOS/Android it surfaces the native OS picker (scrolling wheel); on desktop it shows the browser's standard dropdown. Matches the user's earlier request for "just a normal drop down list with the numbers".

## Test plan

- [ ] Build (`dotnet build DropShot/DropShot.csproj`) succeeds.
- [ ] On the submit page, tap "Tie Break +" — a dropdown opens (native picker on mobile, browser dropdown on desktop).
- [ ] Pick `10` — active cell is set to 10, advances to next cell, the dropdown closes and resets to its placeholder.
- [ ] Pick `10` again — works the same way (no stuck-selected state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)