### PR TITLE
Add calendar exceptions to competition and division setup

### DIFF
--- a/DropShot.Maui/Services/HttpCompetitionAdminService.cs
+++ b/DropShot.Maui/Services/HttpCompetitionAdminService.cs
@@ -586,4 +586,26 @@ public sealed class HttpCompetitionAdminService(HttpClient http) : ICompetitionA
         resp.EnsureSuccessStatusCode();
         return await resp.Content.ReadFromJsonAsync<int>(cancellationToken: ct);
     }
+
+    // ── Calendar exceptions ──────────────────────────────────────────────────
+
+    public async Task<int> AddCalendarExceptionAsync(
+        int competitionId, SaveCalendarExceptionRequest request, CancellationToken ct = default)
+    {
+        var resp = await http.PostAsJsonAsync(
+            $"api/competitions/admin/{competitionId}/calendar-exceptions", request, ct);
+        if (!resp.IsSuccessStatusCode)
+        {
+            var body = await resp.Content.ReadAsStringAsync(ct);
+            throw new InvalidOperationException(string.IsNullOrEmpty(body) ? resp.ReasonPhrase ?? "Failed to add calendar exception." : body);
+        }
+        return await resp.Content.ReadFromJsonAsync<int>(cancellationToken: ct);
+    }
+
+    public async Task DeleteCalendarExceptionAsync(int competitionId, int exceptionId, CancellationToken ct = default)
+    {
+        var resp = await http.DeleteAsync(
+            $"api/competitions/admin/{competitionId}/calendar-exceptions/{exceptionId}", ct);
+        resp.EnsureSuccessStatusCode();
+    }
 }

--- a/DropShot.Shared/Dtos/CompetitionAdminDtos.cs
+++ b/DropShot.Shared/Dtos/CompetitionAdminDtos.cs
@@ -70,9 +70,18 @@ public record CompetitionEditDto(
     IReadOnlyList<RulesSetDto> RulesSets,
     IReadOnlyList<EventDto> Events,
     IReadOnlyList<int> AllowedPlayerIds,
+    IReadOnlyList<CompetitionCalendarExceptionDto> CalendarExceptions,
     bool CanEdit,
     bool IsSuperAdmin,
     string? Description = null);
