### PR TITLE
Competition entry: link to account, offer sub option, sync mobile

### DIFF
--- a/DropShot.Maui/Services/HttpCompetitionService.cs
+++ b/DropShot.Maui/Services/HttpCompetitionService.cs
@@ -99,11 +99,14 @@ public sealed class HttpCompetitionService(HttpClient http) : ICompetitionServic
     }
 
     public async Task EnterCompetitionAsync(
-        int competitionId, PhoneShareConsent consent, CancellationToken ct = default)
+        int competitionId,
+        PhoneShareConsent consent,
+        ParticipantStatus status = ParticipantStatus.FullPlayer,
+        CancellationToken ct = default)
     {
         var resp = await http.PostAsJsonAsync(
             $"api/competitions/{competitionId}/enter",
-            new EnterCompetitionRequest(consent), ct);
+            new EnterCompetitionRequest(consent, status), ct);
         if (!resp.IsSuccessStatusCode)
         {
             var body = await resp.Content.ReadAsStringAsync(ct);

--- a/DropShot.Shared/Dtos/CompetitionDtos.cs
+++ b/DropShot.Shared/Dtos/CompetitionDtos.cs
@@ -328,10 +328,13 @@ public record SelfRegisterRequest(
     PhoneShareConsent Consent);
 
 /// <summary>
-/// Enter-competition request body. No status field (the server picks
-/// Registered) — only the per-competition phone-share consent.
+/// Enter-competition request body. Carries the per-competition phone-share
+/// consent and the participation status the user chose (FullPlayer or
+/// Substitute). The server rejects any other status value.
 /// </summary>
-public record EnterCompetitionRequest(PhoneShareConsent Consent);
+public record EnterCompetitionRequest(
+    PhoneShareConsent Consent,
+    ParticipantStatus Status = ParticipantStatus.FullPlayer);
 
 public record SaveFixtureRequest(
     int? CompetitionStageId,

--- a/DropShot.UI/Components/Pages/Competitions.razor
+++ b/DropShot.UI/Components/Pages/Competitions.razor
@@ -93,10 +93,16 @@
                     <MudTd DataLabel="Dates">@FormatDates(context)</MudTd>
                     <MudTd DataLabel="Register By">@(context.RegisterByDate?.ToString("dd MMM yyyy") ?? "—")</MudTd>
                     <MudTd>
-                        <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary"
-                                   OnClick="@(() => EnterCompetitionAsync(context))">
-                            Enter
-                        </MudButton>
+                        <MudStack Row="true" Spacing="1" Wrap="Wrap.Wrap">
+                            <MudButton Size="Size.Small" Variant="Variant.Filled" Color="Color.Primary"
+                                       OnClick="@(() => EnterCompetitionAsync(context, ParticipantStatus.FullPlayer))">
+                                Enter
+                            </MudButton>
+                            <MudButton Size="Size.Small" Variant="Variant.Outlined" Color="Color.Primary"
+                                       OnClick="@(() => EnterCompetitionAsync(context, ParticipantStatus.Substitute))">
+                                Enter as Sub
+                            </MudButton>
+                        </MudStack>
                     </MudTd>
                 </RowTemplate>
             </MudTable>
@@ -640,14 +646,19 @@ else
         return c.StartDate == c.EndDate ? start : $"{start} – {end}";
     }
 
-    private async Task EnterCompetitionAsync(CompetitionDto comp)
+    private async Task EnterCompetitionAsync(CompetitionDto comp, ParticipantStatus status)
     {
         if (string.IsNullOrWhiteSpace(_myMobileNumber))
         {
             SiteAlerts.Add(
-                "Add a mobile number to your profile before entering competitions — " +
-                "head to My Players.",
-                Severity.Warning);
+                "Add a mobile number to your profile before entering competitions.",
+                Severity.Warning,
+                actionLabel: "Open my account",
+                actionCallback: () =>
+                {
+                    Nav.NavigateTo("/Account/Manage", forceLoad: true);
+                    return Task.CompletedTask;
+                });
             return;
         }
 
@@ -656,15 +667,18 @@ else
             [nameof(DropShot.UI.Components.Shared.EnterCompetitionConsentDialog.CompetitionName)] = comp.CompetitionName,
             [nameof(DropShot.UI.Components.Shared.EnterCompetitionConsentDialog.MobileNumber)] = _myMobileNumber,
         };
