### PR TITLE
RubberScoreDialog: port to the new tile + keypad layout

### DIFF
--- a/DropShot.UI/Components/Shared/RubberScoreDialog.razor
+++ b/DropShot.UI/Components/Shared/RubberScoreDialog.razor
@@ -1,4 +1,5 @@
 @inject ICompetitionService CompetitionService
+@inject IDialogService DialogService
 
 <MudDialog>
     <TitleContent>Enter rubber score</TitleContent>
@@ -13,69 +14,228 @@
         }
         else
         {
-            <MudStack Spacing="3">
-                <MudText Typo="Typo.body1">
-                    <strong>@_context.HomeTeamName</strong> vs <strong>@_context.AwayTeamName</strong>
-                </MudText>
-                <MudText Typo="Typo.caption" Color="Color.Secondary">
-                    @_rubber.Name
-                    <span>&nbsp;·&nbsp;</span>
-                    @(_context.MatchFormat == MatchFormatType.FixedSets ? $"{_bestOf} sets" : $"Best of {_bestOf}")
-                    <span>&nbsp;·&nbsp;</span>
-                    @($"{_context.GamesPerSet} games/set")
-                    <span>&nbsp;·&nbsp;</span>
-                    @(_context.SetWinMode == SetWinMode.WinBy2 ? "Win by 2" : "First to")
-                </MudText>
+            <MudStack Spacing="3" AlignItems="AlignItems.Center" Class="rubber-stack mx-auto">
 
-                <MudDivider />
+                <MudPaper Class="frosted-card pa-3 rubber-section" Elevation="0">
+                    <MudText Typo="Typo.subtitle1" Align="Align.Center">@_rubber.Name</MudText>
+                    <MudText Typo="Typo.body2" Align="Align.Center" Class="mt-1">
+                        <strong>@_context.HomeTeamName</strong> vs <strong>@_context.AwayTeamName</strong>
+                    </MudText>
+                    @{
+                        var homePair = string.Join(" & ", new[] { _rubber.HomePlayer1Name, _rubber.HomePlayer2Name }.Where(n => !string.IsNullOrEmpty(n)));
+                        var awayPair = string.Join(" & ", new[] { _rubber.AwayPlayer1Name, _rubber.AwayPlayer2Name }.Where(n => !string.IsNullOrEmpty(n)));
+                    }
+                    @if (!string.IsNullOrEmpty(homePair) || !string.IsNullOrEmpty(awayPair))
+                    {
+                        <MudText Typo="Typo.caption" Color="Color.Secondary" Align="Align.Center" Class="d-block mt-1">
+                            @(string.IsNullOrEmpty(homePair) ? "TBD" : homePair) — @(string.IsNullOrEmpty(awayPair) ? "TBD" : awayPair)
+                        </MudText>
+                    }
+                    <MudText Typo="Typo.caption" Color="Color.Secondary" Align="Align.Center" Class="d-block mt-1">
+                        @(_context.MatchFormat == MatchFormatType.FixedSets ? $"{_bestOf} sets" : $"Best of {_bestOf}")
+                        &nbsp;·&nbsp;@_context.GamesPerSet games/set
+                        &nbsp;·&nbsp;@(_context.SetWinMode == SetWinMode.WinBy2 ? "Win by 2" : "First to")
+                    </MudText>
+                </MudPaper>
 
-                <MudText Typo="Typo.subtitle2">Set scores</MudText>
-                <MudSimpleTable Dense="true" Style="max-width:320px">
-                    <thead>
-                        <tr>
-                            <th style="width:50px"></th>
-                            <th style="text-align:center">@_context.HomeTeamName</th>
-                            <th style="width:20px"></th>
-                            <th style="text-align:center">@_context.AwayTeamName</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        @for (int i = 0; i < _bestOf; i++)
+                @if (AdminOverride)
+                {
+                    <MudAlert Severity="Severity.Warning" Dense="true" Class="frosted-card rubber-section">
+                        Override Result — score validation is bypassed.
+                    </MudAlert>
+                }
+
+                <MudPaper Class="frosted-card pa-3 rubber-section" Elevation="0">
+                    @for (int i = 0; i < _bestOf; i++)
+                    {
+                        int idx = i;
+                        bool rowActive = idx == _activeSet && _focused;
+                        <div class="@($"rubber-set-row{(rowActive ? " rubber-set-row-active" : "")}")">
+                            <div></div>
+                            <button type="button"
+                                    class="@CellClass(idx, home: true)"
+                                    @onclick="@(() => SetActive(idx, true))">
+                                @(_home[idx]?.ToString() ?? "–")
+                            </button>
+                            <span class="rubber-set-label">Set @(idx + 1)</span>
+                            <button type="button"
+                                    class="@CellClass(idx, home: false)"
+                                    @onclick="@(() => SetActive(idx, false))">
+                                @(_away[idx]?.ToString() ?? "–")
+                            </button>
+                            <div class="rubber-set-status">
+                                @if (IsSetInvalid(idx))
+                                {
+                                    <MudIcon Icon="@Icons.Material.Filled.Close" Color="Color.Error" Size="Size.Small" />
+                                }
+                            </div>
+                        </div>
+                    }
+                </MudPaper>
+
+                <MudPaper Class="frosted-card pa-2 rubber-section" Elevation="0">
+                    <div class="rubber-keypad">
+                        @for (int n = 1; n <= 6; n++)
                         {
-                            int idx = i;
-                            <tr>
-                                <td style="color:#888">Set @(idx + 1)</td>
-                                <td>
-                                    <MudNumericField T="int?" Value="_home[idx]"
-                                                     ValueChanged="@(v => _home[idx] = v)"
-                                                     Variant="Variant.Outlined" Min="0" Max="@_setMaxInput"
-                                                     Style="width:80px" />
-                                </td>
-                                <td style="text-align:center; font-weight:bold">–</td>
-                                <td>
-                                    <MudNumericField T="int?" Value="_away[idx]"
-                                                     ValueChanged="@(v => _away[idx] = v)"
-                                                     Variant="Variant.Outlined" Min="0" Max="@_setMaxInput"
-                                                     Style="width:80px" />
-                                </td>
-                            </tr>
+                            int digit = n;
+                            <button type="button" class="rubber-key" @onclick="@(() => PressDigit(digit))">@digit</button>
                         }
-                    </tbody>
-                </MudSimpleTable>
+                        <button type="button" class="rubber-key rubber-key-control"
+                                @onclick="PressBack" aria-label="Previous field">
+                            <MudIcon Icon="@Icons.Material.Filled.ArrowBack" Size="Size.Medium" />
+                        </button>
+                        <button type="button" class="rubber-key" @onclick="@(() => PressDigit(7))">7</button>
+                        <button type="button" class="rubber-key rubber-key-tb"
+                                @onclick="OpenTieBreakDialogAsync"
+                                aria-label="Tie break — pick a number">
+                            Tie Break +
+                        </button>
+                        <button type="button" class="rubber-key rubber-key-cancel"
+                                @onclick="Cancel" disabled="@_saving"
+                                aria-label="Cancel">
+                            <MudIcon Icon="@Icons.Material.Filled.Close" Size="Size.Medium" />
+                        </button>
+                        <button type="button" class="rubber-key" @onclick="@(() => PressDigit(0))">0</button>
+                        @if (CanSubmit)
+                        {
+                            <button type="button" class="rubber-key rubber-key-submit"
+                                    @onclick="SubmitAsync" disabled="@_saving"
+                                    aria-label="Submit score">
+                                <MudIcon Icon="@Icons.Material.Filled.Check" Size="Size.Medium" />
+                            </button>
+                        }
+                    </div>
+                </MudPaper>
 
                 @if (!string.IsNullOrEmpty(_error))
                 {
-                    <MudAlert Severity="Severity.Error">@_error</MudAlert>
+                    <MudAlert Severity="Severity.Error" Class="frosted-card rubber-section">@_error</MudAlert>
                 }
             </MudStack>
         }
     </DialogContent>