+
+public record CompetitionCalendarExceptionDto(
+    int CompetitionCalendarExceptionId,
+    int CompetitionId,
+    int? CompetitionDivisionId,
+    string? DivisionName,
+    DateOnly ExceptionDate,
+    string? Note);
 
 public record CompetitionMatchWindowDto(
     int CompetitionMatchWindowId,
@@ -374,4 +383,7 @@ public record ConfirmFixtureAssignmentResultDto(
     bool IsValid,
     IReadOnlyList<string> Violations);
 
-
+public record SaveCalendarExceptionRequest(
+    DateOnly ExceptionDate,
+    string? Note,
+    int? CompetitionDivisionId);

--- a/DropShot.UI/Components/Competitions/Setup/CalendarExceptionsSection.razor
+++ b/DropShot.UI/Components/Competitions/Setup/CalendarExceptionsSection.razor
@@ -1,0 +1,227 @@
+@using DropShot.Shared.Dtos
+
+<MudPaper id="section-calendar-exceptions" Class="pa-4 mb-4 setup-section" Elevation="0"
+     Style="background: rgba(255,255,255,0.08); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border: 1px solid rgba(255,255,255,0.12); border-radius: 12px; color: white;">
+    <MudText Typo="Typo.h6" Class="mb-1">Calendar Exceptions</MudText>
+    <MudText Typo="Typo.caption" Style="opacity:0.8" Class="mb-3">
+        Dates excluded from auto-scheduling. Competition-wide exceptions block all divisions; division-scoped exceptions only block that division.
+    </MudText>
+
+    @* ── Add form ───────────────────────────────────────────────────────── *@
+    <MudGrid Spacing="1" Class="mb-3">
+        <MudItem xs="12" sm="3">
+            <MudDatePicker Date="_newDate" DateChanged="@(v => _newDate = v)"
+                           Label="Exception date" Variant="Variant.Outlined" Margin="Margin.Dense"
+                           DateFormat="dd/MM/yyyy" />
+        </MudItem>
+        @if (Divisions.Count > 0)
+        {
+            <MudItem xs="12" sm="3">
+                <MudSelect T="int?" @bind-Value="_newDivisionId" Label="Division (blank = all)"
+                           Variant="Variant.Outlined" Margin="Margin.Dense" Clearable="true">
+                    @foreach (var d in Divisions.OrderBy(d => d.Rank))
+                    {
+                        <MudSelectItem T="int?" Value="@((int?)d.CompetitionDivisionId)">@d.Name</MudSelectItem>
+                    }
+                </MudSelect>
+            </MudItem>
+        }
+        <MudItem xs="12" sm="@(Divisions.Count > 0 ? 4 : 6)">
+            <MudTextField T="string" @bind-Value="_newNote" Label="Note (optional)"
+                          Variant="Variant.Outlined" Margin="Margin.Dense" MaxLength="200" />
+        </MudItem>
+        <MudItem xs="12" sm="2" Class="d-flex align-center">
+            <MudButton Variant="Variant.Filled" Color="Color.Primary" Size="Size.Small"
+                       Disabled="@(!_newDate.HasValue)"
+                       OnClick="AddExceptionAsync">Add</MudButton>
+        </MudItem>
+    </MudGrid>
+
+    @* ── Suggested dates ────────────────────────────────────────────────── *@
+    @if (_suggestedDates.Count > 0)
+    {
+        <MudText Typo="Typo.caption" Style="opacity:0.7" Class="mb-1">Suggested dates</MudText>
+        <MudStack Row="true" Wrap="Wrap.Wrap" Spacing="1" Class="mb-3">
+            @foreach (var s in _suggestedDates)
+            {
+                var alreadyAdded = Exceptions.Any(e =>
+                    e.ExceptionDate == s.Date
+                    && e.CompetitionDivisionId == _newDivisionId);
+                var chipStyle = alreadyAdded ? "cursor:default; opacity:0.5" : "cursor:pointer";
+                <MudTooltip Text="@(alreadyAdded ? "Already added" : $"Add {s.Date:dd MMM yyyy}")">
+                    <MudChip T="string" Label="true" Size="Size.Small"
+                             Variant="@(alreadyAdded ? Variant.Text : Variant.Outlined)"
+                             Color="@(alreadyAdded ? Color.Default : Color.Primary)"
+                             Style="@chipStyle"
+                             OnClick="@(alreadyAdded ? (Func<Task>?)null : () => QuickAddAsync(s.Date, s.Label))">
+                        @s.Label (@s.Date.ToString("d MMM"))
+                    </MudChip>
+                </MudTooltip>
+            }
+        </MudStack>
+    }
+
+    @* ── Existing exceptions table ──────────────────────────────────────── *@
+    @if (Exceptions.Count > 0)
+    {
+        <MudSimpleTable Dense="true">
+            <thead>
+                <tr>
+                    <th>Date</th>
+                    <th>Applies to</th>
+                    <th>Note</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var ex in Exceptions.OrderBy(e => e.CompetitionDivisionId.HasValue).ThenBy(e => e.ExceptionDate))
+                {
+                    <tr>
+                        <td>@ex.ExceptionDate.ToString("ddd dd MMM yyyy")</td>
+                        <td>
+                            @if (ex.CompetitionDivisionId.HasValue)
+                            {
+                                <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">@(ex.DivisionName ?? "Division")</MudChip>
+                            }
+                            else
+                            {
+                                <MudChip T="string" Size="Size.Small" Variant="Variant.Text" Color="Color.Info">All divisions</MudChip>
+                            }
+                        </td>
+                        <td style="opacity:0.8">@ex.Note</td>
+                        <td>
+                            <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small"
+                                           Color="Color.Error"
+                                           OnClick="@(() => OnDelete.InvokeAsync(ex))" />
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </MudSimpleTable>
+    }
+    else
+    {
+        <MudText Typo="Typo.caption" Color="Color.Secondary">
+            No calendar exceptions defined — auto-schedule will not skip any specific dates.
+        </MudText>
+    }
+</MudPaper>
+
+@code {
+    [Parameter, EditorRequired] public IReadOnlyList<CompetitionCalendarExceptionDto> Exceptions { get; set; } = [];
+    [Parameter, EditorRequired] public IReadOnlyList<CompetitionDivisionDto> Divisions { get; set; } = [];
+    [Parameter] public DateTime? CompetitionStartDate { get; set; }
+    [Parameter] public DateTime? CompetitionEndDate { get; set; }
+    [Parameter] public EventCallback<SaveCalendarExceptionRequest> OnAdd { get; set; }
+    [Parameter] public EventCallback<CompetitionCalendarExceptionDto> OnDelete { get; set; }
+
+    private DateTime? _newDate;
+    private int? _newDivisionId;
+    private string _newNote = "";
+
+    private record SuggestedDate(DateOnly Date, string Label);
+    private List<SuggestedDate> _suggestedDates = [];
+
+    protected override void OnParametersSet() => RebuildSuggestions();
+
+    private void RebuildSuggestions()
+    {
+        var startYear = (CompetitionStartDate ?? DateTime.Today).Year;
+        var endYear   = (CompetitionEndDate   ?? CompetitionStartDate ?? DateTime.Today).Year;
+
+        var result = new List<SuggestedDate>();
+        for (var y = startYear; y <= endYear; y++)
+            result.AddRange(GetSuggestionsForYear(y));
+
+        _suggestedDates = result
+            .OrderBy(s => s.Date)
+            .DistinctBy(s => s.Date)
+            .ToList();
+    }
+
+    private static IEnumerable<SuggestedDate> GetSuggestionsForYear(int y)
+    {
+        var easter = EasterSunday(y);
+        yield return new(new DateOnly(y, 1, 1),   "New Year's Day");
+        yield return new(easter.AddDays(-2),       "Good Friday");
+        yield return new(easter,                   "Easter Sunday");
+        yield return new(easter.AddDays(1),        "Easter Monday");
+        yield return new(MotheringSunday(easter),  "Mothering Sunday");
+        yield return new(EarlyMayBankHoliday(y),  "Early May BH");
+        yield return new(SpringBankHoliday(y),    "Spring Bank Holiday");
+        yield return new(FathersDay(y),            "Father's Day");
+        yield return new(SummerBankHoliday(y),    "Summer Bank Holiday");
+        yield return new(new DateOnly(y, 12, 24),  "Christmas Eve");
+        yield return new(new DateOnly(y, 12, 25),  "Christmas Day");
+        yield return new(new DateOnly(y, 12, 26),  "Boxing Day");
+        yield return new(new DateOnly(y, 12, 31),  "New Year's Eve");
+    }
+
+    private async Task AddExceptionAsync()
+    {
+        if (!_newDate.HasValue) return;
+        await OnAdd.InvokeAsync(new SaveCalendarExceptionRequest(
+            DateOnly.FromDateTime(_newDate.Value),
+            string.IsNullOrWhiteSpace(_newNote) ? null : _newNote.Trim(),
+            _newDivisionId));
+        _newDate = null;
+        _newNote = "";
+    }
+
+    private async Task QuickAddAsync(DateOnly date, string label)
+    {
+        await OnAdd.InvokeAsync(new SaveCalendarExceptionRequest(
+            date, label, _newDivisionId));
+    }
+
+    // ── Holiday calculators ────────────────────────────────────────────────
+
+    private static DateOnly EasterSunday(int y)
+    {
+        int a = y % 19, b = y / 100, c = y % 100;
+        int d = b / 4, e = b % 4, f = (b + 8) / 25;
+        int g = (b - f + 1) / 3;
+        int h = (19 * a + b - d - g + 15) % 30;
+        int i = c / 4, k = c % 4;
+        int l = (32 + 2 * e + 2 * i - h - k) % 7;
+        int m = (a + 11 * h + 22 * l) / 451;
+        int month = (h + l - 7 * m + 114) / 31;
+        int day   = ((h + l - 7 * m + 114) % 31) + 1;
+        return new DateOnly(y, month, day);
+    }
+
+    // Mothering Sunday = 3 weeks before Easter (the 4th Sunday of Lent)
+    private static DateOnly MotheringSunday(DateOnly easter) => easter.AddDays(-21);
+
+    // First Monday in May
+    private static DateOnly EarlyMayBankHoliday(int y)
+    {
+        var d = new DateOnly(y, 5, 1);
+        while (d.DayOfWeek != DayOfWeek.Monday) d = d.AddDays(1);
+        return d;
+    }
+
+    // Last Monday in May
+    private static DateOnly SpringBankHoliday(int y)
+    {
+        var d = new DateOnly(y, 5, 31);
+        while (d.DayOfWeek != DayOfWeek.Monday) d = d.AddDays(-1);
+        return d;
+    }
+
+    // 3rd Sunday in June
+    private static DateOnly FathersDay(int y)
+    {
+        var d = new DateOnly(y, 6, 1);
+        while (d.DayOfWeek != DayOfWeek.Sunday) d = d.AddDays(1);
+        return d.AddDays(14); // first Sunday + 2 weeks = 3rd Sunday
+    }
+
+    // Last Monday in August
+    private static DateOnly SummerBankHoliday(int y)
+    {
+        var d = new DateOnly(y, 8, 31);
+        while (d.DayOfWeek != DayOfWeek.Monday) d = d.AddDays(-1);
+        return d;
+    }
+}

--- a/DropShot.UI/Components/Competitions/Setup/DivisionsSection.razor
+++ b/DropShot.UI/Components/Competitions/Setup/DivisionsSection.razor
@@ -225,6 +225,32 @@
                         }
                     }
 
