### PR TITLE
Close the hamburger menu after picking light/dark mode

### DIFF
--- a/DropShot/Components/Layout/NavMenu.razor
+++ b/DropShot/Components/Layout/NavMenu.razor
@@ -232,7 +232,12 @@
                             <hr class="nav-dropdown-divider" />
 
                             <div class="nav-dropdown-item">
-                                <button type="button" class="nav-link theme-toggle-btn" onclick="event.stopPropagation(); toggleDropShotTheme(this)">
+                                @* Intentionally let the click bubble: .nav-content has an onclick
+                                   that toggles the hamburger checkbox, so the mobile menu closes
+                                   right after the theme flips. The desktop dropdown is closed
+                                   separately via the .nav-dropdown-suppressed class applied inside
+                                   toggleDropShotTheme. *@
+                                <button type="button" class="nav-link theme-toggle-btn" onclick="toggleDropShotTheme(this)">
                                     <svg class="nav-icon theme-toggle-icon theme-icon-light" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="currentColor">
                                         <path d="M12 7c-2.76 0-5 2.24-5 5s2.24 5 5 5 5-2.24 5-5-2.24-5-5-5zM2 13h2c.55 0 1-.45 1-1s-.45-1-1-1H2c-.55 0-1 .45-1 1s.45 1 1 1zm18 0h2c.55 0 1-.45 1-1s-.45-1-1-1h-2c-.55 0-1 .45-1 1s.45 1 1 1zM11 2v2c0 .55.45 1 1 1s1-.45 1-1V2c0-.55-.45-1-1-1s-1 .45-1 1zm0 18v2c0 .55.45 1 1 1s1-.45 1-1v-2c0-.55-.45-1-1-1s-1 .45-1 1zM5.99 4.58a.996.996 0 00-1.41 0 .996.996 0 000 1.41l1.06 1.06c.39.39 1.03.39 1.41 0s.39-1.03 0-1.41L5.99 4.58zm12.37 12.37a.996.996 0 00-1.41 0 .996.996 0 000 1.41l1.06 1.06c.39.39 1.03.39 1.41 0a.996.996 0 000-1.41l-1.06-1.06zm1.06-10.96a.996.996 0 000-1.41.996.996 0 00-1.41 0l-1.06 1.06c-.39.39-.39 1.03 0 1.41s1.03.39 1.41 0l1.06-1.06zM7.05 18.36a.996.996 0 000-1.41.996.996 0 00-1.41 0l-1.06 1.06c-.39.39-.39 1.03 0 1.41s1.03.39 1.41 0l1.06-1.06z"/>
                                     </svg>


### PR DESCRIPTION
## Summary

Follow-up to #698. That PR closed the **desktop** nav dropdown after a theme toggle, but the **mobile hamburger** still stayed open.

The mobile hamburger is a CSS checkbox (`#nav-toggle`) whose state is flipped by an `onclick` on `.nav-content` that runs whenever a click bubbles up from any child. The theme button's onclick was `event.stopPropagation(); toggleDropShotTheme(this)` — the `stopPropagation()` killed the bubble, so the checkbox never flipped and the hamburger never closed.

## Fix

Drop `event.stopPropagation()` from the theme button's onclick. The click now bubbles to `.nav-content`, which clicks the hidden `#nav-toggle` checkbox, which un-checks → hamburger closes.

The desktop dropdown is still closed by the `.nav-dropdown-suppressed` class applied inside `toggleDropShotTheme` (added in #698), so that path is unaffected.

## Test plan

- [ ] Build (`dotnet build DropShot/DropShot.csproj`) succeeds.
- [ ] On mobile viewport (≤640px), open the hamburger, tap "Light Mode" → theme flips and the hamburger closes.
- [ ] Re-open the hamburger, tap "Dark Mode" → flips back and closes.
- [ ] On desktop (≥641px), open the user dropdown, click theme toggle → theme flips and the dropdown closes (unchanged behaviour from #698).

🤖 Generated with [Claude Code](https://claude.com/claude-code)