### PR TITLE
Scoreboard voice: fix iOS Safari — use silent non-empty utterance for unlock

### DIFF
--- a/DropShot.Maui/wwwroot/js/scoreboard.js
+++ b/DropShot.Maui/wwwroot/js/scoreboard.js
@@ -5,7 +5,8 @@ let _voiceRate = 0.9;
 export function setVoiceEnabled(enabled) {
     _voiceEnabled = enabled;
     if (enabled && window.speechSynthesis) {
-        const unlock = new SpeechSynthesisUtterance('');
+        const unlock = new SpeechSynthesisUtterance(' ');
+        unlock.volume = 0;
         window.speechSynthesis.speak(unlock);
     }
 }

--- a/DropShot/wwwroot/js/scoreboard.js
+++ b/DropShot/wwwroot/js/scoreboard.js
@@ -7,7 +7,10 @@ export function setVoiceEnabled(enabled) {
     // Unlock the speech engine within the user-gesture that triggered this call.
     // Without this, browsers block speechSynthesis from non-gesture contexts (e.g. SignalR).
     if (enabled && window.speechSynthesis) {
-        const unlock = new SpeechSynthesisUtterance('');
+        // iOS Safari requires a non-empty utterance to unlock the speech engine.
+        // volume:0 keeps it silent while still satisfying the gesture requirement.
+        const unlock = new SpeechSynthesisUtterance(' ');
+        unlock.volume = 0;
         window.speechSynthesis.speak(unlock);
     }
 }


### PR DESCRIPTION
## Problem

Voice announcements worked on desktop but were silent on iPhone. iOS Safari ignores an empty-string `SpeechSynthesisUtterance` when used to unlock the speech engine — only a non-empty utterance satisfies its gesture requirement.

## Fix

Change the unlock utterance from `''` to `' '` (a single space) with `volume: 0`, so iOS Safari registers the gesture unlock while the user hears nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)