### PR TITLE
Move cancel from text button to a red cross key on the keypad

### DIFF
--- a/DropShot.UI/Components/Pages/SubmitScorePage.razor
+++ b/DropShot.UI/Components/Pages/SubmitScorePage.razor
@@ -89,8 +89,12 @@
                         Tie Break +
                     </button>
 
-                    @* Row 4: empty spacer, 0, submit tick *@
-                    <div></div>
+                    @* Row 4: cancel (red cross), 0, submit tick *@
+                    <button type="button" class="keypad-key keypad-cancel"
+                            @onclick="Cancel" disabled="@_saving"
+                            aria-label="Cancel and go back">
+                        <MudIcon Icon="@Icons.Material.Filled.Close" Size="Size.Medium" />
+                    </button>
                     <button type="button" class="keypad-key" @onclick="@(() => PressDigit(0))">0</button>
                     @if (CanSubmit)
                     {
@@ -114,10 +118,6 @@
             {
                 <MudAlert Severity="Severity.Error" Class="frosted-card score-section">@_error</MudAlert>
             }
-
-            <MudButton Variant="Variant.Text" OnClick="Cancel" Disabled="_saving" Class="mt-2">
-                Cancel
-            </MudButton>
         </MudStack>
     }
 </MudContainer>
@@ -198,6 +198,12 @@
         border-color: var(--mud-palette-primary);
     }
     .keypad-submit:hover { background: var(--mud-palette-primary-darken); }
+    .keypad-cancel {
+        background: var(--mud-palette-error);
+        color: var(--mud-palette-error-text);
+        border-color: var(--mud-palette-error);
+    }
+    .keypad-cancel:hover { background: var(--mud-palette-error-darken); }
 
 </style>
 


### PR DESCRIPTION
## Summary

Replace the standalone "Cancel" text button at the bottom of the submit-score page with a red cross key in the bottom-left of the keypad. The layout becomes symmetric:

```
1 2 3
4 5 6
← 7 [Tie Break +]
✗ 0 ✓
```

`✗` (red, `Icons.Material.Filled.Close`) navigates back to `returnUrl`. `✓` (primary, conditional on valid scores) submits.

## Test plan

- [ ] Build (`dotnet build DropShot/DropShot.csproj`) succeeds.
- [ ] Open the submit page → the bottom-left keypad cell is a red cross, no separate Cancel button below.
- [ ] Tap the red cross → navigates back to `returnUrl`.
- [ ] Tick still appears / submits when scores are valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)