### PR TITLE
Theme toggle: show only one label at a time

### DIFF
--- a/DropShot/wwwroot/css/theme-light.css
+++ b/DropShot/wwwroot/css/theme-light.css
@@ -265,18 +265,21 @@
 }
 
 /* Label mirrors the icon — "Light Mode" (the destination) shows while the
-   page is in dark theme, "Dark Mode" shows while in light theme. */
+   page is in dark theme, "Dark Mode" shows while in light theme.
+   The !important is required because NavMenu's scoped .nav-label rule
+   ("display: inline") has higher specificity than these un-scoped class
+   selectors and would otherwise reveal both labels at once. */
 .theme-label-dark {
-    display: none;
+    display: none !important;
 }
 .theme-label-light {
-    display: inline;
+    display: inline !important;
 }
 [data-theme="light"] .theme-label-light {
-    display: none;
+    display: none !important;
 }
 [data-theme="light"] .theme-label-dark {
-    display: inline;
+    display: inline !important;
 }
 
 /* ── Footer ─────────────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary

In dark mode the theme toggle button read **"Light Mode Dark Mode"** — both labels were visible.

The hide rules live in `theme-light.css` as plain class selectors (`.theme-label-dark { display: none }` etc.), but `NavMenu.razor.css` has a scoped `.nav-label { display: inline; }` rule. Blazor's scoped CSS adds an attribute selector (`[b-xxxxx]`) to the class, raising its specificity above the un-scoped theme-label rules — so both labels render as `inline`.

Fix: add `!important` to the four `.theme-label-*` display rules so the intended mutual exclusion is restored: **"Light Mode" in dark theme, "Dark Mode" in light theme**.

The icon equivalents (`.theme-icon-light` / `.theme-icon-dark`) already worked correctly because `.nav-icon` in the scoped CSS doesn't set `display` — only `.nav-label` does.

## Test plan

- [ ] Build (`dotnet build DropShot/DropShot.csproj`) succeeds.
- [ ] In dark theme (default), the toggle reads "Light Mode" only.
- [ ] After toggling, the page switches to light theme and the toggle reads "Dark Mode" only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)