### PR TITLE
Tighten regular set Win-by-2 rule so 16-15 isn't "valid"

### DIFF
--- a/DropShot.UI/Components/Pages/SubmitScorePage.razor
+++ b/DropShot.UI/Components/Pages/SubmitScorePage.razor
@@ -258,12 +258,18 @@
         {
             return winner == target && loser < target;
         }
-        // Win-by-2 regular set — allows margin 1 above target so a tennis
-        // tiebreak-decided set (e.g. 7-6) is valid.
+        // Win-by-2 regular set. Valid shapes are:
+        //   winner == target           — loser ≤ target − 2 (e.g. 6-4)
+        //   winner == target + 1       — loser ∈ {target−1, target}
+        //                                (the 7-5 boundary and 7-6 in-set tiebreak)
+        //   winner > target + 1        — margin must be exactly 2 (no-tiebreak
+        //                                extended set: 8-6, 9-7, 10-8, …).
+        // Anything else — including 16-15 — is not a valid regular set; a
+        // score that high must be played and validated as a tie break.
         if (winner < target) return false;
         if (winner == target) return loser <= target - 2;
-        int margin = Math.Abs(a - b);
-        return margin == 1 || margin == 2;
+        if (winner == target + 1) return loser == target - 1 || loser == target;
+        return loser == winner - 2;
     }
 
     private bool ScorePassesTieBreakRules(int a, int b)


### PR DESCRIPTION
## Summary

You reported that a final-set score of `16-15` against a `tie break to 7, Win by 2` competition rule wasn't flagged as invalid. The bug isn't in the tie-break rule (which correctly rejects `16-15`) — it's in the **regular set** Win-by-2 rule, which has always silently accepted any margin-1 score above `GamesPerSet`. The final-set "either rule passes" check we added in #690 exposed it: `16-15` slipped through the loose regular path and never reached the tie-break path.

## What changed

`ScorePassesRegularSetRules` in [SubmitScorePage.razor](DropShot.UI/Components/Pages/SubmitScorePage.razor). New rule for Win-by-2:

| Winner | Valid loser range | Example |
|---|---|---|
| `gps` | `≤ gps − 2` | `6-4` |
| `gps + 1` | `gps − 1` or `gps` | `7-5`, `7-6` |
| `> gps + 1` | exactly `winner − 2` | `8-6`, `9-7`, `10-8` |

Anything else — `8-7`, `12-11`, `16-15`, `100-99` — is **not** a valid regular set. A score that high must be played and validated as a tie break (which already requires margin exactly 2 above the target).

## Test plan

Final-set validation in a competition with `GamesPerSet=6`, `WinBy2`, `FinalSetTieBreakGames=7`, `FinalSetTieBreakWinMode=WinBy2`:

- [ ] `6-4` → valid (regular set).
- [ ] `7-5` → valid (regular set, boundary).
- [ ] `7-6` → valid (regular set, in-set tiebreak).
- [ ] `8-6` → valid (extended regular set, or valid tie break since `8-6` is also a `first-to-7 win-by-2` tiebreak).
- [ ] `9-7` → valid (extended regular set, or valid tie break).
- [ ] `8-7` → **invalid** (regular set must be margin 2 above gps+1; tie-break to 7 also rejects margin 1 above target).
- [ ] `16-15` → **invalid** (the case you reported).
- [ ] `100-99` → **invalid**.

Non-final sets: same regular-set rule applies (tie-break path isn't used).

🤖 Generated with [Claude Code](https://claude.com/claude-code)