### PR TITLE
Team-match scoring: gate page on participant/admin, not subscription

### DIFF
--- a/DropShot.Shared/Dtos/CompetitionDtos.cs
+++ b/DropShot.Shared/Dtos/CompetitionDtos.cs
@@ -536,7 +536,12 @@ public record FixtureRubberContextDto(
     bool IsAlreadyFinalised,
     IReadOnlyList<RubberDialogDto> Rubbers,
     LeagueScoringMode LeagueScoring = LeagueScoringMode.WinPoints,
-    int? HostClubId = null);
+    int? HostClubId = null,
+    // True when the calling user is allowed to score this fixture — i.e.
+    // they're a competition admin OR a participant on one of the two
+    // teams. Pages that exist solely for score entry redirect home when
+    // this is false so non-participants can't open them by URL.
+    bool CanUserScore = false);
 
 public record RubberDialogDto(
     int RubberId,

--- a/DropShot.UI/Components/Pages/BulkRubberScorePage.razor
+++ b/DropShot.UI/Components/Pages/BulkRubberScorePage.razor
@@ -287,6 +287,11 @@
 
         _context = await CompetitionService.GetFixtureRubberContextAsync(FixtureId);
         if (_context is null) { _loading = false; return; }
+        if (!_context.CanUserScore)
+        {
+            Navigation.NavigateTo("/", replace: true);
+            return;
+        }
 
         _bestOf = _context.MatchFormat == MatchFormatType.FixedSets
             ? Math.Max(1, _context.NumberOfSets)

--- a/DropShot.UI/Components/Pages/RubberScorePage.razor
+++ b/DropShot.UI/Components/Pages/RubberScorePage.razor
@@ -277,6 +277,11 @@
         _context = await CompetitionService.GetFixtureRubberContextAsync(FixtureId);
         _rubber = _context?.Rubbers.FirstOrDefault(r => r.RubberId == RubberId);
 
+        if (_context is not null && !_context.CanUserScore)
+        {
+            Navigation.NavigateTo("/", replace: true);
+            return;
+        }
         if (_context is not null && _rubber is not null)
         {
             _bestOf = _context.MatchFormat == MatchFormatType.FixedSets

--- a/DropShot.UI/Components/Pages/TeamMatchScoring.razor
+++ b/DropShot.UI/Components/Pages/TeamMatchScoring.razor
@@ -158,6 +158,15 @@ else
         _context = await CompetitionService.GetFixtureRubberContextAsync(FixtureId);
         if (_context is not null)
         {
+            // Score-entry pages are reachable only by admins on the host club
+            // and by participants on either team. A logged-in stranger who
+            // types the URL gets bounced home — matches the server-side
+            // check on SubmitRubberScores.
+            if (!_context.CanUserScore)
+            {
+                Navigation.NavigateTo("/", replace: true);
+                return;
+            }
             _isCompetitionAdmin = CurrentUser.CanEditCompetition(_context.HostClubId);
             ComputeScores();
         }

--- a/DropShot/Services/WebCompetitionService.cs
+++ b/DropShot/Services/WebCompetitionService.cs
@@ -550,6 +550,33 @@ public sealed class WebCompetitionService(
         if (fx is null) return null;
 
         var comp = fx.Competition;
+
+        // Compute whether the calling user is allowed to score this fixture.
+        // The pages that exist solely for score entry redirect home when this
+        // is false so a logged-in non-participant can't reach them by URL.
+        // Mirrors the controller-level check in SubmitRubberScores.
+        bool canUserScore = false;
+        var principal = await GetPrincipalAsync();
+        if (await authzService.CanEditCompetitionAsync(principal, comp?.HostClubId, fx.CompetitionId))
+        {
+            canUserScore = true;
+        }
+        else if (!string.IsNullOrEmpty(currentUser.UserId))
+        {
+            var myPlayerId = await db.Players.AsNoTracking()
+                .Where(p => p.UserId == currentUser.UserId)
+                .Select(p => (int?)p.PlayerId)
+                .FirstOrDefaultAsync(ct);
+            if (myPlayerId is { } pid)
+            {
+                canUserScore = await db.CompetitionParticipants.AsNoTracking()
+                    .AnyAsync(cp => cp.CompetitionId == fx.CompetitionId
+                        && cp.PlayerId == pid
+                        && cp.TeamId.HasValue
+                        && (cp.TeamId == fx.HomeTeamId || cp.TeamId == fx.AwayTeamId), ct);
+            }
+        }
+
         var rubbers = fx.Rubbers
             .OrderBy(r => r.Order)
             .Select(r => new RubberDialogDto(
@@ -583,7 +610,8 @@ public sealed class WebCompetitionService(
                 || fx.Status == FixtureStatus.Completed,
             rubbers,
             comp?.LeagueScoring ?? LeagueScoringMode.WinPoints,
-            comp?.HostClubId);
+            comp?.HostClubId,
+            CanUserScore: canUserScore);
     }
 
     public async Task EnsureFixtureRubbersAsync(int fixtureId, CancellationToken ct = default)


### PR DESCRIPTION
## Summary

Good catch — #717 fixed your multi-role redirect but did so too broadly. Any logged-in user could load the team-match scoring page (and the rubber-score pages reached through it) for any fixture ID, even one they had nothing to do with. Server-side `SubmitRubberScores` still rejected the actual save, but the UI was wrong: a stranger could see the rubbers, click buttons, and only find out at submit time.

## Fix

Server-side, compute a per-call `CanUserScore` flag and put it on `FixtureRubberContextDto`. It mirrors the existing `SubmitRubberScores` controller check exactly:

```csharp
bool canUserScore = false;
if (await authzService.CanEditCompetitionAsync(principal, comp?.HostClubId, fx.CompetitionId))
    canUserScore = true;
else if (currentUser.UserId is { } uid)
{
    var myPlayerId = …;
    canUserScore = await db.CompetitionParticipants
        .AnyAsync(cp => cp.CompetitionId == fx.CompetitionId
            && cp.PlayerId == myPlayerId
            && cp.TeamId.HasValue
            && (cp.TeamId == fx.HomeTeamId || cp.TeamId == fx.AwayTeamId), ct);
}
```

All three pages (`TeamMatchScoring`, `RubberScorePage`, `BulkRubberScorePage`) read the flag right after loading their context and redirect to `/` if it's false.

| User                                       | Page behaviour          |
| ------------------------------------------ | ----------------------- |
| Anonymous                                  | Redirected to `/Account/Login` (Authorize on shim) |
| Logged-in stranger                         | **Redirected to `/`** (CanUserScore == false) |
| Logged-in participant (plain User role)    | Page loads               |
| Logged-in admin / club admin               | Page loads               |
| Multi-role user acting as plain User       | Page loads if they're a participant; bounced if not |

`RubberScoreDialog` (used only by the token-authenticated `VerifyResult` admin-edit flow) is unaffected — it doesn't check the flag.

## Test plan

- [ ] Build succeeds.
- [ ] As a participant on either team, click the fixture from home → page loads.
- [ ] As a competition / club admin → page loads.
- [ ] As a logged-in user with no connection to the fixture, paste the URL `/team-match/{id}` → redirected to home immediately.
- [ ] Paste `/score-rubber?fixtureId=X&rubberId=Y` for a fixture you're not on → redirected to home.
- [ ] Paste `/score-all-rubbers?fixtureId=X` for the same → redirected to home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)