### PR TITLE
BulkRubberScorePage: stop scrollIntoView hiding rubbers under the navbar

### DIFF
--- a/DropShot.UI/Components/Pages/BulkRubberScorePage.razor
+++ b/DropShot.UI/Components/Pages/BulkRubberScorePage.razor
@@ -137,6 +137,11 @@
     .rubber-stack { width: 100%; max-width: 380px; }
     .rubber-section { width: 100%; }
 
+    /* The top navbar is position: sticky, so scrollIntoView lands rubber
+       cards under it unless we tell the browser to leave room. ~80px covers
+       the navbar on mobile. */
+    .rubber-section { scroll-margin-top: 80px; }
+
     /* Rubber state: completed cards stay at full opacity (you can scroll back
        to verify), the active card is the one above the keypad (already
        highlighted via .rubber-set-row-active inside). Upcoming cards are


### PR DESCRIPTION
## Summary

On mobile, finishing one rubber and having the next one scroll up was parking the top of the new rubber under the sticky top navbar, so the scores were hidden.

`scrollIntoView({block: 'start'})` aligns the element's top with the viewport's `y=0`, not the visible viewport top. Since the navbar is `position: sticky`, it overlaps that area.

## Fix

Add `scroll-margin-top: 80px` to `.rubber-section`. CSS `scroll-margin-top` tells the browser "leave this much space at the top of this element when scrolling it into view." Browsers honour it for both programmatic `scrollIntoView` and link-fragment jumps, with no JS changes needed.

80 px is enough to clear the navbar at typical mobile sizes and still puts the rubber card close to the top.

## Test plan

- [ ] Build succeeds.
- [ ] On a phone-sized viewport, fill the first rubber's scores. When auto-advance jumps to rubber 2, the rubber 2 card lands fully visible **below** the top navbar — the rubber name and scores are no longer hidden.
- [ ] Tapping any cell in any other rubber still scrolls that rubber into view, same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)