### PR TITLE
Competition wizard UX fixes and team match scoring improvements

### DIFF
--- a/DropShot.UI/Components/Pages/CompetitionWizardPage.razor
+++ b/DropShot.UI/Components/Pages/CompetitionWizardPage.razor
@@ -2,12 +2,14 @@
 @using DropShot.Shared
 @using DropShot.Shared.Dtos
 @using DropShot.UI.Components.Competitions
+@using DropShot.UI.Components.Competitions.Setup
 @using DropShot.UI.Services
 @using DropShot.UI.Services.Auth
 
 @inject ICompetitionAdminService Admin
 @inject NavigationManager Nav
 @inject ISnackbar Snackbar
+@inject IJSRuntime JS
 @inject Microsoft.Extensions.Logging.ILogger<CompetitionWizardPage> Logger
 
 @if (!_loaded)
@@ -34,7 +36,7 @@ else
         <MudStack Spacing="3">
 
             @* ── Step 0: Name + Category ───────────────────── *@
-            @if (_currentStep > 0)
+            @if (_currentStep != 0)
             {
                 <StepSummary Label="Name & Category"
                              Icon="@Icons.Material.Filled.Person"
@@ -46,7 +48,7 @@ else
             {
                 <MudPaper Class="pa-4 wizard-step" Elevation="0">
                     <MudText Typo="Typo.h6" Class="mb-2">Name & Category</MudText>
-                    @StepIntro("Category controls who is considered for entry and who will be offered a spot. Male / Female restricts by registered sex; Mixed is open to all.")
+                    @StepIntro("Category controls who is considered for entry and who will be offered a spot. Male / Female restricts entry based on the competition preference selected at sign-up; Mixed is open to all.")
 
                     <MudTextField T="string" Value="Model.CompetitionName"
                                   ValueChanged="OnCompetitionNameChanged"
@@ -66,12 +68,21 @@ else
                         </MudRadioGroup>
                     </MudField>
 
+                    <MudStack Row="true" AlignItems="AlignItems.Center" Class="mt-4 mb-1" Spacing="1">
+                        <MudText Typo="Typo.subtitle2">General Info</MudText>
+                        <MudTooltip Text="Optional: provide a description or welcome message for this competition. Shown to all players on the competition page." Placement="Placement.Right">
+                            <MudIcon Icon="@Icons.Material.Filled.Info" Size="Size.Small" Style="opacity: 0.6" />
+                        </MudTooltip>
+                    </MudStack>
+                    <GeneralInfoSection Description="@Model.Description"
+                                        DescriptionChanged="@((string? v) => Model.Description = v)" />
+
                     @StepActions(canBack: false, advance: TryAdvanceFromCategory)
                 </MudPaper>
             }
 
             @* ── Step 1: Format ─────────────────────────────── *@
-            @if (_currentStep > 1)
+            @if (_highWaterMark >= 1 && _currentStep != 1)
             {
                 <StepSummary Label="Format"
                              Icon="@Icons.Material.Filled.SportsTennis"
@@ -89,6 +100,7 @@ else
                                Required="true" RequiredError="Please pick a format."
                                Value="Model.Format"
                                ValueChanged="OnFormatChanged"
+                               Error="@(_formatError != null)" ErrorText="@_formatError"
                                Class="mt-3">
                         @foreach (var f in CompetitionFormHelpers.AllowedFormats(Model.Category))
                         {
@@ -144,7 +156,7 @@ else
             }
 
             @* ── Step 2: Age ────────────────────────────────── *@
-            @if (_currentStep > 2)
+            @if (_highWaterMark >= 2 && _currentStep != 2)
             {
                 <StepSummary Label="Age range"
                              Icon="@Icons.Material.Filled.Cake"
@@ -176,7 +188,7 @@ else
             }
 
             @* ── Step 3: Rule set ──────────────────────────── *@
-            @if (_currentStep > 3)
+            @if (_highWaterMark >= 3 && _currentStep != 3)
             {
                 <StepSummary Label="Rule set"
                              Icon="@Icons.Material.Filled.Gavel"
@@ -194,11 +206,9 @@ else
                     {
                         <MudSelect T="int?" Value="Model.HostClubId"
                                    ValueChanged="OnHostClubChanged"
-                                   Label="@(_lockHostClub ? "Host Club" : "Host Club (optional)")"
+                                   Label="Host Club (optional)"
                                    Variant="Variant.Outlined"
-                                   Clearable="@(!_lockHostClub)"
-                                   ReadOnly="@_lockHostClub"
-                                   Disabled="@_lockHostClub"
+                                   Clearable="true"
                                    Class="mt-3">
                             @foreach (var c in _clubs)
                             {
@@ -229,7 +239,7 @@ else
             }
 
             @* ── Step 4: Dates + max participants ──────────── *@
-            @if (_currentStep > 4)
+            @if (_highWaterMark >= 4 && _currentStep != 4)
             {
                 <StepSummary Label="Dates & participants"
                              Icon="@Icons.Material.Filled.CalendarMonth"
@@ -267,7 +277,7 @@ else
                 var _persistedFmt = CompetitionFormHelpers.EffectivePersistedFormat(Model.Category, Model.Format);
                 var _isLadder = _persistedFmt == CompetitionFormat.SinglesLadder;
             }
-            @if (_currentStep > 5 && !_isLadder)
+            @if (_highWaterMark >= 5 && _currentStep != 5 && !_isLadder)
             {
                 <StepSummary Label="Divisions"
                              Icon="@Icons.Material.Filled.AccountTree"
@@ -290,7 +300,7 @@ else
             }
 
             @* ── Step 6: Match/rubber scoring ──────────────── *@
-            @if (_currentStep > 6)
+            @if (_highWaterMark >= 6 && _currentStep != 6)
             {
                 <StepSummary Label="Match scoring"
                              Icon="@Icons.Material.Filled.EmojiEvents"
@@ -381,7 +391,7 @@ else
             }
 
             @* ── Step 7: League scoring ─────────────────────── *@
-            @if (_currentStep > 7)
+            @if (_highWaterMark >= 7 && _currentStep != 7)
             {
                 <StepSummary Label="League scoring"
                              Icon="@Icons.Material.Filled.Leaderboard"
@@ -408,7 +418,7 @@ else
             }
 
             @* ── Step 8: Misc settings ──────────────────────── *@
-            @if (_currentStep > 8)
+            @if (_highWaterMark >= 8 && _currentStep != 8)
             {
                 <StepSummary Label="Misc"
                              Icon="@Icons.Material.Filled.Tune"
@@ -419,7 +429,7 @@ else
             else if (_currentStep == 8 && !_savedCompetitionId.HasValue)
             {
                 <MudPaper Class="pa-4 wizard-step" Elevation="0">
-                    <MudText Typo="Typo.h6" Class="mb-2">Misc settings &amp; save</MudText>
+                    <MudText Typo="Typo.h6" Class="mb-2">Misc settings</MudText>
                     @StepIntro("Fine controls — minimum gap between a player's matches when auto-scheduling, and whether results need an admin to verify them before counting toward the standings. Clicking Save creates the competition; the optional setup steps that follow apply to that saved competition.")
 
                     <MudText Typo="Typo.subtitle2" Class="mt-3 mb-1">Minimum days between matches</MudText>
@@ -456,9 +466,26 @@ else
                                 {
                                     <MudProgressCircular Indeterminate="true" Size="Size.Small" Class="mr-2" />
                                 }
-                                Save &amp; continue
+                                Next
                             </MudButton>
                         </MudStack>
+                    </div>
+                </MudPaper>
+            }
+
+            @* ── Step 8 post-save: shown when navigating back from post-save steps ── *@
+            @if (_currentStep == 8 && _savedCompetitionId.HasValue)
+            {
+                <MudPaper Class="pa-4 wizard-step" Elevation="0">
+                    <MudText Typo="Typo.h6" Class="mb-2">Misc settings</MudText>
+                    @StepIntro("Competition already saved. Click Next to continue to the optional setup steps.")
+                    <div class="d-flex justify-space-between mt-4">
+                        <MudButton Variant="Variant.Text" Color="Color.Default"
+                                   StartIcon="@Icons.Material.Filled.ArrowBack"
+                                   OnClick="GoBack">Back</MudButton>
+                        <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                                   EndIcon="@Icons.Material.Filled.ArrowForward"
+                                   OnClick="TryAdvance">Next</MudButton>
                     </div>
                 </MudPaper>
             }
@@ -676,11 +703,14 @@ else
     private CompetitionFormModel Model { get; set; } = new();
 
     private int _currentStep = 0;
+    private int _highWaterMark = 0;
+    private bool _pendingScroll;
     private bool _loaded;
     private bool _isSaving;
     private string? _serverError;
     private string? _categoryError;
     private string? _nameError;
+    private string? _formatError;
 
     // Lookup data
     private List<ClubDto> _clubs = new();
@@ -688,7 +718,6 @@ else
     private List<EventDto> _events = new();
 
     // Host-club gating mirrors CompetitionPage create flow.
-    private bool _lockHostClub;
     private bool _hideHostClub;
 
     // Post-save state — populated after the user clicks "Save & continue" on
@@ -747,7 +776,7 @@ else
             //  • Premium user (no clubs visible): hide host club entirely.
             if (view.HostClubId.HasValue)
             {
-                _lockHostClub = true;
+                _hideHostClub = true;
                 Model.HostClubId = view.HostClubId;
             }
             else if (_clubs.Count == 0)
@@ -769,25 +798,40 @@ else
     private void GoToStep(int step)
     {
         if (step < 0 || step >= TotalSteps) return;
+        _highWaterMark = Math.Max(_highWaterMark, _currentStep);
         _currentStep = step;
         _serverError = null;
+        _pendingScroll = true;
     }
 
     private void GoBack()
     {
         if (_currentStep <= 0) { _serverError = null; return; }
+        _highWaterMark = Math.Max(_highWaterMark, _currentStep);
         _currentStep--;
         while (_currentStep > 0 && !StepApplies(_currentStep))
             _currentStep--;
         _serverError = null;
+        _pendingScroll = true;
     }
 
     private void TryAdvance()
     {
         if (_currentStep >= TotalSteps - 1) return;
+        _highWaterMark = Math.Max(_highWaterMark, _currentStep);
         _currentStep++;
         while (_currentStep < TotalSteps - 1 && !StepApplies(_currentStep))
             _currentStep++;
+        _pendingScroll = true;
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (_pendingScroll)
+        {
+            _pendingScroll = false;
+            await JS.InvokeVoidAsync("eval", "window.scrollTo(0,0)");
+        }
     }
 
     // Returns false for steps that should be skipped given the current Model.
@@ -811,6 +855,7 @@ else
     private void OnFormatChanged(CompetitionFormatUi? format)
     {
         Model.Format = format;
+        if (format != null) _formatError = null;
         // Divisions don't apply to a SinglesLadder. Clear the toggle so the
         // wizard's Divisions question (and subsequent divisions-list step) is
         // skipped via StepApplies.
@@ -853,9 +898,10 @@ else
     {
         if (Model.Format == null)
         {
-            Snackbar.Add("Please pick a format.", Severity.Warning);
+            _formatError = "Please pick a format.";
             return;
         }
+        _formatError = null;
         TryAdvance();
     }
 
@@ -952,6 +998,7 @@ else
 
             var savedId = await Admin.SaveCompetitionAsync(null, request);
             _savedCompetitionId = savedId;
+            _highWaterMark = Math.Max(_highWaterMark, _currentStep);
             Snackbar.Add("Competition created.", Severity.Success);
 
             // Preload rubber presets so the rubber-template step has something

--- a/DropShot.UI/Components/Pages/TeamMatchScoring.razor
+++ b/DropShot.UI/Components/Pages/TeamMatchScoring.razor
@@ -44,8 +44,8 @@ else if (_resolutionError != null)
             @if (_context is not null)
             {
                 <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.ArrowBack"
-                           Href="@($"/competition/{_context.CompetitionId}")">
-                    Back to Competition
+                           OnClick="NavigateBack">
+                    Back
                 </MudButton>
             }
         </MudStack>
@@ -106,11 +106,14 @@ else
                     <span> (Draw)</span>
                 }
             </MudAlert>
+            <MudAlert Severity="Severity.Info" Class="mt-2">
+                Scores are still editable — tap any rubber above to make changes.
+            </MudAlert>
         }
 
         <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.ArrowBack"
-                   Href="@($"/competition/{_context.CompetitionId}")">
-            Back to Competition
+                   OnClick="NavigateBack">
+            Back
         </MudButton>
     </MudContainer>
 }
@@ -118,6 +121,10 @@ else
 @code {
     [Parameter] public int FixtureId { get; set; }
     [SupplyParameterFromQuery(Name = "edit")] public int? EditMode { get; set; }
+    [SupplyParameterFromQuery(Name = "returnUrl")] public string? ReturnUrl { get; set; }
+
+    private void NavigateBack() =>
+        Navigation.NavigateTo(ReturnUrl ?? (_context is not null ? $"/competition/{_context.CompetitionId}" : "/"));
 
     private FixtureRubberContextDto? _context;
     private bool _loading = true;

--- a/DropShot/Data/Migrations/20260605224301_AddCompetitionCalendarExceptions.Designer.cs
+++ b/DropShot/Data/Migrations/20260605224301_AddCompetitionCalendarExceptions.Designer.cs
@@ -4,16 +4,19 @@ using DropShot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace DropShot.Migrations
+namespace DropShot.Data.Migrations
 {
     [DbContext(typeof(MyDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260605224301_AddCompetitionCalendarExceptions")]
+    partial class AddCompetitionCalendarExceptions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DropShot/Data/Migrations/20260605224301_AddCompetitionCalendarExceptions.cs
+++ b/DropShot/Data/Migrations/20260605224301_AddCompetitionCalendarExceptions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
@@ -26,17 +26,22 @@ namespace DropShot.Data.Migrations
                 {
                     table.PrimaryKey("PK_CompetitionCalendarExceptions", x => x.CompetitionCalendarExceptionId);
                     table.ForeignKey(
+                        name: "FK_CompetitionCalendarExceptions_CompetitionDivisions_CompetitionDivisionId",
+                        column: x => x.CompetitionDivisionId,
+                        principalTable: "CompetitionDivisions",
+                        principalColumn: "CompetitionDivisionId");
+                    table.ForeignKey(
                         name: "FK_CompetitionCalendarExceptions_Competition_CompetitionId",
                         column: x => x.CompetitionId,
                         principalTable: "Competition",
                         principalColumn: "CompetitionID",
                         onDelete: ReferentialAction.Cascade);
-                    table.ForeignKey(
-                        name: "FK_CompetitionCalendarExceptions_CompetitionDivisions_CompetitionDivisionId",
-                        column: x => x.CompetitionDivisionId,
-                        principalTable: "CompetitionDivisions",
-                        principalColumn: "CompetitionDivisionId");
                 });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CompetitionCalendarExceptions_CompetitionDivisionId",
+                table: "CompetitionCalendarExceptions",
+                column: "CompetitionDivisionId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_CompetitionCalendarExceptions_CompetitionId_CompetitionDivisionId_ExceptionDate",
@@ -44,11 +49,6 @@ namespace DropShot.Data.Migrations
                 columns: new[] { "CompetitionId", "CompetitionDivisionId", "ExceptionDate" },
                 unique: true,
                 filter: "[CompetitionDivisionId] IS NOT NULL");
-
-            migrationBuilder.CreateIndex(
-                name: "IX_CompetitionCalendarExceptions_CompetitionDivisionId",
-                table: "CompetitionCalendarExceptions",
-                column: "CompetitionDivisionId");
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
## Summary

- Remove 'registered sex' wording in wizard step 0; reword to reference the competition preference selected at sign-up
- ClubAdmins: hide Host Club dropdown entirely (pre-filled silently) rather than showing a locked/disabled field
- Misc settings: rename section heading and button from 'Misc settings & save' / 'Save & continue' to 'Misc settings' / 'Next'
- Format step: replace yellow Snackbar warning with inline red field validation error
- Wizard back-navigation: track a high-water mark so previously visited steps remain visible as collapsible summaries when navigating back
- Fix back from Step 9 (Competition admins) losing nav buttons — new render block handles the post-save step-8 state
- Add General Info section with tooltip to Step 0, wired to `Model.Description`
- Scroll to top of page on each wizard step change
- TeamMatchScoring: rename 'Back to Competition' → 'Back'; support `returnUrl` query param for context-aware navigation
- TeamMatchScoring: show 'Scores are still editable' info alert when all rubbers are complete

## Test plan

- [ ] Walk the wizard as a ClubAdmin — confirm Host Club field is not shown; competition still saves with the correct host club
- [ ] Walk the wizard as an Admin/SuperAdmin — confirm Host Club dropdown is shown
- [ ] Click Next on the Format step without selecting a format — confirm inline red error (not yellow popup)
- [ ] Navigate forward to Step 9 (admins), then click Back — confirm Back/Next buttons are present on step 8
- [ ] Navigate back from any step — confirm all previously completed steps remain visible as summaries with edit icons
- [ ] Verify page scrolls to top on each Next/Back click
- [ ] Confirm Step 0 shows a General Info section with tooltip
- [ ] Confirm Misc settings heading says "Misc settings" and the button says "Next"
- [ ] Confirm category intro text no longer mentions "registered sex"
- [ ] On a team match scoring page, confirm back button says "Back" and navigates correctly
- [ ] Complete all rubbers — confirm "Scores are still editable" info alert appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)