-    <DialogActions>
-        <MudButton OnClick="Cancel">Cancel</MudButton>
-        <MudButton Color="Color.Primary" Variant="Variant.Filled"
-                   OnClick="SubmitAsync" Disabled="@(_saving || _loading || _context is null)">Submit</MudButton>
-    </DialogActions>
 </MudDialog>
+
+<style>
+    .rubber-stack { width: 100%; max-width: 380px; }
+    .rubber-section { width: 100%; }
+
+    @@media (min-width: 601px) {
+        .rubber-stack { max-width: 460px; }
+    }
+
+    .rubber-set-row {
+        display: grid;
+        grid-template-columns: 24px 1fr auto 1fr 24px;
+        align-items: center;
+        gap: 8px;
+        padding: 5px 0;
+    }
+    .rubber-set-row:first-child { padding-top: 0; }
+    .rubber-set-row:last-child  { padding-bottom: 0; }
+    .rubber-set-row + .rubber-set-row { border-top: 1px solid rgba(255,255,255,0.06); }
+    [data-theme="light"] .rubber-set-row + .rubber-set-row { border-top-color: rgba(0,0,0,0.08); }
+    .rubber-set-status { display: flex; align-items: center; justify-content: center; }
+
+    .rubber-score-cell {
+        font-weight: 600;
+        font-size: 1rem;
+        line-height: 1;
+        background: transparent;
+        border: 1px solid rgba(255,255,255,0.18);
+        color: inherit;
+        border-radius: 8px;
+        padding: 3px 0;
+        min-height: 30px;
+        cursor: pointer;
+        transition: background 120ms, border-color 120ms, color 120ms,
+                    font-size 150ms, min-height 150ms, padding 150ms;
+    }
+    .rubber-set-row-active .rubber-score-cell {
+        font-size: 1.6rem;
+        padding: 8px 0;
+        min-height: 52px;
+    }
+    .rubber-score-cell.side-left  { justify-self: end;   width: 100%; max-width: 90px; }
+    .rubber-score-cell.side-right { justify-self: start; width: 100%; max-width: 90px; }
+    [data-theme="light"] .rubber-score-cell { border-color: rgba(0,0,0,0.18); }
+    .rubber-score-cell.active {
+        border-color: var(--mud-palette-primary);
+        background: rgba(var(--mud-palette-primary-rgb, 25, 118, 210), 0.15);
+        color: var(--mud-palette-primary);
+    }
+    .rubber-score-cell.unentered { color: var(--mud-palette-text-disabled); opacity: 0.7; }
+    .rubber-score-cell.unentered.active { color: var(--mud-palette-primary); opacity: 1; }
+
+    .rubber-set-label {
+        font-size: 0.9rem;
+        color: var(--mud-palette-text-secondary);
+        white-space: nowrap;
+        padding: 0 4px;
+    }
+
+    .rubber-keypad {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 6px;
+    }
+    .rubber-key {
+        height: 50px;
+        font: 600 1.25rem/1 inherit;
+        background: rgba(255,255,255,0.08);
+        border: 1px solid rgba(255,255,255,0.12);
+        color: inherit;
+        border-radius: 9px;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transition: background 120ms;
+        padding: 0 6px;
+    }
+    [data-theme="light"] .rubber-key {
+        background: rgba(255,255,255,0.55);
+        border-color: rgba(0,0,0,0.1);
+    }
+    .rubber-key:hover { background: rgba(255,255,255,0.16); }
+    [data-theme="light"] .rubber-key:hover { background: rgba(255,255,255,0.85); }
+    .rubber-key:active { transform: scale(0.97); }
+    .rubber-key:disabled { opacity: 0.5; cursor: not-allowed; }
+    .rubber-key-tb { font-size: 0.8rem; letter-spacing: 0.2px; }
+
+    .rubber-key-submit,
+    [data-theme="light"] .rubber-key-submit {
+        background: var(--mud-palette-primary);
+        color: var(--mud-palette-primary-text);
+        border-color: var(--mud-palette-primary);
+        animation: rubber-submit-pulse 1.6s ease-out infinite;
+    }
+    .rubber-key-submit:hover,
+    [data-theme="light"] .rubber-key-submit:hover { background: var(--mud-palette-primary-darken); }
+    @@keyframes rubber-submit-pulse {
+        0%   { box-shadow: 0 0 0 0   rgba(var(--mud-palette-primary-rgb, 25, 118, 210), 0.65); }
+        70%  { box-shadow: 0 0 0 8px rgba(var(--mud-palette-primary-rgb, 25, 118, 210), 0);    }
+        100% { box-shadow: 0 0 0 0   rgba(var(--mud-palette-primary-rgb, 25, 118, 210), 0);    }
+    }
+    .rubber-key-cancel,
+    [data-theme="light"] .rubber-key-cancel {
+        background: var(--mud-palette-error);
+        color: var(--mud-palette-error-text);
+        border-color: var(--mud-palette-error);
+    }
+    .rubber-key-cancel:hover,
+    [data-theme="light"] .rubber-key-cancel:hover { background: var(--mud-palette-error-darken); }
+
+    @@media (min-width: 601px) {
+        .rubber-score-cell { font-size: 1.15rem; min-height: 36px; padding: 4px 0; }
+        .rubber-set-row-active .rubber-score-cell { font-size: 2rem; min-height: 64px; padding: 12px 0; }
+        .rubber-score-cell.side-left, .rubber-score-cell.side-right { max-width: 110px; }
+        .rubber-keypad { gap: 8px; }
+        .rubber-key { height: 60px; font-size: 1.5rem; }
+        .rubber-key-tb { font-size: 0.95rem; }
+        .rubber-set-label { font-size: 1rem; }
+    }
+</style>
 
 @code {
     [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = default!;
@@ -87,12 +247,18 @@
     private FixtureRubberContextDto? _context;
     private RubberDialogDto? _rubber;
     private int _bestOf = 3;
-    private int _setMaxInput = 20;
     private int?[] _home = new int?[3];
     private int?[] _away = new int?[3];
     private bool _saving;
     private bool _loading = true;
     private string? _error;
+
+    // Active cell + focus tracking (same model as SubmitScorePage).
+    private int _activeSet;
+    private bool _activeIsHome = true;
+    private bool _focused = true;
+
+    private bool _isLastCell => _activeSet == _bestOf - 1 && !_activeIsHome;
 
     protected override async Task OnInitializedAsync()
     {
@@ -104,7 +270,6 @@
             _bestOf = _context.MatchFormat == MatchFormatType.FixedSets
                 ? Math.Max(1, _context.NumberOfSets)
                 : Math.Max(1, _context.BestOf);
-            _setMaxInput = _context.GamesPerSet + 8;
             _home = new int?[_bestOf];
             _away = new int?[_bestOf];
 
@@ -114,15 +279,168 @@
                 _home[i] = _rubber.ExistingSetScores[i].Home;
                 _away[i] = _rubber.ExistingSetScores[i].Away;
             }
+
+            _activeSet = 0;
+            _activeIsHome = true;
+            _focused = true;
         }
 
         _loading = false;
     }
 