+                    @* Calendar exceptions sub-section *@
+                    @if (CalendarExceptions.Count > 0 || true)
+                    {
+                        var divExceptions = CalendarExceptions
+                            .Where(e => e.CompetitionDivisionId == divId)
+                            .OrderBy(e => e.ExceptionDate)
+                            .ToList();
+                        if (divExceptions.Count > 0)
+                        {
+                            <MudDivider Class="my-3" />
+                            <MudText Typo="Typo.subtitle1" Class="mb-1">Calendar Exceptions</MudText>
+                            <MudText Typo="Typo.caption" Style="opacity:0.7" Class="mb-2">
+                                Dates excluded from auto-scheduling for this division only. Competition-wide exceptions are managed in the Calendar Exceptions section.
+                            </MudText>
+                            <MudStack Row="true" Wrap="Wrap.Wrap" Spacing="1">
+                                @foreach (var ex in divExceptions)
+                                {
+                                    <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined"
+                                             OnClose="@(() => OnDeleteCalendarException.InvokeAsync(ex))">
+                                        @ex.ExceptionDate.ToString("ddd d MMM yyyy")@(ex.Note != null ? $" ({ex.Note})" : "")
+                                    </MudChip>
+                                }
+                            </MudStack>
+                        }
+                    }
+
                     @* Match windows sub-section *@
                     <MudDivider Class="my-3" />
                     <MudText Typo="Typo.subtitle1" Class="mb-2">Match Windows</MudText>
