### PR TITLE
SubmitScorePage: tighten mobile margins, fix invisible submit/cancel in light mode

### DIFF
--- a/DropShot.UI/Components/Pages/SubmitScorePage.razor
+++ b/DropShot.UI/Components/Pages/SubmitScorePage.razor
@@ -127,6 +127,17 @@
     .submit-score-stack { width: 100%; max-width: 360px; }
     .score-section { width: 100%; }
 
+    /* On phones, let the column take more of the screen by shrinking the
+       MudContainer's intrinsic horizontal padding and lifting the stack's
+       max-width cap. */
+    @@media (max-width: 600px) {
+        .submit-score-page {
+            padding-left: 6px !important;
+            padding-right: 6px !important;
+        }
+        .submit-score-stack { max-width: 100%; }
+    }
+
     .set-row {
         display: grid;
         grid-template-columns: 28px 1fr auto 1fr 28px;
@@ -207,18 +218,27 @@
     .keypad-key:active { transform: scale(0.97); }
     .keypad-key:disabled { opacity: 0.5; cursor: not-allowed; }
     .keypad-tb { font-size: 0.85rem; letter-spacing: 0.2px; }
-    .keypad-submit {
+    /* The submit (tick) and cancel (cross) keys carry their own coloured
+       backgrounds. We re-assert them under [data-theme="light"] because the
+       generic [data-theme="light"] .keypad-key rule above otherwise wins on
+       specificity and paints them translucent-white — making the icons
+       invisible against the same-coloured surface. */
+    .keypad-submit,
+    [data-theme="light"] .keypad-submit {
         background: var(--mud-palette-primary);
         color: var(--mud-palette-primary-text);
         border-color: var(--mud-palette-primary);
     }
-    .keypad-submit:hover { background: var(--mud-palette-primary-darken); }
-    .keypad-cancel {
+    .keypad-submit:hover,
+    [data-theme="light"] .keypad-submit:hover { background: var(--mud-palette-primary-darken); }
+    .keypad-cancel,
+    [data-theme="light"] .keypad-cancel {
         background: var(--mud-palette-error);
         color: var(--mud-palette-error-text);
         border-color: var(--mud-palette-error);
     }
-    .keypad-cancel:hover { background: var(--mud-palette-error-darken); }
+    .keypad-cancel:hover,
+    [data-theme="light"] .keypad-cancel:hover { background: var(--mud-palette-error-darken); }
 
 </style>
 


### PR DESCRIPTION
## Summary

Two small bugs on `/match/submit/{fixtureId}`:

### 1. Mobile margins

The page was wrapped in `<MudContainer MaxWidth.ExtraSmall>` which has intrinsic horizontal padding (~16-24px each side) — on a 360px-wide phone that ate ~32-48px of usable width. Drop it to 6px each side at `≤600px` and lift the stack's `max-width: 360px` to `100%` so the column expands to fill the (now wider) inner area.

### 2. Light-mode tick + cross invisible

The `.keypad-submit` (tick) and `.keypad-cancel` (cross) keys carry coloured backgrounds (primary / error). In light mode they were rendering with the generic translucent-white keypad background because `[data-theme="light"] .keypad-key { background: ... }` has higher specificity than `.keypad-submit` / `.keypad-cancel`. Result: icon (white) painted on a near-white surface, invisible but still clickable.

Re-assert the palette under `[data-theme="light"]` for those two classes (and their `:hover` states) so the coloured backgrounds win.

## Test plan

- [ ] Build (`dotnet build DropShot/DropShot.csproj`) succeeds.
- [ ] In Chrome DevTools iPhone SE viewport, the score column extends to ~6px from each edge of the screen instead of being inset by ~16-24px.
- [ ] In light theme, the bottom-left key shows a clearly visible red cross icon and the bottom-right shows a clearly visible primary-coloured tick when scores are valid.
- [ ] Dark theme is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)