### PR TITLE
SubmitScorePage: distinguish unentered cells from a real 0-0

### DIFF
--- a/DropShot.UI/Components/Pages/SubmitScorePage.razor
+++ b/DropShot.UI/Components/Pages/SubmitScorePage.razor
@@ -50,13 +50,13 @@
                         <button type="button"
                                 class="@CellClass(idx, side1: true)"
                                 @onclick="@(() => SetActive(idx, true))">
-                            @(_score1[idx]?.ToString() ?? "0")
+                            @(_score1[idx]?.ToString() ?? "–")
                         </button>
                         <span class="set-label">Set @(idx + 1)</span>
                         <button type="button"
                                 class="@CellClass(idx, side1: false)"
                                 @onclick="@(() => SetActive(idx, false))">
-                            @(_score2[idx]?.ToString() ?? "0")
+                            @(_score2[idx]?.ToString() ?? "–")
                         </button>
                         <div class="set-status">
                             @if (IsSetInvalid(idx))
@@ -182,6 +182,10 @@
         background: rgba(var(--mud-palette-primary-rgb, 25, 118, 210), 0.15);
         color: var(--mud-palette-primary);
     }
+    /* Unentered cells show "–" and a muted colour so it's obvious that no
+       score was recorded — they're not a real 0-0. */
+    .score-cell.unentered { color: var(--mud-palette-text-disabled); opacity: 0.7; }
+    .score-cell.unentered.active { color: var(--mud-palette-primary); opacity: 1; }
 
     .set-label {
         font-size: 0.95rem;
@@ -457,7 +461,8 @@
     private string CellClass(int setIdx, bool side1)
     {
         bool isActive = setIdx == _activeSet && side1 == _activeIsSide1;
-        return $"score-cell {(side1 ? "side-left" : "side-right")}{(isActive ? " active" : "")}";
+        bool hasValue = (side1 ? _score1[setIdx] : _score2[setIdx]).HasValue;
+        return $"score-cell {(side1 ? "side-left" : "side-right")}{(isActive ? " active" : "")}{(hasValue ? "" : " unentered")}";
     }
 
     private void SetActive(int setIdx, bool side1)


### PR DESCRIPTION
## Summary

You reported that in a best-of-5 the match was registering as valid even though sets 4 and 5 showed `0-0`. After investigating, `CanSubmit` is correct: in `BestOf` mode the tick appears once a side has won `(bestOf/2)+1` sets — so after a 3-0 clinch the unplayed sets 4 and 5 are intentionally ignored. The real problem is **visual**: the score cell rendered `0` for *both* "not played" (null) and "user typed 0", making unplayed sets look identical to a real `0-0`.

## What changed

- Unentered cells now render an en-dash `–` instead of `0`.
- Score cells without a value get a new `.unentered` class that applies a muted colour + slight opacity, so "not played" is obvious at a glance.
- Active-cell highlighting still wins (`.score-cell.unentered.active` re-asserts the primary colour while the user is typing into a fresh cell).

## Test plan

- [ ] Build (`dotnet build DropShot/DropShot.csproj`) succeeds.
- [ ] In a Best-of-5 fixture, enter `6-0`, `6-0`, `6-0` → sets 4 and 5 render `– Set 4 –` / `– Set 5 –` in a muted colour. The tick correctly shows (match clinched).
- [ ] In a Best-of-5 fixture, only enter set 1 = `6-0` → tick stays hidden; sets 2-5 all show muted `–`.
- [ ] When you tap into an unentered cell to start typing, it picks up the primary highlight (overriding the muted colour).
- [ ] Entered cells (including a legitimate `0`) show the value in full opacity / normal colour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)