+        var dialogTitle = status == ParticipantStatus.Substitute
+            ? "Enter as substitute — share your mobile number"
+            : "Share your mobile number with competitors";
         var dialog = await DialogService.ShowAsync<DropShot.UI.Components.Shared.EnterCompetitionConsentDialog>(
-            "Share your mobile number with competitors", parameters);
+            dialogTitle, parameters);
         var result = await dialog.Result;
         if (result is null || result.Canceled) return;
         if (result.Data is not PhoneShareConsent consent) return;
 
         try
         {
-            await CompetitionService.EnterCompetitionAsync(comp.CompetitionId, consent);
+            await CompetitionService.EnterCompetitionAsync(comp.CompetitionId, consent, status);
         }
         catch (InvalidOperationException ex)
         {
@@ -672,7 +686,8 @@ else
             return;
         }
 
-        SiteAlerts.Add($"Entered '{comp.CompetitionName}'.", Severity.Success);
+        var enteredAs = status == ParticipantStatus.Substitute ? " as substitute" : "";
+        SiteAlerts.Add($"Entered '{comp.CompetitionName}'{enteredAs}.", Severity.Success);
 
         _availableComps.RemoveAll(c => c.CompetitionId == comp.CompetitionId);
         _myEnteredComps.Add(comp);

--- a/DropShot.UI/Services/ICompetitionService.cs
+++ b/DropShot.UI/Services/ICompetitionService.cs
@@ -116,15 +116,20 @@ public interface ICompetitionService
     Task DeleteCompetitionAsync(int competitionId, CancellationToken ct = default);
 
     /// <summary>
-    /// Self-enter the authenticated user's player into the competition.
-    /// Server enforces date/eligibility/capacity/duplicate-entry guards and
-    /// throws <see cref="InvalidOperationException"/> with a user-facing
-    /// message when any of them fail. The <paramref name="consent"/> payload
-    /// is recorded against the player at the same time the participant row
-    /// is created (single transaction).
+    /// Self-enter the authenticated user's player into the competition with
+    /// the chosen participation status (FullPlayer or Substitute). Server
+    /// enforces date/eligibility/capacity/duplicate-entry guards and throws
+    /// <see cref="InvalidOperationException"/> with a user-facing message
+    /// when any of them fail, or when <paramref name="status"/> is not one
+    /// of the two allowed values. The <paramref name="consent"/> payload is
+    /// recorded against the player at the same time the participant row is
+    /// created (single transaction).
     /// </summary>
     Task EnterCompetitionAsync(
-        int competitionId, PhoneShareConsent consent, CancellationToken ct = default);
+        int competitionId,
+        PhoneShareConsent consent,
+        ParticipantStatus status = ParticipantStatus.FullPlayer,
+        CancellationToken ct = default);
 
     /// <summary>
     /// Leave a competition. Sets the participant's status to

--- a/DropShot/Components/Account/Pages/Manage/Index.razor
+++ b/DropShot/Components/Account/Pages/Manage/Index.razor
@@ -205,6 +205,22 @@
             {
                 RedirectManager.RedirectToCurrentPageWithStatus("Error: Failed to set phone number.", HttpContext);
             }
+
+            // Mirror onto the linked Player record so competition entry (which
+            // gates on Player.MobileNumber) sees the new number without the
+            // user having to also edit it in My Players.
+            if (linkedPlayerId.HasValue)
+            {
+                await using var db = DbFactory.CreateDbContext();
+                var player = await db.Players.FindAsync(linkedPlayerId.Value);
+                if (player is not null)
+                {
+                    player.MobileNumber = string.IsNullOrWhiteSpace(Input.PhoneNumber)
+                        ? null
+                        : Input.PhoneNumber.Trim();
+                    await db.SaveChangesAsync();
+                }
+            }
         }
 
         await SignInManager.RefreshSignInAsync(user);

