### PR TITLE
Rubber score: move pages off /team-match/ prefix entirely

### DIFF
--- a/DropShot.UI/Components/Pages/TeamMatchScoring.razor
+++ b/DropShot.UI/Components/Pages/TeamMatchScoring.razor
@@ -214,10 +214,12 @@ else
     {
         var returnUrl = $"/team-match/{FixtureId}";
         var admin = _isCompetitionAdmin ? "&admin=1" : "";
-        // forceLoad bypasses Blazor enhanced navigation. We saw the rubber
-        // page nav fall back to the team-match page intermittently otherwise.
+        // Use a route prefix that doesn't share any segments with /team-match/
+        // so server-side routing can never collide with TeamMatchScoring,
+        // which redirects to home when CanScoreMatch is briefly false during
+        // load.
         Navigation.NavigateTo(
-            $"/team-match/{FixtureId}/submit-all?returnUrl={Uri.EscapeDataString(returnUrl)}{admin}",
+            $"/score-all-rubbers?fixtureId={FixtureId}&returnUrl={Uri.EscapeDataString(returnUrl)}{admin}",
             forceLoad: true);
     }
 
@@ -226,7 +228,7 @@ else
         var returnUrl = $"/team-match/{FixtureId}";
         var admin = _isCompetitionAdmin ? "&admin=1" : "";
         Navigation.NavigateTo(
-            $"/team-match/{FixtureId}/rubber-submit?rubberId={rubber.RubberId}&returnUrl={Uri.EscapeDataString(returnUrl)}{admin}",
+            $"/score-rubber?fixtureId={FixtureId}&rubberId={rubber.RubberId}&returnUrl={Uri.EscapeDataString(returnUrl)}{admin}",
             forceLoad: true);
     }
 

--- a/DropShot/Components/Pages/BulkRubberScorePage.razor
+++ b/DropShot/Components/Pages/BulkRubberScorePage.razor
@@ -1,11 +1,18 @@
-@page "/team-match/{FixtureId:int}/submit-all"
+@page "/score-all-rubbers"
 @using Microsoft.AspNetCore.Authorization
 @attribute [Authorize]
 @rendermode InteractiveServer
+@inject NavigationManager Navigation
 
 <MudProviders />
-<DropShot.UI.Components.Pages.BulkRubberScorePage FixtureId="@FixtureId" />
+<DropShot.UI.Components.Pages.BulkRubberScorePage FixtureId="@_fixtureId" />
 
 @code {
-    [Parameter] public int FixtureId { get; set; }
+    private int _fixtureId;
+
+    protected override void OnParametersSet()
+    {
+        var query = System.Web.HttpUtility.ParseQueryString(new Uri(Navigation.Uri).Query);
+        if (int.TryParse(query["fixtureId"], out var f)) _fixtureId = f;
+    }
 }

--- a/DropShot/Components/Pages/RubberScorePage.razor
+++ b/DropShot/Components/Pages/RubberScorePage.razor
@@ -1,23 +1,24 @@
-@page "/team-match/{FixtureId:int}/rubber-submit"
+@page "/score-rubber"
 @using Microsoft.AspNetCore.Authorization
 @attribute [Authorize]
 @rendermode InteractiveServer
 @inject NavigationManager Navigation
 
 <MudProviders />
-<DropShot.UI.Components.Pages.RubberScorePage FixtureId="@FixtureId" RubberId="@_rubberId" />
+<DropShot.UI.Components.Pages.RubberScorePage FixtureId="@_fixtureId" RubberId="@_rubberId" />
 
 @code {
-    [Parameter] public int FixtureId { get; set; }
-
+    private int _fixtureId;
     private int _rubberId;
 
     protected override void OnParametersSet()
     {
-        // Single-int route parameter pattern is the only shape this codebase
-        // relies on for shim binding; carry the rubber id in a query string
-        // instead of as a second route segment.
+        // Both ids come from the query string. We used to use route parameters
+        // but the /team-match/{int}/... shape was clashing with the existing
+        // TeamMatchScoring route on the server side and intermittently routing
+        // users to the wrong page.
         var query = System.Web.HttpUtility.ParseQueryString(new Uri(Navigation.Uri).Query);
-        if (int.TryParse(query["rubberId"], out var v)) _rubberId = v;
+        if (int.TryParse(query["fixtureId"], out var f)) _fixtureId = f;
+        if (int.TryParse(query["rubberId"], out var r)) _rubberId = r;
     }
 }


### PR DESCRIPTION
## Summary

You reported the rubber score nav still bouncing to home intermittently after the `forceLoad: true` change. After re-examining `TeamMatchScoring.razor`, here's what's actually happening:

```csharp
// TeamMatchScoring.OnInitializedAsync
if (!CurrentUser.CanScoreMatch)
{
    Navigation.NavigateTo("/", replace: true);   // <-- THIS is the redirect to home
}
```

That happens whenever the user's `CanScoreMatch` returns false during page load — which can transiently happen during a fresh SignalR/auth state load. When server-side routing **mistakenly** matched the rubber-submit URL to TeamMatchScoring (because of the shared `/team-match/{FixtureId:int}` prefix on the route templates), this redirect to `"/"` fired exactly as you described.

## Fix

Move both pages off the `/team-match/` prefix entirely — no shared segments, no possible route collision:

```
/score-rubber?fixtureId=X&rubberId=Y&returnUrl=...
/score-all-rubbers?fixtureId=X&returnUrl=...
```

All ids ride in the query string; the shim parses them in `OnParametersSet` and passes them into the existing UI components unchanged. `TeamMatchScoring`'s nav helpers are updated to point at the new paths (still with `forceLoad: true` from #714 for good measure).

## Test plan

- [ ] Build succeeds.
- [ ] Click "Enter score" on a rubber repeatedly → every click lands on the new rubber score page. No bounces to home.
- [ ] Click "Enter all rubber scores" → opens the bulk page.
- [ ] Submit / cancel both return to `/team-match/{id}` as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)