### PR TITLE
Support FAQ: working accordions + frosted styling

### DIFF
--- a/DropShot.UI/Components/Pages/Features.razor
+++ b/DropShot.UI/Components/Pages/Features.razor
@@ -19,37 +19,37 @@
     </MudStack>
     <MudGrid Spacing="3">
         <MudItem xs="12" sm="6" md="4">
-            <MudCard Outlined="true" Class="pa-4" Style="height:100%">
+            <MudCard Class="pa-4 frosted-card" Style="height:100%">
                 <MudText Typo="Typo.subtitle1"><strong>Real-Time Point Tracking</strong></MudText>
                 <MudText Typo="Typo.body2" Class="mt-1">Score matches point-by-point with standard tennis rules, including deuce, advantage, and tiebreak handling.</MudText>
             </MudCard>
         </MudItem>
         <MudItem xs="12" sm="6" md="4">
-            <MudCard Outlined="true" Class="pa-4" Style="height:100%">
+            <MudCard Class="pa-4 frosted-card" Style="height:100%">
                 <MudText Typo="Typo.subtitle1"><strong>Singles &amp; Doubles</strong></MudText>
                 <MudText Typo="Typo.body2" Class="mt-1">Full support for singles and doubles matches, with team assignment and up to four players per match.</MudText>
             </MudCard>
         </MudItem>
         <MudItem xs="12" sm="6" md="4">
-            <MudCard Outlined="true" Class="pa-4" Style="height:100%">
+            <MudCard Class="pa-4 frosted-card" Style="height:100%">
                 <MudText Typo="Typo.subtitle1"><strong>Flexible Rules</strong></MudText>
                 <MudText Typo="Typo.body2" Class="mt-1">Choose best-of-1 or best-of-3 sets, no-ad deuce, or game-scoring mode. Customise rules to suit your format.</MudText>
             </MudCard>
         </MudItem>
         <MudItem xs="12" sm="6" md="4">
-            <MudCard Outlined="true" Class="pa-4" Style="height:100%">
+            <MudCard Class="pa-4 frosted-card" Style="height:100%">
                 <MudText Typo="Typo.subtitle1"><strong>Step-by-Step Match Setup</strong></MudText>
                 <MudText Typo="Typo.body2" Class="mt-1">A guided wizard walks you through match type, player selection, and rules before play begins.</MudText>
             </MudCard>
         </MudItem>
         <MudItem xs="12" sm="6" md="4">
-            <MudCard Outlined="true" Class="pa-4" Style="height:100%">
+            <MudCard Class="pa-4 frosted-card" Style="height:100%">
                 <MudText Typo="Typo.subtitle1"><strong>Fuzzy Player Search</strong></MudText>
                 <MudText Typo="Typo.body2" Class="mt-1">Find and assign players quickly with intelligent name-matching across your entire player list.</MudText>
             </MudCard>
         </MudItem>
         <MudItem xs="12" sm="6" md="4">
-            <MudCard Outlined="true" Class="pa-4" Style="height:100%">
+            <MudCard Class="pa-4 frosted-card" Style="height:100%">
                 <MudText Typo="Typo.subtitle1"><strong>Saved Match History</strong></MudText>
                 <MudText Typo="Typo.body2" Class="mt-1">Every match is saved automatically so you can review scores, players, and results any time.</MudText>
             </MudCard>
@@ -64,31 +64,31 @@
     </MudStack>
     <MudGrid Spacing="3">
         <MudItem xs="12" sm="6" md="4">
-            <MudCard Outlined="true" Class="pa-4" Style="height:100%">
+            <MudCard Class="pa-4 frosted-card" Style="height:100%">
                 <MudText Typo="Typo.subtitle1"><strong>Default Scoreboard</strong></MudText>
                 <MudText Typo="Typo.body2" Class="mt-1">A clean, minimalist display showing points, games, sets, and serve indicator. Perfect for courtside screens.</MudText>
             </MudCard>
         </MudItem>
         <MudItem xs="12" sm="6" md="4">
