### PR TITLE
Back arrow clears entries on the way; pulse the green tick when ready

### DIFF
--- a/DropShot.UI/Components/Pages/SubmitScorePage.razor
+++ b/DropShot.UI/Components/Pages/SubmitScorePage.razor
@@ -232,9 +232,17 @@
         background: var(--mud-palette-primary);
         color: var(--mud-palette-primary-text);
         border-color: var(--mud-palette-primary);
+        /* Pulsing outline draws the eye to the tick the moment it becomes
+           available, prompting the user to submit. */
+        animation: keypad-submit-pulse 1.6s ease-out infinite;
     }
     .keypad-submit:hover,
     [data-theme="light"] .keypad-submit:hover { background: var(--mud-palette-primary-darken); }
+    @@keyframes keypad-submit-pulse {
+        0%   { box-shadow: 0 0 0 0   rgba(var(--mud-palette-primary-rgb, 25, 118, 210), 0.65); }
+        70%  { box-shadow: 0 0 0 8px rgba(var(--mud-palette-primary-rgb, 25, 118, 210), 0);    }
+        100% { box-shadow: 0 0 0 0   rgba(var(--mud-palette-primary-rgb, 25, 118, 210), 0);    }
+    }
     .keypad-cancel,
     [data-theme="light"] .keypad-cancel {
         background: var(--mud-palette-error);
@@ -496,6 +504,10 @@
         {
             _activeIsSide1 = true;
         }
+        // Clear whatever was previously entered in the cell we just landed on
+        // so the user can re-type it. This makes ← behave like a backspace
+        // through the score sequence: tap N times to undo N entries.
+        (_activeIsSide1 ? _score1 : _score2)[_activeSet] = null;
     }
 
     private void AdvanceOne()


### PR DESCRIPTION
## Summary

Two small UX tweaks to `/match/submit/{fixtureId}`.

### 1. Back arrow clears as it moves

`←` on the keypad now nulls out the value of the cell it moves back *into*. Tap N times to undo N entries, like a backspace through the score sequence. If you'd rather navigate without clearing, tap the destination cell directly — `SetActive` is unchanged.

### 2. Pulse the tick when the match is ready to submit

When `CanSubmit` becomes true, the green tick now carries an infinite `keypad-submit-pulse` animation: a primary-colour box-shadow ring that expands and fades every 1.6 s, drawing the user's eye to it. The animation lives on `.keypad-submit`, which is conditionally rendered, so it disappears with the button if the scores stop being valid.

## Test plan

- [ ] Build (`dotnet build DropShot/DropShot.csproj`) succeeds.
- [ ] Enter a sequence like `6-4 6-3`. Press `←` once → set 2 side 2 (`3`) clears and becomes active. Press `←` again → set 2 side 1 (`6`) clears, etc.
- [ ] Enter a full match (e.g. `6-4 6-4` in a best-of-3 with the regular set rule). The tick appears and pulses with a soft primary-colour halo. Tapping it submits as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)