+    private string CellClass(int setIdx, bool home)
+    {
+        bool isActive = _focused && setIdx == _activeSet && home == _activeIsHome;
+        bool hasValue = (home ? _home[setIdx] : _away[setIdx]).HasValue;
+        return $"rubber-score-cell {(home ? "side-left" : "side-right")}{(isActive ? " active" : "")}{(hasValue ? "" : " unentered")}";
+    }
+
+    private void SetActive(int setIdx, bool home)
+    {
+        _activeSet = setIdx;
+        _activeIsHome = home;
+        _focused = true;
+        _error = null;
+    }
+
+    private int?[] ActiveArray => _activeIsHome ? _home : _away;
+
+    private void WriteAndAdvance(int value)
+    {
+        _error = null;
+        _focused = true;
+        ActiveArray[_activeSet] = value;
+        if (!_isLastCell)
+        {
+            AdvanceOne();
+        }
+        else
+        {
+            _focused = false;
+        }
+    }
+
+    private void PressDigit(int digit) => WriteAndAdvance(digit);
+
+    private void PressBack()
+    {
+        _error = null;
+        _focused = true;
+        var current = _activeIsHome ? _home : _away;
+        if (current[_activeSet].HasValue)
+        {
+            current[_activeSet] = null;
+            return;
+        }
+        if (_activeIsHome)
+        {
+            if (_activeSet == 0) return;
+            _activeSet--;
+            _activeIsHome = false;
+        }
+        else
+        {
+            _activeIsHome = true;
+        }
+        (_activeIsHome ? _home : _away)[_activeSet] = null;
+    }
+
+    private void AdvanceOne()
+    {
+        if (_activeIsHome)
+        {
+            _activeIsHome = false;
+        }
+        else if (_activeSet < _bestOf - 1)
+        {
+            _activeSet++;
+            _activeIsHome = true;
+        }
+    }
+
+    private async Task OpenTieBreakDialogAsync()
+    {
+        int? otherSide = _activeIsHome ? _away[_activeSet] : _home[_activeSet];
+        var parameters = new DialogParameters<TieBreakPickerDialog>
+        {
+            { x => x.HighlightValue, otherSide }
+        };
+        var dialog = await DialogService.ShowAsync<TieBreakPickerDialog>("Tie break score", parameters);
+        var result = await dialog.Result;
+        if (result is { Canceled: false, Data: int picked })
+        {
+            WriteAndAdvance(picked);
+        }
+    }
+
+    private void Cancel() => MudDialog.Cancel();
+
+    // Rubbers don't have the final-set tie-break setting, so only the
+    // regular set rules apply.
+    private bool IsSetInvalid(int idx)
+    {
+        if (_context is null) return false;
+        if (!_home[idx].HasValue || !_away[idx].HasValue) return false;
+        int a = _home[idx]!.Value, b = _away[idx]!.Value;
+        if (a == b) return true;
+        return !ScorePassesRegularSetRules(a, b);
+    }
+
+    private bool ScorePassesRegularSetRules(int a, int b)
+    {
+        int target = _context!.GamesPerSet;
+        int winner = Math.Max(a, b), loser = Math.Min(a, b);
+        if (_context.SetWinMode == SetWinMode.FirstTo)
+        {
+            return winner == target && loser < target;
+        }
+        if (winner < target) return false;
+        if (winner == target) return loser <= target - 2;
+        if (winner == target + 1) return loser == target - 1 || loser == target;
+        return loser == winner - 2;
+    }
+
+    private bool CanSubmit
+    {
+        get
+        {
+            if (_context is null || _saving) return false;
+            if (AdminOverride)
+            {
+                for (int i = 0; i < _bestOf; i++)
+                    if (_home[i].HasValue || _away[i].HasValue) return true;
+                return false;
+            }
+
+            int s1 = 0, s2 = 0;
+            for (int i = 0; i < _bestOf; i++)
+            {
+                bool hasA = _home[i].HasValue;
+                bool hasB = _away[i].HasValue;
+                if (hasA != hasB) return false;
+                if (IsSetInvalid(i)) return false;
+                if (hasA && hasB)
+                {
+                    if (_home[i] > _away[i]) s1++;
+                    else if (_away[i] > _home[i]) s2++;
+                }
+            }
+
+            if (_context.MatchFormat == MatchFormatType.FixedSets)
+            {
+                for (int i = 0; i < _bestOf; i++)
+                    if (!_home[i].HasValue || !_away[i].HasValue) return false;
+                return true;
+            }
+
+            int targetWins = (_bestOf / 2) + 1;
+            return s1 >= targetWins || s2 >= targetWins;
+        }
+    }
+
     private async Task SubmitAsync()
     {
         if (_context is null || _rubber is null) return;
-
         _error = null;
 
         var entered = Enumerable.Range(0, _bestOf)
@@ -141,44 +459,12 @@
         {
             if (!_home[i].HasValue || !_away[i].HasValue) continue;
             int h = _home[i]!.Value, a = _away[i]!.Value;
-            if (h == a) { _error = $"Set {i + 1}: scores are tied."; return; }
 
-            if (!AdminOverride)
+            if (!AdminOverride && IsSetInvalid(i))
             {
-                int winner = Math.Max(h, a);
-                int loser = Math.Min(h, a);
-                int gps = _context.GamesPerSet;
-                if (_context.SetWinMode == SetWinMode.FirstTo)
-                {
-                    if (winner != gps)
-                    {
-                        _error = $"Set {i + 1}: winner must reach exactly {gps} games (First to mode).";
-                        return;
-                    }
-                    if (loser >= gps)
-                    {
-                        _error = $"Set {i + 1}: loser cannot have {loser} games when target is {gps}.";
-                        return;
-                    }
-                }
-                else
-                {
-                    if (winner < gps)
-                    {
-                        _error = $"Set {i + 1}: winner must have at least {gps} games.";
-                        return;
-                    }
-                    if (winner == gps && loser > gps - 2)
-                    {
-                        _error = $"Set {i + 1}: at {gps} games, opponent can have at most {gps - 2} (Win by 2). Use {gps + 1}-{gps} for a tie-break.";
-                        return;
-                    }
-                    if (winner > gps && Math.Abs(h - a) != 1 && Math.Abs(h - a) != 2)
-                    {
-                        _error = $"Set {i + 1}: above {gps}-all the margin must be 1 (tie-break) or 2 (extended).";
-                        return;
-                    }
-                }
+                _error = $"Set {i + 1}: score is not valid for a {_context.GamesPerSet}-game " +
+                         $"({(_context.SetWinMode == SetWinMode.WinBy2 ? "Win by 2" : "First to")}) set.";
+                return;
             }
 
             homeGames += h; awayGames += a;
@@ -216,6 +502,4 @@
             _saving = false;
         }
     }
