### PR TITLE
Allow same team name across divisions; disambiguate dropdown labels

### DIFF
--- a/DropShot.UI/Components/Pages/CompetitionPage.razor
+++ b/DropShot.UI/Components/Pages/CompetitionPage.razor
@@ -946,12 +946,12 @@ else
                     {
                         <MudSelect T="int?" MultiSelection="true" @bind-SelectedValues="_filterTeamIds"
                                    Label="@teamColLabel" Variant="Variant.Outlined" Margin="Margin.Dense" Clearable="true"
-                                   ToStringFunc="@(id => id.HasValue ? (_teams.FirstOrDefault(t => t.CompetitionTeamId == id.Value)?.Name ?? id.Value.ToString()) : "(Unassigned)")"
+                                   ToStringFunc="@(id => id.HasValue ? (TeamLabel(_teams.FirstOrDefault(t => t.CompetitionTeamId == id.Value)) ?? id.Value.ToString()) : "(Unassigned)")"
                                    Style="min-width:160px">
                             <MudSelectItem T="int?" Value="@((int?)null)">(Unassigned)</MudSelectItem>
                             @foreach (var t in _teams)
                             {
-                                <MudSelectItem T="int?" Value="@((int?)t.CompetitionTeamId)">@t.Name</MudSelectItem>
+                                <MudSelectItem T="int?" Value="@((int?)t.CompetitionTeamId)">@TeamLabel(t)</MudSelectItem>
                             }
                         </MudSelect>
                     }
@@ -1088,10 +1088,11 @@ else
                             <MudTd>
                                 <MudSelect T="int?" Value="context.TeamId" Dense="true" Variant="Variant.Text"
                                            Clearable="true"
+                                           ToStringFunc="@(id => id.HasValue ? TeamLabel(_teams.FirstOrDefault(t => t.CompetitionTeamId == id.Value)) : "")"
                                            ValueChanged="@((int? tid) => AssignTeam(context, tid))">
                                     @foreach (var t in _teams)
                                     {
-                                        <MudSelectItem T="int?" Value="@((int?)t.CompetitionTeamId)">@t.Name</MudSelectItem>
+                                        <MudSelectItem T="int?" Value="@((int?)t.CompetitionTeamId)">@TeamLabel(t)</MudSelectItem>
                                     }
                                 </MudSelect>
                             </MudTd>
@@ -1626,19 +1627,21 @@ else
                 var teamLabel = IsDoublesFormat() ? "Pair" : "Team";
                 <MudItem xs="12" sm="6">
                     <MudSelect @bind-Value="_fixtureForm.HomeTeamId" Label="@($"Home {teamLabel}")"
-                               Variant="Variant.Outlined" Clearable="true">
+                               Variant="Variant.Outlined" Clearable="true"
+                               ToStringFunc="@(id => id.HasValue ? TeamLabel(_teams.FirstOrDefault(t => t.CompetitionTeamId == id.Value)) : "")">
                         @foreach (var t in _teams)
                         {
-                            <MudSelectItem T="int?" Value="@((int?)t.CompetitionTeamId)">@t.Name</MudSelectItem>
+                            <MudSelectItem T="int?" Value="@((int?)t.CompetitionTeamId)">@TeamLabel(t)</MudSelectItem>
                         }
                     </MudSelect>
                 </MudItem>
                 <MudItem xs="12" sm="6">
                     <MudSelect @bind-Value="_fixtureForm.AwayTeamId" Label="@($"Away {teamLabel}")"
-                               Variant="Variant.Outlined" Clearable="true">
+                               Variant="Variant.Outlined" Clearable="true"
+                               ToStringFunc="@(id => id.HasValue ? TeamLabel(_teams.FirstOrDefault(t => t.CompetitionTeamId == id.Value)) : "")">
                         @foreach (var t in _teams)
                         {
-                            <MudSelectItem T="int?" Value="@((int?)t.CompetitionTeamId)">@t.Name</MudSelectItem>
+                            <MudSelectItem T="int?" Value="@((int?)t.CompetitionTeamId)">@TeamLabel(t)</MudSelectItem>
                         }
                     </MudSelect>
                 </MudItem>
@@ -3564,6 +3567,23 @@ else
             return $"{divName} • {role}";
         }
         return role;
+    }
+
+    /// <summary>
+    /// Display label for a team in dropdowns. When the competition has
+    /// divisions, append the division name in parens so identically-named
+    /// teams across divisions (e.g. "Team A" in Div 1 and Div 2) stay
+    /// distinguishable. Returns an empty string when the team is missing
+    /// from the local cache so the dropdown doesn't render "null" / "0".
+    /// </summary>
+    private string TeamLabel(CompetitionTeamDto? team)
+    {
+        if (team is null) return "";
+        if (!Model.HasDivisions) return team.Name;
+        var divName = team.CompetitionDivisionId.HasValue
+            ? _divisions.FirstOrDefault(d => d.CompetitionDivisionId == team.CompetitionDivisionId.Value)?.Name
+            : null;
+        return string.IsNullOrEmpty(divName) ? team.Name : $"{team.Name} ({divName})";
     }
 
     private async Task PromoteParticipantAsync(CompetitionParticipantDto cp, int direction)