@@ -374,6 +400,7 @@
     [Parameter, EditorRequired] public IReadOnlyList<CompetitionTeamDto> Teams { get; set; } = [];
     [Parameter, EditorRequired] public IReadOnlyList<CompetitionParticipantDto> Participants { get; set; } = [];
     [Parameter, EditorRequired] public IReadOnlyList<CompetitionMatchWindowDto> MatchWindows { get; set; } = [];
+    [Parameter] public IReadOnlyList<CompetitionCalendarExceptionDto> CalendarExceptions { get; set; } = [];
     [Parameter, EditorRequired] public IReadOnlyList<CourtDto> Courts { get; set; } = [];
     [Parameter, EditorRequired] public IReadOnlyList<CompetitionSeedSourceDto> SeedSourceCandidates { get; set; } = [];
     [Parameter] public CompetitionFormat? Format { get; set; }
@@ -428,6 +455,7 @@
     [Parameter] public EventCallback<CompetitionMatchWindowDto> OnCopyDivisionMatchWindowToForm { get; set; }
     [Parameter] public EventCallback<CompetitionMatchWindowDto> OnEditDivisionMatchWindow { get; set; }
     [Parameter] public EventCallback<CompetitionMatchWindowDto> OnDeleteMatchWindow { get; set; }
+    [Parameter] public EventCallback<CompetitionCalendarExceptionDto> OnDeleteCalendarException { get; set; }
     [Parameter] public EventCallback<(CompetitionTeamDto Team, int? PlayerId)> OnAssignCaptain { get; set; }
     [Parameter] public EventCallback<CompetitionTeamDto> OnValidateTeam { get; set; }
     [Parameter] public EventCallback<CompetitionTeamDto> OnOpenEditTeamDialog { get; set; }

--- a/DropShot.UI/Components/Pages/CompetitionPage.razor
+++ b/DropShot.UI/Components/Pages/CompetitionPage.razor
@@ -515,6 +515,15 @@ else
                     OnAutoGenerate="AutoGenerateMatchWindowsAsync" />
             }
 
