### PR TITLE
BulkRubberScorePage: nudge scroll-margin-top up to 90px

### DIFF
--- a/DropShot.UI/Components/Pages/BulkRubberScorePage.razor
+++ b/DropShot.UI/Components/Pages/BulkRubberScorePage.razor
@@ -138,9 +138,9 @@
     .rubber-section { width: 100%; }
 
     /* The top navbar is position: sticky, so scrollIntoView lands rubber
-       cards under it unless we tell the browser to leave room. ~80px covers
-       the navbar on mobile. */
-    .rubber-section { scroll-margin-top: 80px; }
+       cards under it unless we tell the browser to leave room. ~90px covers
+       the navbar on mobile with a small visual gap. */
+    .rubber-section { scroll-margin-top: 90px; }
 
     /* Rubber state: completed cards stay at full opacity (you can scroll back
        to verify), the active card is the one above the keypad (already


### PR DESCRIPTION
Follow-up to #725. The 80 px landing position was still hiding the rubber title under the navbar by ~5-10 px. Bump scroll-margin-top to 90 px so the card sits cleanly below the bar with a small visual gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)