--- a/DropShot/Services/WebCompetitionAdminService.cs
+++ b/DropShot/Services/WebCompetitionAdminService.cs
@@ -1508,6 +1508,8 @@ public sealed class WebCompetitionAdminService(
             ?? throw new KeyNotFoundException("Team not found.");
         if (team.CompetitionId != competitionId)
             throw new InvalidOperationException("Team belongs to a different competition.");
+        await EnsureUniqueTeamNameAsync(db, competitionId, team.Name,
+            request.CompetitionDivisionId, teamId, ct);
         team.CompetitionDivisionId = request.CompetitionDivisionId;
         await db.SaveChangesAsync(ct);
     }
@@ -1524,16 +1526,14 @@ public sealed class WebCompetitionAdminService(
         await LoadAndAuthorizeAsync(db, competitionId, ct);
 
         var trimmed = request.Name.Trim();
-        var nameClash = await db.CompetitionTeams.AnyAsync(t =>
-            t.CompetitionId == competitionId
-            && t.Name == trimmed
-            && (teamId == null || t.CompetitionTeamId != teamId.Value), ct);
-        if (nameClash)
-            throw new InvalidOperationException(
-                $"A team named '{trimmed}' already exists in this competition.");
 
         if (teamId is null)
         {
+            // New team starts unassigned (division is set later via
+            // AssignTeamDivisionAsync, which re-runs the same check). Only
+            // clash with other unassigned teams here — two divisions can
+            // legitimately each have their own "Team A".
+            await EnsureUniqueTeamNameAsync(db, competitionId, trimmed, null, null, ct);
             var team = new CompetitionTeam { CompetitionId = competitionId, Name = trimmed };
             db.CompetitionTeams.Add(team);
             await db.SaveChangesAsync(ct);
@@ -1545,10 +1545,40 @@ public sealed class WebCompetitionAdminService(
                 ?? throw new KeyNotFoundException("Team not found.");
             if (row.CompetitionId != competitionId)
                 throw new InvalidOperationException("Team belongs to a different competition.");
+            await EnsureUniqueTeamNameAsync(db, competitionId, trimmed,
+                row.CompetitionDivisionId, teamId.Value, ct);
             row.Name = trimmed;
             await db.SaveChangesAsync(ct);
             return row.CompetitionTeamId;
         }
+    }
+
+    /// <summary>
+    /// Team names must be unique within a (competition, division) bucket —
+    /// the same name in two different divisions is fine (e.g. "Team A" in
+    /// Div 1 AND in Div 2) and the dropdown disambiguates by appending the
+    /// division name. <paramref name="excludeTeamId"/> skips the row being
+    /// renamed so a no-op save doesn't flag itself.
+    /// </summary>
+    private static async Task EnsureUniqueTeamNameAsync(
+        MyDbContext db, int competitionId, string name, int? divisionId,
+        int? excludeTeamId, CancellationToken ct)
+    {
+        var clash = await db.CompetitionTeams.AnyAsync(t =>
+            t.CompetitionId == competitionId
+            && t.Name == name
+            && t.CompetitionDivisionId == divisionId
+            && (excludeTeamId == null || t.CompetitionTeamId != excludeTeamId.Value), ct);
+        if (!clash) return;
+
+        var where = divisionId.HasValue
+            ? await db.CompetitionDivisions
+                .Where(d => d.CompetitionDivisionId == divisionId.Value)
+                .Select(d => $"division '{d.Name}'")
+                .FirstOrDefaultAsync(ct) ?? "this division"
+            : "the unassigned bucket";
+        throw new InvalidOperationException(
+            $"A team named '{name}' already exists in {where}.");
     }
 
     public async Task DeleteTeamAsync(int competitionId, int teamId, CancellationToken ct = default)


### PR DESCRIPTION
## Summary
Two divisions can each legitimately have their own \"Team A\" — that's not a duplicate, just two distinct teams that share a name. The recently-added uniqueness check was too strict (competition-wide) and the dropdown gave no way to tell them apart.

- Scope `SaveTeamAsync` and `AssignTeamDivisionAsync` uniqueness to `(competition, division)`. The same name across different divisions is allowed; the same name within one division is still rejected, with the error naming the destination division.
- Roster team dropdown, team filter, and fixture-form Home/Away selects now render \"Team A (Division 1)\" when the competition has divisions, via a shared `TeamLabel` helper. Non-division competitions render just the name as before.

## Test plan
- [ ] Create \"Team A\" in Div 1 and another \"Team A\" in Div 2 — both succeed.
- [ ] Try to create a second \"Team A\" in Div 1 — friendly error names the clashing division.
- [ ] Move a team named \"Team A\" from Div 2 into Div 1 (where one already lives) — friendly error, no DB change.
- [ ] Roster team dropdown shows \"Team A (Div 1)\" / \"Team A (Div 2)\" instead of two visually-identical rows.
- [ ] Non-division competition's dropdowns still show plain team names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)