### PR TITLE
Footer: link About, Support, and What's New

### DIFF
--- a/DropShot/Components/Layout/Footer.razor
+++ b/DropShot/Components/Layout/Footer.razor
@@ -5,12 +5,15 @@
                 <MudText Typo="Typo.subtitle2" Class="footer-heading mb-2">Product</MudText>
                 <div class="footer-links">
                     <MudLink Href="/features" Color="Color.Inherit" Typo="Typo.body2">Features</MudLink>
+                    <MudLink Href="/whats-new" Color="Color.Inherit" Typo="Typo.body2">What's New</MudLink>
                 </div>
             </MudItem>
 
             <MudItem xs="6" sm="4">
                 <MudText Typo="Typo.subtitle2" Class="footer-heading mb-2">Resources</MudText>
                 <div class="footer-links">
+                    <MudLink Href="/about" Color="Color.Inherit" Typo="Typo.body2">About</MudLink>
+                    <MudLink Href="/support" Color="Color.Inherit" Typo="Typo.body2">Support</MudLink>
                     <MudLink Href="/contact" Color="Color.Inherit" Typo="Typo.body2">Contact</MudLink>
                 </div>
             </MudItem>


### PR DESCRIPTION
## Summary
The About, Support, and What's New content pages had no link anywhere in the UI — they were only reachable by typing the URL directly. This adds them to the footer:

- **Product** → Features, What's New
- **Resources** → About, Support, Contact

Also gives Google internal links to crawl these pages for indexing (relevant to the pending AdSense review).

## Test plan
- [x] `dotnet build` succeeds
- [ ] Confirm footer links resolve on the deployed site

🤖 Generated with [Claude Code](https://claude.com/claude-code)