-
-    private void Cancel() => MudDialog.Cancel();
 }


### PR DESCRIPTION
## Summary

Follow-up to #710. The team-league per-rubber scoring dialog (`RubberScoreDialog`) was still on the **old** layout — MudSimpleTable with two MudNumericFields per set. Rebuild it on the **same tile + keypad model** that SubmitScorePage uses so team matches feel consistent with the singles/doubles flow.

## What's new

- **Header card** with the rubber name, team vs team, doubles pair names, and the competition's scoring rules.
- **Frosted-card set list**: each row renders `{home} Set X {away}`. The active set's row enlarges via `_focused` + `.rubber-set-row-active`; the rest shrink. Unentered cells render `–` muted; invalid sets get a red ✗ on the right (same `IsSetInvalid` predicate as the singles page).
- **Keypad** (1–7 / 0 / `←` / `Tie Break +` / ✗ / ✓):
  - Digit press writes the active cell and auto-advances.
  - `←` clears the current cell or rewinds to the previous one (same semantics as `SubmitScorePage`).
  - `Tie Break +` opens the existing `TieBreakPickerDialog` for 8–99 with the opposing side's score pre-highlighted.
  - ✗ is the red cancel key (closes the dialog).
  - ✓ only renders when `CanSubmit` is true; pulses to draw the eye; submits via the existing pipeline.
