### PR TITLE
Tie-break picker: scroll to and highlight the opposing side's score

### DIFF
--- a/DropShot.UI/Components/Pages/SubmitScorePage.razor
+++ b/DropShot.UI/Components/Pages/SubmitScorePage.razor
@@ -469,7 +469,15 @@
 
     private async Task OpenTieBreakDialogAsync()
     {
-        var dialog = await DialogService.ShowAsync<TieBreakPickerDialog>("Tie break score");
+        // Highlight the opposing side's score so the user can quickly find the
+        // related number in the long 8-99 list — final-set tie-break scores
+        // usually correlate (e.g. 12-10, 10-8).
+        int? otherSide = _activeIsSide1 ? _score2[_activeSet] : _score1[_activeSet];
+        var parameters = new DialogParameters<TieBreakPickerDialog>
+        {
+            { x => x.HighlightValue, otherSide }
+        };
+        var dialog = await DialogService.ShowAsync<TieBreakPickerDialog>("Tie break score", parameters);
         var result = await dialog.Result;
         if (result is { Canceled: false, Data: int picked })
         {

--- a/DropShot.UI/Components/Shared/TieBreakPickerDialog.razor
+++ b/DropShot.UI/Components/Shared/TieBreakPickerDialog.razor
@@ -1,3 +1,5 @@
+@inject IJSRuntime JS
+
 <MudDialog>
     <TitleContent>
         Tie break score
@@ -7,7 +9,11 @@
             @for (int n = 8; n <= 99; n++)
             {
                 int val = n;
-                <button type="button" class="tb-dialog-item" @onclick="@(() => Pick(val))">
+                bool highlight = HighlightValue == val;
+                <button id="@($"tb-item-{val}")"
+                        type="button"
+                        class="@($"tb-dialog-item{(highlight ? " tb-dialog-item-highlight" : "")}")"
+                        @onclick="@(() => Pick(val))">
                     @val
                 </button>
             }
@@ -44,10 +50,32 @@
         border-color: var(--mud-palette-primary);
     }
     .tb-dialog-item:active { transform: scale(0.98); }
+    .tb-dialog-item-highlight {
+        border-color: var(--mud-palette-primary);
+        background: rgba(var(--mud-palette-primary-rgb, 25, 118, 210), 0.18);
+    }
 </style>
 
 @code {
     [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = default!;
+
+    /// <summary>
+    /// Optional value to highlight + scroll into view on open. Used by the
+    /// submit-score page to point the user at the opposing side's score so
+    /// they can pick a related tie-break number without scrolling the whole
+    /// 8-99 list.
+    /// </summary>
+    [Parameter] public int? HighlightValue { get; set; }
+
+    private bool _scrolled;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (_scrolled || HighlightValue is not int v || v < 8 || v > 99) return;
+        _scrolled = true;
+        await JS.InvokeVoidAsync("eval",
+            $"document.getElementById('tb-item-{v}')?.scrollIntoView({{block:'center'}});");
+    }
 
     private void Pick(int value) => MudDialog.Close(DialogResult.Ok(value));
     private void Cancel() => MudDialog.Cancel();


### PR DESCRIPTION
## Summary

When opening the Tie Break + dialog on a cell whose opposing side already has a tie-break value, the dialog now:

- visually marks the matching list item (primary-coloured border + tint), and
- scrolls it to the middle of the visible list.

Final-set tie-break partners (e.g. `12-10`, `10-8`) are usually close together, so this saves the user scrolling through the full `8`–`99` list to find the related number.

## What changed

- [TieBreakPickerDialog](DropShot.UI/Components/Shared/TieBreakPickerDialog.razor) gains an optional `HighlightValue` parameter. Each list item has `id="tb-item-{n}"`; the matching one picks up a `.tb-dialog-item-highlight` class. On first render the dialog uses a small JS interop call (`scrollIntoView({block:'center'})`) to bring the highlighted item into view.
- [SubmitScorePage.OpenTieBreakDialogAsync](DropShot.UI/Components/Pages/SubmitScorePage.razor) reads the opposing side's value for the active set and passes it as `HighlightValue`.

## Edge cases

- Opposing side empty → `HighlightValue` is null, dialog renders unchanged (no highlight, no scroll).
- Opposing side has a value `< 8` (i.e. on the keypad) → null, same as above.
- Works on any set, but the highlight only matches when both sides land in the `[8, 99]` range. That's most useful for the final set's tie-break scenario.

## Test plan

- [ ] Build (`dotnet build DropShot/DropShot.csproj`) succeeds.
- [ ] On the submit page, enter `12` for the final set side 1 via Tie Break + (so the opposing side is still 0/empty). Open Tie Break + on side 2 — no highlight (opposing side is `12`, but side 2 is empty so this opens for side 2 with the opposing being side 1 = 12). Actually opposite — open side 2 → opposing side is side 1 (which is 12). Confirm: the dialog scrolls so `12` is centred and `12` has the highlight.
- [ ] Pick `10` for side 2 → cell receives 10, auto-advances. Re-open Tie Break + on side 1 — `10` is highlighted and centred.
- [ ] Open Tie Break + on a set where the opposing side is empty → no highlight, dialog opens scrolled to the top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)