### PR TITLE
Scoreboard voice: fix iOS Chrome — bypass async interop with native gesture listener

### DIFF
--- a/DropShot.Maui/wwwroot/js/scoreboard.js
+++ b/DropShot.Maui/wwwroot/js/scoreboard.js
@@ -1,14 +1,29 @@
 let _handler = null;
 let _voiceEnabled = false;
 let _voiceRate = 0.9;
+let _speechUnlocked = false;
+
+function _unlockSpeech() {
+    if (_speechUnlocked || !window.speechSynthesis) return;
+    _speechUnlocked = true;
+    const unlock = new SpeechSynthesisUtterance(' ');
+    unlock.volume = 0;
+    window.speechSynthesis.speak(unlock);
+}
+
+export function initVoiceUnlock() {
+    const handler = () => {
+        _unlockSpeech();
+        document.removeEventListener('touchstart', handler, true);
+        document.removeEventListener('click', handler, true);
+    };
+    document.addEventListener('touchstart', handler, { capture: true, once: true });
+    document.addEventListener('click', handler, { capture: true, once: true });
+}
 
 export function setVoiceEnabled(enabled) {
     _voiceEnabled = enabled;
-    if (enabled && window.speechSynthesis) {
-        const unlock = new SpeechSynthesisUtterance(' ');
-        unlock.volume = 0;
-        window.speechSynthesis.speak(unlock);
-    }
+    if (enabled) _unlockSpeech();
 }
 
 export function announceScore(text) {

--- a/DropShot.UI/Components/Pages/Scoreboard.razor
+++ b/DropShot.UI/Components/Pages/Scoreboard.razor
@@ -225,6 +225,7 @@
         _dotNetRef = DotNetObjectReference.Create(this);
         await _jsModule.InvokeVoidAsync("registerEscHandler", _dotNetRef);
         await _jsModule.InvokeVoidAsync("setScoreboardActive", true);
+        await _jsModule.InvokeVoidAsync("initVoiceUnlock");
 
         var savedVoice = await JS.InvokeAsync<string?>("localStorage.getItem", "scoreboard-voice");
         _voiceEnabled = savedVoice == "true";

--- a/DropShot/wwwroot/js/scoreboard.js
+++ b/DropShot/wwwroot/js/scoreboard.js
@@ -1,18 +1,35 @@
 let _handler = null;
 let _voiceEnabled = false;
 let _voiceRate = 0.9;
+let _speechUnlocked = false;
+
+function _unlockSpeech() {
+    if (_speechUnlocked || !window.speechSynthesis) return;
+    _speechUnlocked = true;
+    // Speak a silent non-empty utterance synchronously within the user gesture.
+    // Required on iOS (Safari and Chrome/WebKit) — an empty string is ignored,
+    // and the unlock must happen synchronously inside the gesture handler.
+    const unlock = new SpeechSynthesisUtterance(' ');
+    unlock.volume = 0;
+    window.speechSynthesis.speak(unlock);
+}
+
+// Attach native capture-phase listeners so the unlock fires synchronously on
+// the very first touch/click, before Blazor's async interop can run. This is
+// necessary on iOS where the gesture context expires before async callbacks fire.
+export function initVoiceUnlock() {
+    const handler = () => {
+        _unlockSpeech();
+        document.removeEventListener('touchstart', handler, true);
+        document.removeEventListener('click', handler, true);
+    };
+    document.addEventListener('touchstart', handler, { capture: true, once: true });
+    document.addEventListener('click', handler, { capture: true, once: true });
+}
 
 export function setVoiceEnabled(enabled) {
     _voiceEnabled = enabled;
-    // Unlock the speech engine within the user-gesture that triggered this call.
-    // Without this, browsers block speechSynthesis from non-gesture contexts (e.g. SignalR).
-    if (enabled && window.speechSynthesis) {
-        // iOS Safari requires a non-empty utterance to unlock the speech engine.
-        // volume:0 keeps it silent while still satisfying the gesture requirement.
-        const unlock = new SpeechSynthesisUtterance(' ');
-        unlock.volume = 0;
-        window.speechSynthesis.speak(unlock);
-    }
+    if (enabled) _unlockSpeech();
 }
 
 export function announceScore(text) {


### PR DESCRIPTION
## Problem

Voice announcements were silent on iOS Chrome (and iOS Safari). The previous fix spoke a silent unlock utterance inside the Blazor toggle handler, but Blazor's JS interop is **asynchronous** — by the time the JS actually runs on iOS, the user-gesture context has already expired and the browser silently blocks `speechSynthesis`.

## Fix

Add `initVoiceUnlock()`, called once after the JS module loads. It registers native **synchronous capture-phase** `touchstart` and `click` listeners on `document`. These fire before any Blazor event handling, so the unlock utterance is spoken strictly within the gesture context — exactly what iOS requires.

`setVoiceEnabled` still calls `_unlockSpeech()` as a fallback for desktop browsers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)