### PR TITLE
Scoring pages: confirm before discarding entered scores on cancel

### DIFF
--- a/DropShot.UI/Components/Pages/BulkRubberScorePage.razor
+++ b/DropShot.UI/Components/Pages/BulkRubberScorePage.razor
@@ -414,7 +414,22 @@
         }
     }
 
-    private void Cancel() => Navigation.NavigateTo(_returnUrl);
+    private async Task Cancel()
+    {
+        bool anyEntered = false;
+        for (int r = 0; r < _rubbers.Count && !anyEntered; r++)
+            for (int i = 0; i < _bestOf; i++)
+                if (_home[r][i].HasValue || _away[r][i].HasValue) { anyEntered = true; break; }
+        if (anyEntered)
+        {
+            var confirmed = await DialogService.ShowMessageBoxAsync(
+                "Discard scores?",
+                "You've entered scores that haven't been submitted yet. Leave anyway?",
+                yesText: "Discard", cancelText: "Stay");
+            if (confirmed != true) return;
+        }
+        Navigation.NavigateTo(_returnUrl);
+    }
 
     private bool IsSetInvalid(int rubberIdx, int idx)
     {

--- a/DropShot.UI/Components/Pages/RubberScorePage.razor
+++ b/DropShot.UI/Components/Pages/RubberScorePage.razor
@@ -379,7 +379,21 @@
         }
     }
 
-    private void Cancel() => Navigation.NavigateTo(_returnUrl);
+    private async Task Cancel()
+    {
+        bool anyEntered = false;
+        for (int i = 0; i < _bestOf; i++)
+            if (_home[i].HasValue || _away[i].HasValue) { anyEntered = true; break; }
+        if (anyEntered)
+        {
+            var confirmed = await DialogService.ShowMessageBoxAsync(
+                "Discard scores?",
+                "You've entered scores that haven't been submitted yet. Leave anyway?",
+                yesText: "Discard", cancelText: "Stay");
+            if (confirmed != true) return;
+        }
+        Navigation.NavigateTo(_returnUrl);
+    }
 
     private bool IsSetInvalid(int idx)
     {

--- a/DropShot.UI/Components/Pages/SubmitScorePage.razor
+++ b/DropShot.UI/Components/Pages/SubmitScorePage.razor
@@ -586,7 +586,23 @@
         }
     }
 
-    private void Cancel() => Navigation.NavigateTo(_returnUrl);
+    private async Task Cancel()
+    {
+        // If any cell has been entered, double-check before throwing away the
+        // user's work. Untouched pages cancel without a prompt.
+        bool anyEntered = false;
+        for (int i = 0; i < _bestOf; i++)
+            if (_score1[i].HasValue || _score2[i].HasValue) { anyEntered = true; break; }
+        if (anyEntered)
+        {
+            var confirmed = await DialogService.ShowMessageBoxAsync(
+                "Discard scores?",
+                "You've entered scores that haven't been submitted yet. Leave anyway?",
+                yesText: "Discard", cancelText: "Stay");
+            if (confirmed != true) return;
+        }
+        Navigation.NavigateTo(_returnUrl);
+    }
 
     private async Task SubmitAsync()
     {


### PR DESCRIPTION
## Summary

The red cancel cross on the keypad currently fires `Navigation.NavigateTo(_returnUrl)` immediately — one mis-tap and the user loses a half-typed match. Add a confirmation MessageBox that only appears when at least one cell has been entered; cancelling an untouched page still navigates silently.

```text
┌──────────────────────────────────────────────────┐
│  Discard scores?                                 │
│                                                  │
│  You've entered scores that haven't been         │
│  submitted yet. Leave anyway?                    │
│                                                  │
│             [Discard]      [Stay]                │
└──────────────────────────────────────────────────┘
```

Applied to all three scoring pages:

- `SubmitScorePage` (singles / doubles)
- `RubberScorePage` (single team rubber)
- `BulkRubberScorePage` (all rubbers in one match — the prompt checks across every rubber)

## Test plan

- [ ] Build (`dotnet build DropShot/DropShot.csproj`) succeeds.
- [ ] Open a scoring page without entering anything → red cross navigates back immediately, no prompt.
- [ ] Enter at least one cell → red cross opens the confirmation. "Stay" keeps you on the page; "Discard" navigates back to `returnUrl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)