-            <MudCard Outlined="true" Class="pa-4" Style="height:100%">
+            <MudCard Class="pa-4 frosted-card" Style="height:100%">
                 <MudText Typo="Typo.subtitle1"><strong>Wimbledon-Style Scoreboard</strong></MudText>
                 <MudText Typo="Typo.body2" Class="mt-1">A broadcast-quality columnar layout with elapsed match time and high-contrast styling for large displays.</MudText>
             </MudCard>
         </MudItem>
         <MudItem xs="12" sm="6" md="4">
-            <MudCard Outlined="true" Class="pa-4" Style="height:100%">
+            <MudCard Class="pa-4 frosted-card" Style="height:100%">
                 <MudText Typo="Typo.subtitle1"><strong>Multi-Court Display Control</strong></MudText>
                 <MudText Typo="Typo.body2" Class="mt-1">Manage scoreboards across multiple courts from a single admin screen. Switch layouts and toggle fullscreen per court.</MudText>
             </MudCard>
         </MudItem>
         <MudItem xs="12" sm="6" md="4">
-            <MudCard Outlined="true" Class="pa-4" Style="height:100%">
+            <MudCard Class="pa-4 frosted-card" Style="height:100%">
                 <MudText Typo="Typo.subtitle1"><strong>YouTube Live Stream Overlay</strong></MudText>
                 <MudText Typo="Typo.body2" Class="mt-1">Embed a YouTube stream URL to overlay live video with your scoreboard for broadcast and streaming.</MudText>
             </MudCard>
         </MudItem>
         <MudItem xs="12" sm="6" md="4">
-            <MudCard Outlined="true" Class="pa-4" Style="height:100%">
+            <MudCard Class="pa-4 frosted-card" Style="height:100%">
                 <MudText Typo="Typo.subtitle1"><strong>Live Sync via SignalR</strong></MudText>
                 <MudText Typo="Typo.body2" Class="mt-1">Scoreboards update in real time across every connected screen. No refresh needed.</MudText>
             </MudCard>
@@ -103,37 +103,37 @@
     </MudStack>
     <MudGrid Spacing="3">
         <MudItem xs="12" sm="6" md="4">
-            <MudCard Outlined="true" Class="pa-4" Style="height:100%">
+            <MudCard Class="pa-4 frosted-card" Style="height:100%">
                 <MudText Typo="Typo.subtitle1"><strong>Multiple Formats</strong></MudText>
                 <MudText Typo="Typo.body2" Class="mt-1">Run singles, doubles, mixed doubles, or team competitions with customisable eligibility criteria.</MudText>
             </MudCard>
         </MudItem>
         <MudItem xs="12" sm="6" md="4">
-            <MudCard Outlined="true" Class="pa-4" Style="height:100%">
+            <MudCard Class="pa-4 frosted-card" Style="height:100%">
                 <MudText Typo="Typo.subtitle1"><strong>Multi-Stage Brackets</strong></MudText>
                 <MudText Typo="Typo.body2" Class="mt-1">Set up round-robin groups flowing into knockout rounds, quarter-finals, semi-finals, and finals.</MudText>
             </MudCard>
         </MudItem>
         <MudItem xs="12" sm="6" md="4">
-            <MudCard Outlined="true" Class="pa-4" Style="height:100%">
+            <MudCard Class="pa-4 frosted-card" Style="height:100%">
                 <MudText Typo="Typo.subtitle1"><strong>Automatic Progression</strong></MudText>
                 <MudText Typo="Typo.body2" Class="mt-1">Winners advance through bracket stages automatically as results are verified, keeping your tournament moving.</MudText>
             </MudCard>
         </MudItem>
         <MudItem xs="12" sm="6" md="4">
