### PR TITLE
Add workflow_dispatch to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,8 @@ name: Deploy Blazor App to Azure
 on:
   push:
     branches:
-      - main  # or your deployment branch
+      - main
+  workflow_dispatch:
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
Allows the deployment to be manually triggered from the GitHub Actions tab, in addition to the existing push-to-main trigger.