### PR TITLE
SubmitScorePage: scale up on desktop

### DIFF
--- a/DropShot.UI/Components/Pages/SubmitScorePage.razor
+++ b/DropShot.UI/Components/Pages/SubmitScorePage.razor
@@ -3,7 +3,7 @@
 @inject ISiteAlertService SiteAlerts
 @inject IDialogService DialogService
 
-<MudContainer MaxWidth="MaxWidth.ExtraSmall" Class="pt-2 pb-4 submit-score-page">
+<MudContainer MaxWidth="MaxWidth.Small" Class="pt-2 pb-4 submit-score-page">
     @if (!_loaded)
     {
         <div class="d-flex justify-center"><MudProgressCircular Indeterminate="true" /></div>
@@ -136,6 +136,20 @@
             padding-right: 6px !important;
         }
         .submit-score-stack { max-width: 100%; }
+    }
+
+    /* On desktop the default mobile-sized layout looks cramped on a large
+       monitor. Scale up the column and the keypad / score cells so the page
+       fills the available space without losing its phone-first feel. */
+    @@media (min-width: 601px) {
+        .submit-score-stack { max-width: 480px; }
+        .score-cell { font-size: 1.2rem; min-height: 38px; padding: 5px 0; }
+        .set-row-active .score-cell { font-size: 2.2rem; min-height: 72px; padding: 14px 0; }
+        .score-cell.side-left, .score-cell.side-right { max-width: 120px; }
+        .keypad { gap: 10px; }
+        .keypad-key { height: 72px; font-size: 1.7rem; }
+        .keypad-tb { font-size: 1rem; }
+        .set-label { font-size: 1.1rem; }
     }
 
     .set-row {


### PR DESCRIPTION
## Summary

The new SubmitScorePage layout looks good on a phone but felt cramped on a desktop monitor — the column was capped at 360 px, keypad keys at 56 px, score cells at 1 rem. Add a `@media (min-width: 601px)` block that scales the layout up while keeping the mobile sizing unchanged.

## What changed

- Container promoted from `MaxWidth.ExtraSmall` (~444 px) to `MaxWidth.Small` (~600 px) so the wider stack isn't clipped.
- Stack `max-width: 480px` on desktop (was 360px).
- Score cells: 1.2rem / 38px when inactive; 2.2rem / 72px on the active row (was 1.0/30 and 1.8/56).
- Keypad keys: 72px tall, 1.7rem digit, 10px grid gap (was 56px / 1.4rem / 8px).
- "Set N" label and "Tie Break +" label bumped to match the new scale.

## Follow-up

The "apply this layout to Team-League scoring" half of the original request (`RubberScoreDialog`) is a larger refactor that needs its own PR — I'll do that next.

## Test plan

- [ ] Build (`dotnet build DropShot/DropShot.csproj`) succeeds.
- [ ] At >=601px viewport, the score column expands to ~480px and the keypad / score cells visibly enlarge.
- [ ] At <=600px viewport, sizes remain unchanged from before.
- [ ] All keypad interactions (digit press, ←, ✗, Tie Break +, ✓) still work and the pulsing animation on the tick is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)