### PR TITLE
Rubber score page: move RubberId to a query string

### DIFF
--- a/DropShot.UI/Components/Pages/TeamMatchScoring.razor
+++ b/DropShot.UI/Components/Pages/TeamMatchScoring.razor
@@ -223,7 +223,7 @@ else
         var returnUrl = $"/team-match/{FixtureId}";
         var admin = _isCompetitionAdmin ? "&admin=1" : "";
         Navigation.NavigateTo(
-            $"/team-match/{FixtureId}/rubber/{rubber.RubberId}/submit?returnUrl={Uri.EscapeDataString(returnUrl)}{admin}");
+            $"/team-match/{FixtureId}/rubber-submit?rubberId={rubber.RubberId}&returnUrl={Uri.EscapeDataString(returnUrl)}{admin}");
     }
 
     private RenderFragment RenderRubber(RubberDialogDto rubber) => __builder =>

--- a/DropShot/Components/Pages/RubberScorePage.razor
+++ b/DropShot/Components/Pages/RubberScorePage.razor
@@ -1,12 +1,23 @@
-@page "/team-match/{FixtureId:int}/rubber/{RubberId:int}/submit"
+@page "/team-match/{FixtureId:int}/rubber-submit"
 @using Microsoft.AspNetCore.Authorization
 @attribute [Authorize]
 @rendermode InteractiveServer
+@inject NavigationManager Navigation
 
 <MudProviders />
-<DropShot.UI.Components.Pages.RubberScorePage FixtureId="@FixtureId" RubberId="@RubberId" />
+<DropShot.UI.Components.Pages.RubberScorePage FixtureId="@FixtureId" RubberId="@_rubberId" />
 
 @code {
     [Parameter] public int FixtureId { get; set; }
-    [Parameter] public int RubberId { get; set; }
+
+    private int _rubberId;
+
+    protected override void OnParametersSet()
+    {
+        // Single-int route parameter pattern is the only shape this codebase
+        // relies on for shim binding; carry the rubber id in a query string
+        // instead of as a second route segment.
+        var query = System.Web.HttpUtility.ParseQueryString(new Uri(Navigation.Uri).Query);
+        if (int.TryParse(query["rubberId"], out var v)) _rubberId = v;
+    }
 }


### PR DESCRIPTION
## Summary

You reported that clicking the rubber-score button on a team match was redirecting back to the home page instead of opening the new rubber score page.

The new shim from #712 used **two adjacent int route parameters**:

```
/team-match/{FixtureId:int}/rubber/{RubberId:int}/submit
```

Every other working shim in this codebase uses a single int route parameter. Whether the issue is Blazor's router, the production reverse proxy, or some interaction with the existing `/team-match/{FixtureId:int}` route, the simplest fix is to match the shape the rest of the codebase already uses.

## Fix

New route:

```
/team-match/{FixtureId:int}/rubber-submit?rubberId={RubberId}
```

The shim reads `rubberId` from the query string in `OnParametersSet` and passes it to the UI component exactly as before — no other code changes are needed on the page side. `TeamMatchScoring.EnterRubberScore`'s navigation is updated to match.

The bulk page (`/team-match/{FixtureId:int}/submit-all`) already uses a single int route parameter and is unaffected.

## Test plan

- [ ] Build succeeds.
- [ ] Click "Enter score" on a rubber from the team-match page → navigates to the new rubber score page and renders the tile + keypad layout.
- [ ] Submitting / cancelling returns to `/team-match/{FixtureId}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)