### PR TITLE
Scoring page shims: disable prerendering to stop the load flicker

### DIFF
--- a/DropShot/Components/Pages/BulkRubberScorePage.razor
+++ b/DropShot/Components/Pages/BulkRubberScorePage.razor
@@ -1,7 +1,8 @@
 @page "/score-all-rubbers"
 @using Microsoft.AspNetCore.Authorization
 @attribute [Authorize]
-@rendermode InteractiveServer
+@* Prerender disabled — see RubberScorePage shim for rationale. *@
+@rendermode @(new InteractiveServerRenderMode(prerender: false))
 @inject NavigationManager Navigation
 
 <MudProviders />

--- a/DropShot/Components/Pages/RubberScorePage.razor
+++ b/DropShot/Components/Pages/RubberScorePage.razor
@@ -1,7 +1,10 @@
 @page "/score-rubber"
 @using Microsoft.AspNetCore.Authorization
 @attribute [Authorize]
-@rendermode InteractiveServer
+@* Skip prerendering — the OnParametersSetAsync fetch otherwise runs twice
+   (once during SSR, once when the interactive circuit takes over) and the
+   loading skeleton briefly re-appears, producing a visible flicker. *@
+@rendermode @(new InteractiveServerRenderMode(prerender: false))
 @inject NavigationManager Navigation
 
 <MudProviders />

--- a/DropShot/Components/Pages/SubmitScorePage.razor
+++ b/DropShot/Components/Pages/SubmitScorePage.razor
@@ -1,7 +1,8 @@
 @page "/match/submit/{FixtureId:int}"
 @using Microsoft.AspNetCore.Authorization
 @attribute [Authorize]
-@rendermode InteractiveServer
+@* Prerender disabled — see RubberScorePage shim for rationale. *@
+@rendermode @(new InteractiveServerRenderMode(prerender: false))
 
 <MudProviders />
 <DropShot.UI.Components.Pages.SubmitScorePage FixtureId="@FixtureId" />

--- a/DropShot/Components/Pages/TeamMatchScoring.razor
+++ b/DropShot/Components/Pages/TeamMatchScoring.razor
@@ -1,7 +1,9 @@
 @page "/team-match/{FixtureId:int}"
 @using Microsoft.AspNetCore.Authorization
 @attribute [Authorize]
-@rendermode InteractiveServer
+@* Prerender disabled — the OnInitializedAsync load otherwise runs twice
+   (SSR + interactive handoff) and flashes the loading skeleton. *@
+@rendermode @(new InteractiveServerRenderMode(prerender: false))
 
 <MudProviders />
 


### PR DESCRIPTION
## Summary

You noticed scoring pages load and then "quickly flicker once". That's Blazor Server prerendering. With `@rendermode InteractiveServer` (the default, which is `prerender: true`), every page runs its `OnInitializedAsync` / `OnParametersSetAsync` **twice**:

1. Once during SSR — fetch finishes, fully populated HTML is sent to the browser.
2. Once again after the SignalR circuit takes over — the load runs from scratch.

Between steps 1 and 2 the loading-spinner branch briefly re-appears, which is the flicker.

## Fix

Switch the four scoring shims to `@rendermode @(new InteractiveServerRenderMode(prerender: false))`:

- `/match/submit/{FixtureId:int}` — singles / doubles
- `/team-match/{FixtureId:int}` — team-match overview
- `/score-rubber` — single rubber score entry
- `/score-all-rubbers` — bulk rubber score entry

The page now waits for the interactive circuit before running its load. `OnParametersSetAsync` runs once, the loading state paints once, and the flicker goes away. Trade-off is a small amount of extra latency before first paint — fine for auth-gated pages where SSR-fast first paint isn't a goal.

## Test plan

- [ ] Build succeeds.
- [ ] Open each of the four scoring pages → loading spinner appears, scoring UI replaces it, no second flicker.
- [ ] Refresh each page → same.
- [ ] All existing functionality (score entry, cancel confirm, tick submit, etc.) still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)