-            <MudCard Outlined="true" Class="pa-4" Style="height:100%">
+            <MudCard Class="pa-4 frosted-card" Style="height:100%">
                 <MudText Typo="Typo.subtitle1"><strong>Fixture Scheduling</strong></MudText>
                 <MudText Typo="Typo.body2" Class="mt-1">Assign fixtures to specific dates, times, and courts. Use scheduling templates to auto-allocate slots.</MudText>
             </MudCard>
         </MudItem>
         <MudItem xs="12" sm="6" md="4">
-            <MudCard Outlined="true" Class="pa-4" Style="height:100%">
+            <MudCard Class="pa-4 frosted-card" Style="height:100%">
                 <MudText Typo="Typo.subtitle1"><strong>Result Verification</strong></MudText>
                 <MudText Typo="Typo.body2" Class="mt-1">A two-tier system lets players submit results and admins quick-approve or fully review with a complete audit trail.</MudText>
             </MudCard>
         </MudItem>
         <MudItem xs="12" sm="6" md="4">
-            <MudCard Outlined="true" Class="pa-4" Style="height:100%">
+            <MudCard Class="pa-4 frosted-card" Style="height:100%">
                 <MudText Typo="Typo.subtitle1"><strong>Participant &amp; Team Management</strong></MudText>
                 <MudText Typo="Typo.body2" Class="mt-1">Register individual players or create teams. Track status from registration through to withdrawal.</MudText>
             </MudCard>
@@ -148,19 +148,19 @@
     </MudStack>
     <MudGrid Spacing="3">
         <MudItem xs="12" sm="6" md="4">
-            <MudCard Outlined="true" Class="pa-4" Style="height:100%">
+            <MudCard Class="pa-4 frosted-card" Style="height:100%">
                 <MudText Typo="Typo.subtitle1"><strong>Event Grouping</strong></MudText>
                 <MudText Typo="Typo.body2" Class="mt-1">Bundle related competitions into a single event, making it easy for players to browse and enter.</MudText>
             </MudCard>
         </MudItem>
         <MudItem xs="12" sm="6" md="4">
-            <MudCard Outlined="true" Class="pa-4" Style="height:100%">
+            <MudCard Class="pa-4 frosted-card" Style="height:100%">
                 <MudText Typo="Typo.subtitle1"><strong>Event Details</strong></MudText>
                 <MudText Typo="Typo.body2" Class="mt-1">Set event names, descriptions, date ranges, and host clubs to keep everything organised in one place.</MudText>
             </MudCard>
         </MudItem>
         <MudItem xs="12" sm="6" md="4">
-            <MudCard Outlined="true" Class="pa-4" Style="height:100%">
+            <MudCard Class="pa-4 frosted-card" Style="height:100%">
                 <MudText Typo="Typo.subtitle1"><strong>Smart Stage Suggestions</strong></MudText>
                 <MudText Typo="Typo.body2" Class="mt-1">When creating competitions within an event, DropShot suggests appropriate stage structures based on participant numbers.</MudText>
             </MudCard>
@@ -175,31 +175,31 @@
     </MudStack>
     <MudGrid Spacing="3">
         <MudItem xs="12" sm="6" md="4">
-            <MudCard Outlined="true" Class="pa-4" Style="height:100%">
+            <MudCard Class="pa-4 frosted-card" Style="height:100%">
                 <MudText Typo="Typo.subtitle1"><strong>Club Profiles</strong></MudText>
                 <MudText Typo="Typo.body2" Class="mt-1">Create and manage club details including address, contact information, and website.</MudText>
             </MudCard>
         </MudItem>
         <MudItem xs="12" sm="6" md="4">
-            <MudCard Outlined="true" Class="pa-4" Style="height:100%">
+            <MudCard Class="pa-4 frosted-card" Style="height:100%">
                 <MudText Typo="Typo.subtitle1"><strong>Court Management</strong></MudText>
                 <MudText Typo="Typo.body2" Class="mt-1">Add courts with surface type (hard, clay, grass, carpet) and indoor/outdoor designation.</MudText>
             </MudCard>
         </MudItem>
         <MudItem xs="12" sm="6" md="4">
