### PR TITLE
Roster: block duplicate roles per team, surface assignment errors

### DIFF
--- a/DropShot.Maui/Services/HttpCompetitionAdminService.cs
+++ b/DropShot.Maui/Services/HttpCompetitionAdminService.cs
@@ -238,7 +238,11 @@ public sealed class HttpCompetitionAdminService(HttpClient http) : ICompetitionA
     {
         var resp = await http.PutAsJsonAsync(
             $"api/competitions/admin/{competitionId}/participants/{playerId}/team", request, ct);
-        resp.EnsureSuccessStatusCode();
+        if (!resp.IsSuccessStatusCode)
+        {
+            var body = await resp.Content.ReadAsStringAsync(ct);
+            throw new InvalidOperationException(ExtractErrorMessage(body) ?? resp.ReasonPhrase ?? "Failed to assign team.");
+        }
     }
 
     public async Task AssignParticipantRoleAsync(
@@ -246,7 +250,32 @@ public sealed class HttpCompetitionAdminService(HttpClient http) : ICompetitionA
     {
         var resp = await http.PutAsJsonAsync(
             $"api/competitions/admin/{competitionId}/participants/{playerId}/role", request, ct);
-        resp.EnsureSuccessStatusCode();
+        if (!resp.IsSuccessStatusCode)
+        {
+            var body = await resp.Content.ReadAsStringAsync(ct);
+            throw new InvalidOperationException(ExtractErrorMessage(body) ?? resp.ReasonPhrase ?? "Failed to assign role.");
+        }
+    }
+
+    /// <summary>
+    /// Parse the <c>{ "message": "..." }</c> body the API returns on
+    /// BadRequest/NotFound so the surfaced error is the friendly message,
+    /// not the raw JSON envelope. Returns null when the body isn't that
+    /// shape so callers fall back to ReasonPhrase.
+    /// </summary>
+    private static string? ExtractErrorMessage(string? body)
+    {
+        if (string.IsNullOrWhiteSpace(body)) return null;
+        try
+        {
+            using var doc = System.Text.Json.JsonDocument.Parse(body);
+            if (doc.RootElement.ValueKind == System.Text.Json.JsonValueKind.Object
+                && doc.RootElement.TryGetProperty("message", out var msg)
+                && msg.ValueKind == System.Text.Json.JsonValueKind.String)
+                return msg.GetString();
+        }
+        catch (System.Text.Json.JsonException) { }
+        return body;
     }
 
     public async Task AssignParticipantDivisionAsync(

--- a/DropShot.UI/Components/Pages/CompetitionPage.razor
+++ b/DropShot.UI/Components/Pages/CompetitionPage.razor
@@ -3259,7 +3259,20 @@ else
 
     private async Task AssignTeam(CompetitionParticipantDto cp, int? teamId)
     {
-        await Admin.AssignParticipantTeamAsync(Id, cp.PlayerId, new AssignParticipantTeamRequest(teamId));
+        try
+        {
+            await Admin.AssignParticipantTeamAsync(Id, cp.PlayerId, new AssignParticipantTeamRequest(teamId));
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or UnauthorizedAccessException
+                                      or HttpRequestException)
+        {
+            SiteAlerts.Add(FriendlyAssignmentError(ex, "team assignment"), Severity.Warning);
+            // Roll the row back to its prior state so the dropdown re-renders
+            // with the unchanged value (otherwise the UI optimistically shows
+            // the rejected pick).
+            await ReloadAfterServerMutationAsync();
+            return;
+        }
         var idx = _participants.IndexOf(cp);
         if (idx >= 0)
         {
@@ -3273,10 +3286,29 @@ else
     private async Task AssignRole(CompetitionParticipantDto cp, string? role)
     {
         var trimmed = string.IsNullOrWhiteSpace(role) ? null : role;
-        await Admin.AssignParticipantRoleAsync(Id, cp.PlayerId, new SetParticipantRoleRequest(trimmed));
+        try
+        {
+            await Admin.AssignParticipantRoleAsync(Id, cp.PlayerId, new SetParticipantRoleRequest(trimmed));
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or UnauthorizedAccessException
+                                      or HttpRequestException)
+        {
+            SiteAlerts.Add(FriendlyAssignmentError(ex, "role change"), Severity.Warning);
+            await ReloadAfterServerMutationAsync();
+            return;
+        }
         var idx = _participants.IndexOf(cp);
         if (idx >= 0) _participants[idx] = cp with { Role = trimmed };
     }
+
+    private static string FriendlyAssignmentError(Exception ex, string action) => ex switch
+    {
+        UnauthorizedAccessException => $"You don't have permission to make this {action}.",
+        InvalidOperationException => ex.Message,
+        HttpRequestException http when http.StatusCode == System.Net.HttpStatusCode.Forbidden
+            => $"You don't have permission to make this {action}.",
+        _ => $"Couldn't save the {action}: {ex.Message}",
+    };
 
     private async Task AssignCaptain(CompetitionTeamDto team, int? captainPlayerId)
     {

--- a/DropShot/Controllers/CompetitionsAdminController.cs
+++ b/DropShot/Controllers/CompetitionsAdminController.cs
@@ -265,6 +265,7 @@ public class CompetitionsAdminController(
         try { await admin.AssignParticipantTeamAsync(id, playerId, req, ct); return NoContent(); }
         catch (UnauthorizedAccessException) { return Forbid(); }
         catch (KeyNotFoundException) { return NotFound(); }
+        catch (InvalidOperationException ex) { return BadRequest(new { message = ex.Message }); }
     }
 
     [HttpPut("{id:int}/participants/{playerId:int}/role")]
@@ -274,6 +275,7 @@ public class CompetitionsAdminController(
         try { await admin.AssignParticipantRoleAsync(id, playerId, req, ct); return NoContent(); }
         catch (UnauthorizedAccessException) { return Forbid(); }
         catch (KeyNotFoundException) { return NotFound(); }
+        catch (InvalidOperationException ex) { return BadRequest(new { message = ex.Message }); }
     }
 
     [HttpPut("{id:int}/participants/{playerId:int}/division")]

--- a/DropShot/Services/WebCompetitionAdminService.cs
+++ b/DropShot/Services/WebCompetitionAdminService.cs
@@ -1157,6 +1157,9 @@ public sealed class WebCompetitionAdminService(
         await LoadAndAuthorizeAsync(db, competitionId, ct);
         var row = await db.CompetitionParticipants.FindAsync([competitionId, playerId], ct)
             ?? throw new KeyNotFoundException("Participant not found.");
+
+        await EnsureNoDuplicateRoleOnTeamAsync(db, competitionId, request.TeamId, row.Role, playerId, ct);
+
         row.TeamId = request.TeamId;
         await db.SaveChangesAsync(ct);
     }
@@ -1168,8 +1171,38 @@ public sealed class WebCompetitionAdminService(
         await LoadAndAuthorizeAsync(db, competitionId, ct);
         var row = await db.CompetitionParticipants.FindAsync([competitionId, playerId], ct)
             ?? throw new KeyNotFoundException("Participant not found.");
-        row.Role = string.IsNullOrWhiteSpace(request.Role) ? null : request.Role;
+
+        var newRole = string.IsNullOrWhiteSpace(request.Role) ? null : request.Role;
+        await EnsureNoDuplicateRoleOnTeamAsync(db, competitionId, row.TeamId, newRole, playerId, ct);
+
+        row.Role = newRole;
         await db.SaveChangesAsync(ct);
+    }
+
+    /// <summary>
+    /// Block assignments that would put two players with the same role on the
+    /// same team (e.g. two MA on one team). Roles are unique within a team for
+    /// the rubber template (MA/MB/FA/FB or D1A/D1B/D2A/D2B); allowing duplicates
+    /// breaks fixture generation. Null role or null team can't conflict.
+    /// </summary>
+    private static async Task EnsureNoDuplicateRoleOnTeamAsync(
+        MyDbContext db, int competitionId, int? teamId, string? role, int playerId, CancellationToken ct)
+    {
+        if (teamId is null || string.IsNullOrWhiteSpace(role)) return;
+
+        var clash = await db.CompetitionParticipants
+            .AnyAsync(p => p.CompetitionId == competitionId
+                && p.TeamId == teamId
+                && p.PlayerId != playerId
+                && p.Role == role, ct);
+        if (!clash) return;
+
+        var teamName = await db.CompetitionTeams
+            .Where(t => t.CompetitionTeamId == teamId)
+            .Select(t => t.Name)
+            .FirstOrDefaultAsync(ct) ?? "this team";
+        throw new InvalidOperationException(
+            $"{teamName} already has a player in role '{role}'. Move or re-role the existing player first.");
     }
 
     public async Task AssignParticipantDivisionAsync(


### PR DESCRIPTION
## Summary
- Block team / role assignments that would put two players with the same role (e.g. two MA) on the same team. Validation lives in both `AssignParticipantTeamAsync` and `AssignParticipantRoleAsync` so neither door lets a conflict through; the error message names the team and role.
- Catch `InvalidOperationException` in the admin endpoints so the friendly message reaches the client as a 400 instead of bubbling as a 500.
- MAUI HTTP client parses the `{message}` envelope and rethrows as `InvalidOperationException` so the page sees the actual message, not the raw `HttpRequestException`.
- `CompetitionPage`'s `AssignTeam` / `AssignRole` now catch `Invalid/Unauthorized/HttpRequest` and surface via `SiteAlerts`, then reload to roll the dropdown back to its prior value. Fixes the unhandled-exception crash when a non-editor tried to clear a role from the roster.

## Test plan
- [ ] As an admin/club admin, try to assign a player with `Role=MA` to a team that already has another player with `Role=MA` — expect a warning alert (\"{team} already has a player in role 'MA'...\"), no DB change, dropdown reverts.
- [ ] Same scenario via role change instead of team change — same behaviour.
- [ ] Clear / change a role normally where no conflict exists — saves silently as before.
- [ ] Switch your active role to plain User, navigate to a competition's roster, and (if reachable) clear a role — instead of the unhandled-exception page, see a friendly \"You don't have permission...\" alert and the dropdown rolls back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)