### PR TITLE
Close nav dropdown after picking light/dark mode

### DIFF
--- a/DropShot/Components/Layout/NavMenu.razor
+++ b/DropShot/Components/Layout/NavMenu.razor
@@ -232,7 +232,7 @@
                             <hr class="nav-dropdown-divider" />
 
                             <div class="nav-dropdown-item">
-                                <button type="button" class="nav-link theme-toggle-btn" onclick="event.stopPropagation(); toggleDropShotTheme()">
+                                <button type="button" class="nav-link theme-toggle-btn" onclick="event.stopPropagation(); toggleDropShotTheme(this)">
                                     <svg class="nav-icon theme-toggle-icon theme-icon-light" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="currentColor">
                                         <path d="M12 7c-2.76 0-5 2.24-5 5s2.24 5 5 5 5-2.24 5-5-2.24-5-5-5zM2 13h2c.55 0 1-.45 1-1s-.45-1-1-1H2c-.55 0-1 .45-1 1s.45 1 1 1zm18 0h2c.55 0 1-.45 1-1s-.45-1-1-1h-2c-.55 0-1 .45-1 1s.45 1 1 1zM11 2v2c0 .55.45 1 1 1s1-.45 1-1V2c0-.55-.45-1-1-1s-1 .45-1 1zm0 18v2c0 .55.45 1 1 1s1-.45 1-1v-2c0-.55-.45-1-1-1s-1 .45-1 1zM5.99 4.58a.996.996 0 00-1.41 0 .996.996 0 000 1.41l1.06 1.06c.39.39 1.03.39 1.41 0s.39-1.03 0-1.41L5.99 4.58zm12.37 12.37a.996.996 0 00-1.41 0 .996.996 0 000 1.41l1.06 1.06c.39.39 1.03.39 1.41 0a.996.996 0 000-1.41l-1.06-1.06zm1.06-10.96a.996.996 0 000-1.41.996.996 0 00-1.41 0l-1.06 1.06c-.39.39-.39 1.03 0 1.41s1.03.39 1.41 0l1.06-1.06zM7.05 18.36a.996.996 0 000-1.41.996.996 0 00-1.41 0l-1.06 1.06c-.39.39-.39 1.03 0 1.41s1.03.39 1.41 0l1.06-1.06z"/>
                                     </svg>

--- a/DropShot/Components/Layout/NavMenu.razor.css
+++ b/DropShot/Components/Layout/NavMenu.razor.css
@@ -154,6 +154,14 @@
     display: block;
 }
 
+/* When a menu item (e.g. the theme toggle) sets this class via JS, force
+   the dropdown closed even if the cursor still hovers the trigger / a
+   child is focused. The class is removed after a short timeout so the
+   dropdown opens normally again on the next intentional hover/focus. */
+.nav-dropdown.nav-dropdown-suppressed > .nav-dropdown-menu {
+    display: none !important;
+}
+
 .nav-dropdown:hover > .nav-dropdown-trigger .nav-expand-icon,
 .nav-dropdown:focus-within > .nav-dropdown-trigger .nav-expand-icon {
     transform: rotate(180deg);

--- a/DropShot/wwwroot/js/theme-switcher.js
+++ b/DropShot/wwwroot/js/theme-switcher.js
@@ -57,11 +57,29 @@
     });
     observer.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
 
-    // Expose toggle function globally for onclick
-    window.toggleDropShotTheme = function () {
+    // Expose toggle function globally for onclick. Optional `sourceEl` (the
+    // <button> that fired the click) lets us close the containing nav
+    // dropdown so the menu doesn't stay open after the user picks a mode.
+    window.toggleDropShotTheme = function (sourceEl) {
         var current = getPreferred();
         var next = current === 'dark' ? 'light' : 'dark';
         localStorage.setItem(STORAGE_KEY, next);
         applyTheme(next);
+
+        if (sourceEl && typeof sourceEl.blur === 'function') {
+            sourceEl.blur();
+            var dropdown = sourceEl.closest && sourceEl.closest('.nav-dropdown');
+            if (dropdown) {
+                // The dropdown is shown via :hover / :focus-within CSS, so
+                // simply blurring the button isn't enough on desktop where
+                // the cursor still hovers the menu. Briefly mark it as
+                // suppressed so a matching CSS rule force-hides it; the
+                // class self-clears so the dropdown can reopen normally.
+                dropdown.classList.add('nav-dropdown-suppressed');
+                setTimeout(function () {
+                    dropdown.classList.remove('nav-dropdown-suppressed');
+                }, 500);
+            }
+        }
     };
 })();


### PR DESCRIPTION
## Summary

The user-menu dropdown that contains the "Light Mode / Dark Mode" toggle stayed open after clicking it. The dropdown is shown via pure CSS `:hover / :focus-within`, so after the click the button kept focus (and on desktop the cursor was still over the menu) — neither state lifted, so the menu remained visible.

## Fix

- The button's onclick now passes `this` into `toggleDropShotTheme(sourceEl)`.
- The function `.blur()`s the button and adds a transient `.nav-dropdown-suppressed` class to its `.nav-dropdown` ancestor, with a new CSS rule that force-hides the menu via `display: none !important`. The class self-clears after 500ms, so the dropdown can be reopened normally on the next hover/focus.
- No change to the toggle behaviour itself — theme still flips on click and persists in `localStorage`.

## Test plan

- [ ] Build (`dotnet build DropShot/DropShot.csproj`) succeeds.
- [ ] Open the top-right user dropdown, click "Light Mode" → theme switches and the dropdown closes.
- [ ] Open it again, click "Dark Mode" → theme switches back and the dropdown closes.
- [ ] Hover the trigger again ≥0.5s later → dropdown reopens normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)