-            <MudCard Outlined="true" Class="pa-4" Style="height:100%">
+            <MudCard Class="pa-4 frosted-card" Style="height:100%">
                 <MudText Typo="Typo.subtitle1"><strong>Scheduling Templates</strong></MudText>
                 <MudText Typo="Typo.body2" Class="mt-1">Define available match windows per court and day of week, then reuse them across competitions.</MudText>
             </MudCard>
         </MudItem>
         <MudItem xs="12" sm="6" md="4">
-            <MudCard Outlined="true" Class="pa-4" Style="height:100%">
+            <MudCard Class="pa-4 frosted-card" Style="height:100%">
                 <MudText Typo="Typo.subtitle1"><strong>Club Administrators</strong></MudText>
                 <MudText Typo="Typo.body2" Class="mt-1">Designate admins with edit permissions for club-level management without needing full system access.</MudText>
             </MudCard>
         </MudItem>
         <MudItem xs="12" sm="6" md="4">
-            <MudCard Outlined="true" Class="pa-4" Style="height:100%">
+            <MudCard Class="pa-4 frosted-card" Style="height:100%">
                 <MudText Typo="Typo.subtitle1"><strong>Email Templates</strong></MudText>
                 <MudText Typo="Typo.body2" Class="mt-1">Customise email notifications at the club level for result submissions, verifications, and announcements.</MudText>
             </MudCard>
@@ -214,31 +214,31 @@
     </MudStack>
     <MudGrid Spacing="3">
         <MudItem xs="12" sm="6" md="4">
-            <MudCard Outlined="true" Class="pa-4" Style="height:100%">
+            <MudCard Class="pa-4 frosted-card" Style="height:100%">
                 <MudText Typo="Typo.subtitle1"><strong>Player Profiles</strong></MudText>
                 <MudText Typo="Typo.body2" Class="mt-1">Full profiles with display name, contact details, date of birth, and avatar. Edit your own from your account page.</MudText>
             </MudCard>
         </MudItem>
         <MudItem xs="12" sm="6" md="4">
-            <MudCard Outlined="true" Class="pa-4" Style="height:100%">
+            <MudCard Class="pa-4 frosted-card" Style="height:100%">
                 <MudText Typo="Typo.subtitle1"><strong>My Players List</strong></MudText>
                 <MudText Typo="Typo.body2" Class="mt-1">Maintain your own list of players you regularly play with. Quick-add light profiles or link to verified accounts.</MudText>
             </MudCard>
         </MudItem>
         <MudItem xs="12" sm="6" md="4">
-            <MudCard Outlined="true" Class="pa-4" Style="height:100%">
+            <MudCard Class="pa-4 frosted-card" Style="height:100%">
                 <MudText Typo="Typo.subtitle1"><strong>ELO Ratings</strong></MudText>
                 <MudText Typo="Typo.body2" Class="mt-1">An ELO rating system with margin-of-victory weighting tracks player skill over time.</MudText>
             </MudCard>
         </MudItem>
         <MudItem xs="12" sm="6" md="4">
-            <MudCard Outlined="true" Class="pa-4" Style="height:100%">
+            <MudCard Class="pa-4 frosted-card" Style="height:100%">
                 <MudText Typo="Typo.subtitle1"><strong>League Table &amp; Standings</strong></MudText>
                 <MudText Typo="Typo.body2" Class="mt-1">View cumulative match statistics, wins, losses, and points in a searchable league table.</MudText>
             </MudCard>
         </MudItem>
         <MudItem xs="12" sm="6" md="4">
-            <MudCard Outlined="true" Class="pa-4" Style="height:100%">
+            <MudCard Class="pa-4 frosted-card" Style="height:100%">
                 <MudText Typo="Typo.subtitle1"><strong>Account Linking</strong></MudText>
                 <MudText Typo="Typo.body2" Class="mt-1">Link light player profiles to full accounts so casual entries seamlessly upgrade to verified profiles.</MudText>
             </MudCard>
@@ -253,13 +253,13 @@
     </MudStack>
     <MudGrid Spacing="3">
         <MudItem xs="12" sm="6" md="4">
