### PR TITLE
Light-mode: fix invisible tennis backdrop on the home page (and everywhere else)

### DIFF
--- a/DropShot/wwwroot/css/theme-light.css
+++ b/DropShot/wwwroot/css/theme-light.css
@@ -6,8 +6,12 @@
 /* ── Base overrides ─────────────────────────────────────────────────── */
 /* Mirrors the dark gradient + tennis tile in app.css with light-mode
    equivalents: the inverted (light) tennis image under an 85% near-white
-   overlay produces the same "barely visible pattern" feel as dark mode. */
-[data-theme="light"] html,
+   overlay produces the same "barely visible pattern" feel as dark mode.
+   The bare `[data-theme="light"]` selector matches the <html> element
+   itself (where the attribute lives); `[data-theme="light"] body`
+   matches body as a descendant of that html. Both need the override
+   because app.css paints the dark backdrop on both `html` and `body`. */
+[data-theme="light"],
 [data-theme="light"] body {
     background-color: #f5f5f5 !important;
     background-image:
@@ -99,8 +103,12 @@
 }
 
 /* ── Content area ───────────────────────────────────────────────────── */
+/* Keep transparent so the body's light tennis tile shows through; the
+   body's #f5f5f5 fallback already covers the case where the image fails
+   to load. An opaque colour here would hide the new backdrop on every
+   page narrower than the 1280px content cap (i.e. all mobile views). */
 [data-theme="light"] .content {
-    background-color: #f5f5f5;
+    background-color: transparent;
 }
 
 [data-theme="light"] a,


### PR DESCRIPTION
Follow-up to [#703](https://github.com/kingbeazer/DropShot/pull/703). The new `background-light.png` tile was wired onto the body, but it didn't actually show up on any page.

## Cause
`theme-light.css` already had:
```css
[data-theme="light"] .content {
    background-color: #f5f5f5;
}
```
`.content` is `flex: 1` with `max-width: 1280px`, so on any viewport narrower than that cap (i.e. every mobile screen) it fully covers the body, and that opaque `#f5f5f5` was sitting on top of the new tennis tile.

There was also a selector bug in #703: `[data-theme="light"] html` is a descendant selector and matches nothing — the `data-theme` attribute lives on `<html>` itself, not on an ancestor. The body override still worked (body is a descendant of html), but the html override silently did nothing.

## Fix
- `.content` background → `transparent` in light mode. The body's `#f5f5f5` fallback under the tile still handles the image-load-failure case.
- Switch `[data-theme="light"] html` → bare `[data-theme="light"]` so the html override actually applies.

## Test plan
- [ ] Toggle to Light mode on the home page (mobile width) — light tennis tile is visible behind cards.
- [ ] Same check on a competition page — tile shows behind the sticky band and content.
- [ ] Toggle back to Dark — original dark tile still appears unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)