+            @* ── Calendar Exceptions ──────────────────────────── *@
+            <CalendarExceptionsSection
+                Exceptions="_calendarExceptions"
+                Divisions="_divisions"
+                CompetitionStartDate="Model.StartDateDt"
+                CompetitionEndDate="Model.EndDateDt"
+                OnAdd="AddCalendarExceptionAsync"
+                OnDelete="DeleteCalendarExceptionAsync" />
+
             @* ── Rubber Template ─────────────────────────────── *@
             @if (EffectivePersistedFormat() == CompetitionFormat.TeamMatch)
             {
@@ -613,6 +622,8 @@ else
                     OnCopyDivisionMatchWindowToForm="CopyDivisionMatchWindowToForm"
                     OnEditDivisionMatchWindow="EditDivisionMatchWindow"
                     OnDeleteMatchWindow="DeleteMatchWindow"
+                    CalendarExceptions="_calendarExceptions"
+                    OnDeleteCalendarException="DeleteCalendarExceptionAsync"
                     OnAssignCaptain="@((args) => AssignCaptain(args.Team, args.PlayerId))"
                     OnValidateTeam="ValidateTeam"
                     OnOpenEditTeamDialog="OpenEditTeamDialog"
@@ -2198,6 +2209,9 @@ else
     private List<ClubSchedulingTemplateDto> _clubTemplates = [];
     private int? _selectedTemplateId;
 
+    // Calendar exceptions
+    private List<CompetitionCalendarExceptionDto> _calendarExceptions = [];
+
     // Competition templates
     private List<CompetitionTemplateDto> _competitionTemplates = [];
     private int? _selectedCompetitionTemplateId;
@@ -2472,6 +2486,7 @@ else
             _teams = view.Teams.ToList();
             _divisions = view.Divisions.ToList();
             _matchWindows = view.MatchWindows.ToList();
+            _calendarExceptions = view.CalendarExceptions.ToList();
             _seedSourceCandidates = view.SeedSourceCandidates.ToList();
             _courtPairs = view.CourtPairs.ToList();
             _courts = view.HostClubCourts.ToList();
@@ -2804,6 +2819,7 @@ else
         _teams = view.Teams.ToList();
         _divisions = view.Divisions.ToList();
         _matchWindows = view.MatchWindows.ToList();
+        _calendarExceptions = view.CalendarExceptions.ToList();
         _courtPairs = view.CourtPairs.ToList();
         _competitionAdmins = view.Admins.ToList();
         _isStarted = view.IsStarted;
@@ -4447,6 +4463,39 @@ else
             SiteAlerts.Add("All windows from that template are already present.", Severity.Info);
         else
             SiteAlerts.Add($"Imported {imported} window(s) from template.", Severity.Success);
+    }
+
+    // ── Calendar exceptions ──────────────────────────────────────────────────
+
+    private async Task AddCalendarExceptionAsync(SaveCalendarExceptionRequest request)
+    {
+        try
+        {
+            var id = await Admin.AddCalendarExceptionAsync(Id, request);
+            var divisionName = request.CompetitionDivisionId.HasValue
+                ? _divisions.FirstOrDefault(d => d.CompetitionDivisionId == request.CompetitionDivisionId.Value)?.Name
+                : null;
+            _calendarExceptions.Add(new CompetitionCalendarExceptionDto(
+                id, Id, request.CompetitionDivisionId, divisionName,
+                request.ExceptionDate, request.Note));
+        }
+        catch (Exception ex)
+        {
+            SiteAlerts.Add($"Failed to add exception: {ex.Message}", Severity.Error);
+        }
+    }
+
+    private async Task DeleteCalendarExceptionAsync(CompetitionCalendarExceptionDto exception)
+    {
+        try
+        {
+            await Admin.DeleteCalendarExceptionAsync(Id, exception.CompetitionCalendarExceptionId);
+            _calendarExceptions.Remove(exception);
+        }
+        catch (Exception ex)
+        {
+            SiteAlerts.Add($"Failed to delete exception: {ex.Message}", Severity.Error);
+        }
     }
 
     // ── Competition Templates ────────────────────────────────────────────────

--- a/DropShot.UI/Services/ICompetitionAdminService.cs
+++ b/DropShot.UI/Services/ICompetitionAdminService.cs
@@ -380,4 +380,17 @@ public interface ICompetitionAdminService
     /// </summary>
     Task<int> ImportMatchWindowsFromTemplateAsync(
         int competitionId, ImportMatchWindowsFromTemplateRequest request, CancellationToken ct = default);
