### PR TITLE
Fix CalendarExceptions migration: add Designer.cs snapshot

### DIFF
--- a/DropShot/Data/Migrations/20260605224301_AddCompetitionCalendarExceptions.Designer.cs
+++ b/DropShot/Data/Migrations/20260605224301_AddCompetitionCalendarExceptions.Designer.cs
@@ -4,16 +4,19 @@ using DropShot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace DropShot.Migrations
+namespace DropShot.Data.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260605224301_AddCompetitionCalendarExceptions")]
+    partial class AddCompetitionCalendarExceptions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DropShot/Data/Migrations/20260605224301_AddCompetitionCalendarExceptions.cs
+++ b/DropShot/Data/Migrations/20260605224301_AddCompetitionCalendarExceptions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
@@ -26,17 +26,22 @@ namespace DropShot.Data.Migrations
                 {
                     table.PrimaryKey("PK_CompetitionCalendarExceptions", x => x.CompetitionCalendarExceptionId);
                     table.ForeignKey(
+                        name: "FK_CompetitionCalendarExceptions_CompetitionDivisions_CompetitionDivisionId",
+                        column: x => x.CompetitionDivisionId,
+                        principalTable: "CompetitionDivisions",
+                        principalColumn: "CompetitionDivisionId");
+                    table.ForeignKey(
                         name: "FK_CompetitionCalendarExceptions_Competition_CompetitionId",
                         column: x => x.CompetitionId,
                         principalTable: "Competition",
                         principalColumn: "CompetitionID",
                         onDelete: ReferentialAction.Cascade);
-                    table.ForeignKey(
-                        name: "FK_CompetitionCalendarExceptions_CompetitionDivisions_CompetitionDivisionId",
-                        column: x => x.CompetitionDivisionId,
-                        principalTable: "CompetitionDivisions",
-                        principalColumn: "CompetitionDivisionId");
                 });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CompetitionCalendarExceptions_CompetitionDivisionId",
+                table: "CompetitionCalendarExceptions",
+                column: "CompetitionDivisionId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_CompetitionCalendarExceptions_CompetitionId_CompetitionDivisionId_ExceptionDate",
@@ -44,11 +49,6 @@ namespace DropShot.Data.Migrations
                 columns: new[] { "CompetitionId", "CompetitionDivisionId", "ExceptionDate" },
                 unique: true,
                 filter: "[CompetitionDivisionId] IS NOT NULL");
-
-            migrationBuilder.CreateIndex(
-                name: "IX_CompetitionCalendarExceptions_CompetitionDivisionId",
-                table: "CompetitionCalendarExceptions",
-                column: "CompetitionDivisionId");
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Replaces the manually-written migration from #732 with one generated by `dotnet ef migrations add`, which includes the required `.Designer.cs` snapshot file. Without it, EF throws `PendingModelChangesWarning` and blocks `database update`.