- **Focus handoff** — after writing the final cell `_focused` drops so the cell's active highlight clears and the row shrinks to match the others.
- **Desktop scaling** — a `@media (min-width: 601px)` block bumps cell + key sizes so the dialog feels good on a desktop monitor as well as a phone.

## What's NOT changed

- `RubberDialogDto` / `FixtureRubberContextDto` shape — same DTOs.
- `SubmitRubberScoresRequest` + `SubmitRubberScoresAsync` submit pipeline.
- Validation rules — rubbers don't carry the final-set tie-break setting (that's a singles/doubles-only field), so the dialog only uses the regular set rules. The tightened "Win-by-2" rule from #691 is applied via `ScorePassesRegularSetRules` so `16-15` and friends fail.
- The bulk "enter all rubbers at once" dialog (`BulkRubberScoreDialog`) is left on its existing layout for now — that's a separate refactor.

## Test plan

- [ ] Build (`dotnet build DropShot/DropShot.csproj`) succeeds.
- [ ] From the TeamMatchScoring page, open a rubber → new tile / keypad layout appears.
- [ ] Enter a full match (`6-4 6-4`) → tick appears, pulses, submitting closes the dialog and updates the rubber.
- [ ] `←` clears the just-typed cell on the final position; rewinds on earlier positions.
- [ ] Tie Break + opens the picker with the opposing side highlighted.
- [ ] ✗ cancels and closes without saving.
- [ ] Re-opening a rubber that already has scores re-populates the cells from `ExistingSetScores`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)