+
+    // ── Calendar exceptions ──────────────────────────────────────────────────
+
+    /// <summary>
+    /// Add a calendar exception date to exclude from auto-scheduling. When
+    /// <see cref="SaveCalendarExceptionRequest.CompetitionDivisionId"/> is null
+    /// the exception applies competition-wide; when set it is division-scoped.
+    /// Returns the new exception's id.
+    /// </summary>
+    Task<int> AddCalendarExceptionAsync(
+        int competitionId, SaveCalendarExceptionRequest request, CancellationToken ct = default);
+
+    Task DeleteCalendarExceptionAsync(int competitionId, int exceptionId, CancellationToken ct = default);
 }

--- a/DropShot/Controllers/CompetitionsAdminController.cs
+++ b/DropShot/Controllers/CompetitionsAdminController.cs
@@ -618,4 +618,24 @@ public class CompetitionsAdminController(
         catch (UnauthorizedAccessException) { return Forbid(); }
         catch (KeyNotFoundException) { return NotFound(); }
     }
+
+    // ── Calendar exceptions ──────────────────────────────────────────────────
+
+    [HttpPost("{id:int}/calendar-exceptions")]
+    public async Task<ActionResult<int>> AddCalendarException(
+        int id, [FromBody] SaveCalendarExceptionRequest req, CancellationToken ct)
+    {
+        try { return await admin.AddCalendarExceptionAsync(id, req, ct); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+        catch (InvalidOperationException ex) { return BadRequest(new { message = ex.Message }); }
+    }
+
+    [HttpDelete("{id:int}/calendar-exceptions/{exceptionId:int}")]
+    public async Task<IActionResult> DeleteCalendarException(int id, int exceptionId, CancellationToken ct)
+    {
+        try { await admin.DeleteCalendarExceptionAsync(id, exceptionId, ct); return NoContent(); }
+        catch (UnauthorizedAccessException) { return Forbid(); }
+        catch (KeyNotFoundException) { return NotFound(); }
+    }
 }

--- a/DropShot/Data/Migrations/20260605000000_AddCompetitionCalendarExceptions.cs
+++ b/DropShot/Data/Migrations/20260605000000_AddCompetitionCalendarExceptions.cs
@@ -1,0 +1,61 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropShot.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCompetitionCalendarExceptions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "CompetitionCalendarExceptions",
+                columns: table => new
+                {
+                    CompetitionCalendarExceptionId = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    CompetitionId = table.Column<int>(type: "int", nullable: false),
+                    CompetitionDivisionId = table.Column<int>(type: "int", nullable: true),
+                    ExceptionDate = table.Column<DateOnly>(type: "date", nullable: false),
+                    Note = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CompetitionCalendarExceptions", x => x.CompetitionCalendarExceptionId);
+                    table.ForeignKey(
+                        name: "FK_CompetitionCalendarExceptions_Competition_CompetitionId",
+                        column: x => x.CompetitionId,
+                        principalTable: "Competition",
+                        principalColumn: "CompetitionID",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_CompetitionCalendarExceptions_CompetitionDivisions_CompetitionDivisionId",
+                        column: x => x.CompetitionDivisionId,
+                        principalTable: "CompetitionDivisions",
+                        principalColumn: "CompetitionDivisionId");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CompetitionCalendarExceptions_CompetitionId_CompetitionDivisionId_ExceptionDate",
+                table: "CompetitionCalendarExceptions",
+                columns: new[] { "CompetitionId", "CompetitionDivisionId", "ExceptionDate" },
+                unique: true,
+                filter: "[CompetitionDivisionId] IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CompetitionCalendarExceptions_CompetitionDivisionId",
+                table: "CompetitionCalendarExceptions",
+                column: "CompetitionDivisionId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "CompetitionCalendarExceptions");
+        }
+    }
+}

--- a/DropShot/Data/MyDbContext.cs
+++ b/DropShot/Data/MyDbContext.cs
@@ -47,6 +47,7 @@ namespace DropShot.Data
         public DbSet<PlayerRatingSnapshot> PlayerRatingSnapshots { get; set; }
         public DbSet<LadderInactivityDecay> LadderInactivityDecays { get; set; }
         public DbSet<CompetitionEntryConsent> CompetitionEntryConsents { get; set; }
