### PR TITLE
Shrink the final set's row when focus is dropped after completion

### DIFF
--- a/DropShot.UI/Components/Pages/SubmitScorePage.razor
+++ b/DropShot.UI/Components/Pages/SubmitScorePage.razor
@@ -44,7 +44,7 @@
                 @for (int i = 0; i < _bestOf; i++)
                 {
                     int idx = i;
-                    bool rowActive = idx == _activeSet;
+                    bool rowActive = idx == _activeSet && _focused;
                     <div class="@($"set-row{(rowActive ? " set-row-active" : "")}")">
                         <div></div>
                         <button type="button"


### PR DESCRIPTION
## Summary

Follow-up to #701. That PR dropped the *cell's* active highlight after the final entry but left the row itself rendered at the enlarged `.set-row-active` size, so the final set still looked physically larger than the others while the submit tick was the actual next thing to click.

`set-row-active` previously fired on `idx == _activeSet`. Now also requires `_focused`, so the moment `WriteAndAdvance` drops `_focused = false` on the final cell, the row shrinks back to the inactive size — matching the rest of the sets and putting full visual weight on the tick.

Any user action (`←`, tapping a cell, typing) restores `_focused = true` so the active row re-enlarges immediately.

## Test plan

- [ ] Build (`dotnet build DropShot/DropShot.csproj`) succeeds.
- [ ] Enter `6-4 6-4 6-4`. After the last `4`, the final set's row shrinks to the same size as sets 1 and 2; the tick is the only thing pulsing.
- [ ] Press `←` → final set's row grows back (active again, cell highlighted, value cleared).
- [ ] Tap a different set → that row enlarges and the previously active one shrinks (existing animation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)