-            <MudCard Outlined="true" Class="pa-4" Style="height:100%">
+            <MudCard Class="pa-4 frosted-card" Style="height:100%">
                 <MudText Typo="Typo.subtitle1"><strong>Custom Rule Sets</strong></MudText>
                 <MudText Typo="Typo.body2" Class="mt-1">Create named rule sets with numbered items and descriptions. Attach them to any competition.</MudText>
             </MudCard>
         </MudItem>
         <MudItem xs="12" sm="6" md="4">
-            <MudCard Outlined="true" Class="pa-4" Style="height:100%">
+            <MudCard Class="pa-4 frosted-card" Style="height:100%">
                 <MudText Typo="Typo.subtitle1"><strong>Reusable Across Competitions</strong></MudText>
                 <MudText Typo="Typo.body2" Class="mt-1">Define your rules once and apply them to multiple competitions without re-entering them every time.</MudText>
             </MudCard>
@@ -274,25 +274,25 @@
     </MudStack>
     <MudGrid Spacing="3">
         <MudItem xs="12" sm="6" md="4">
-            <MudCard Outlined="true" Class="pa-4" Style="height:100%">
+            <MudCard Class="pa-4 frosted-card" Style="height:100%">
                 <MudText Typo="Typo.subtitle1"><strong>QR Code Login</strong></MudText>
                 <MudText Typo="Typo.body2" Class="mt-1">Generate a QR code on any screen and scan it with your phone to log in instantly. No password needed courtside.</MudText>
             </MudCard>
         </MudItem>
         <MudItem xs="12" sm="6" md="4">
-            <MudCard Outlined="true" Class="pa-4" Style="height:100%">
+            <MudCard Class="pa-4 frosted-card" Style="height:100%">
                 <MudText Typo="Typo.subtitle1"><strong>Mobile App</strong></MudText>
                 <MudText Typo="Typo.body2" Class="mt-1">A native cross-platform app for Android and iOS lets you manage competitions, players, and clubs on the go.</MudText>
             </MudCard>
         </MudItem>
         <MudItem xs="12" sm="6" md="4">
-            <MudCard Outlined="true" Class="pa-4" Style="height:100%">
+            <MudCard Class="pa-4 frosted-card" Style="height:100%">
                 <MudText Typo="Typo.subtitle1"><strong>Role-Based Access</strong></MudText>
                 <MudText Typo="Typo.body2" Class="mt-1">Admin, ClubAdmin, and player roles control what each user can see and do across the platform.</MudText>
             </MudCard>
         </MudItem>
         <MudItem xs="12" sm="6" md="4">
-            <MudCard Outlined="true" Class="pa-4" Style="height:100%">
+            <MudCard Class="pa-4 frosted-card" Style="height:100%">
                 <MudText Typo="Typo.subtitle1"><strong>Dark &amp; Light Themes</strong></MudText>
                 <MudText Typo="Typo.body2" Class="mt-1">Switch between dark and light mode to suit your preference or screen environment.</MudText>
             </MudCard>
@@ -307,19 +307,19 @@
     </MudStack>
     <MudGrid Spacing="3">
         <MudItem xs="12" sm="6" md="4">
-            <MudCard Outlined="true" Class="pa-4" Style="height:100%">
+            <MudCard Class="pa-4 frosted-card" Style="height:100%">
                 <MudText Typo="Typo.subtitle1"><strong>Live Score Broadcasting</strong></MudText>
                 <MudText Typo="Typo.body2" Class="mt-1">Score updates push to every connected scoreboard, phone, and browser in real time via SignalR.</MudText>
             </MudCard>
         </MudItem>
         <MudItem xs="12" sm="6" md="4">
-            <MudCard Outlined="true" Class="pa-4" Style="height:100%">
+            <MudCard Class="pa-4 frosted-card" Style="height:100%">
                 <MudText Typo="Typo.subtitle1"><strong>Email Notifications</strong></MudText>
                 <MudText Typo="Typo.body2" Class="mt-1">Automated emails for result submissions, verification requests, and admin review invitations.</MudText>
             </MudCard>
         </MudItem>
         <MudItem xs="12" sm="6" md="4">