+        public DbSet<CompetitionCalendarException> CompetitionCalendarExceptions { get; set; }
 
         protected override void OnModelCreating(ModelBuilder builder)
         {
@@ -715,6 +716,24 @@ namespace DropShot.Data
 
                 // Hot path: "any active consent row for (competition, player)?"
                 entity.HasIndex(c => new { c.CompetitionId, c.PlayerId, c.WithdrawnUtc });
+            });
+
+            // ── CompetitionCalendarException ────────────────────────────────────
+            builder.Entity<CompetitionCalendarException>(entity =>
+            {
+                entity.Property(e => e.Note).HasMaxLength(200);
+                entity.HasIndex(e => new { e.CompetitionId, e.CompetitionDivisionId, e.ExceptionDate })
+                      .IsUnique();
+
+                entity.HasOne(e => e.Competition)
+                      .WithMany(c => c.CalendarExceptions)
+                      .HasForeignKey(e => e.CompetitionId)
+                      .OnDelete(DeleteBehavior.Cascade);
+
+                entity.HasOne(e => e.Division)
+                      .WithMany(d => d.CalendarExceptions)
+                      .HasForeignKey(e => e.CompetitionDivisionId)
+                      .OnDelete(DeleteBehavior.NoAction);
             });
 
             // ── RoleSwitchLog ───────────────────────────────────────────────────

--- a/DropShot/Models/Competition.cs
+++ b/DropShot/Models/Competition.cs
@@ -121,6 +121,7 @@ namespace DropShot.Models
         public ICollection<CompetitionAdmin> Admins { get; set; } = [];
         public ICollection<CourtPair> CourtPairs { get; set; } = [];
         public ICollection<CompetitionAllowedPlayer> AllowedPlayers { get; set; } = [];
+        public ICollection<CompetitionCalendarException> CalendarExceptions { get; set; } = [];
         public CompetitionRubberTemplate? RubberTemplate { get; set; }
     }
 }

--- a/DropShot/Models/CompetitionDivision.cs
+++ b/DropShot/Models/CompetitionDivision.cs
@@ -18,4 +18,5 @@ public class CompetitionDivision
     public Competition Competition { get; set; } = null!;
     public ICollection<CompetitionParticipant> Participants { get; set; } = [];
     public ICollection<CompetitionTeam> Teams { get; set; } = [];
+    public ICollection<CompetitionCalendarException> CalendarExceptions { get; set; } = [];
 }

--- a/DropShot/Models/SchedulingModels.cs
+++ b/DropShot/Models/SchedulingModels.cs
@@ -45,6 +45,24 @@ public class ClubSchedulingTemplateWindow
     public ClubSchedulingTemplate Template { get; set; } = null!;
 }
 
+public class CompetitionCalendarException
+{
+    public int CompetitionCalendarExceptionId { get; set; }
+    public int CompetitionId { get; set; }
+
+    /// <summary>
+    /// When set, the exception only blocks scheduling for that division.
+    /// When null, it applies competition-wide (all divisions).
+    /// </summary>
+    public int? CompetitionDivisionId { get; set; }
+
+    public DateOnly ExceptionDate { get; set; }
+    public string? Note { get; set; }
+
+    public Competition Competition { get; set; } = null!;
+    public CompetitionDivision? Division { get; set; }
+}
+
 public class CompetitionTemplate
 {
     public int CompetitionTemplateId { get; set; }

--- a/DropShot/Services/WebCompetitionAdminService.cs
+++ b/DropShot/Services/WebCompetitionAdminService.cs
@@ -93,6 +93,7 @@ public sealed class WebCompetitionAdminService(
                 HostClubCourts: [],
                 Clubs: clubs, RulesSets: rulesSets, Events: events,
                 AllowedPlayerIds: [],
+                CalendarExceptions: [],
                 CanEdit: canCreate,
                 IsSuperAdmin: isSuperAdminCreate);
         }
