### PR TITLE
Rubber score nav: forceLoad to bypass enhanced navigation

### DIFF
--- a/DropShot.UI/Components/Pages/TeamMatchScoring.razor
+++ b/DropShot.UI/Components/Pages/TeamMatchScoring.razor
@@ -214,8 +214,11 @@ else
     {
         var returnUrl = $"/team-match/{FixtureId}";
         var admin = _isCompetitionAdmin ? "&admin=1" : "";
+        // forceLoad bypasses Blazor enhanced navigation. We saw the rubber
+        // page nav fall back to the team-match page intermittently otherwise.
         Navigation.NavigateTo(
-            $"/team-match/{FixtureId}/submit-all?returnUrl={Uri.EscapeDataString(returnUrl)}{admin}");
+            $"/team-match/{FixtureId}/submit-all?returnUrl={Uri.EscapeDataString(returnUrl)}{admin}",
+            forceLoad: true);
     }
 
     private void EnterRubberScore(RubberDialogDto rubber)
@@ -223,7 +226,8 @@ else
         var returnUrl = $"/team-match/{FixtureId}";
         var admin = _isCompetitionAdmin ? "&admin=1" : "";
         Navigation.NavigateTo(
-            $"/team-match/{FixtureId}/rubber-submit?rubberId={rubber.RubberId}&returnUrl={Uri.EscapeDataString(returnUrl)}{admin}");
+            $"/team-match/{FixtureId}/rubber-submit?rubberId={rubber.RubberId}&returnUrl={Uri.EscapeDataString(returnUrl)}{admin}",
+            forceLoad: true);
     }
 
     private RenderFragment RenderRubber(RubberDialogDto rubber) => __builder =>


### PR DESCRIPTION
## Summary

You reported the rubber-score navigation still being **intermittent** after #713 — sometimes you'd see `/team-match/{id}` briefly in the address bar and then get bounced to the home page, other times the new page opened correctly.

This is a classic Blazor **enhanced navigation** failure mode. Enhanced nav patches the DOM rather than triggering a real browser navigation; if the patch fails — circuit out of sync, particular server instance hasn't loaded the new shim yet, transient SignalR drop — Blazor falls back to *something* that can look like the page you're on (`/team-match/{id}`) before bouncing.

## Fix

Pass `forceLoad: true` on both navigations from `TeamMatchScoring`:

```csharp
Navigation.NavigateTo($"/team-match/{FixtureId}/rubber-submit?…", forceLoad: true);
Navigation.NavigateTo($"/team-match/{FixtureId}/submit-all?…",  forceLoad: true);
```

`forceLoad: true` bypasses enhanced nav and triggers a normal full-page browser navigation. The new shim is fetched fresh from the server, and routing happens without depending on whichever circuit state Blazor was holding. The cost is one extra round-trip (basically negligible).

The two reverse navigations from the new pages back to `/team-match/{id}` keep the default behaviour — that route is already cached on the client.

## Test plan

- [ ] Build succeeds.
- [ ] Click "Enter score" repeatedly on different rubbers in a team match → every click lands on the new rubber score page (no bounces to home).
- [ ] Click "Enter all rubber scores" → opens the bulk page.
- [ ] On submit / cancel, both pages return to `/team-match/{id}` as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)