-            <MudCard Outlined="true" Class="pa-4" Style="height:100%">
+            <MudCard Class="pa-4 frosted-card" Style="height:100%">
                 <MudText Typo="Typo.subtitle1"><strong>Chat Hub</strong></MudText>
                 <MudText Typo="Typo.body2" Class="mt-1">Built-in real-time messaging for match communication and coordination between players.</MudText>
             </MudCard>

--- a/DropShot.UI/Components/Pages/Support.razor
+++ b/DropShot.UI/Components/Pages/Support.razor
@@ -10,104 +10,108 @@
 
     <MudText Typo="Typo.h5" Class="mt-6 mb-3">Getting started</MudText>
 
-    <MudExpansionPanels MultiExpansion="true" Class="mb-6">
-        <MudExpansionPanel Text="How do I create an account?">
-            <MudText Typo="Typo.body2">
-                Choose <MudLink Href="/Account/Register">Sign Up</MudLink> and register with your email
-                address and a password. A free account lets you score casual matches, build your player
-                list, and join competitions you're invited to.
-            </MudText>
-        </MudExpansionPanel>
-        <MudExpansionPanel Text="How do I log in on a scoreboard or shared screen?">
-            <MudText Typo="Typo.body2">
-                Use QR-code login. On the shared screen, open the login page to display a QR code, then
-                scan it with your phone where you're already signed in. You'll be logged in on the screen
-                in a couple of seconds — no need to type a password in front of anyone courtside.
-            </MudText>
-        </MudExpansionPanel>
-        <MudExpansionPanel Text="Is there a mobile app?">
-            <MudText Typo="Typo.body2">
-                Yes. DropShot runs in any web browser and as a native app for Android and iOS, so you can
-                manage competitions on a laptop and score from courtside on your phone.
-            </MudText>
-        </MudExpansionPanel>
-    </MudExpansionPanels>
+    <details class="frosted-card faq-item">
+        <summary>How do I create an account?</summary>
+        <div class="faq-body">
+            Choose <MudLink Href="/Account/Register">Sign Up</MudLink> and register with your email
+            address and a password. A free account lets you score casual matches, build your player
+            list, and join competitions you're invited to.
+        </div>
+    </details>
+    <details class="frosted-card faq-item">
+        <summary>How do I log in on a scoreboard or shared screen?</summary>
+        <div class="faq-body">
+            Use QR-code login. On the shared screen, open the login page to display a QR code, then
+            scan it with your phone where you're already signed in. You'll be logged in on the screen
+            in a couple of seconds — no need to type a password in front of anyone courtside.
+        </div>
+    </details>
+    <details class="frosted-card faq-item">
+        <summary>Is there a mobile app?</summary>
+        <div class="faq-body">
+            Yes. DropShot runs in any web browser and as a native app for Android and iOS, so you can
+            manage competitions on a laptop and score from courtside on your phone.
+        </div>
+    </details>
 
     <MudText Typo="Typo.h5" Class="mt-6 mb-3">Scoring matches</MudText>
 
