### PR TITLE
BulkRubberScorePage: scroll-margin-top 90px -> 110px

### DIFF
--- a/DropShot.UI/Components/Pages/BulkRubberScorePage.razor
+++ b/DropShot.UI/Components/Pages/BulkRubberScorePage.razor
@@ -138,9 +138,10 @@
     .rubber-section { width: 100%; }
 
     /* The top navbar is position: sticky, so scrollIntoView lands rubber
-       cards under it unless we tell the browser to leave room. ~90px covers
-       the navbar on mobile with a small visual gap. */
-    .rubber-section { scroll-margin-top: 90px; }
+       cards under it unless we tell the browser to leave room. 110px covers
+       the navbar on mobile (including the role banner when it's visible)
+       with a comfortable visual gap. */
+    .rubber-section { scroll-margin-top: 110px; }
 
     /* Rubber state: completed cards stay at full opacity (you can scroll back
        to verify), the active card is the one above the keypad (already


### PR DESCRIPTION
Follow-up. 90 px was still a touch high — 110 px gives the card more breathing room below the navbar (and the role banner if it's present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)