### PR TITLE
Scoreboard voice: fix silent announcements due to browser autoplay policy

### DIFF
--- a/DropShot.Maui/wwwroot/js/scoreboard.js
+++ b/DropShot.Maui/wwwroot/js/scoreboard.js
@@ -4,6 +4,10 @@ let _voiceRate = 0.9;
 
 export function setVoiceEnabled(enabled) {
     _voiceEnabled = enabled;
+    if (enabled && window.speechSynthesis) {
+        const unlock = new SpeechSynthesisUtterance('');
+        window.speechSynthesis.speak(unlock);
+    }
 }
 
 export function announceScore(text) {

--- a/DropShot/wwwroot/js/scoreboard.js
+++ b/DropShot/wwwroot/js/scoreboard.js
@@ -4,6 +4,12 @@ let _voiceRate = 0.9;
 
 export function setVoiceEnabled(enabled) {
     _voiceEnabled = enabled;
+    // Unlock the speech engine within the user-gesture that triggered this call.
+    // Without this, browsers block speechSynthesis from non-gesture contexts (e.g. SignalR).
+    if (enabled && window.speechSynthesis) {
+        const unlock = new SpeechSynthesisUtterance('');
+        window.speechSynthesis.speak(unlock);
+    }
 }
 
 export function announceScore(text) {


### PR DESCRIPTION
## Problem

Voice announcements were enabled but silent when scores arrived via SignalR. Browsers (Chrome, Safari, Firefox) block `speechSynthesis.speak()` calls that originate outside a direct user gesture — SignalR callbacks don't qualify, so every announcement was silently dropped.

## Fix

When the user clicks the volume toggle to enable voice, we immediately speak a silent (empty) utterance *inside that click handler*, which counts as a user gesture and unlocks the speech engine for the session. Subsequent calls from SignalR then go through.

## Note on page reload

If voice was enabled in a previous session and is restored from `localStorage` on load, announcements won't play until the user next interacts with the page. This matches the browser's own audio autoplay rules and is the expected behaviour — there's no way around it without a user gesture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)