-    <MudExpansionPanels MultiExpansion="true" Class="mb-6">
-        <MudExpansionPanel Text="How do I score a match?">
-            <MudText Typo="Typo.body2">
-                Start a match and follow the setup wizard — it walks you through match type (singles or
-                doubles), player selection, and the rules to use. Once play begins you score
-                point-by-point, and DropShot handles deuce, advantage, and tiebreaks for you.
-            </MudText>
-        </MudExpansionPanel>
-        <MudExpansionPanel Text="What rule formats are supported?">
-            <MudText Typo="Typo.body2">
-                You can play best-of-1 or best-of-3 sets, switch on no-ad (sudden-death) deuce, and choose
-                whether the final set uses a tiebreak. Organisers can also save named rule sets and reuse
-                them across competitions.
-            </MudText>
-        </MudExpansionPanel>
-        <MudExpansionPanel Text="Can I correct a score I entered by mistake?">
-            <MudText Typo="Typo.body2">
-                Yes. Scores can be edited during a match, and on submission screens the back control clears
-                the cell it lands on so you can re-enter a value before confirming.
-            </MudText>
-        </MudExpansionPanel>
-        <MudExpansionPanel Text="Can I put the score on a big screen?">
-            <MudText Typo="Typo.body2">
-                Yes — choose between a clean default scoreboard or a broadcast-style layout with match
-                time. Scoreboards sync live across every connected screen, and you can manage multiple
-                courts from a single display-control page.
-            </MudText>
-        </MudExpansionPanel>
-    </MudExpansionPanels>
+    <details class="frosted-card faq-item">
+        <summary>How do I score a match?</summary>
+        <div class="faq-body">
+            Start a match and follow the setup wizard — it walks you through match type (singles or
+            doubles), player selection, and the rules to use. Once play begins you score
+            point-by-point, and DropShot handles deuce, advantage, and tiebreaks for you.
+        </div>
+    </details>
+    <details class="frosted-card faq-item">
+        <summary>What rule formats are supported?</summary>
+        <div class="faq-body">
+            You can play best-of-1 or best-of-3 sets, switch on no-ad (sudden-death) deuce, and choose
+            whether the final set uses a tiebreak. Organisers can also save named rule sets and reuse
+            them across competitions.
+        </div>
+    </details>
+    <details class="frosted-card faq-item">
+        <summary>Can I correct a score I entered by mistake?</summary>
+        <div class="faq-body">
+            Yes. Scores can be edited during a match, and on submission screens the back control clears
+            the cell it lands on so you can re-enter a value before confirming.
+        </div>
+    </details>
+    <details class="frosted-card faq-item">
+        <summary>Can I put the score on a big screen?</summary>
+        <div class="faq-body">
+            Yes — choose between a clean default scoreboard or a broadcast-style layout with match
+            time. Scoreboards sync live across every connected screen, and you can manage multiple
+            courts from a single display-control page.
+        </div>
+    </details>
 
     <MudText Typo="Typo.h5" Class="mt-6 mb-3">Competitions &amp; results</MudText>
 
-    <MudExpansionPanels MultiExpansion="true" Class="mb-6">
-        <MudExpansionPanel Text="How do I set up a competition?">
-            <MudText Typo="Typo.body2">
-                Create a competition, choose the format (singles, doubles, mixed, or team), and set up the
-                stages — for example round-robin groups feeding into knockout rounds. You can then schedule
-                fixtures to dates, times, and courts.
-            </MudText>
-        </MudExpansionPanel>
-        <MudExpansionPanel Text="How does result verification work?">
-            <MudText Typo="Typo.body2">
-                Results go through a two-tier check: a player submits the score, and an administrator can
-                quick-approve it or open a full review. Once verified, winners progress through the bracket
-                automatically and the league table updates.
-            </MudText>
-        </MudExpansionPanel>
-        <MudExpansionPanel Text="How are player ratings calculated?">
-            <MudText Typo="Typo.body2">
-                DropShot uses an ELO rating system that weights each result by margin of victory, so a
-                comfortable win moves your rating more than a tight one. Ratings update as verified results
-                come in.
-            </MudText>
-        </MudExpansionPanel>
-    </MudExpansionPanels>
+    <details class="frosted-card faq-item">
+        <summary>How do I set up a competition?</summary>
+        <div class="faq-body">
+            Create a competition, choose the format (singles, doubles, mixed, or team), and set up the
+            stages — for example round-robin groups feeding into knockout rounds. You can then schedule
+            fixtures to dates, times, and courts.
+        </div>
+    </details>
+    <details class="frosted-card faq-item">
+        <summary>How does result verification work?</summary>
+        <div class="faq-body">
+            Results go through a two-tier check: a player submits the score, and an administrator can
+            quick-approve it or open a full review. Once verified, winners progress through the bracket
+            automatically and the league table updates.
+        </div>
+    </details>
+    <details class="frosted-card faq-item">
+        <summary>How are player ratings calculated?</summary>
+        <div class="faq-body">
+            DropShot uses an ELO rating system that weights each result by margin of victory, so a
+            comfortable win moves your rating more than a tight one. Ratings update as verified results
+            come in.
+        </div>
+    </details>
 
     <MudText Typo="Typo.h5" Class="mt-6 mb-3">Account &amp; privacy</MudText>
 