--- a/DropShot/Controllers/CompetitionsController.cs
+++ b/DropShot/Controllers/CompetitionsController.cs
@@ -652,7 +652,7 @@ public class CompetitionsController(
     {
         try
         {
-            await competitionService.EnterCompetitionAsync(id, req.Consent, ct);
+            await competitionService.EnterCompetitionAsync(id, req.Consent, req.Status, ct);
             return NoContent();
         }
         catch (KeyNotFoundException ex) { return NotFound(new { message = ex.Message }); }

--- a/DropShot/Services/WebCompetitionService.cs
+++ b/DropShot/Services/WebCompetitionService.cs
@@ -133,11 +133,13 @@ public sealed class WebCompetitionService(
             // projection because the entry-consent dialog needs it before
             // the caller is in the participants list. Always populated for
             // the caller themselves (rule #1 in PhoneVisibilityService).
-            myMobileNumber = await db.Players
-                .AsNoTracking()
-                .Where(p => p.UserId == currentUser.UserId)
-                .Select(p => p.MobileNumber)
-                .FirstOrDefaultAsync(ct);
+            // Lazy-sync from ApplicationUser.PhoneNumber if the Player row
+            // is empty — covers historical accounts that set their number
+            // before the save-time sync was added.
+            var callerPlayer = await db.Players
+                .FirstOrDefaultAsync(p => p.UserId == currentUser.UserId, ct);
+            if (callerPlayer is not null)
+                myMobileNumber = await EnsurePlayerMobileSyncedAsync(db, callerPlayer, ct);
         }
 
         var ratingsByPlayer = await ratings.GetRosterRatingsAsync(id, ct);
@@ -308,6 +310,7 @@ public sealed class WebCompetitionService(
         var player = await db.Players.FirstOrDefaultAsync(p => p.UserId == currentUser.UserId, ct)
             ?? throw new KeyNotFoundException("Could not find your player record.");
 
+        await EnsurePlayerMobileSyncedAsync(db, player, ct);
         RequirePhoneAndConsent(player, consent);
 
         var existing = await db.CompetitionParticipants
@@ -342,6 +345,7 @@ public sealed class WebCompetitionService(
                 && cp.Player!.UserId == currentUser.UserId, ct)
             ?? throw new KeyNotFoundException("Could not find your participant record.");
 
+        await EnsurePlayerMobileSyncedAsync(db, participant.Player!, ct);
         RequirePhoneAndConsent(participant.Player!, consent);
 
         participant.Status = status;
@@ -357,6 +361,32 @@ public sealed class WebCompetitionService(
         return new LadderSimulationResultDto(
             r.Participants, r.ActivePlayers, r.IdlePlayers,
             r.FixturesGenerated, r.DecayEventsGenerated);
+    }
+
+    /// <summary>
+    /// Lazy-sync helper: if <paramref name="player"/>.MobileNumber is empty
+    /// but the linked Identity user has a PhoneNumber, copy it onto the
+    /// player row and save. Covers users who set their phone on /Account/Manage
+    /// before the save-time sync existed — the two columns weren't kept
+    /// aligned, so competition entry (which reads Player.MobileNumber) blocked
+    /// them even though their account showed a number. Returns the effective
+    /// mobile number after any backfill.
+    /// </summary>
+    private static async Task<string?> EnsurePlayerMobileSyncedAsync(
+        MyDbContext db, Player player, CancellationToken ct)
+    {
+        if (!string.IsNullOrWhiteSpace(player.MobileNumber)) return player.MobileNumber;
+        if (string.IsNullOrEmpty(player.UserId)) return null;
+
+        var identityPhone = await db.Users
+            .Where(u => u.Id == player.UserId)
+            .Select(u => u.PhoneNumber)
+            .FirstOrDefaultAsync(ct);
+        if (string.IsNullOrWhiteSpace(identityPhone)) return null;
+
+        player.MobileNumber = identityPhone.Trim();
+        await db.SaveChangesAsync(ct);
+        return player.MobileNumber;
     }
 
     private static void RequirePhoneAndConsent(Player player, PhoneShareConsent consent)
@@ -856,11 +886,12 @@ public sealed class WebCompetitionService(
         var available = candidates
             .Where(c => EligibilityEvaluator.Evaluate(c, eligibilityPlayer).Count == 0)
             .Select(ToDto).ToList();
+        var myMobile = await EnsurePlayerMobileSyncedAsync(db, eligibilityPlayer, ct);
         return new MyCompetitionsViewDto(
             true,
             enteredEntities.Select(ToDto).ToList(),
             available,
-            eligibilityPlayer.MobileNumber);
+            myMobile);
     }
 
     public async Task<List<CompetitionFixtureDto>> GetPendingVerificationFixturesAsync(CancellationToken ct = default)
@@ -1044,8 +1075,15 @@ public sealed class WebCompetitionService(
     }
 
     public async Task EnterCompetitionAsync(
-        int competitionId, PhoneShareConsent consent, CancellationToken ct = default)
+        int competitionId,
+        PhoneShareConsent consent,
+        ParticipantStatus status = ParticipantStatus.FullPlayer,
+        CancellationToken ct = default)
     {
+        if (status is not (ParticipantStatus.FullPlayer or ParticipantStatus.Substitute))
+            throw new InvalidOperationException(
+                "Choose to enter as a full player or as a substitute.");
+
         if (string.IsNullOrEmpty(currentUser.UserId))
             throw new InvalidOperationException("Not authenticated.");
 
@@ -1054,6 +1092,7 @@ public sealed class WebCompetitionService(
             .FirstOrDefaultAsync(p => p.UserId == currentUser.UserId && !p.IsLight, ct)
             ?? throw new InvalidOperationException("You need a player profile before entering competitions.");
 
+        await EnsurePlayerMobileSyncedAsync(db, player, ct);
         RequirePhoneAndConsent(player, consent);
 
         var comp = await db.Competition
@@ -1075,10 +1114,13 @@ public sealed class WebCompetitionService(
         if (violations.Count > 0)
             throw new InvalidOperationException($"You're not eligible for this competition: {violations[0].Message}");
 
-        if (comp.MaxParticipants.HasValue)
+        // MaxParticipants caps the full roster only — substitutes don't count
+        // against it (they're explicitly extra coverage).
+        if (status == ParticipantStatus.FullPlayer && comp.MaxParticipants.HasValue)
         {
             var currentCount = await db.CompetitionParticipants
-                .CountAsync(cp => cp.CompetitionId == competitionId, ct);
+                .CountAsync(cp => cp.CompetitionId == competitionId
+                    && cp.Status == ParticipantStatus.FullPlayer, ct);
             if (currentCount >= comp.MaxParticipants.Value)
                 throw new InvalidOperationException("This competition is full.");
         }
@@ -1093,7 +1135,7 @@ public sealed class WebCompetitionService(
             CompetitionId = competitionId,
             PlayerId = player.PlayerId,
             RegisteredAt = DateTime.UtcNow,
-            Status = ParticipantStatus.Registered
+            Status = status
         });
         db.CompetitionEntryConsents.Add(BuildConsentRow(competitionId, player.PlayerId, consent));
         await db.SaveChangesAsync(ct);


### PR DESCRIPTION
## Summary
- Missing-mobile warning on the Competitions page now redirects to `/Account/Manage` (was: text-only "head to My Players") and includes an **Open my account** action button on the site-alert banner.
- `/Account/Manage` now mirrors the saved phone number onto the linked `Player.MobileNumber`, and a lazy-sync helper backfills `Player.MobileNumber` from `ApplicationUser.PhoneNumber` on first competition read for users whose account number was set before this sync existed.
- Available competitions now offer **Enter** (full player) and **Enter as Sub** buttons. Both go through the same mobile + consent gate; substitutes don't count against `MaxParticipants`.

## Test plan
- [ ] As a user with no mobile, click Enter on a competition — alert shows with **Open my account** button that navigates to `/Account/Manage`.
- [ ] As a user whose `ApplicationUser.PhoneNumber` is set but `Player.MobileNumber` is null (the bug reported in the conversation), load the Competitions page — the Enter button should now work; verify the player row was backfilled.
- [ ] Save a new phone number on `/Account/Manage` — confirm both the Identity column and the linked Player row are updated.
- [ ] Press **Enter as Sub** on an available competition — confirm participant row is created with `Status = Substitute` and full roster `MaxParticipants` cap isn't applied.
- [ ] Press **Enter** on an available competition — confirm participant row is created with `Status = FullPlayer` (was `Registered`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)