@@ -125,6 +126,7 @@ public sealed class WebCompetitionAdminService(
             .Include(c => c.MatchWindows).ThenInclude(w => w.Division)
             .Include(c => c.Divisions)
             .Include(c => c.AllowedPlayers)
+            .Include(c => c.CalendarExceptions).ThenInclude(e => e.Division)
             .AsSplitQuery()
             .AsNoTracking()
             .FirstOrDefaultAsync(c => c.CompetitionID == id, ct);
@@ -272,6 +274,12 @@ public sealed class WebCompetitionAdminService(
             HostClubCourts: hostClubCourts,
             Clubs: clubs, RulesSets: rulesSets, Events: events,
             AllowedPlayerIds: comp.AllowedPlayers.Select(ap => ap.PlayerId).ToList(),
+            CalendarExceptions: comp.CalendarExceptions
+                .OrderBy(e => e.ExceptionDate)
+                .Select(e => new CompetitionCalendarExceptionDto(
+                    e.CompetitionCalendarExceptionId, e.CompetitionId, e.CompetitionDivisionId,
+                    e.Division?.Name, e.ExceptionDate, e.Note))
+                .ToList(),
             CanEdit: canEdit,
             IsSuperAdmin: isSuperAdmin,
             Description: comp.Description);
@@ -2594,5 +2602,39 @@ public sealed class WebCompetitionAdminService(
         db.CompetitionMatchWindows.AddRange(toAdd);
         await db.SaveChangesAsync(ct);
         return toAdd.Count;
+    }
+
+    // ── Calendar exceptions ──────────────────────────────────────────────────
+
+    public async Task<int> AddCalendarExceptionAsync(
+        int competitionId, SaveCalendarExceptionRequest request, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        await LoadAndAuthorizeAsync(db, competitionId, ct);
+
+        var entry = new CompetitionCalendarException
+        {
+            CompetitionId        = competitionId,
+            CompetitionDivisionId = request.CompetitionDivisionId,
+            ExceptionDate        = request.ExceptionDate,
+            Note                 = request.Note?.Trim(),
+        };
+        db.CompetitionCalendarExceptions.Add(entry);
+        await db.SaveChangesAsync(ct);
+        return entry.CompetitionCalendarExceptionId;
+    }
+
+    public async Task DeleteCalendarExceptionAsync(int competitionId, int exceptionId, CancellationToken ct = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        await LoadAndAuthorizeAsync(db, competitionId, ct);
+
+        var entry = await db.CompetitionCalendarExceptions
+            .FirstOrDefaultAsync(e => e.CompetitionCalendarExceptionId == exceptionId
+                                      && e.CompetitionId == competitionId, ct)
+            ?? throw new KeyNotFoundException("Calendar exception not found.");
+
+        db.CompetitionCalendarExceptions.Remove(entry);
+        await db.SaveChangesAsync(ct);
     }
 }


### PR DESCRIPTION
## Summary

- New `CompetitionCalendarException` entity stores dates to exclude from auto-scheduling, scoped to either the whole competition or a specific division
- **Competition-level exceptions** appear in a new Calendar Exceptions section on the setup page (between Match Windows and Rubber Template)
- **Division-level exceptions** are surfaced inline within each division's expansion panel in the Divisions section
- Suggested dates panel computes UK bank holidays and notable days (New Year, Good Friday, Easter, Mothering Sunday, Early May BH, Spring BH, Father's Day, Summer BH, Christmas, Boxing Day, etc.) for the competition's year range — one click to add

## What changed

- `CompetitionCalendarException` model + navigation properties on `Competition` and `CompetitionDivision`
- EF config + migration `20260605000000_AddCompetitionCalendarExceptions`
- `CompetitionCalendarExceptionDto`, `SaveCalendarExceptionRequest` in shared DTOs; `CalendarExceptions` added to `CompetitionEditDto`
- `AddCalendarExceptionAsync` / `DeleteCalendarExceptionAsync` on `ICompetitionAdminService` — implemented in `WebCompetitionAdminService` and `HttpCompetitionAdminService`
- Two new API endpoints: `POST /api/competitions/admin/{id}/calendar-exceptions` and `DELETE .../calendar-exceptions/{exceptionId}`
- New `CalendarExceptionsSection.razor` component
- `DivisionsSection.razor` shows division-scoped exceptions inline per division

## Test plan

- [ ] Add a competition-wide exception — verify it appears in the table with "All divisions" scope
- [ ] Add a division-scoped exception — verify it appears both in the table and inside the relevant division panel
- [ ] Click a suggested-date chip — verify it adds with the holiday name pre-filled as the note
- [ ] Verify a chip already added at the selected scope is dimmed and non-clickable
- [ ] Delete an exception from the table row
- [ ] Delete a division exception from the division panel chip
- [ ] Run the migration against a local dev database

🤖 Generated with [Claude Code](https://claude.com/claude-code)