-    <MudExpansionPanels MultiExpansion="true" Class="mb-6">
-        <MudExpansionPanel Text="How do I edit my profile?">
-            <MudText Typo="Typo.body2">
-                Open your account page to update your display name, contact details, date of birth, and
-                avatar. You can also maintain your own list of players you regularly play with.
-            </MudText>
-        </MudExpansionPanel>
-        <MudExpansionPanel Text="How is my data handled?">
-            <MudText Typo="Typo.body2">
-                See our <MudLink Href="/privacy">Privacy Policy</MudLink> for how we collect and use your
-                data, and our <MudLink Href="/cookie-policy">Cookie Policy</MudLink> for details on cookies
-                and advertising.
-            </MudText>
-        </MudExpansionPanel>
-    </MudExpansionPanels>
+    <details class="frosted-card faq-item">
+        <summary>How do I edit my profile?</summary>
+        <div class="faq-body">
+            Open your account page to update your display name, contact details, date of birth, and
+            avatar. You can also maintain your own list of players you regularly play with.
+        </div>
+    </details>
+    <details class="frosted-card faq-item">
+        <summary>How is my data handled?</summary>
+        <div class="faq-body">
+            See our <MudLink Href="/privacy">Privacy Policy</MudLink> for how we collect and use your
+            data, and our <MudLink Href="/cookie-policy">Cookie Policy</MudLink> for details on cookies
+            and advertising.
+        </div>
+    </details>
 
     <GoogleAd />
 

--- a/DropShot.UI/Components/Pages/Support.razor.css
+++ b/DropShot.UI/Components/Pages/Support.razor.css
@@ -1,0 +1,40 @@
+.faq-item {
+    margin-bottom: 0.75rem;
+    overflow: hidden;
+}
+
+.faq-item > summary {
+    list-style: none;
+    cursor: pointer;
+    padding: 1rem 1.25rem;
+    font-weight: 500;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+/* Hide the native disclosure triangle (Chrome/Safari + Firefox). */
+.faq-item > summary::-webkit-details-marker {
+    display: none;
+}
+
+/* Custom +/− indicator that flips when the panel is open. */
+.faq-item > summary::after {
+    content: "+";
+    font-size: 1.25rem;
+    line-height: 1;
+    opacity: 0.7;
+    flex: 0 0 auto;
+}
+
+.faq-item[open] > summary::after {
+    content: "\2212"; /* minus sign */
+}
+
+.faq-body {
+    padding: 0 1.25rem 1rem;
+    font-size: 0.875rem;
+    line-height: 1.5;
+    opacity: 0.9;
+}


### PR DESCRIPTION
## Summary
- **Fixes the dead expanders on /support.** The content pages render statically (no `@rendermode`), so the interactive `MudExpansionPanels` never expanded. Replaced with native HTML `<details>` accordions — they work with zero JS and stay fully crawlable for AdSense. Custom +/− indicator via scoped `Support.razor.css`.
- **Frosted background** applied to the FAQ items and the Features grid cards (the global `frosted-card` glass/blur look), for consistency with the rest of the app. About has no neutral card surfaces (prose + an intentionally-coloured CTA), so it's unchanged.

## Test plan
- [x] `dotnet build` succeeds
- [ ] Confirm FAQ items expand/collapse on the deployed /support page
- [ ] Confirm frosted look renders against the branded background

🤖 Generated with [Claude Code](https://claude.com/claude-code)