### PR TITLE
Scoring pages: bigger desktop scaling, plus an XL tier at 961px+

### DIFF
--- a/DropShot.UI/Components/Pages/BulkRubberScorePage.razor
+++ b/DropShot.UI/Components/Pages/BulkRubberScorePage.razor
@@ -3,7 +3,7 @@
 @inject NavigationManager Navigation
 @inject ISiteAlertService SiteAlerts
 
-<MudContainer MaxWidth="MaxWidth.Small" Class="pt-2 pb-4 rubber-page">
+<MudContainer MaxWidth="MaxWidth.Medium" Class="pt-2 pb-4 rubber-page">
     @if (_loading)
     {
         <div class="d-flex justify-center"><MudProgressCircular Indeterminate="true" /></div>
@@ -135,14 +135,24 @@
         .rubber-stack { max-width: 100%; }
     }
     @@media (min-width: 601px) {
-        .rubber-stack { max-width: 520px; }
-        .rubber-score-cell { font-size: 1.2rem; min-height: 38px; padding: 5px 0; }
-        .rubber-set-row-active .rubber-score-cell { font-size: 2rem; min-height: 64px; padding: 12px 0; }
-        .rubber-score-cell.side-left, .rubber-score-cell.side-right { max-width: 120px; }
+        .rubber-stack { max-width: 540px; }
+        .rubber-score-cell { font-size: 1.3rem; min-height: 42px; padding: 6px 0; }
+        .rubber-set-row-active .rubber-score-cell { font-size: 2.2rem; min-height: 72px; padding: 14px 0; }
+        .rubber-score-cell.side-left, .rubber-score-cell.side-right { max-width: 130px; }
         .rubber-keypad { gap: 10px; }
-        .rubber-key { height: 64px; font-size: 1.6rem; }
-        .rubber-key-tb { font-size: 0.95rem; }
-        .rubber-set-label { font-size: 1.05rem; }
+        .rubber-key { height: 72px; font-size: 1.8rem; }
+        .rubber-key-tb { font-size: 1rem; }
+        .rubber-set-label { font-size: 1.15rem; }
+    }
+    @@media (min-width: 961px) {
+        .rubber-stack { max-width: 680px; }
+        .rubber-score-cell { font-size: 1.5rem; min-height: 50px; padding: 8px 0; }
+        .rubber-set-row-active .rubber-score-cell { font-size: 2.6rem; min-height: 88px; padding: 18px 0; }
+        .rubber-score-cell.side-left, .rubber-score-cell.side-right { max-width: 160px; }
+        .rubber-keypad { gap: 12px; }
+        .rubber-key { height: 88px; font-size: 2rem; }
+        .rubber-key-tb { font-size: 1.15rem; }
+        .rubber-set-label { font-size: 1.25rem; }
     }
 
     .rubber-set-row {

--- a/DropShot.UI/Components/Pages/RubberScorePage.razor
+++ b/DropShot.UI/Components/Pages/RubberScorePage.razor
@@ -3,7 +3,7 @@
 @inject NavigationManager Navigation
 @inject ISiteAlertService SiteAlerts
 
-<MudContainer MaxWidth="MaxWidth.Small" Class="pt-2 pb-4 rubber-page">
+<MudContainer MaxWidth="MaxWidth.Medium" Class="pt-2 pb-4 rubber-page">
     @if (_loading)
     {
         <div class="d-flex justify-center"><MudProgressCircular Indeterminate="true" /></div>
@@ -128,14 +128,24 @@
         .rubber-stack { max-width: 100%; }
     }
     @@media (min-width: 601px) {
-        .rubber-stack { max-width: 480px; }
-        .rubber-score-cell { font-size: 1.2rem; min-height: 38px; padding: 5px 0; }
-        .rubber-set-row-active .rubber-score-cell { font-size: 2.2rem; min-height: 72px; padding: 14px 0; }
-        .rubber-score-cell.side-left, .rubber-score-cell.side-right { max-width: 120px; }
+        .rubber-stack { max-width: 500px; }
+        .rubber-score-cell { font-size: 1.3rem; min-height: 42px; padding: 6px 0; }
+        .rubber-set-row-active .rubber-score-cell { font-size: 2.4rem; min-height: 80px; padding: 16px 0; }
+        .rubber-score-cell.side-left, .rubber-score-cell.side-right { max-width: 130px; }
         .rubber-keypad { gap: 10px; }
-        .rubber-key { height: 72px; font-size: 1.7rem; }
-        .rubber-key-tb { font-size: 1rem; }
-        .rubber-set-label { font-size: 1.1rem; }
+        .rubber-key { height: 80px; font-size: 1.9rem; }
+        .rubber-key-tb { font-size: 1.05rem; }
+        .rubber-set-label { font-size: 1.15rem; }
+    }
+    @@media (min-width: 961px) {
+        .rubber-stack { max-width: 640px; }
+        .rubber-score-cell { font-size: 1.5rem; min-height: 50px; padding: 8px 0; }
+        .rubber-set-row-active .rubber-score-cell { font-size: 3rem; min-height: 96px; padding: 20px 0; }
+        .rubber-score-cell.side-left, .rubber-score-cell.side-right { max-width: 160px; }
+        .rubber-keypad { gap: 12px; }
+        .rubber-key { height: 96px; font-size: 2.2rem; }
+        .rubber-key-tb { font-size: 1.2rem; }
+        .rubber-set-label { font-size: 1.3rem; }
     }
 
     .rubber-set-row {

--- a/DropShot.UI/Components/Pages/SubmitScorePage.razor
+++ b/DropShot.UI/Components/Pages/SubmitScorePage.razor
@@ -3,7 +3,7 @@
 @inject ISiteAlertService SiteAlerts
 @inject IDialogService DialogService
 
-<MudContainer MaxWidth="MaxWidth.Small" Class="pt-2 pb-4 submit-score-page">
+<MudContainer MaxWidth="MaxWidth.Medium" Class="pt-2 pb-4 submit-score-page">
     @if (!_loaded)
     {
         <div class="d-flex justify-center"><MudProgressCircular Indeterminate="true" /></div>
@@ -140,16 +140,27 @@
 
     /* On desktop the default mobile-sized layout looks cramped on a large
        monitor. Scale up the column and the keypad / score cells so the page
-       fills the available space without losing its phone-first feel. */
+       fills the available space without losing its phone-first feel. The
+       tablet tier kicks in at 601px and a larger desktop tier at 961px. */
     @@media (min-width: 601px) {
-        .submit-score-stack { max-width: 480px; }
-        .score-cell { font-size: 1.2rem; min-height: 38px; padding: 5px 0; }
-        .set-row-active .score-cell { font-size: 2.2rem; min-height: 72px; padding: 14px 0; }
-        .score-cell.side-left, .score-cell.side-right { max-width: 120px; }
+        .submit-score-stack { max-width: 500px; }
+        .score-cell { font-size: 1.3rem; min-height: 42px; padding: 6px 0; }
+        .set-row-active .score-cell { font-size: 2.4rem; min-height: 80px; padding: 16px 0; }
+        .score-cell.side-left, .score-cell.side-right { max-width: 130px; }
         .keypad { gap: 10px; }
-        .keypad-key { height: 72px; font-size: 1.7rem; }
-        .keypad-tb { font-size: 1rem; }
-        .set-label { font-size: 1.1rem; }
+        .keypad-key { height: 80px; font-size: 1.9rem; }
+        .keypad-tb { font-size: 1.05rem; }
+        .set-label { font-size: 1.15rem; }
+    }
+    @@media (min-width: 961px) {
+        .submit-score-stack { max-width: 640px; }
+        .score-cell { font-size: 1.5rem; min-height: 50px; padding: 8px 0; }
+        .set-row-active .score-cell { font-size: 3rem; min-height: 96px; padding: 20px 0; }
+        .score-cell.side-left, .score-cell.side-right { max-width: 160px; }
+        .keypad { gap: 12px; }
+        .keypad-key { height: 96px; font-size: 2.2rem; }
+        .keypad-tb { font-size: 1.2rem; }
+        .set-label { font-size: 1.3rem; }
     }
 
     .set-row {


### PR DESCRIPTION
## Summary

The previous "scale up on desktop" PR (#710) bumped the column from 360 → 480 px and the keys from 56 → 72 px, but two things kept the desktop layout looking tiny:

1. The `MudContainer` was still `MaxWidth.Small` (~600 px) — the stack literally couldn't grow past that.
2. The bump from 480 px column / 72 px keys to anything bigger never happened on real desktop monitors.

This PR fixes both.

## Changes

- Promote the container from `MaxWidth.Small` to `MaxWidth.Medium` (~900 px). Stack has room to grow.
- Replace the single 601 px breakpoint with a two-tier ramp:

| Breakpoint           | Stack max | Active score | Inactive score | Key size      |
| -------------------- | --------- | ------------ | -------------- | ------------- |
| Mobile (≤600 px)     | 100%      | 1.8 rem/56 px | 1 rem/30 px    | 56 px/1.4 rem |
| Tablet (≥601 px)     | 500 px    | 2.4 rem/80 px | 1.3 rem/42 px  | 80 px/1.9 rem |
| Desktop (≥961 px)    | 640 px    | 3 rem/96 px   | 1.5 rem/50 px  | 96 px/2.2 rem |

Side-cell max-widths, gaps, and the "Set N" / "Tie Break +" label sizes scale proportionally.

Applied to all three scoring pages (`SubmitScorePage`, `RubberScorePage`, `BulkRubberScorePage`). The bulk page's stack is a touch wider at each tier so multi-rubber cards get more breathing room (540 / 680 px).

Mobile is unchanged.

## Test plan

- [ ] Build (`dotnet build DropShot/DropShot.csproj`) succeeds.
- [ ] Open SubmitScorePage at 1920 px desktop → score column is ~640 px wide, active-row scores read at ~3 rem, keypad keys ~96 px tall.
- [ ] Resize to ~800 px tablet width → column shrinks to ~500 px, scores ~2.4 rem.
- [ ] Resize to mobile width (≤600 px) → unchanged from before.
- [ ] Same for `/score-rubber` and `/score-all-rubbers`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)