### PR TITLE
Shrink non-active set rows further

### DIFF
--- a/DropShot.UI/Components/Pages/SubmitScorePage.razor
+++ b/DropShot.UI/Components/Pages/SubmitScorePage.razor
@@ -146,14 +146,14 @@
        active set's row gets the larger original size via .set-row-active. */
     .score-cell {
         font-weight: 600;
-        font-size: 1.3rem;
+        font-size: 1rem;
         line-height: 1;
         background: transparent;
         border: 1px solid rgba(255,255,255,0.18);
         color: inherit;
-        border-radius: 10px;
-        padding: 6px 0;
-        min-height: 40px;
+        border-radius: 8px;
+        padding: 3px 0;
+        min-height: 30px;
         cursor: pointer;
         transition: background 120ms, border-color 120ms, color 120ms,
                     font-size 150ms, min-height 150ms, padding 150ms;


### PR DESCRIPTION
## Summary

Follow-up tuning to #694. Make the inactive set rows visibly smaller — they were still close in size to the active one.

- `font-size`: 1.3rem → 1rem
- `min-height`: 40px → 30px
- `padding`: 6px 0 → 3px 0
- `border-radius`: 10px → 8px

The `.set-row-active` override is unchanged, so the focused set's row still scales up to the original 1.8rem / 56px / 10px padding when selected.

## Test plan

- [ ] Build (`dotnet build DropShot/DropShot.csproj`) succeeds.
- [ ] Inactive sets in a Best-of-3 read as compact summary rows; the active set is clearly bigger and primary-coloured.
- [ ] Moving between sets animates smoothly (transition unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)